### PR TITLE
feat(analytics): add AnalyzeButton drill-down component

### DIFF
--- a/packages/frontend/src/components/analytics/AnalyzeButton.tsx
+++ b/packages/frontend/src/components/analytics/AnalyzeButton.tsx
@@ -1,0 +1,268 @@
+/**
+ * AnalyzeButton Component
+ * ========================
+ * Provides deep-dive navigation from Live Metrics cards to Detailed Usage.
+ * This component encapsulates the "Analyze" button logic that appears in
+ * Live Metrics card modals, allowing users to drill down into detailed
+ * analytics with pre-configured filters based on the current card context.
+ *
+ * Navigation behavior:
+ *   - **Default (no onClick prop):** Opens the Detailed Usage page in a new
+ *     browser tab via `window.open()`. The URL includes a query string that
+ *     pre-configures the chart type, grouping, metrics, and filters.
+ *   - **With onClick prop:** The parent component (e.g., LiveTab) can override
+ *     the default behavior by passing an `onClick` handler. LiveTab uses this
+ *     to open the DetailedUsage component inside a modal dialog instead of
+ *     navigating away. The ExternalLink icon is still rendered for visual
+ *     consistency, but the actual behavior is an in-page modal open.
+ *
+ * Usage:
+ *   // Default: opens Detailed Usage in a new browser tab
+ *   <AnalyzeButton
+ *     cardType="provider"
+ *     context={{ provider: "synthetic_new" }}
+ *   />
+ *
+ *   // Modal mode: LiveTab passes onClick to open DetailedUsage in a modal
+ *   <AnalyzeButton
+ *     cardType="provider"
+ *     context={{ provider: "synthetic_new" }}
+ *     onClick={() => openDetailedUsageModal("provider", { provider: "synthetic_new" })}
+ *   />
+ */
+
+import React from 'react';
+import { Button } from '../ui/Button';
+import { BarChart3, ExternalLink } from 'lucide-react';
+
+/**
+ * Supported card types from Live Metrics that can navigate to Detailed Usage.
+ *
+ * Each value corresponds to a specific Live Metrics dashboard card:
+ * - `'velocity'`    - Request velocity card showing requests-per-second trends over time.
+ * - `'provider'`    - Provider breakdown card showing distribution across LLM providers.
+ * - `'model'`       - Individual model performance card for a single model's stats.
+ * - `'timeline'`    - Timeline card showing chronological request activity.
+ * - `'modelstack'`  - Stacked model comparison card showing all models together.
+ * - `'requests'`    - Raw request count card showing total request volume.
+ * - `'concurrency'` - Concurrency/error card showing rate limits and cooldowns.
+ */
+export type CardType =
+  | 'velocity'
+  | 'provider'
+  | 'model'
+  | 'timeline'
+  | 'modelstack'
+  | 'requests'
+  | 'concurrency';
+
+/** Context data passed from Live Metrics cards to pre-configure Detailed Usage */
+export interface AnalyzeContext {
+  /** Provider name for provider-specific analysis */
+  provider?: string;
+  /** Model name for model-specific analysis */
+  model?: string;
+  /** Time range override (defaults to 'live' for 5m window) */
+  timeRange?: string;
+  /** Group by dimension for the detailed view */
+  groupBy?: 'time' | 'provider' | 'model' | 'status';
+  /** Initial view mode (chart vs list) */
+  viewMode?: 'chart' | 'list';
+}
+
+interface AnalyzeButtonProps {
+  /** Type of card that triggered the analysis */
+  cardType: CardType;
+  /** Contextual data for pre-filtering Detailed Usage */
+  context?: AnalyzeContext;
+  /** Optional button size variant */
+  size?: 'sm' | 'md';
+  /** Optional additional CSS classes */
+  className?: string;
+  /**
+   * Optional click handler that overrides the default navigation behavior.
+   *
+   * When NOT provided: clicking the button calls `window.open()` to open
+   * the Detailed Usage page in a new browser tab with pre-configured query params.
+   *
+   * When provided: the handler is called instead, and `window.open()` is skipped
+   * entirely. This is used by LiveTab to intercept the click and open
+   * DetailedUsage inside a modal dialog, keeping the user on the Live Metrics page.
+   * The parent is responsible for calling `buildQueryString()` separately to get
+   * the query string and passing it as `initialQueryString` to the embedded
+   * DetailedUsage component.
+   */
+  onClick?: () => void;
+}
+
+/**
+ * Build the query string for Detailed Usage based on card type and context.
+ *
+ * This function translates the semantic meaning of each Live Metrics card into
+ * the appropriate Detailed Usage URL parameters. The resulting query string
+ * pre-configures the DetailedUsage page so the user sees relevant data
+ * immediately, without needing to manually adjust filters.
+ *
+ * The mapping logic ensures continuity between what the user was viewing on
+ * the Live Metrics dashboard and what they see in the detailed drill-down:
+ *
+ * | Card Type       | groupBy    | chartType  | viewMode | Extra Params                |
+ * |-----------------|------------|------------|----------|-----------------------------|
+ * | `provider`      | provider   | pie        | chart    | filterProvider (if set)     |
+ * | `model`         | model      | pie        | chart    | filterModel (if set)        |
+ * | `modelstack`    | model      | pie        | chart    | filterModel (if set)        |
+ * | `velocity`      | time       | composed   | chart    | metrics=requests,velocity,errors |
+ * | `timeline`      | time       | composed   | chart    | metrics=requests,velocity,errors |
+ * | `requests`      | time       | bar        | list     | (none)                      |
+ * | `concurrency`   | time       | bar        | list     | filterStatus=error          |
+ * | (default)       | time       | area       | chart    | (none)                      |
+ *
+ * @param cardType - The type of Live Metrics card that triggered the drill-down.
+ * @param context  - Optional contextual data (provider name, model name, etc.)
+ *                   carried from the card to pre-filter the detailed view.
+ * @returns A URL-encoded query string (without leading '?') suitable for
+ *          appending to the `/ui/detailed-usage` route.
+ */
+export const buildQueryString = (cardType: CardType, context?: AnalyzeContext): string => {
+  const params = new URLSearchParams();
+
+  // Default to live (5-minute) window for real-time analysis continuity.
+  // This preserves the temporal context the user was viewing on the Live Metrics dashboard.
+  params.set('range', context?.timeRange || 'live');
+
+  switch (cardType) {
+    case 'provider':
+      // Provider card: group by provider with a pie chart to show the distribution
+      // of requests across all LLM providers. If the user clicked into a specific
+      // provider's card, filterProvider narrows the view to that provider only.
+      params.set('groupBy', 'provider');
+      params.set('chartType', 'pie');
+      params.set('metric', 'requests');
+      if (context?.provider) {
+        params.set('filterProvider', context.provider);
+      }
+      break;
+
+    case 'model':
+    case 'modelstack':
+      // Model cards (both single-model and stacked): group by model to show
+      // per-model breakdown. 'model' is a single model card, 'modelstack' is
+      // the stacked comparison. Both use the same drill-down configuration.
+      // If a specific model was selected, filterModel narrows the view.
+      params.set('groupBy', 'model');
+      params.set('chartType', 'pie');
+      params.set('metric', 'requests');
+      if (context?.model) {
+        params.set('filterModel', context.model);
+      }
+      break;
+
+    case 'velocity':
+    case 'timeline':
+      // Time-series cards: use a composed chart (bars + lines overlaid) to show
+      // requests as bars with velocity and error trends as lines. This gives a
+      // rich temporal view that extends what the velocity/timeline cards show.
+      params.set('groupBy', 'time');
+      params.set('chartType', 'composed');
+      params.set('metrics', 'requests,velocity,errors');
+      break;
+
+    case 'requests':
+      // Raw requests card: switch to list view so users can inspect individual
+      // requests. The bar chart type is set as a fallback if the user toggles
+      // back to chart view.
+      params.set('groupBy', 'time');
+      params.set('viewMode', 'list');
+      params.set('chartType', 'bar');
+      break;
+
+    case 'concurrency':
+      // Concurrency card: focus on errors and rate-limit cooldowns by pre-filtering
+      // to error status. List view shows individual failed requests for debugging.
+      params.set('groupBy', 'time');
+      params.set('viewMode', 'list');
+      params.set('chartType', 'bar');
+      params.set('filterStatus', 'error');
+      break;
+
+    default:
+      // Fallback for any unknown card type: sensible defaults with time-based
+      // grouping and an area chart for general usage visualization.
+      params.set('groupBy', 'time');
+      params.set('chartType', 'area');
+  }
+
+  return params.toString();
+};
+
+/**
+ * Get human-readable label for the analysis action based on card type.
+ * Provides contextual messaging so users understand what they're navigating to.
+ */
+const getAnalyzeLabel = (cardType: CardType): string => {
+  const labels: Record<CardType, string> = {
+    velocity: 'Analyze Velocity Trends',
+    provider: 'Analyze Provider Performance',
+    model: 'Analyze Model Usage',
+    modelstack: 'Analyze Model Stack',
+    timeline: 'Analyze Timeline',
+    requests: 'View Detailed Logs',
+    concurrency: 'Analyze Concurrency',
+  };
+  return labels[cardType] || 'Analyze in Detail';
+};
+
+/**
+ * AnalyzeButton - Navigation component for Live Metrics to Detailed Usage drill-down.
+ *
+ * Renders a styled button with a BarChart3 icon (left) and ExternalLink icon (right).
+ * The ExternalLink icon serves as a visual affordance indicating "more detail available."
+ * Note: despite the ExternalLink icon, when an `onClick` override is provided (modal mode),
+ * clicking does NOT open a new tab -- it triggers the parent's handler instead (typically
+ * opening a modal). The icon is kept for visual consistency across both modes.
+ *
+ * Architecture:
+ *   - Builds query string via `buildQueryString` helper based on card type + context
+ *   - Default mode: opens `/ui/detailed-usage?{queryString}` in a new tab via `window.open()`
+ *   - Modal mode (onClick provided): delegates entirely to the parent's click handler
+ *   - Maintains 5-minute live window continuity by default (range=live)
+ *   - Supports all 7 Live Metrics card types (see CardType)
+ *   - Button label is contextual, e.g., "Analyze Provider Performance" or "View Detailed Logs"
+ */
+export const AnalyzeButton: React.FC<AnalyzeButtonProps> = ({
+  cardType,
+  context,
+  size = 'sm',
+  className = '',
+  onClick,
+}) => {
+  /**
+   * Handle navigation to Detailed Usage.
+   * If onClick is provided, use that (e.g., to open modal).
+   * Otherwise, open Detailed Usage in new tab via window.open().
+   */
+  const handleAnalyze = () => {
+    if (onClick) {
+      onClick();
+      return;
+    }
+    const queryString = buildQueryString(cardType, context);
+    const url = `${window.location.origin}/ui/detailed-usage?${queryString}`;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <Button
+      size={size}
+      variant="primary"
+      onClick={handleAnalyze}
+      className={`flex items-center gap-2 ${className}`}
+    >
+      <BarChart3 size={size === 'sm' ? 14 : 16} />
+      {getAnalyzeLabel(cardType)}
+      <ExternalLink size={size === 'sm' ? 12 : 14} className="ml-1 opacity-70" />
+    </Button>
+  );
+};
+
+export default AnalyzeButton;

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -122,6 +122,28 @@ export interface TodayMetrics {
   totalCost: number;
 }
 
