### PR TITLE
feat(quota): add POE point balance quota checker

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -153,6 +153,10 @@ const ApertisQuotaCheckerOptionsSchema = z.object({
   endpoint: z.string().url().optional(),
 });
 
+const PoeQuotaCheckerOptionsSchema = z.object({
+  endpoint: z.string().url().optional(),
+});
+
 const ProviderQuotaCheckerSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('naga'),
@@ -258,6 +262,13 @@ const ProviderQuotaCheckerSchema = z.discriminatedUnion('type', [
     intervalMinutes: z.number().min(1).default(30),
     id: z.string().trim().min(1).optional(),
     options: MiniMaxCodingQuotaCheckerOptionsSchema.optional().default({}),
+  }),
+  z.object({
+    type: z.literal('poe'),
+    enabled: z.boolean().default(true),
+    intervalMinutes: z.number().min(1).default(30),
+    id: z.string().trim().min(1).optional(),
+    options: PoeQuotaCheckerOptionsSchema.optional().default({}),
   }),
 ]);
 
@@ -854,6 +865,7 @@ export const VALID_QUOTA_CHECKER_TYPES = [
   'copilot',
   'wisdomgate',
   'apertis',
+  'poe',
 ] as const;
 
 export type QuotaCheckerType = (typeof VALID_QUOTA_CHECKER_TYPES)[number];

