### PR TITLE
Add vision descriptor service and related tests for image processing

### DIFF
--- a/packages/backend/drizzle/migrations/0017_cooing_rawhide_kid.sql
+++ b/packages/backend/drizzle/migrations/0017_cooing_rawhide_kid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `request_usage` ADD `is_vision_fallthrough` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `request_usage` ADD `is_descriptor_request` integer DEFAULT 0 NOT NULL;

--- a/packages/backend/drizzle/migrations/meta/0017_snapshot.json
+++ b/packages/backend/drizzle/migrations/meta/0017_snapshot.json
@@ -1,0 +1,1594 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3d3d6dd6-38a1-4ca6-9377-211f09bffc90",
+  "prevId": "5a8bd4fa-1bc8-4daa-a6e3-fccf6bf63e8a",
+  "tables": {
+    "request_usage": {
+      "name": "request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            "expiry"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "columns": [
+            "provider",
+            "model"
+          ],
+          "name": "provider_cooldowns_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debug_logs": {
+      "name": "debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inference_errors": {
+      "name": "inference_errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_performance": {
+      "name": "provider_performance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            "provider",
+            "model",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_snapshots": {
+      "name": "quota_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            "checker_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            "group_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "response_items": {
+      "name": "response_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            "response_id",
+            "item_index"
+          ],
+          "isUnique": false
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "responses": {
+      "name": "responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            "previous_response_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            "server_name"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_state": {
+      "name": "quota_state",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/backend/drizzle/migrations/meta/_journal.json
+++ b/packages/backend/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1771981769509,
       "tag": "0016_superb_sally_floyd",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1772404194032,
+      "tag": "0017_cooing_rawhide_kid",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/migrations_pg/0017_uneven_maverick.sql
+++ b/packages/backend/drizzle/migrations_pg/0017_uneven_maverick.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "request_usage" ADD COLUMN "is_vision_fallthrough" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "request_usage" ADD COLUMN "is_descriptor_request" integer DEFAULT 0 NOT NULL;

--- a/packages/backend/drizzle/migrations_pg/meta/0017_snapshot.json
+++ b/packages/backend/drizzle/migrations_pg/meta/0017_snapshot.json
@@ -1,0 +1,1684 @@
+{
+  "id": "17826f7f-7196-479c-af30-586b684b339b",
+  "prevId": "82982dda-0d37-459c-88d0-4da86114cb6f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.request_usage": {
+      "name": "request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            {
+              "expression": "expiry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "name": "provider_cooldowns_provider_model_pk",
+          "columns": [
+            "provider",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_errors": {
+      "name": "inference_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_performance": {
+      "name": "provider_performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_snapshots": {
+      "name": "quota_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_items": {
+      "name": "response_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.responses": {
+      "name": "responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            {
+              "expression": "previous_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            {
+              "expression": "server_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_state": {
+      "name": "quota_state",
+      "schema": "",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/migrations_pg/meta/_journal.json
+++ b/packages/backend/drizzle/migrations_pg/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1771982126915,
       "tag": "0016_sleepy_the_hand",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1772404194268,
+      "tag": "0017_uneven_maverick",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/schema/postgres/request-usage.ts
+++ b/packages/backend/drizzle/schema/postgres/request-usage.ts
@@ -47,6 +47,9 @@ export const requestUsage = pgTable(
     // Response metadata
     toolCallsCount: integer('tool_calls_count'),
     finishReason: text('finish_reason'),
+    // Vision Fallthrough metadata
+    isVisionFallthrough: integer('is_vision_fallthrough').notNull().default(0),
+    isDescriptorRequest: integer('is_descriptor_request').notNull().default(0),
     // Energy estimation
     kwhUsed: real('kwh_used'),
   },

--- a/packages/backend/drizzle/schema/sqlite/request-usage.ts
+++ b/packages/backend/drizzle/schema/sqlite/request-usage.ts
@@ -48,6 +48,9 @@ export const requestUsage = sqliteTable(
     // Response metadata
     toolCallsCount: integer('tool_calls_count'),
     finishReason: text('finish_reason'),
+    // Vision Fallthrough metadata
+    isVisionFallthrough: integer('is_vision_fallthrough').notNull().default(0),
+    isDescriptorRequest: integer('is_descriptor_request').notNull().default(0),
     // Energy estimation
     kwhUsed: real('kwh_used'),
   },

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -4,6 +4,7 @@ import yaml from 'yaml';
 import path from 'path';
 import { logger } from './utils/logger';
 import { QuotaScheduler } from './services/quota/quota-scheduler';
+import { DEFAULT_VISION_DESCRIPTION_PROMPT } from './utils/constants';
 
 // --- Zod Schemas ---
 
@@ -386,6 +387,7 @@ const ModelConfigSchema = z.object({
   priority: z.enum(['selector', 'api_match']).default('selector'),
   targets: z.array(ModelTargetSchema),
   additional_aliases: z.array(z.string()).optional(),
+  use_image_fallthrough: z.boolean().default(false).optional(),
   type: z.enum(['chat', 'responses', 'embeddings', 'transcriptions', 'speech', 'image']).optional(),
   advanced: z.array(ModelBehaviorSchema).optional(),
   metadata: ModelMetadataSchema.optional(),
@@ -421,6 +423,11 @@ const CooldownPolicySchema = z.object({
   maxMinutes: z.number().min(1).default(300),
 });
 
+const VisionFallthroughConfigSchema = z.object({
+  descriptor_model: z.string().min(1),
+  default_prompt: z.string().default(DEFAULT_VISION_DESCRIPTION_PROMPT),
+});
+
 const RawPlexusConfigSchema = z
   .object({
     providers: z.record(z.string(), ProviderConfigSchema),
@@ -429,6 +436,7 @@ const RawPlexusConfigSchema = z
     adminKey: z.string(),
     failover: FailoverPolicySchema.optional(),
     cooldown: CooldownPolicySchema.optional(),
+    vision_fallthrough: VisionFallthroughConfigSchema.optional(),
     performanceExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
     latencyExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
     mcp_servers: z.record(z.string(), McpServerConfigSchema).optional(),

--- a/packages/backend/src/db/client.ts
+++ b/packages/backend/src/db/client.ts
@@ -83,12 +83,25 @@ export function initializeDatabase(connectionString?: string) {
     sqlite.exec('PRAGMA foreign_keys = ON');
 
     const sqliteSchema = require('../../drizzle/schema/sqlite/index');
-    const { requestUsage, providerCooldowns, debugLogs, inferenceErrors, providerPerformance } =
-      sqliteSchema;
+    const {
+      requestUsage,
+      providerCooldowns,
+      debugLogs,
+      inferenceErrors,
+      providerPerformance,
+      quotaState,
+    } = sqliteSchema;
 
     currentSchema = sqliteSchema;
     dbInstance = drizzle(sqlite, {
-      schema: { requestUsage, providerCooldowns, debugLogs, inferenceErrors, providerPerformance },
+      schema: {
+        requestUsage,
+        providerCooldowns,
+        debugLogs,
+        inferenceErrors,
+        providerPerformance,
+        quotaState,
+      },
       logger: createDrizzleLogger(),
     });
   } else {
@@ -106,12 +119,25 @@ export function initializeDatabase(connectionString?: string) {
     });
 
     const pgSchema = require('../../drizzle/schema/postgres/index');
-    const { requestUsage, providerCooldowns, debugLogs, inferenceErrors, providerPerformance } =
-      pgSchema;
+    const {
+      requestUsage,
+      providerCooldowns,
+      debugLogs,
+      inferenceErrors,
+      providerPerformance,
+      quotaState,
+    } = pgSchema;
 
     currentSchema = pgSchema;
     dbInstance = drizzlePg(sqlClient, {
-      schema: { requestUsage, providerCooldowns, debugLogs, inferenceErrors, providerPerformance },
+      schema: {
+        requestUsage,
+        providerCooldowns,
+        debugLogs,
+        inferenceErrors,
+        providerPerformance,
+        quotaState,
+      },
       logger: createDrizzleLogger(),
     });
   }

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -26,10 +26,14 @@ export async function registerConfigRoutes(fastify: FastifyInstance) {
     }
 
     try {
-      const body = request.body as string;
-      let configStr = body;
-      if (typeof body !== 'string') {
-        configStr = JSON.stringify(body);
+      const body = request.body as any;
+      let configStr: string;
+
+      if (typeof body === 'string') {
+        configStr = body;
+      } else {
+        // If the body is an object (JSON), stringify it as YAML for the file
+        configStr = yaml.stringify(body);
       }
 
       try {
@@ -45,9 +49,51 @@ export async function registerConfigRoutes(fastify: FastifyInstance) {
       logger.info(`Configuration updated via API at ${configPath}`);
       await loadConfig(configPath);
 
-      return reply.code(200).header('Content-Type', 'application/x-yaml').send(configStr);
+      reply.header('Content-Type', 'application/x-yaml');
+      return reply.code(200).send(configStr);
     } catch (e: any) {
       logger.error('Failed to update config', e);
+      return reply.code(500).send({ error: e.message });
+    }
+  });
+
+  fastify.get('/v0/management/config/vision-fallthrough', async (request, reply) => {
+    const configPath = getConfigPath();
+    if (!configPath) return reply.code(500).send({ error: 'Config path not found' });
+
+    try {
+      const file = Bun.file(configPath);
+      const content = await file.text();
+      const parsed = yaml.parse(content);
+      return reply.send(parsed.vision_fallthrough || {});
+    } catch (e: any) {
+      return reply.code(500).send({ error: e.message });
+    }
+  });
+
+  fastify.patch('/v0/management/config/vision-fallthrough', async (request, reply) => {
+    const configPath = getConfigPath();
+    if (!configPath) return reply.code(500).send({ error: 'Config path not found' });
+
+    try {
+      const updates = request.body as any;
+      const file = Bun.file(configPath);
+      const content = await file.text();
+      const parsed = yaml.parse(content);
+
+      parsed.vision_fallthrough = {
+        ...(parsed.vision_fallthrough || {}),
+        ...updates,
+      };
+
+      const updatedYaml = yaml.stringify(parsed);
+      validateConfig(updatedYaml);
+      await Bun.write(configPath, updatedYaml);
+      await loadConfig(configPath);
+
+      return reply.send(parsed.vision_fallthrough);
+    } catch (e: any) {
+      logger.error('Failed to patch vision-fallthrough config', e);
       return reply.code(500).send({ error: e.message });
     }
   });

--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { DebugLoggingInspector } from '../inspectors/debug-logging';
+import { DebugManager } from '../debug-manager';
+
+describe('DebugLoggingInspector Reconstruction', () => {
+  const requestId = 'test-reconstruction-id';
+
+  beforeEach(() => {
+    const dm = DebugManager.getInstance();
+    dm.setEnabled(true);
+    // @ts-ignore - access private for testing
+    dm.pendingLogs.clear();
+  });
+
+  test('reconstructChatCompletions handles non-streaming JSON', async () => {
+    const inspector = new DebugLoggingInspector(requestId, 'raw');
+    const stream = inspector.createInspector('chat');
+
+    const jsonResponse = {
+      id: 'chatcmpl-123',
+      object: 'chat.completion',
+      choices: [{ message: { content: 'hello', tool_calls: [{}, {}] }, finish_reason: 'tool_calls' }],
+    };
+
+    stream.write(Buffer.from(JSON.stringify(jsonResponse)));
+    stream.end();
+
+    // Small delay for the 'finish' event to process
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const dm = DebugManager.getInstance();
+    const snapshot = dm.getReconstructedRawResponse(requestId);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot.id).toBe('chatcmpl-123');
+    expect(snapshot.choices[0].message.tool_calls).toHaveLength(2);
+  });
+
+  test('reconstructMessages handles non-streaming JSON (Anthropic style)', async () => {
+    const inspector = new DebugLoggingInspector(requestId, 'raw');
+    const stream = inspector.createInspector('messages');
+
+    const jsonResponse = {
+      id: 'msg_123',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'hi' }, { type: 'tool_use', id: 't1' }],
+      stop_reason: 'tool_use',
+    };
+
+    stream.write(Buffer.from(JSON.stringify(jsonResponse)));
+    stream.end();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const dm = DebugManager.getInstance();
+    const snapshot = dm.getReconstructedRawResponse(requestId);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot.id).toBe('msg_123');
+    expect(snapshot.stop_reason).toBe('tool_use');
+  });
+
+  test('reconstructGemini handles non-streaming JSON', async () => {
+    const inspector = new DebugLoggingInspector(requestId, 'raw');
+    const stream = inspector.createInspector('gemini');
+
+    const jsonResponse = {
+      candidates: [
+        {
+          content: { parts: [{ text: 'thinking' }, { functionCall: { name: 'fn' } }] },
+          finishReason: 'STOP',
+        }
+      ],
+    };
+
+    stream.write(Buffer.from(JSON.stringify(jsonResponse)));
+    stream.end();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const dm = DebugManager.getInstance();
+    const snapshot = dm.getReconstructedRawResponse(requestId);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot.candidates[0].finishReason).toBe('STOP');
+  });
+});

--- a/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { PassThrough } from 'stream';
+import { UsageInspector } from '../inspectors/usage-logging';
+import { DebugManager } from '../debug-manager';
+import type { UsageRecord } from '../../types/usage';
+
+describe('UsageInspector Metadata Robustness', () => {
+  let mockStorage: any;
+  let mockPricing: any;
+
+  beforeEach(() => {
+    mockStorage = {
+      saveRequest: mock(() => Promise.resolve()),
+      updatePerformanceMetrics: mock(() => Promise.resolve()),
+    };
+    mockPricing = {
+      inputCostPerToken: 0,
+      outputCostPerToken: 0,
+    };
+    const dm = DebugManager.getInstance();
+    dm.setEnabled(true);
+  });
+
+  afterEach(() => {
+    const dm = DebugManager.getInstance();
+    dm.setEnabled(false);
+  });
+
+  const runInspector = async (
+    requestId: string,
+    apiType: string,
+    snapshot: any
+  ): Promise<UsageRecord | null> => {
+    const inspector = new UsageInspector(
+      requestId,
+      mockStorage,
+      { requestId } as Partial<UsageRecord>,
+      mockPricing,
+      undefined,
+      Date.now(),
+      false,
+      apiType
+    );
+
+    const dm = DebugManager.getInstance();
+    dm.startLog(requestId, {});
+    dm.addReconstructedRawResponse(requestId, snapshot);
+
+    let capturedRecord: UsageRecord | null = null;
+    spyOn(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+      capturedRecord = record;
+      return Promise.resolve();
+    });
+
+    const mockStream = new PassThrough();
+    mockStream.pipe(inspector);
+    mockStream.end();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return capturedRecord;
+  };
+
+  it('should extract tool call count from OpenAI non-streaming choices[0].message.tool_calls', async () => {
+    const requestId = 'openai-nonstream-tools';
+    const snapshot = {
+      choices: [
+        { message: { content: '...', tool_calls: [{}, {}, {}] }, finish_reason: 'tool_calls' },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 20 },
+    };
+
+    const record = await runInspector(requestId, 'chat', snapshot);
+    expect(record?.toolCallsCount).toBe(3);
+    expect(record?.finishReason).toBe('tool_calls');
+  });
+
+  it('should extract tool call count from Gemini-in-OpenAI mixed format', async () => {
+    const requestId = 'gemini-mixed-format';
+    // This snapshot looks like chat (apiType='chat') but contains gemini 'candidates'
+    const snapshot = {
+      candidates: [
+        {
+          content: { parts: [{ text: 'thinking' }, { functionCall: { name: 'f1' } }] },
+          finishReason: 'STOP',
+        },
+      ],
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 20 },
+    };
+
+    const record = await runInspector(requestId, 'chat', snapshot);
+    expect(record?.toolCallsCount).toBe(1);
+    expect(record?.finishReason).toBe('tool_calls');
+  });
+
+  it('should normalize Gemini "STOP" finish reason to "tool_calls" when tools are present', async () => {
+    const requestId = 'gemini-stop-with-tools';
+    const snapshot = {
+      candidates: [
+        {
+          content: { parts: [{ text: 'thinking' }, { functionCall: { name: 'f1' } }] },
+          finishReason: 'STOP',
+        },
+      ],
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 20 },
+    };
+
+    const record = await runInspector(requestId, 'gemini', snapshot);
+    expect(record?.toolCallsCount).toBe(1);
+    expect(record?.finishReason).toBe('tool_calls');
+  });
+
+  it('should normalize Gemini "STOP" to "tool_use" when incoming API is Anthropic messages', async () => {
+    const requestId = 'gemini-to-anthropic-tools';
+    const snapshot = {
+      candidates: [
+        {
+          content: { parts: [{ text: 'thinking' }, { functionCall: { name: 'f1' } }] },
+          finishReason: 'STOP',
+        },
+      ],
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 20 },
+    };
+
+    // runInspector(requestId, apiType, snapshot)
+    // apiType here is the provider API type ('gemini')
+    // We need to simulate the inspector being initialized with incomingApiType='messages'
+    const inspector = new UsageInspector(
+      requestId,
+      mockStorage,
+      { requestId } as Partial<UsageRecord>,
+      mockPricing,
+      undefined,
+      Date.now(),
+      false,
+      'gemini', // providerApiType
+      'messages' // incomingApiType
+    );
+
+    const dm = DebugManager.getInstance();
+    dm.startLog(requestId, {});
+    dm.addReconstructedRawResponse(requestId, snapshot);
+
+    let capturedRecord: any = null;
+    spyOn(mockStorage, 'saveRequest').mockImplementation(async (record: any) => {
+      capturedRecord = record;
+      return Promise.resolve();
+    });
+
+    const mockStream = new PassThrough();
+    mockStream.pipe(inspector);
+    mockStream.end();
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(capturedRecord?.toolCallsCount).toBe(1);
+    expect(capturedRecord?.finishReason).toBe('tool_use');
+  });
+
+  it('should extract tool call count from Anthropic messages format', async () => {
+    const requestId = 'anthropic-metadata';
+    const snapshot = {
+      content: [
+        { type: 'text', text: 'using tool' },
+        { type: 'tool_use', id: 't1' },
+        { type: 'tool_use', id: 't2' },
+      ],
+      stop_reason: 'tool_use',
+      usage: { input_tokens: 10, output_tokens: 20 },
+    };
+
+    const record = await runInspector(requestId, 'messages', snapshot);
+    expect(record?.toolCallsCount).toBe(2);
+    expect(record?.finishReason).toBe('tool_use');
+  });
+
+  it('should handle generic fallback for unknown formats', async () => {
+    const requestId = 'generic-fallback';
+    const snapshot = {
+      tool_calls: [{}, {}],
+      finish_reason: 'something_else',
+      usage: { prompt_tokens: 10, completion_tokens: 20 },
+    };
+
+    const record = await runInspector(requestId, 'unknown-api', snapshot);
+    expect(record?.toolCallsCount).toBe(2);
+    expect(record?.finishReason).toBe('something_else');
+  });
+});

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -22,6 +22,11 @@ import { CooldownParserRegistry } from './cooldown-parsers';
 import { getConfig, getProviderTypes } from '../config';
 import { applyModelBehaviors } from './model-behaviors';
 import { getModels } from '@mariozechner/pi-ai';
+import { VisionDescriptorService } from './vision-descriptor-service';
+import { ModelMetadataManager } from './model-metadata-manager';
+import { DEFAULT_VISION_DESCRIPTION_PROMPT } from '../utils/constants';
+import { UsageRecord } from '../types/usage';
+import { calculateCosts } from '../utils/calculate-costs';
 
 export class Dispatcher {
   private usageStorage?: UsageStorageService;
@@ -29,7 +34,8 @@ export class Dispatcher {
   private async recordAttemptMetric(
     route: RouteResult,
     requestId: string | undefined,
-    success: boolean
+    success: boolean,
+    metadata?: { isVisionFallthrough?: boolean; isDescriptorRequest?: boolean }
   ): Promise<void> {
     if (!this.usageStorage) return;
 
@@ -41,7 +47,8 @@ export class Dispatcher {
         route.provider,
         route.model,
         route.canonicalModel ?? null,
-        metricRequestId
+        metricRequestId,
+        metadata
       );
       return;
     }
@@ -50,7 +57,8 @@ export class Dispatcher {
       route.provider,
       route.model,
       route.canonicalModel ?? null,
-      metricRequestId
+      metricRequestId,
+      metadata
     );
   }
 
@@ -80,11 +88,63 @@ export class Dispatcher {
     const attemptedProviders: string[] = [];
     let lastError: any = null;
 
+    // Check if this is already a vision descriptor request to prevent recursion
+    const isVisionDescriptorRequest = (request as any)._isVisionDescriptorRequest === true;
+
     for (let i = 0; i < targets.length; i++) {
+      let currentRequest = { ...request };
       const route = targets[i]!;
 
+      // Vision Fallthrough (Image-to-Text Preprocessing)
+      // Check if:
+      // 1. Opt-in is enabled for this alias
+      // 2. We're not already in a descriptor call (recursion guard)
+      // 3. Request contains images
+      if (
+        !isVisionDescriptorRequest &&
+        route.modelConfig?.use_image_fallthrough &&
+        VisionDescriptorService.hasImages(currentRequest.messages)
+      ) {
+        const vfConfig = config.vision_fallthrough;
+        if (vfConfig?.descriptor_model) {
+          try {
+            logger.debug(
+              `[vision-fallthrough] Before process: ${JSON.stringify(currentRequest.messages.map((m) => ({ role: m.role, contentCount: Array.isArray(m.content) ? m.content.length : 'string' })))}`
+            );
+            currentRequest = await VisionDescriptorService.process(
+              currentRequest,
+              vfConfig.descriptor_model,
+              vfConfig.default_prompt || DEFAULT_VISION_DESCRIPTION_PROMPT,
+              this.usageStorage // Pass usage storage to record descriptor call
+            );
+            logger.debug(
+              `[vision-fallthrough] After process: ${JSON.stringify(currentRequest.messages.map((m) => ({ role: m.role, contentCount: Array.isArray(m.content) ? m.content.length : 'string' })))}`
+            );
+
+            // Verify if images are actually gone in the modified request
+            const stillHasImages = VisionDescriptorService.hasImages(currentRequest.messages);
+            if (stillHasImages) {
+              logger.error(
+                `[vision-fallthrough] CRITICAL: VisionDescriptorService.process returned a request that STILL contains images!`
+              );
+            }
+
+            // Tag the request as having undergone fallthrough
+            (currentRequest as any)._hasVisionFallthrough = true;
+            logger.info(
+              `[vision-fallthrough] Successfully preprocessed images for ${route.provider}/${route.model}`
+            );
+          } catch (vfError) {
+            logger.error(`[vision-fallthrough] Error in descriptor service:`, vfError);
+          }
+        } else {
+          logger.warn(
+            `[vision-fallthrough] Feature enabled for alias '${request.model}' but 'vision_fallthrough.descriptor_model' not configured globally.`
+          );
+        }
+      }
+
       // Re-check cooldown status before attempting this target
-      // This ensures cooldowns set during the retry loop are respected
       const isHealthy = await CooldownManager.getInstance().isProviderHealthy(
         route.provider,
         route.model
@@ -101,7 +161,7 @@ export class Dispatcher {
         // Determine Target API Type
         const { targetApiType, selectionReason } = this.selectTargetApiType(
           route,
-          request.incomingApiType
+          currentRequest.incomingApiType
         );
 
         logger.info(
@@ -113,7 +173,7 @@ export class Dispatcher {
         const transformer = TransformerFactory.getTransformer(transformerType);
 
         // 3. Transform Request
-        const requestWithTargetModel = { ...request, model: route.model };
+        const requestWithTargetModel = { ...currentRequest, model: route.model };
 
         const { payload: providerPayload, bypassTransformation } =
           await this.transformRequestPayload(
@@ -124,21 +184,27 @@ export class Dispatcher {
           );
 
         // Capture transformed request
-        if (request.requestId) {
-          DebugManager.getInstance().addTransformedRequest(request.requestId, providerPayload);
+        if (currentRequest.requestId) {
+          DebugManager.getInstance().addTransformedRequest(
+            currentRequest.requestId,
+            providerPayload
+          );
         }
 
         if (this.isOAuthRoute(route, targetApiType)) {
           try {
             const oauthResponse = await this.dispatchOAuthRequest(
               providerPayload,
-              request,
+              currentRequest,
               route,
               targetApiType,
               transformer
             );
-            await this.recordAttemptMetric(route, request.requestId, true);
-            this.attachAttemptMetadata(oauthResponse, attemptedProviders, route);
+            await this.recordAttemptMetric(route, currentRequest.requestId, true, {
+              isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+              isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+            });
+            this.attachAttemptMetadata(oauthResponse, attemptedProviders, route, targetApiType);
             return oauthResponse;
           } catch (oauthError: any) {
             lastError = oauthError;
@@ -146,7 +212,10 @@ export class Dispatcher {
               failoverEnabled && i < targets.length - 1 && this.isRetryableOAuthError(oauthError);
 
             if (canRetry) {
-              await this.recordAttemptMetric(route, request.requestId, false);
+              await this.recordAttemptMetric(route, currentRequest.requestId, false, {
+                isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+                isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+              });
               CooldownManager.getInstance().markProviderFailure(
                 route.provider,
                 route.model,
@@ -166,10 +235,10 @@ export class Dispatcher {
         // 4. Execute Request
         const url = this.buildRequestUrl(route, transformer, requestWithTargetModel, targetApiType);
         const headers = this.setupHeaders(route, targetApiType, requestWithTargetModel);
-        const incomingApi = request.incomingApiType || 'unknown';
+        const incomingApi = currentRequest.incomingApiType || 'unknown';
 
         logger.info(
-          `Dispatching ${request.model} to ${route.provider}:${route.model} ${incomingApi} <-> ${transformer.name}`
+          `Dispatching ${currentRequest.model} to ${route.provider}:${route.model} ${incomingApi} <-> ${transformer.name}`
         );
 
         logger.silly('Upstream Request Payload', providerPayload);
@@ -191,13 +260,16 @@ export class Dispatcher {
               url,
               headers,
               targetApiType,
-              request.requestId
+              currentRequest.requestId
             );
           } catch (e: any) {
             lastError = e;
 
             if (canRetry) {
-              await this.recordAttemptMetric(route, request.requestId, false);
+              await this.recordAttemptMetric(route, currentRequest.requestId, false, {
+                isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+                isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+              });
               // Only mark as failed if the error actually triggered a cooldown (i.e., it's not a caller error like validation)
               // Caller errors (400 validation errors, 413, 422) should not cause cooldown
               if (e?.routingContext?.cooldownTriggered) {
@@ -224,7 +296,7 @@ export class Dispatcher {
         }
 
         // 5. Handle Response
-        if (request.stream) {
+        if (currentRequest.stream) {
           const streamProbe = await this.probeStreamingStart(response);
 
           if (!streamProbe.ok) {
@@ -238,7 +310,10 @@ export class Dispatcher {
               this.isRetryableNetworkError(error, failover?.retryableErrors || []);
 
             if (canRetry) {
-              await this.recordAttemptMetric(route, request.requestId, false);
+              await this.recordAttemptMetric(route, currentRequest.requestId, false, {
+                isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+                isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+              });
               // Always mark as failed when retrying — provider couldn't serve this request
               CooldownManager.getInstance().markProviderFailure(
                 route.provider,
@@ -257,28 +332,39 @@ export class Dispatcher {
 
           const streamResponse = this.handleStreamingResponse(
             streamProbe.response,
-            request,
+            currentRequest,
             route,
             targetApiType,
             bypassTransformation
           );
-          await this.recordAttemptMetric(route, request.requestId, true);
+          await this.recordAttemptMetric(route, currentRequest.requestId, true, {
+            isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+            isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+          });
           CooldownManager.getInstance().markProviderSuccess(route.provider, route.model);
-          this.attachAttemptMetadata(streamResponse, attemptedProviders, route);
+          this.attachAttemptMetadata(streamResponse, attemptedProviders, route, targetApiType);
           return streamResponse;
         }
 
         const nonStreamingResponse = await this.handleNonStreamingResponse(
           response,
-          request,
+          currentRequest,
           route,
           targetApiType,
           transformer,
           bypassTransformation
         );
-        await this.recordAttemptMetric(route, request.requestId, true);
+        await this.recordAttemptMetric(route, currentRequest.requestId, true, {
+          isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+          isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+        });
+
+        if ((currentRequest as any)._isVisionDescriptorRequest && this.usageStorage) {
+          // ... (this part is fine)
+        }
+
         CooldownManager.getInstance().markProviderSuccess(route.provider, route.model);
-        this.attachAttemptMetadata(nonStreamingResponse, attemptedProviders, route);
+        this.attachAttemptMetadata(nonStreamingResponse, attemptedProviders, route, targetApiType);
         return nonStreamingResponse;
       } catch (error: any) {
         lastError = error;
@@ -296,7 +382,10 @@ export class Dispatcher {
             error.message
           );
         }
-        await this.recordAttemptMetric(route, request.requestId, false);
+        await this.recordAttemptMetric(route, currentRequest.requestId, false, {
+          isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+          isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+        });
 
         const canRetryNetwork =
           failoverEnabled &&
@@ -473,7 +562,8 @@ export class Dispatcher {
   private attachAttemptMetadata(
     response: any,
     attemptedProviders: string[],
-    finalRoute: RouteResult
+    finalRoute: RouteResult,
+    apiType: string
   ): void {
     response.plexus = {
       ...(response.plexus || {}),
@@ -481,6 +571,15 @@ export class Dispatcher {
       finalAttemptProvider: finalRoute.provider,
       finalAttemptModel: finalRoute.model,
       allAttemptedProviders: JSON.stringify(attemptedProviders),
+      canonicalModel: finalRoute.canonicalModel,
+      provider: finalRoute.provider,
+      model: finalRoute.model,
+      apiType,
+      pricing: finalRoute.modelConfig?.pricing,
+      providerDiscount: (finalRoute.config as any).discount,
+      config: {
+        estimateTokens: finalRoute.config.estimateTokens,
+      },
     } as any;
   }
 
@@ -865,6 +964,12 @@ export class Dispatcher {
     targetApiType: string,
     route: RouteResult
   ): boolean {
+    // If vision fallthrough was applied, we must use the translated pathway
+    // to ensure the modified messages (text instead of images) are sent.
+    if ((request as any)._hasVisionFallthrough) {
+      return false;
+    }
+
     const isCompatible =
       !!request.incomingApiType?.toLowerCase() &&
       request.incomingApiType?.toLowerCase() === targetApiType.toLowerCase();
@@ -1346,7 +1451,7 @@ export class Dispatcher {
         };
 
         await this.recordAttemptMetric(route, request.requestId, true);
-        this.attachAttemptMetadata(enrichedResponse, attemptedProviders, route);
+        this.attachAttemptMetadata(enrichedResponse, attemptedProviders, route, 'embeddings');
         return enrichedResponse;
       } catch (error: any) {
         lastError = error;
@@ -1535,7 +1640,7 @@ export class Dispatcher {
         };
 
         await this.recordAttemptMetric(route, request.requestId, true);
-        this.attachAttemptMetadata(unifiedResponse, attemptedProviders, route);
+        this.attachAttemptMetadata(unifiedResponse, attemptedProviders, route, 'transcriptions');
         return unifiedResponse;
       } catch (error: any) {
         lastError = error;
@@ -1756,7 +1861,7 @@ export class Dispatcher {
         };
 
         await this.recordAttemptMetric(route, request.requestId, true);
-        this.attachAttemptMetadata(unifiedResponse, attemptedProviders, route);
+        this.attachAttemptMetadata(unifiedResponse, attemptedProviders, route, 'speech');
         return unifiedResponse;
       } catch (error: any) {
         lastError = error;
@@ -1936,7 +2041,7 @@ export class Dispatcher {
         };
 
         await this.recordAttemptMetric(route, request.requestId, true);
-        this.attachAttemptMetadata(unifiedResponse, attemptedProviders, route);
+        this.attachAttemptMetadata(unifiedResponse, attemptedProviders, route, 'images');
         return unifiedResponse;
       } catch (error: any) {
         lastError = error;
@@ -2114,7 +2219,7 @@ export class Dispatcher {
         };
 
         await this.recordAttemptMetric(route, request.requestId, true);
-        this.attachAttemptMetadata(unifiedResponse, attemptedProviders, route);
+        this.attachAttemptMetadata(unifiedResponse, attemptedProviders, route, 'images');
         return unifiedResponse;
       } catch (error: any) {
         lastError = error;

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -123,6 +123,18 @@ export class DebugLoggingInspector extends BaseInspector {
   }
 
   private reconstructChatCompletions(fullBody: string): any {
+    const trimmed = fullBody.trim();
+    if (!trimmed) return null;
+
+    // Try parsing as a single JSON object (non-streaming)
+    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      try {
+        return JSON.parse(trimmed);
+      } catch (e) {
+        // Not a single JSON object, continue to stream parsing
+      }
+    }
+
     const lines = fullBody.split(/\r?\n/);
     let snapshot: any = null;
 
@@ -142,6 +154,18 @@ export class DebugLoggingInspector extends BaseInspector {
   }
 
   private reconstructResponses(fullBody: string): any {
+    const trimmed = fullBody.trim();
+    if (!trimmed) return null;
+
+    // Try parsing as a single JSON object (non-streaming)
+    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      try {
+        return JSON.parse(trimmed);
+      } catch (e) {
+        // Not a single JSON object, continue to stream parsing
+      }
+    }
+
     const lines = fullBody.split(/\r?\n/);
     let snapshot: any = null;
 
@@ -161,6 +185,18 @@ export class DebugLoggingInspector extends BaseInspector {
   }
 
   private reconstructMessages(fullBody: string): any {
+    const trimmed = fullBody.trim();
+    if (!trimmed) return null;
+
+    // Try parsing as a single JSON object (non-streaming)
+    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      try {
+        return JSON.parse(trimmed);
+      } catch (e) {
+        // Not a single JSON object, continue to stream parsing
+      }
+    }
+
     const lines = fullBody.split(/\r?\n/);
     let snapshot: any = null;
 
@@ -180,6 +216,18 @@ export class DebugLoggingInspector extends BaseInspector {
   }
 
   private reconstructGemini(fullBody: string): any {
+    const trimmed = fullBody.trim();
+    if (!trimmed) return null;
+
+    // Try parsing as a single JSON object (non-streaming)
+    if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      try {
+        return JSON.parse(trimmed);
+      } catch (e) {
+        // Not a single JSON object, continue to stream parsing
+      }
+    }
+
     const lines = fullBody.split(/\r?\n/);
     let snapshot: any = null;
 

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -249,11 +249,54 @@ export class UsageInspector extends PassThrough {
 
     switch (apiType) {
       case 'chat': {
-        // OpenAI format: tool_calls are in choices[0].delta.tool_calls
+        // OpenAI format: tool_calls are in choices[0].delta.tool_calls in the reconstructed snapshot
+        // or choices[0].message.tool_calls in a full non-streaming response.
         const choice = reconstructed.choices?.[0];
-        const toolCalls = choice?.delta?.tool_calls;
-        const finishReason = choice?.finish_reason ?? null;
-        const toolCallsCount = toolCalls?.length ?? 0;
+        const toolCalls =
+          choice?.delta?.tool_calls ||
+          choice?.message?.tool_calls ||
+          choice?.tool_calls ||
+          reconstructed.tool_calls ||
+          choice?.message?.function_call ||
+          reconstructed.function_call;
+        let finishReason = choice?.finish_reason || choice?.finishReason || null;
+
+        // Fallback for Gemini-style content in OpenAI-compatible response (some providers do this)
+        let toolCallsCount = Array.isArray(toolCalls) ? toolCalls.filter(Boolean).length : 0;
+        if (
+          toolCallsCount === 0 &&
+          (choice?.message?.function_call || reconstructed.function_call)
+        ) {
+          toolCallsCount = 1;
+        }
+
+        // Deep search fallback for any field named 'tool_calls' or 'functionCall'
+        if (toolCallsCount === 0) {
+          toolCallsCount = this.deepSearchToolCalls(reconstructed);
+        }
+
+        if (toolCallsCount === 0 && reconstructed.candidates?.[0]) {
+          const candidate = reconstructed.candidates[0];
+          if (candidate.content?.parts && Array.isArray(candidate.content.parts)) {
+            toolCallsCount = candidate.content.parts.filter(
+              (part: any) => part.functionCall
+            ).length;
+          }
+          if (!finishReason) {
+            finishReason = candidate.finishReason || null;
+          }
+        }
+
+        // Normalize finish reason
+        if (finishReason) {
+          finishReason = finishReason.toLowerCase();
+          if ((finishReason === 'stop' || finishReason === 'end_turn') && toolCallsCount > 0) {
+            finishReason = this.incomingApiType === 'messages' ? 'tool_use' : 'tool_calls';
+          }
+        } else if (toolCallsCount > 0) {
+          finishReason = this.incomingApiType === 'messages' ? 'tool_use' : 'tool_calls';
+        }
+
         return { toolCallsCount: toolCallsCount > 0 ? toolCallsCount : null, finishReason };
       }
       case 'responses': {
@@ -276,7 +319,7 @@ export class UsageInspector extends PassThrough {
             (block: any) => block.type === 'tool_use'
           ).length;
         }
-        const finishReason = reconstructed.stop_reason ?? null;
+        const finishReason = reconstructed.stop_reason || reconstructed.finish_reason || null;
         return { toolCallsCount: toolCallsCount > 0 ? toolCallsCount : null, finishReason };
       }
       case 'gemini': {
@@ -286,7 +329,36 @@ export class UsageInspector extends PassThrough {
         if (candidate?.content?.parts && Array.isArray(candidate.content.parts)) {
           toolCallsCount = candidate.content.parts.filter((part: any) => part.functionCall).length;
         }
-        const finishReason = candidate?.finishReason ?? null;
+
+        // Fallback for OpenAI-style tool_calls or deep search if direct part check fails
+        if (toolCallsCount === 0) {
+          toolCallsCount = this.deepSearchToolCalls(reconstructed);
+        }
+
+        let finishReason = candidate?.finishReason || null;
+
+        // Fallback for OpenAI-style tool_calls in a Gemini-identified response
+        if (toolCallsCount === 0 && reconstructed.choices?.[0]) {
+          const choice = reconstructed.choices[0];
+          const toolCalls = choice.delta?.tool_calls || choice.message?.tool_calls;
+          if (Array.isArray(toolCalls)) {
+            toolCallsCount = toolCalls.filter(Boolean).length;
+          }
+          if (!finishReason) {
+            finishReason = choice.finish_reason || null;
+          }
+        }
+
+        // Normalize finish reason
+        if (finishReason) {
+          finishReason = finishReason.toLowerCase();
+          if (finishReason === 'stop' && toolCallsCount > 0) {
+            finishReason = this.incomingApiType === 'messages' ? 'tool_use' : 'tool_calls';
+          }
+        } else if (toolCallsCount > 0) {
+          finishReason = this.incomingApiType === 'messages' ? 'tool_use' : 'tool_calls';
+        }
+
         return { toolCallsCount: toolCallsCount > 0 ? toolCallsCount : null, finishReason };
       }
       case 'oauth': {
@@ -294,8 +366,46 @@ export class UsageInspector extends PassThrough {
         const finishReason = reconstructed.finishReason ?? null;
         return { toolCallsCount: toolCallsCount > 0 ? toolCallsCount : null, finishReason };
       }
-      default:
-        return { toolCallsCount: null, finishReason: null };
+      default: {
+        // Generic fallback
+        const toolCalls = reconstructed.tool_calls || reconstructed.choices?.[0]?.tool_calls;
+        const toolCallsCount = Array.isArray(toolCalls) ? toolCalls.length : 0;
+        const finishReason =
+          reconstructed.finish_reason || reconstructed.choices?.[0]?.finish_reason || null;
+        return { toolCallsCount: toolCallsCount > 0 ? toolCallsCount : null, finishReason };
+      }
     }
+  }
+
+  private deepSearchToolCalls(obj: any): number {
+    if (!obj || typeof obj !== 'object') return 0;
+
+    let count = 0;
+
+    // Check common field names
+    if (Array.isArray(obj.tool_calls)) {
+      count = Math.max(count, obj.tool_calls.filter(Boolean).length);
+    }
+    if (obj.functionCall) {
+      count = Math.max(count, 1);
+    }
+    if (Array.isArray(obj.parts)) {
+      const functionCalls = obj.parts.filter((p: any) => p.functionCall).length;
+      count = Math.max(count, functionCalls);
+    }
+
+    // Recurse into common containers
+    if (Array.isArray(obj.choices)) {
+      for (const choice of obj.choices) {
+        count = Math.max(count, this.deepSearchToolCalls(choice.message || choice.delta || choice));
+      }
+    }
+    if (Array.isArray(obj.candidates)) {
+      for (const candidate of obj.candidates) {
+        count = Math.max(count, this.deepSearchToolCalls(candidate.content || candidate));
+      }
+    }
+
+    return count;
   }
 }

--- a/packages/backend/src/services/quota/quota-estimator.ts
+++ b/packages/backend/src/services/quota/quota-estimator.ts
@@ -48,9 +48,6 @@ export class QuotaEstimator {
       .sort((a, b) => b.checkedAt - a.checkedAt); // Ensure DESC order
 
     if (relevantHistory.length < 2) {
-      logger.debug(
-        `[QuotaEstimator] Not enough history for ${checkerId}:${windowType} (${relevantHistory.length} snapshots)`
-      );
       return null;
     }
 
@@ -61,9 +58,6 @@ export class QuotaEstimator {
     const recentHistory = relevantHistory.filter((s) => s.checkedAt >= lookbackStart);
 
     if (recentHistory.length < 2) {
-      logger.debug(
-        `[QuotaEstimator] Not enough recent history for ${checkerId}:${windowType} (${recentHistory.length} snapshots in last ${lookbackMs}ms)`
-      );
       return null;
     }
 
@@ -72,9 +66,6 @@ export class QuotaEstimator {
     const usageRate = this.calculateUsageRate(recentHistory);
 
     if (usageRate === null || usageRate <= 0) {
-      logger.debug(
-        `[QuotaEstimator] Invalid usage rate for ${checkerId}:${windowType}: ${usageRate}`
-      );
       return null;
     }
 
@@ -100,16 +91,6 @@ export class QuotaEstimator {
     const projectionBasedOnMinutes = oldestSnapshotUsed
       ? Math.round((now - oldestSnapshotUsed.checkedAt) / 60_000)
       : 0;
-
-    logger.debug(
-      `[QuotaEstimator] ${checkerId}:${windowType} - ` +
-        `current=${currentUsed.toFixed(1)}, ` +
-        `rate=${(usageRate * 3600_000).toFixed(2)}/hr, ` +
-        `projected=${projectedUsedAtReset.toFixed(1)} ` +
-        `(${projectedUtilizationPercent.toFixed(1)}%), ` +
-        `willExceed=${willExceed}, ` +
-        `basedOn=${projectionBasedOnMinutes}min`
-    );
 
     return {
       projectedUsedAtReset,

--- a/packages/backend/src/services/usage-storage.ts
+++ b/packages/backend/src/services/usage-storage.ts
@@ -73,6 +73,19 @@ export class UsageStorageService extends EventEmitter {
             : 0
           : record.parallelToolCallsEnabled;
 
+      const isVisionFallthroughValue =
+        typeof record.isVisionFallthrough === 'boolean'
+          ? record.isVisionFallthrough
+            ? 1
+            : 0
+          : record.isVisionFallthrough;
+      const isDescriptorRequestValue =
+        typeof record.isDescriptorRequest === 'boolean'
+          ? record.isDescriptorRequest
+            ? 1
+            : 0
+          : record.isDescriptorRequest;
+
       await this.ensureDb()
         .insert(this.schema.requestUsage)
         .values({
@@ -80,6 +93,8 @@ export class UsageStorageService extends EventEmitter {
           isStreamed: isStreamedValue,
           isPassthrough: isPassthroughValue,
           parallelToolCallsEnabled: parallelToolCallsValue,
+          isVisionFallthrough: isVisionFallthroughValue,
+          isDescriptorRequest: isDescriptorRequestValue,
           createdAt: record.createdAt || Date.now(),
         });
 
@@ -586,8 +601,23 @@ export class UsageStorageService extends EventEmitter {
     provider: string,
     model: string,
     canonicalModelName: string | null,
-    requestId: string
+    requestId: string,
+    metadata?: { isVisionFallthrough?: boolean; isDescriptorRequest?: boolean }
   ) {
+    if (metadata) {
+      try {
+        await this.ensureDb()
+          .update(this.schema.requestUsage)
+          .set({
+            isVisionFallthrough: metadata.isVisionFallthrough ? 1 : 0,
+            isDescriptorRequest: metadata.isDescriptorRequest ? 1 : 0,
+          })
+          .where(eq(this.schema.requestUsage.requestId, requestId));
+      } catch (error) {
+        logger.error('Failed to update vision fallthrough metadata', error);
+      }
+    }
+
     await this.updatePerformanceMetrics(
       provider,
       model,
@@ -597,6 +627,39 @@ export class UsageStorageService extends EventEmitter {
       0,
       requestId,
       true
+    );
+  }
+
+  async recordFailedAttempt(
+    provider: string,
+    model: string,
+    canonicalModelName: string | null,
+    requestId: string,
+    metadata?: { isVisionFallthrough?: boolean; isDescriptorRequest?: boolean }
+  ) {
+    if (metadata) {
+      try {
+        await this.ensureDb()
+          .update(this.schema.requestUsage)
+          .set({
+            isVisionFallthrough: metadata.isVisionFallthrough ? 1 : 0,
+            isDescriptorRequest: metadata.isDescriptorRequest ? 1 : 0,
+          })
+          .where(eq(this.schema.requestUsage.requestId, requestId));
+      } catch (error) {
+        logger.error('Failed to update vision fallthrough metadata for failed attempt', error);
+      }
+    }
+
+    await this.updatePerformanceMetrics(
+      provider,
+      model,
+      canonicalModelName,
+      null,
+      null,
+      0,
+      requestId,
+      false
     );
   }
 

--- a/packages/backend/src/services/vision-descriptor-service.ts
+++ b/packages/backend/src/services/vision-descriptor-service.ts
@@ -1,0 +1,193 @@
+import {
+  UnifiedChatRequest,
+  UnifiedMessage,
+  ImageContent,
+  TextContent,
+  UnifiedChatResponse,
+} from '../types/unified';
+import { Dispatcher } from './dispatcher';
+import { logger } from '../utils/logger';
+import { DEFAULT_VISION_DESCRIPTION_PROMPT } from '../utils/constants';
+import { UsageStorageService } from './usage-storage';
+
+export class VisionDescriptorService {
+  /**
+   * Processes a request by converting images to text descriptions if needed.
+   * Modifies a clone of the original request.
+   *
+   * @param request The original UnifiedChatRequest
+   * @param descriptorModel The model ID to use for generating descriptions
+   * @param defaultPrompt The prompt to send with each image
+   * @param usageStorage Optional usage storage to record the descriptor call
+   * @returns A modified UnifiedChatRequest with images replaced by text
+   */
+  public static async process(
+    request: UnifiedChatRequest,
+    descriptorModel: string,
+    defaultPrompt = DEFAULT_VISION_DESCRIPTION_PROMPT,
+    usageStorage?: UsageStorageService
+  ): Promise<UnifiedChatRequest> {
+    const images = this.extractImages(request.messages);
+    if (images.length === 0) return request;
+
+    logger.info(
+      `[vision-fallthrough] Describing ${images.length} images using model '${descriptorModel}'`
+    );
+
+    // Concurrent execution of all image descriptions
+    const descriptions = await Promise.all(
+      images.map((url) =>
+        this.describeImage(url, descriptorModel, defaultPrompt, usageStorage, request)
+      )
+    );
+
+    // Inject descriptions back into messages
+    const modifiedMessages = this.injectDescriptions(request.messages, descriptions);
+
+    return {
+      ...request,
+      messages: modifiedMessages,
+    };
+  }
+
+  /**
+   * Checks if a request contains any images.
+   */
+  public static hasImages(messages: UnifiedMessage[]): boolean {
+    for (const msg of messages) {
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (block.type === 'image_url' || (block as any).type === 'image') {
+            logger.debug(
+              `[vision-fallthrough] Found image block: type=${block.type || (block as any).type}`
+            );
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  private static extractImages(messages: UnifiedMessage[]): string[] {
+    const urls: string[] = [];
+    for (const msg of messages) {
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (block.type === 'image_url') {
+            urls.push(block.image_url.url);
+          } else if ((block as any).type === 'image') {
+            // Handle Anthropic-style image blocks
+            const source = (block as any).source;
+            if (source?.data) {
+              const mediaType = source.media_type || 'image/png';
+              urls.push(`data:${mediaType};base64,${source.data}`);
+            } else {
+              logger.warn(
+                '[vision-fallthrough] Found Anthropic image block but missing source.data'
+              );
+            }
+          }
+        }
+      }
+    }
+    logger.debug(`[vision-fallthrough] Extracted ${urls.length} images for description`);
+    return urls;
+  }
+
+  private static async describeImage(
+    url: string,
+    model: string,
+    prompt: string,
+    usageStorage?: UsageStorageService,
+    parentRequest?: UnifiedChatRequest
+  ): Promise<string> {
+    const dispatcher = new Dispatcher();
+    if (usageStorage) {
+      dispatcher.setUsageStorage(usageStorage);
+    }
+
+    // Create a request for the descriptor model
+    const descriptorRequest: UnifiedChatRequest = {
+      model: model,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: { url },
+            },
+            {
+              type: 'text',
+              text: prompt,
+            },
+          ],
+        },
+      ],
+      // Pass through parent request context for logging
+      incomingApiType: 'chat',
+      ...(parentRequest
+        ? {
+            sourceIp: (parentRequest as any).sourceIp,
+            apiKey: (parentRequest as any).apiKey,
+            keyName: (parentRequest as any).keyName,
+            attribution: (parentRequest as any).attribution,
+          }
+        : {}),
+    };
+
+    // Recursion guard: tag this request so Dispatcher doesn't try to fallthrough again
+    (descriptorRequest as any)._isVisionDescriptorRequest = true;
+    (descriptorRequest as any)._descriptorStartTime = Date.now();
+    (descriptorRequest as any).requestId = `desc-${crypto.randomUUID()}`;
+
+    try {
+      logger.debug(`[vision-fallthrough] Dispatching description request to model '${model}'`);
+      const response = await dispatcher.dispatch(descriptorRequest);
+      const description = response.content;
+
+      if (!description) {
+        logger.warn(`[vision-fallthrough] Model ${model} returned empty description for image`);
+        return 'No description available.';
+      }
+
+      logger.debug(`[vision-fallthrough] Received description (${description.length} chars)`);
+      return description;
+    } catch (error) {
+      logger.error(`[vision-fallthrough] Error describing image with ${model}:`, error);
+      return 'Error generating image description.';
+    }
+  }
+
+  private static injectDescriptions(
+    messages: UnifiedMessage[],
+    descriptions: string[]
+  ): UnifiedMessage[] {
+    let descIdx = 0;
+    const result = messages.map((msg) => {
+      // If content is a string, we need to convert it to an array of blocks if it has images
+      // but images are only in array-style content, so if it's a string, we just return it.
+      if (!Array.isArray(msg.content)) return msg;
+
+      const newContent = msg.content.map((block) => {
+        if (block.type === 'image_url' || (block as any).type === 'image') {
+          const desc = descriptions[descIdx++] || 'No description available.';
+          logger.debug(
+            `[vision-fallthrough] Replacing image block with description (length: ${desc.length})`
+          );
+          return {
+            type: 'text',
+            text: `[Image Description: ${desc}]`,
+          } as TextContent;
+        }
+        return block;
+      });
+
+      return { ...msg, content: newContent };
+    });
+
+    logger.debug(`[vision-fallthrough] injectDescriptions finished. Replaced ${descIdx} images.`);
+    return result;
+  }
+}

--- a/packages/backend/src/transformers/anthropic/response-transformer.ts
+++ b/packages/backend/src/transformers/anthropic/response-transformer.ts
@@ -59,6 +59,7 @@ export async function transformAnthropicResponse(response: any): Promise<Unified
     content: text || null,
     reasoning_content: reasoning || null,
     tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+    finishReason: response.stop_reason || null,
     usage: {
       input_tokens: inputTokens,
       output_tokens: realOutputTokens,

--- a/packages/backend/src/transformers/gemini/response-transformer.ts
+++ b/packages/backend/src/transformers/gemini/response-transformer.ts
@@ -51,6 +51,9 @@ export async function transformGeminiResponse(response: any): Promise<UnifiedCha
 
   const usage = response.usageMetadata ? normalizeGeminiUsage(response.usageMetadata) : undefined;
 
+  const rawFinishReason = candidate?.finishReason?.toLowerCase() || null;
+  const finishReason = tool_calls.length > 0 && rawFinishReason === 'stop' ? 'tool_calls' : rawFinishReason;
+
   return {
     id: response.responseId || 'gemini-' + Date.now(),
     model: response.modelVersion || 'gemini-model',
@@ -60,6 +63,7 @@ export async function transformGeminiResponse(response: any): Promise<UnifiedCha
       ? { content: reasoning_content, signature: thoughtSignature }
       : undefined,
     tool_calls: tool_calls.length > 0 ? tool_calls : undefined,
+    finishReason,
     usage,
   };
 }

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -101,6 +101,7 @@ export class OpenAITransformer implements Transformer {
       reasoning_content: message?.reasoning_content || null,
       tool_calls: message?.tool_calls,
       usage,
+      finishReason: choice?.finish_reason || null,
     };
   }
 

--- a/packages/backend/src/types/usage.ts
+++ b/packages/backend/src/types/usage.ts
@@ -44,6 +44,9 @@ export interface UsageRecord {
   // Response metadata
   toolCallsCount?: number | null;
   finishReason?: string | null;
+  // Vision Fallthrough metadata
+  isVisionFallthrough?: boolean;
+  isDescriptorRequest?: boolean;
   // Energy estimation
   kwhUsed?: number | null;
 }

--- a/packages/backend/src/utils/constants.ts
+++ b/packages/backend/src/utils/constants.ts
@@ -15,3 +15,17 @@ export const QUOTA_ERROR_PATTERNS = [
   'quota limit',
   'usage limit',
 ];
+
+/**
+ * Default prompt for vision-to-text conversion.
+ */
+export const DEFAULT_VISION_DESCRIPTION_PROMPT = `Please provide a comprehensive and detailed description of this image for a highly intelligent text-only language model.
+
+Your description should include:
+1. **Overall Context**: What is the primary subject or scene?
+2. **Visual Layout**: Where are key elements positioned?
+3. **Important Details**: Text (OCR), colors, textures, and specific objects.
+4. **Atmosphere/Style**: Mood, lighting, and artistic style if applicable.
+5. **Action/Dynamics**: What is happening in the scene?
+
+Focus on information that is critical for understanding the image's meaning or answering questions about it. Avoid generic descriptions; be precise and descriptive.`;

--- a/packages/backend/test/quota-enforcer.test.ts
+++ b/packages/backend/test/quota-enforcer.test.ts
@@ -19,6 +19,12 @@ const createTestConfig = (
     retryableStatusCodes: [500, 502, 503, 504],
     retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
   },
+  cooldown: {
+    initialMinutes: 2,
+    maxMinutes: 300,
+  },
+  performanceExplorationRate: 0.05,
+  latencyExplorationRate: 0.05,
   quotas: [],
   user_quotas: userQuotas,
 });

--- a/packages/backend/test/vision-detection-repro.test.ts
+++ b/packages/backend/test/vision-detection-repro.test.ts
@@ -1,0 +1,45 @@
+import { expect, test, describe } from 'bun:test';
+import { VisionDescriptorService } from '../src/services/vision-descriptor-service';
+
+describe('Vision Detection Reproduction', () => {
+  test("detects images in the user's specific payload", () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'SNIP>' },
+          { type: 'text', text: 'SNIP' },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'thinking',
+            thinking: '...',
+            signature: '...',
+          },
+          { type: 'text', text: '...' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '<attachments>\n' },
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              data: 'base64datahereSNIP>gg==',
+              media_type: 'image/png',
+            },
+          },
+          { type: 'text', text: '\n</attachments>\n...' },
+        ],
+      },
+    ];
+
+    const hasImages = VisionDescriptorService.hasImages(messages as any);
+    expect(hasImages).toBe(true);
+  });
+});

--- a/packages/backend/test/vision-fallthrough-e2e.test.ts
+++ b/packages/backend/test/vision-fallthrough-e2e.test.ts
@@ -1,0 +1,97 @@
+import { expect, test, describe, beforeEach, spyOn, mock } from 'bun:test';
+import { Dispatcher } from '../src/services/dispatcher';
+import { VisionDescriptorService } from '../src/services/vision-descriptor-service';
+import { Router } from '../src/services/router';
+import * as configModule from '../src/config';
+
+describe('Vision Fallthrough E2E', () => {
+  test('Dispatcher triggers vision fallthrough when enabled', async () => {
+    // 1. Mock the config to enable fallthrough for an alias
+    const mockConfig = {
+      providers: {
+        'test-provider': {
+          api_base_url: 'https://api.test.com',
+          api_key: 'test-key',
+          models: ['text-model', 'vision-model'],
+          enabled: true,
+        },
+      },
+      models: {
+        'text-only-alias': {
+          use_image_fallthrough: true,
+          targets: [{ provider: 'test-provider', model: 'text-model', enabled: true }],
+        },
+      },
+      vision_fallthrough: {
+        descriptor_model: 'vision-model',
+      },
+      failover: { enabled: false },
+      cooldown: { initialMinutes: 1, maxMinutes: 5 },
+    };
+
+    configModule.setConfigForTesting(mockConfig as any);
+
+    // 2. Mock VisionDescriptorService.process to return a modified request
+    const processSpy = spyOn(VisionDescriptorService, 'process').mockImplementation(async (req) => {
+      return {
+        ...req,
+        messages: [
+          { role: 'user', content: [{ type: 'text', text: 'This is a description of an image.' }] },
+        ],
+      } as any;
+    });
+
+    // 3. Mock Router.resolveCandidates to return a valid candidate with the modelConfig
+    spyOn(Router, 'resolveCandidates').mockResolvedValue([
+      {
+        provider: 'test-provider',
+        model: 'text-model',
+        config: mockConfig.providers['test-provider'] as any,
+        modelConfig: mockConfig.models['text-only-alias'],
+        incomingModelAlias: 'text-only-alias',
+      },
+    ]);
+
+    // 4. Mock Dispatcher internal methods to prevent actual network calls
+    const dispatcher = new Dispatcher();
+    spyOn(dispatcher as any, 'selectTargetApiType').mockReturnValue({
+      targetApiType: 'chat',
+      selectionReason: 'test',
+    });
+
+    // Mock the actual execution to return success
+    spyOn(dispatcher as any, 'executeProviderRequest').mockImplementation(async () => {
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: 'I see the description.' } }] }),
+        text: async () => '{}',
+        status: 200,
+        headers: new Headers(),
+      } as any;
+    });
+
+    // 4. Dispatch a request with an image
+    const request = {
+      model: 'text-only-alias',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is this?' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    await dispatcher.dispatch(request as any);
+
+    // 5. Verify the descriptor service was called
+    expect(processSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/test/vision-fallthrough-full.test.ts
+++ b/packages/backend/test/vision-fallthrough-full.test.ts
@@ -1,0 +1,68 @@
+import { expect, test, describe, spyOn } from 'bun:test';
+import { Dispatcher } from '../src/services/dispatcher';
+import { VisionDescriptorService } from '../src/services/vision-descriptor-service';
+import * as configModule from '../src/config';
+
+describe('Vision Fallthrough Full Logic', () => {
+  test('triggers for MiniMax-M2.5 with image payload', async () => {
+    const mockConfig = {
+      providers: {
+        minimax: {
+          api_base_url: 'https://api.minimax.chat/v1',
+          api_key: 'test-key',
+          models: ['MiniMax-M2.5'],
+          enabled: true,
+        },
+      },
+      models: {
+        'MiniMax-M2.5': {
+          use_image_fallthrough: true,
+          targets: [{ provider: 'minimax', model: 'MiniMax-M2.5', enabled: true }],
+        },
+      },
+      vision_fallthrough: {
+        descriptor_model: 'gpt-4o',
+      },
+      failover: { enabled: false },
+      cooldown: { initialMinutes: 1, maxMinutes: 5 },
+    };
+
+    spyOn(configModule, 'getConfig').mockReturnValue(mockConfig as any);
+
+    // Track if process was called
+    const processSpy = spyOn(VisionDescriptorService, 'process').mockImplementation(async (req) => {
+      return {
+        ...req,
+        messages: [{ role: 'user', content: 'Description' }],
+      } as any;
+    });
+
+    const dispatcher = new Dispatcher();
+    spyOn(dispatcher as any, 'selectTargetApiType').mockReturnValue({
+      targetApiType: 'chat',
+      selectionReason: 'test',
+    });
+    spyOn(dispatcher as any, 'executeProviderRequest').mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({}),
+      text: async () => '{}',
+      status: 200,
+      headers: new Headers(),
+    }));
+
+    const payload = {
+      model: 'MiniMax-M2.5',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'base64', data: '...', media_type: 'image/png' } },
+          ],
+        },
+      ],
+    };
+
+    await dispatcher.dispatch(payload as any);
+    expect(processSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/backend/test/vision-fallthrough-verification.test.ts
+++ b/packages/backend/test/vision-fallthrough-verification.test.ts
@@ -1,0 +1,62 @@
+import { expect, test, describe, spyOn } from 'bun:test';
+import { VisionDescriptorService } from '../src/services/vision-descriptor-service';
+import { UnifiedMessage, UnifiedChatRequest, TextContent } from '../src/types/unified';
+
+describe('VisionDescriptorService Detailed Verification', () => {
+  test('injectDescriptions correctly replaces images with text', () => {
+    const messages: UnifiedMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Look at this:' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,123' } },
+          { type: 'text', text: 'And this:' },
+          {
+            type: 'image',
+            source: { type: 'base64', data: '456', media_type: 'image/png' },
+          } as any,
+        ],
+      },
+    ];
+
+    const descriptions = ['A cute cat', 'A big dog'];
+
+    // @ts-ignore - accessing private for testing
+    const result = VisionDescriptorService.injectDescriptions(messages, descriptions);
+
+    expect(result[0].content).toHaveLength(4);
+    expect((result[0].content as any)[0].type).toBe('text');
+    expect((result[0].content as any)[1].type).toBe('text');
+    expect((result[0].content as any)[1].text).toContain('A cute cat');
+    expect((result[0].content as any)[2].type).toBe('text');
+    expect((result[0].content as any)[3].type).toBe('text');
+    expect((result[0].content as any)[3].text).toContain('A big dog');
+
+    // Verify no images left
+    expect(VisionDescriptorService.hasImages(result)).toBe(false);
+  });
+
+  test('process correctly modifies the request object', async () => {
+    const request: UnifiedChatRequest = {
+      model: 'test',
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'image_url', image_url: { url: 'data:...' } }],
+        },
+      ],
+    };
+
+    // Mock describeImage to avoid Dispatcher dependency in this unit test
+    spyOn(VisionDescriptorService as any, 'describeImage').mockResolvedValue(
+      'This is a description of an image.'
+    );
+
+    const result = await VisionDescriptorService.process(request, 'desc-model');
+
+    expect(VisionDescriptorService.hasImages(result.messages)).toBe(false);
+    expect(result.messages[0].content).toHaveLength(1);
+    const firstContent = (result.messages[0].content as any)[0] as TextContent;
+    expect(firstContent?.text).toContain('This is a description of an image.');
+  });
+});

--- a/packages/backend/test/vision-fallthrough.test.ts
+++ b/packages/backend/test/vision-fallthrough.test.ts
@@ -1,0 +1,53 @@
+import { expect, test, describe, beforeEach, mock } from 'bun:test';
+import { VisionDescriptorService } from '../src/services/vision-descriptor-service';
+import { Dispatcher } from '../src/services/dispatcher';
+import { UnifiedChatRequest } from '../src/types/unified';
+import * as configModule from '../src/config';
+import { DEFAULT_VISION_DESCRIPTION_PROMPT } from '../src/utils/constants';
+
+describe('Vision Fallthrough', () => {
+  let mockRequest: UnifiedChatRequest;
+
+  beforeEach(() => {
+    mockRequest = {
+      model: 'test-model',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is this?' },
+            {
+              type: 'image_url',
+              image_url: {
+                url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+              },
+            },
+          ],
+        },
+      ],
+    };
+  });
+
+  test('hasImages detects images in request', () => {
+    expect(VisionDescriptorService.hasImages(mockRequest.messages)).toBe(true);
+
+    const noImages = [{ role: 'user', content: 'hello' }];
+    expect(VisionDescriptorService.hasImages(noImages as any)).toBe(false);
+  });
+
+  test('hasImages detects Anthropic-style images', () => {
+    const anthropicRequest = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Look at this' },
+          {
+            type: 'image',
+            source: { type: 'base64', media_type: 'image/png', data: '...' },
+          } as any,
+        ],
+      },
+    ];
+    expect(VisionDescriptorService.hasImages(anthropicRequest as any)).toBe(true);
+  });
+});

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -261,6 +261,7 @@ export interface Alias {
   targets: Array<{ provider: string; model: string; apiType?: string[]; enabled?: boolean }>;
   advanced?: AliasBehavior[];
   metadata?: AliasMetadata;
+  use_image_fallthrough?: boolean;
 }
 
 export interface InferenceError {
@@ -337,6 +338,9 @@ export interface UsageRecord {
   finishReason?: string;
   // Retry metadata
   attemptCount?: number;
+  // Vision Fallthrough metadata
+  isVisionFallthrough?: boolean;
+  isDescriptorRequest?: boolean;
   // Energy estimation
   kwhUsed?: number;
 }
@@ -1496,6 +1500,28 @@ export const api = {
     await api.saveConfig(newYaml);
   },
 
+  getVisionFallthroughConfig: async (): Promise<{
+    descriptor_model?: string;
+    default_prompt?: string;
+  }> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/vision-fallthrough`);
+    if (!res.ok) throw new Error('Failed to fetch vision fallthrough config');
+    return res.json();
+  },
+
+  updateVisionFallthroughConfig: async (updates: {
+    descriptor_model?: string;
+    default_prompt?: string;
+  }): Promise<any> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/vision-fallthrough`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    });
+    if (!res.ok) throw new Error('Failed to update vision fallthrough config');
+    return res.json();
+  },
+
   deleteProvider: async (
     providerId: string,
     cascade?: boolean
@@ -1566,6 +1592,7 @@ export const api = {
       selector: alias.selector,
       priority: alias.priority || 'selector',
       additional_aliases: alias.aliases,
+      use_image_fallthrough: alias.use_image_fallthrough || false,
       ...(alias.type && { type: alias.type }),
       ...(alias.advanced && alias.advanced.length > 0 && { advanced: alias.advanced }),
       ...(alias.metadata && { metadata: alias.metadata }),
@@ -1661,6 +1688,7 @@ export const api = {
             selector: val.selector,
             priority: val.priority,
             type: val.type,
+            use_image_fallthrough: val.use_image_fallthrough || false,
             advanced: val.advanced || [],
             targets,
             metadata: val.metadata,

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -46,6 +46,8 @@ import {
   RotateCcw,
   PencilLine,
   Plane,
+  Eye,
+  ScanSearch,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useNavigate } from 'react-router-dom';
@@ -539,6 +541,38 @@ export const Logs = () => {
                             )}
                           </div>
                         </div>
+
+                        {/* Vision Fallthrough icons */}
+                        {(log.isVisionFallthrough || log.isDescriptorRequest) && (
+                          <div
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: '2px',
+                              marginTop: '2px',
+                            }}
+                          >
+                            <div
+                              style={{ width: '16px', display: 'flex', justifyContent: 'center' }}
+                            >
+                              {log.isVisionFallthrough && (
+                                <div title="Vision Fallthrough (Images converted to text)">
+                                  <ScanSearch size={12} className="text-amber-500" />
+                                </div>
+                              )}
+                            </div>
+                            <span style={{ width: '14px' }}></span>
+                            <div
+                              style={{ width: '16px', display: 'flex', justifyContent: 'center' }}
+                            >
+                              {log.isDescriptorRequest && (
+                                <div title="Descriptor Request (Generated image description)">
+                                  <Eye size={12} className="text-blue-500" />
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        )}
                       </div>
                     </td>
                     <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { api, Alias, AliasMetadata, AliasBehavior, Provider, Model } from '../lib/api';
 import { useModels } from '../hooks/useModels';
@@ -21,6 +21,8 @@ import {
   X,
   CheckCircle,
   GripVertical,
+  Save,
+  Eye,
 } from 'lucide-react';
 
 export const Models = () => {
@@ -82,6 +84,37 @@ export const Models = () => {
   // Drag and Drop State
   const [dragSourceIndex, setDragSourceIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  // Global Descriptor State
+  const [globalDescriptorModel, setGlobalDescriptorModel] = useState('');
+  const [isSavingDescriptor, setIsSavingDescriptor] = useState(false);
+
+  useEffect(() => {
+    const fetchVFConfig = async () => {
+      try {
+        const config = await api.getVisionFallthroughConfig();
+        if (config?.descriptor_model) {
+          setGlobalDescriptorModel(config.descriptor_model);
+        }
+      } catch (e) {
+        console.error('Failed to load VF config', e);
+      }
+    };
+    fetchVFConfig();
+  }, []);
+
+  const handleSaveDescriptor = async () => {
+    setIsSavingDescriptor(true);
+    try {
+      await api.updateVisionFallthroughConfig({
+        descriptor_model: globalDescriptorModel,
+      });
+    } catch (e) {
+      console.error('Failed to save descriptor model', e);
+    } finally {
+      setIsSavingDescriptor(false);
+    }
+  };
 
   const handleSave = async () => {
     if (!editingAlias.id) return;
@@ -347,7 +380,41 @@ export const Models = () => {
     <div className="min-h-screen p-6 transition-all duration-300 bg-linear-to-br from-bg-deep to-bg-surface">
       <div className="mb-6">
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <h1 className="font-heading text-3xl font-bold text-text m-0">Models</h1>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            <h1 className="font-heading text-3xl font-bold text-text m-0">Models</h1>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '4px' }}>
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-bg-glass border border-border-glass">
+                <Eye size={14} className="text-text-secondary" />
+                <span className="text-xs font-medium text-text-secondary">
+                  Vision Fall Through Model:
+                </span>
+                <select
+                  className="bg-transparent border-none text-xs text-text outline-none focus:ring-0 cursor-pointer"
+                  value={globalDescriptorModel}
+                  onChange={(e) => setGlobalDescriptorModel(e.target.value)}
+                >
+                  <option value="">(None)</option>
+                  {aliases.map((a) => (
+                    <option key={a.id} value={a.id}>
+                      {a.id}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleSaveDescriptor}
+                  disabled={isSavingDescriptor}
+                  className="ml-1 text-text-secondary hover:text-primary transition-colors disabled:opacity-50"
+                  title="Save descriptor model"
+                >
+                  {isSavingDescriptor ? (
+                    <Loader2 size={14} className="animate-spin" />
+                  ) : (
+                    <Save size={14} />
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <div style={{ position: 'relative', width: '280px' }}>
               <Search
@@ -585,6 +652,23 @@ export const Models = () => {
                     <Switch
                       checked={getBehavior('strip_adaptive_thinking')}
                       onChange={(val) => setBehavior('strip_adaptive_thinking', val)}
+                      size="sm"
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between py-1">
+                    <div>
+                      <span className="font-body text-[13px] text-text">Vision Fallthrough</span>
+                      <p className="font-body text-[11px] text-text-muted mt-0.5">
+                        If the request contains images and the target model is text-only, use the
+                        descriptor model to convert images to text.
+                      </p>
+                    </div>
+                    <Switch
+                      checked={editingAlias.use_image_fallthrough || false}
+                      onChange={(val) =>
+                        setEditingAlias({ ...editingAlias, use_image_fallthrough: val })
+                      }
                       size="sm"
                     />
                   </div>


### PR DESCRIPTION
- Implement VisionDescriptorService to handle image-to-text description conversion.
- Add methods for extracting images from messages and injecting descriptions back into the request.
- Create unit tests for VisionDescriptorService to verify image detection and description injection.
- Implement end-to-end tests for vision fallthrough logic with various configurations and payloads.
- Ensure compatibility with different message formats including OpenAI and Anthropic styles.
- Enhance logging for better traceability during image processing.