+/**
+ * Represents a single data point in the concurrency time series.
+ *
+ * Each entry describes how many requests were active (in-flight) for a specific
+ * provider and model during a 1-minute time bucket. The backend computes this by
+ * grouping request records whose startTime falls within the same 60-second window,
+ * then counting them per provider+model combination.
+ *
+ * Used by the "Concurrency" card on the Live Metrics dashboard to render
+ * time-series charts showing request volume per provider over time.
+ */
+export interface ConcurrencyData {
+  /** The LLM provider name, e.g., "anthropic", "openai", "google" */
+  provider: string;
+  /** The canonical model name as resolved by the router, e.g., "claude-sonnet-4-20250514" */
+  model: string;
+  /** Number of requests that started within this 1-minute bucket */
+  count: number;
+  /** Start of the 1-minute bucket as epoch milliseconds (floored to nearest 60000ms) */
+  timestamp: number;
+}
+
 export interface DashboardData {
   stats: Stat[];
   usageData: UsageData[];
@@ -2420,6 +2442,35 @@ export const api = {
     if (!res.ok) {
       const err = await res.json().catch(() => ({ error: 'Unknown error' }));
       throw new Error(err.error?.message || err.error || 'Failed to clear quota');
+    }
+  },
+
+  /**
+   * Fetches concurrency data from the backend for the Live Metrics dashboard.
+   *
+   * Calls GET /v0/management/concurrency with an optional timeRange query parameter.
+   * The backend returns request counts grouped by provider, model, and 1-minute time
+   * buckets, which the frontend uses to render concurrency charts.
+   *
+   * On failure, logs the error and returns an empty array so the UI degrades
+   * gracefully (shows an empty chart rather than crashing).
+   *
+   * @param timeRange - How far back to look: 'hour' (default), 'day', 'week', or 'month'
+   * @returns Array of {@link ConcurrencyData} entries, or an empty array on error
+   */
+  getConcurrencyData: async (
+    timeRange: 'hour' | 'day' | 'week' | 'month' = 'hour'
+  ): Promise<ConcurrencyData[]> => {
+    try {
+      const res = await fetchWithAuth(
+        `${API_BASE}/v0/management/concurrency?timeRange=${timeRange}`
+      );
+      if (!res.ok) throw new Error('Failed to fetch concurrency data');
+      const data = (await res.json()) as { data: ConcurrencyData[] };
+      return data.data || [];
+    } catch (e) {
+      console.error('API Error getConcurrencyData', e);
+      return [];
     }
   },
 };

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -1,3 +1,81 @@
+/**
+ * CSS.escape polyfill -- MUST be defined before any other imports.
+ *
+ * Why this is needed:
+ *   Monaco Editor v0.55.1+ internally calls CSS.escape() to generate scoped CSS
+ *   class names for its editor widgets, syntax highlighting tokens, and overlay
+ *   elements. If CSS.escape is undefined, Monaco throws a TypeError at
+ *   initialization time, which crashes the entire Config page editor.
+ *
+ * Why it must be before React imports:
+ *   ES module imports are hoisted to the top of the module and evaluated before
+ *   any other code. However, top-level side effects (like this polyfill assignment)
+ *   that appear BEFORE import statements are executed first in the module
+ *   evaluation order. By placing this polyfill above all imports, we guarantee
+ *   CSS.escape is available by the time Monaco's module is lazily loaded and
+ *   initialized. If we placed it after the imports, React and its dependency
+ *   tree could trigger Monaco's lazy-loading before the polyfill runs.
+ *
+ * Browser compatibility:
+ *   CSS.escape is supported in all modern browsers (Chrome 46+, Firefox 31+,
+ *   Safari 10+, Edge 79+), but may be absent in older WebViews, embedded
+ *   browsers (e.g., Electron with old Chromium), or environments where the
+ *   CSS global object exists but escape() was not implemented. The guard
+ *   `typeof CSS !== 'undefined' && typeof CSS.escape !== 'function'` ensures
+ *   we only polyfill when the CSS object exists but escape() is missing --
+ *   we do not create a CSS object from scratch if it does not exist at all.
+ *
+ * Implementation:
+ *   This is a faithful implementation of the CSSOM spec for CSS.escape():
+ *   https://drafts.csswg.org/cssom/#the-css.escape()-method
+ *   It handles null bytes (replaced with U+FFFD), control characters (hex-escaped),
+ *   leading digits (which are invalid at the start of CSS identifiers), lone
+ *   hyphens, and all other characters that need backslash-escaping per the spec.
+ */
+if (typeof CSS !== 'undefined' && typeof CSS.escape !== 'function') {
+  CSS.escape = (value: string): string => {
+    const str = String(value);
+    const len = str.length;
+    let result = '';
+    for (let i = 0; i < len; i++) {
+      const ch = str.charCodeAt(i);
+      // Null bytes are replaced with the Unicode replacement character (U+FFFD)
+      if (ch === 0) {
+        result += '\uFFFD';
+      } else if (
+        // Control characters (U+0001 to U+001F, U+007F) and leading digits
+        // must be hex-escaped (e.g., \31 for '1') because they are not valid
+        // at certain positions in CSS identifiers.
+        (ch >= 0x0001 && ch <= 0x001f) ||
+        ch === 0x007f ||
+        (i === 0 && ch >= 0x0030 && ch <= 0x0039) ||
+        (i === 1 && ch >= 0x0030 && ch <= 0x0039 && str.charCodeAt(0) === 0x002d)
+      ) {
+        result += `\\${ch.toString(16)} `;
+      } else if (i === 0 && ch === 0x002d && len === 1) {
+        // A lone hyphen at the start must be backslash-escaped
+        result += `\\${str.charAt(i)}`;
+      } else if (
+        // Characters that are safe to include verbatim in CSS identifiers:
+        // non-ASCII (U+0080+), hyphens, underscores, digits (non-leading),
+        // uppercase letters, and lowercase letters.
+        ch >= 0x0080 ||
+        ch === 0x002d ||
+        ch === 0x005f ||
+        (ch >= 0x0030 && ch <= 0x0039) ||
+        (ch >= 0x0041 && ch <= 0x005a) ||
+        (ch >= 0x0061 && ch <= 0x007a)
+      ) {
+        result += str.charAt(i);
+      } else {
+        // Everything else (punctuation, symbols, etc.) is backslash-escaped
+        result += `\\${str.charAt(i)}`;
+      }
+    }
+    return result;
+  };
+}
+
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';