--- a/packages/backend/src/services/quota/checkers/__tests__/poe-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/poe-checker.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { QuotaCheckerConfig } from '../../../../types/quota';
+import { PoeQuotaChecker } from '../poe-checker';
+import { QuotaCheckerFactory } from '../../quota-checker-factory';
+
+const makeConfig = (options: Record<string, unknown> = {}): QuotaCheckerConfig => ({
+  id: 'poe-test',
+  provider: 'poe',
+  type: 'poe',
+  enabled: true,
+  intervalMinutes: 30,
+  options: {
+    apiKey: 'poe-api-key',
+    ...options,
+  },
+});
+
+describe('PoeQuotaChecker', () => {
+  const setFetchMock = (impl: (...args: any[]) => Promise<Response>): void => {
+    global.fetch = mock(impl) as unknown as typeof fetch;
+  };
+
+  beforeEach(() => {
+    mock.restore();
+  });
+
+  it('is registered under poe', () => {
+    expect(QuotaCheckerFactory.isRegistered('poe')).toBe(true);
+  });
+
+  it('queries balance endpoint and maps current_point_balance to subscription points window', async () => {
+    let capturedUrl: string | undefined;
+    let capturedAuth: string | undefined;
+
+    setFetchMock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrl = String(input);
+      const headers = new Headers(init?.headers);
+      capturedAuth = headers.get('Authorization') ?? undefined;
+
+      return new Response(JSON.stringify({ current_point_balance: 4948499 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const checker = new PoeQuotaChecker(makeConfig());
+    const result = await checker.checkQuota();
+
+    expect(capturedUrl).toBe('https://api.poe.com/usage/current_balance');
+    expect(capturedAuth).toBe('Bearer poe-api-key');
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.windows).toHaveLength(1);
+    expect(result.windows?.[0]?.windowType).toBe('subscription');
+    expect(result.windows?.[0]?.unit).toBe('points');
+    expect(result.windows?.[0]?.remaining).toBe(4948499);
+    expect(result.windows?.[0]?.description).toBe('POE point balance');
+  });
+
+  it('uses custom endpoint when provided', async () => {
+    let capturedUrl: string | undefined;
+
+    setFetchMock(async (input: RequestInfo | URL) => {
+      capturedUrl = String(input);
+      return new Response(JSON.stringify({ current_point_balance: 1000 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const checker = new PoeQuotaChecker(
+      makeConfig({ endpoint: 'https://custom.poe.com/balance' })
+    );
+    await checker.checkQuota();
+
+    expect(capturedUrl).toBe('https://custom.poe.com/balance');
+  });
+
+  it('returns error for non-200 response', async () => {
+    setFetchMock(
+      async () => new Response('unauthorized', { status: 401, statusText: 'Unauthorized' })
+    );
+
+    const checker = new PoeQuotaChecker(makeConfig());
+    const result = await checker.checkQuota();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('HTTP 401: Unauthorized');
+  });
+
+  it('returns error when balance is not numeric', async () => {
+    setFetchMock(async () => {
+      return new Response(JSON.stringify({ current_point_balance: 'not-a-number' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const checker = new PoeQuotaChecker(makeConfig());
+    const result = await checker.checkQuota();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid balance received: not-a-number');
+  });
+});

--- a/packages/backend/src/services/quota/checkers/poe-checker.ts
+++ b/packages/backend/src/services/quota/checkers/poe-checker.ts
@@ -1,0 +1,61 @@
+import type { QuotaCheckResult, QuotaWindow, QuotaCheckerConfig } from '../../../types/quota';
+import { QuotaChecker } from '../quota-checker';
+import { logger } from '../../../utils/logger';
+
+interface PoeBalanceResponse {
+  current_point_balance?: number;
+}
+
+export class PoeQuotaChecker extends QuotaChecker {
+  private endpoint: string;
+
+  constructor(config: QuotaCheckerConfig) {
+    super(config);
+    this.endpoint = this.getOption<string>('endpoint', 'https://api.poe.com/usage/current_balance');
+  }
+
+  async checkQuota(): Promise<QuotaCheckResult> {
+    const apiKey = this.requireOption<string>('apiKey');
+
+    try {
+      logger.silly(`[poe] Calling ${this.endpoint}`);
+
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      };
+
+      const response = await fetch(this.endpoint, {
+        method: 'GET',
+        headers,
+      });
+
+      if (!response.ok) {
+        return this.errorResult(new Error(`HTTP ${response.status}: ${response.statusText}`));
+      }
+
+      const data: PoeBalanceResponse = await response.json();
+      const balance = Number(data.current_point_balance);
+
+      if (!Number.isFinite(balance)) {
+        return this.errorResult(
+          new Error(`Invalid balance received: ${String(data.current_point_balance)}`)
+        );
+      }
+
+      const window: QuotaWindow = this.createWindow(
+        'subscription',
+        undefined,
+        undefined,
+        balance,
+        'points',
+        undefined,
+        'POE point balance'
+      );
+
+      return this.successResult([window]);
+    } catch (error) {
+      return this.errorResult(error as Error);
+    }
+  }
+}

--- a/packages/backend/src/services/quota/quota-checker-factory.ts
+++ b/packages/backend/src/services/quota/quota-checker-factory.ts
@@ -14,6 +14,7 @@ import { KimiCodeQuotaChecker } from './checkers/kimi-code-checker';
 import { CopilotQuotaChecker } from './checkers/copilot-checker';
 import { WisdomGateQuotaChecker } from './checkers/wisdomgate-checker';
 import { ApertisQuotaChecker } from './checkers/apertis-checker';
+import { PoeQuotaChecker } from './checkers/poe-checker';
 
 const CHECKER_REGISTRY: Record<string, new (config: QuotaCheckerConfig) => QuotaChecker> = {
   synthetic: SyntheticQuotaChecker,
@@ -31,6 +32,7 @@ const CHECKER_REGISTRY: Record<string, new (config: QuotaCheckerConfig) => Quota
   copilot: CopilotQuotaChecker,
   wisdomgate: WisdomGateQuotaChecker,
   apertis: ApertisQuotaChecker,
+  poe: PoeQuotaChecker,
 };
 
 export class QuotaCheckerFactory {

--- a/packages/backend/src/types/quota.ts
+++ b/packages/backend/src/types/quota.ts
@@ -9,7 +9,7 @@ export type QuotaWindowType =
   | 'monthly'
   | 'custom';
 
-export type QuotaUnit = 'dollars' | 'requests' | 'tokens' | 'percentage';
+export type QuotaUnit = 'dollars' | 'requests' | 'tokens' | 'percentage' | 'points';
 
 export type QuotaStatus = 'ok' | 'warning' | 'critical' | 'exhausted';
 

--- a/packages/frontend/src/components/quota/BalanceHistoryModal.tsx
+++ b/packages/frontend/src/components/quota/BalanceHistoryModal.tsx
@@ -12,7 +12,7 @@ import { clsx } from 'clsx';
 import { X, Clock, Calendar, Wallet, TrendingDown } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import { api } from '../../lib/api';
-import { formatCost } from '../../lib/format';
+import { formatCost, formatPoints } from '../../lib/format';
 import type { QuotaCheckerInfo, QuotaSnapshot } from '../../types/quota';
 
 type TimeRange = '1h' | '3h' | '6h' | '12h' | '24h' | '1w' | '4w';
@@ -148,6 +148,16 @@ export const BalanceHistoryModal: React.FC<BalanceHistoryModalProps> = ({
     return { current, min, max, change, percentChange };
   }, [chartData]);
 
+  // Determine if this checker uses points (not dollars)
+  const isPointsUnit = useMemo(() => {
+    return history.some((s) => s.unit === 'points');
+  }, [history]);
+
+  const formatValue = (value: number) => {
+    if (isPointsUnit) return `${formatPoints(value)} pts`;
+    return formatCost(value);
+  };
+
   // Handle escape key
   useEffect(() => {
     const handleEsc = (e: KeyboardEvent) => {
@@ -229,7 +239,7 @@ export const BalanceHistoryModal: React.FC<BalanceHistoryModalProps> = ({
                   <Wallet size={12} />
                   <span>Current</span>
                 </div>
-                <div className="text-lg font-semibold text-info">{formatCost(stats.current)}</div>
+                <div className="text-lg font-semibold text-info">{formatValue(stats.current)}</div>
               </div>
               <div className="bg-bg-subtle rounded-lg p-3 border border-border">
                 <div className="flex items-center gap-2 text-text-secondary text-xs mb-1">
@@ -243,7 +253,7 @@ export const BalanceHistoryModal: React.FC<BalanceHistoryModalProps> = ({
                   )}
                 >
                   {stats.change < 0 ? '' : '+'}
-                  {formatCost(stats.change)}
+                  {formatValue(stats.change)}
                 </div>
               </div>
               <div className="bg-bg-subtle rounded-lg p-3 border border-border">
@@ -251,14 +261,14 @@ export const BalanceHistoryModal: React.FC<BalanceHistoryModalProps> = ({
                   <Calendar size={12} />
                   <span>High</span>
                 </div>
-                <div className="text-lg font-semibold text-text">{formatCost(stats.max)}</div>
+                <div className="text-lg font-semibold text-text">{formatValue(stats.max)}</div>
               </div>
               <div className="bg-bg-subtle rounded-lg p-3 border border-border">
                 <div className="flex items-center gap-2 text-text-secondary text-xs mb-1">
                   <Calendar size={12} />
                   <span>Low</span>
                 </div>
-                <div className="text-lg font-semibold text-text">{formatCost(stats.min)}</div>
+                <div className="text-lg font-semibold text-text">{formatValue(stats.min)}</div>
               </div>
             </div>
           )}
@@ -313,7 +323,7 @@ export const BalanceHistoryModal: React.FC<BalanceHistoryModalProps> = ({
                       tick={{ fill: 'var(--color-text-secondary)', fontSize: 11 }}
                       axisLine={false}
                       tickLine={false}
-                      tickFormatter={(value: number) => formatCost(value)}
+                      tickFormatter={(value: number) => formatValue(value)}
                       domain={['auto', 'auto']}
                     />
                     <Tooltip
@@ -338,7 +348,7 @@ export const BalanceHistoryModal: React.FC<BalanceHistoryModalProps> = ({
                                 <div className="w-2 h-2 rounded-full bg-cyan-400" />
                                 <span className="text-xs text-text-secondary">Balance:</span>
                                 <span className="text-sm font-semibold text-text">
-                                  {formatCost(balance as number)}
+                                  {formatValue(balance as number)}
                                 </span>
                               </div>
                             </div>

--- a/packages/frontend/src/components/quota/CombinedBalancesCard.tsx
+++ b/packages/frontend/src/components/quota/CombinedBalancesCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { clsx } from 'clsx';
 import { Wallet, AlertTriangle, RefreshCw } from 'lucide-react';
-import { formatCost, toTitleCase } from '../../lib/format';
+import { formatCost, formatPoints, toTitleCase } from '../../lib/format';
 import type { QuotaCheckerInfo } from '../../types/quota';
 import { Button } from '../ui/Button';
 import { BalanceHistoryModal } from './BalanceHistoryModal';
@@ -20,6 +20,7 @@ const CHECKER_DISPLAY_NAMES: Record<string, string> = {
   moonshot: 'Moonshot',
   naga: 'Naga',
   kilo: 'Kilo',
+  poe: 'POE',
   apertis: 'Apertis',
 };
 
@@ -50,6 +51,7 @@ export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
     else if (checkerType.includes('moonshot')) normalizedType = 'moonshot';
     else if (checkerType.includes('naga')) normalizedType = 'naga';
     else if (checkerType.includes('kilo')) normalizedType = 'kilo';
+    else if (checkerType.includes('poe')) normalizedType = 'poe';
     else if (checkerType.includes('apertis')) normalizedType = 'apertis';
     return CHECKER_DISPLAY_NAMES[normalizedType] || quota.checkerId;
   };
@@ -75,12 +77,19 @@ export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
     else if (checkerType.includes('moonshot')) normalizedType = 'moonshot';
     else if (checkerType.includes('naga')) normalizedType = 'naga';
     else if (checkerType.includes('kilo')) normalizedType = 'kilo';
+    else if (checkerType.includes('poe')) normalizedType = 'poe';
     else if (checkerType.includes('apertis')) normalizedType = 'apertis';
 
     const displayName = CHECKER_DISPLAY_NAMES[normalizedType] || quota.checkerId;
     const windows = result.windows || [];
     const subscriptionWindow = windows.find((w: any) => w.windowType === 'subscription');
     const balance = subscriptionWindow?.remaining;
+    const unit = subscriptionWindow?.unit;
+
+    const formatBalance = (value: number) => {
+      if (unit === 'points') return `${formatPoints(value)} pts`;
+      return formatCost(value);
+    };
 
     return (
       <div
@@ -111,7 +120,7 @@ export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
             <div className="flex items-baseline gap-2">
               <span className="text-xs text-text-secondary">Balance</span>
               <span className="text-base font-semibold text-info tabular-nums">
-                {formatCost(balance)}
+                {formatBalance(balance)}
               </span>
             </div>
           ) : (

--- a/packages/frontend/src/components/quota/CompactBalancesCard.tsx
+++ b/packages/frontend/src/components/quota/CompactBalancesCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { formatCost, toTitleCase } from '../../lib/format';
+import { formatCost, formatPoints, toTitleCase } from '../../lib/format';
 import type { QuotaCheckerInfo } from '../../types/quota';
 
 interface CompactBalancesCardProps {
@@ -43,15 +43,23 @@ export const CompactBalancesCard: React.FC<CompactBalancesCardProps> = ({
         const windows = result.windows || [];
         const subscriptionWindow = windows.find((w: any) => w.windowType === 'subscription');
         const balance = subscriptionWindow?.remaining;
+        const unit = subscriptionWindow?.unit;
+
+        const formattedBalance =
+          balance !== undefined
+            ? unit === 'points'
+              ? `${formatPoints(balance)} pts`
+              : formatCost(balance)
+            : undefined;
 
         return (
           <div key={quota.checkerId} className="flex items-center justify-between min-w-0">
             <span className="text-xs text-text-secondary truncate">{displayName}:</span>
             {!result.success ? (
               <span className="text-xs text-danger flex-shrink-0 ml-2">Error</span>
-            ) : balance !== undefined ? (
+            ) : formattedBalance !== undefined ? (
               <span className="text-xs font-semibold text-text-secondary tabular-nums flex-shrink-0 ml-2">
-                {formatCost(balance)}
+                {formattedBalance}
               </span>
             ) : (
               <span className="text-xs text-text-muted flex-shrink-0">—</span>

--- a/packages/frontend/src/components/quota/PoeQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/PoeQuotaConfig.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Input } from '../ui/Input';
+
+export interface PoeQuotaConfigProps {
+  options: Record<string, unknown>;
+  onChange: (options: Record<string, unknown>) => void;
+}
+
+export const PoeQuotaConfig: React.FC<PoeQuotaConfigProps> = ({ options, onChange }) => {
+  const handleChange = (key: string, value: string) => {
+    onChange({ ...options, [key]: value });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1">
+        <label className="font-body text-[13px] font-medium text-text-secondary">
+          Endpoint (optional)
+        </label>
+        <Input
+          value={(options.endpoint as string) ?? ''}
+          onChange={(e) => handleChange('endpoint', e.target.value)}
+          placeholder="https://api.poe.com/usage/current_balance"
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/quota/PoeQuotaDisplay.tsx
+++ b/packages/frontend/src/components/quota/PoeQuotaDisplay.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { clsx } from 'clsx';
+import { Wallet, AlertTriangle } from 'lucide-react';
+import { formatPoints } from '../../lib/format';
+import type { QuotaCheckResult } from '../../types/quota';
+
+interface PoeQuotaDisplayProps {
+  result: QuotaCheckResult;
+  isCollapsed: boolean;
+}
+
+export const PoeQuotaDisplay: React.FC<PoeQuotaDisplayProps> = ({ result, isCollapsed }) => {
+  if (!result.success) {
+    return (
+      <div className="px-2 py-2">
+        <div
+          className={clsx('flex items-center gap-2 text-danger', isCollapsed && 'justify-center')}
+        >
+          <AlertTriangle size={16} />
+          {!isCollapsed && <span className="text-xs">Error</span>}
+        </div>
+      </div>
+    );
+  }
+
+  const windows = result.windows || [];
+  const subscriptionWindow = windows.find((w) => w.windowType === 'subscription');
+  const balance = subscriptionWindow?.remaining;
+
+  if (isCollapsed) {
+    return (
+      <div className="px-2 py-2 flex justify-center">
+        <Wallet size={18} className="text-info" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-2 py-1 space-y-1">
+      <div className="flex items-center gap-2 min-w-0">
+        <Wallet size={14} className="text-info" />
+        <span className="text-xs font-semibold text-text whitespace-nowrap">POE</span>
+      </div>
+      {balance !== undefined && (
+        <div className="flex items-baseline gap-2">
+          <span className="text-xs font-semibold text-text-secondary">Points</span>
+          <span className="text-xs font-semibold text-info ml-auto">
+            {formatPoints(balance)} pts
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/quota/index.ts
+++ b/packages/frontend/src/components/quota/index.ts
@@ -26,6 +26,8 @@ export { WisdomGateQuotaDisplay } from './WisdomGateQuotaDisplay';
 export { WisdomGateQuotaConfig } from './WisdomGateQuotaConfig';
 export { ApertisQuotaDisplay } from './ApertisQuotaDisplay';
 export { ApertisQuotaConfig } from './ApertisQuotaConfig';
+export { PoeQuotaDisplay } from './PoeQuotaDisplay';
+export { PoeQuotaConfig } from './PoeQuotaConfig';
 export { CombinedBalancesCard } from './CombinedBalancesCard';
 export { CompactBalancesCard } from './CompactBalancesCard';
 export { CompactQuotasCard } from './CompactQuotasCard';

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -78,6 +78,20 @@ export function formatCost(cost: number, maxDecimals: number = 6): string {
 }
 
 /**
+ * Format large point balances with k, M, B suffixes (e.g., 4948499 -> "4.9M", 1500 -> "1k")
+ */
+export function formatPoints(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${Math.round(n / 1000)}k`;
+  if (n < 1_000_000_000) {
+    const val = (n / 1_000_000).toFixed(1).replace(/\.0$/, '');
+    return `${val}M`;
+  }
+  const val = (n / 1_000_000_000).toFixed(1).replace(/\.0$/, '');
+  return `${val}B`;
+}
+
+/**
  * Format milliseconds to seconds with appropriate precision
  */
 export function formatMs(ms: number): string {

--- a/packages/frontend/src/pages/Providers.tsx
+++ b/packages/frontend/src/pages/Providers.tsx
@@ -27,6 +27,7 @@ import { KiloQuotaConfig } from '../components/quota/KiloQuotaConfig';
 import { WisdomGateQuotaConfig } from '../components/quota/WisdomGateQuotaConfig';
 import { ApertisQuotaConfig } from '../components/quota/ApertisQuotaConfig';
 import { KimiCodeQuotaConfig } from '../components/quota/KimiCodeQuotaConfig';
+import { PoeQuotaConfig } from '../components/quota/PoeQuotaConfig';
 
 const KNOWN_APIS = [
   'chat',
@@ -63,6 +64,7 @@ const QUOTA_CHECKER_TYPES_FALLBACK = [
   'kilo',
   'wisdomgate',
   'apertis',
+  'poe',
   'copilot',
 ] as const;
 
@@ -1664,6 +1666,23 @@ export const Providers = () => {
               {selectedQuotaCheckerType && selectedQuotaCheckerType === 'kilo' && (
                 <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
                   <KiloQuotaConfig
+                    options={editingProvider.quotaChecker?.options || {}}
+                    onChange={(options) =>
+                      setEditingProvider({
+                        ...editingProvider,
+                        quotaChecker: {
+                          ...editingProvider.quotaChecker,
+                          options,
+                        } as Provider['quotaChecker'],
+                      })
+                    }
+                  />
+                </div>
+              )}
+
+              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'poe' && (
+                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                  <PoeQuotaConfig
                     options={editingProvider.quotaChecker?.options || {}}
                     onChange={(options) =>
                       setEditingProvider({

--- a/packages/frontend/src/pages/Quotas.tsx
+++ b/packages/frontend/src/pages/Quotas.tsx
@@ -21,13 +21,14 @@ import {
   CopilotQuotaDisplay,
   WisdomGateQuotaDisplay,
   KimiCodeQuotaDisplay,
+  PoeQuotaDisplay,
   CombinedBalancesCard,
   QuotaHistoryModal,
   BalanceHistoryModal,
 } from '../components/quota';
 
 // Checker type categories
-const BALANCE_CHECKERS = ['openrouter', 'minimax', 'moonshot', 'naga', 'kilo', 'apertis'];
+const BALANCE_CHECKERS = ['openrouter', 'minimax', 'moonshot', 'naga', 'kilo', 'poe', 'apertis'];
 const RATE_LIMIT_CHECKERS = [
   'openai-codex',
   'codex',
@@ -51,6 +52,7 @@ const CHECKER_DISPLAY_NAMES: Record<string, string> = {
   moonshot: 'Moonshot',
   naga: 'Naga',
   kilo: 'Kilo',
+  poe: 'POE',
   'openai-codex': 'OpenAI Codex',
   codex: 'Codex',
   'claude-code': 'Claude Code',
@@ -187,6 +189,8 @@ export const Quotas = () => {
         baseType = 'naga';
       } else if (baseType.includes('kilo')) {
         baseType = 'kilo';
+      } else if (baseType.includes('poe')) {
+        baseType = 'poe';
       } else if (baseType.includes('zai')) {
         baseType = 'zai';
       } else if (baseType.includes('synthetic')) {
@@ -310,6 +314,10 @@ export const Quotas = () => {
 
     if (checkerIdentifier.includes('kilo')) {
       return wrapper(<KiloQuotaDisplay result={result} isCollapsed={false} />);
+    }
+
+    if (checkerIdentifier.includes('poe')) {
+      return wrapper(<PoeQuotaDisplay result={result} isCollapsed={false} />);
     }
 
     if (checkerIdentifier.includes('copilot')) {

--- a/packages/frontend/src/types/quota.ts
+++ b/packages/frontend/src/types/quota.ts
@@ -9,7 +9,7 @@ export type QuotaWindowType =
   | 'monthly'
   | 'custom';
 
-export type QuotaUnit = 'dollars' | 'requests' | 'tokens' | 'percentage';
+export type QuotaUnit = 'dollars' | 'requests' | 'tokens' | 'percentage' | 'points';
 
 export type QuotaStatus = 'ok' | 'warning' | 'critical' | 'exhausted';
 


### PR DESCRIPTION
## Summary

- Add a new **POE quota provider** that fetches the current point balance from `https://api.poe.com/usage/current_balance` using the provider's API key (Bearer auth)
- Introduce a new `points` QuotaUnit type and `formatPoints()` helper that formats large numbers with k/M/B suffixes (e.g., `4948499` → `"4.9M pts"`)
- Update existing balance display components (`CombinedBalancesCard`, `CompactBalancesCard`, `BalanceHistoryModal`) to handle `points` unit alongside `dollars`

### New Files
| File | Description |
|------|-------------|
| `packages/backend/src/services/quota/checkers/poe-checker.ts` | Backend checker — maps `current_point_balance` to a subscription window with unit `points` |
| `packages/backend/src/services/quota/checkers/__tests__/poe-checker.test.ts` | 5 unit tests (registration, balance mapping, custom endpoint, HTTP errors, invalid balance) |
| `packages/frontend/src/components/quota/PoeQuotaConfig.tsx` | Config component with optional endpoint override |
| `packages/frontend/src/components/quota/PoeQuotaDisplay.tsx` | Display component showing formatted point balance |

### Modified Files
- **Backend:** `config.ts` (schema + valid types), `quota-checker-factory.ts` (registry), `types/quota.ts` (`points` unit)
- **Frontend:** `format.ts` (`formatPoints`), `types/quota.ts` (`points` unit), `index.ts` (exports), `Providers.tsx` + `Quotas.tsx` (wiring), balance card components (unit-aware formatting)

### Config Example
```yaml
providers:
  poe-provider:
    api_base_url: "https://api.poe.com"
    api_key: "your-poe-api-key"
    quota_checker:
      type: poe
      enabled: true
      intervalMinutes: 30
```

The API key is automatically injected from the provider config — no separate key needed in quota checker options.

## Test plan
- [x] All 5 POE checker unit tests pass (`bun test poe-checker.test.ts`)
- [x] Existing Kilo checker tests still pass
- [x] No TypeScript errors in any modified files
- [ ] Manual: configure a POE provider with quota checker and verify balance displays correctly on Quotas page
- [ ] Manual: verify balance history modal formats points correctly (not as dollars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)