### PR TITLE
fix: add 'in_order' selector to alias validation schema

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -104,7 +104,7 @@ const ModelTargetSchema = z.object({
 });
 
 const ModelConfigSchema = z.object({
-  selector: z.enum(['random', 'cost', 'latency', 'usage', 'performance']).optional(),
+  selector: z.enum(['random', 'in_order', 'cost', 'latency', 'usage', 'performance']).optional(),
   priority: z.enum(['selector', 'api_match']).default('selector'),
   targets: z.array(ModelTargetSchema),
   additional_aliases: z.array(z.string()).optional(),


### PR DESCRIPTION
The 'in_order' selector option was available in the UI but was not
included in the backend validation schema, causing alias creation to
fail when selecting "In Order (Defined Priority)" as the selector.

This fix adds 'in_order' to the allowed selector enum values in
ModelConfigSchema to match the frontend options and selector factory
implementation.