### PR DESCRIPTION
## Summary

Add the AnalyzeButton component and supporting utilities for navigating from Live Metrics cards to detailed analytics.

- **`AnalyzeButton.tsx`**: Drill-down button with `buildQueryString` helper that translates card context (provider, model, time range) into DetailedUsage URL parameters. Supports both new-tab navigation (`window.open`) and modal mode (via `onClick` prop override)
- **`api.ts`**: Add `getConcurrency()` API client and `ConcurrencyData` type for the management concurrency endpoint
- **`main.tsx`**: Add `CSS.escape` W3C polyfill required by Monaco Editor 0.55.1 — must load before React to prevent runtime errors in the Config page editor

## PR Stack

This is **PR 2 of 6** in the Live Metrics Enhancement stack:
1. DnD Foundation (#59)
2. **→ AnalyzeButton + Utilities** (this PR)
3. DetailedUsage Page
4. Concurrency Backend + Usage Viz
5. Config JSON Export
6. LiveTab DnD Integration

## Test plan

- [ ] `bun run --filter frontend typecheck` passes
- [ ] AnalyzeButton renders with correct label per card type
- [ ] `buildQueryString` produces correct URL params for each card type
- [ ] CSS.escape polyfill loads without errors
- [ ] `getConcurrency()` returns typed data from backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

