### PR TITLE
fix(frontend): keep live metrics polling fresh

### DIFF
--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -915,12 +915,13 @@ export const api = {
   },
 
   getDashboardData: async (
-    range: 'hour' | 'day' | 'week' | 'month' = 'day'
+    range: 'hour' | 'day' | 'week' | 'month' = 'day',
+    cache = true
   ): Promise<DashboardData> => {
     try {
       const now = normalizeNow();
       const [summary, cooldowns, config] = await Promise.all([
-        fetchUsageSummary(range, true),
+        fetchUsageSummary(range, cache),
         api.getCooldowns(),
         fetchConfigCached(),
       ]);

--- a/packages/frontend/src/pages/LiveMetrics.tsx
+++ b/packages/frontend/src/pages/LiveMetrics.tsx
@@ -114,7 +114,7 @@ export const LiveMetrics = () => {
 
     try {
       const [dashboardData, logData] = await Promise.all([
-        api.getDashboardData('day'),
+        api.getDashboardData('day', false),
         api.getLogs(RECENT_REQUEST_LIMIT, 0),
       ]);
       setStats(dashboardData.stats);


### PR DESCRIPTION
## Summary
- Ensure Live Metrics polling always fetches uncached dashboard summary data so cards and freshness indicators update on each poll tick.
- Keep change scope minimal and frontend-only by extending `getDashboardData` with an optional cache flag and disabling cache only for Live Metrics.
- Preserve behavior for other pages by leaving default caching enabled everywhere else.

## Changes Made
- `packages/frontend/src/lib/api.ts`
  - Add optional `cache` parameter to `api.getDashboardData(range, cache = true)`.
  - Wire `cache` through to `fetchUsageSummary(range, cache)`.
- `packages/frontend/src/pages/LiveMetrics.tsx`
  - Update live poll path to call `api.getDashboardData('day', false)`.

## Testing
- `bun x @biomejs/biome format --write src/lib/api.ts src/pages/LiveMetrics.tsx` ✅
- `lsp_diagnostics` on modified files ✅
- `bun run build` (frontend package) ✅
- `bun test` (frontend package) ✅

## Scope / Notes
- Frontend-only, 2 files.
- Diff size: 7 lines changed (4 insertions, 3 deletions).
- Fits strict chunking requirement (`<= 500 LOC`).