### PR TITLE
feat(config): add request shaper environment variables and defaults

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -21,3 +21,21 @@
 
 # Provider performance rolling window size per provider:model combo (default: 100)
 # PLEXUS_PROVIDER_PERFORMANCE_RETENTION_LIMIT=100
+
+
+# Low-RPM Request Shaper Configuration
+#
+# These values provide runtime defaults only. Provider-specific `rate_limit`
+# settings such as `queue_depth` still belong in `plexus.yaml`.
+#
+# Optional: Queue timeout default for providers that opt into rate_limit but omit
+# queue_timeout_ms (milliseconds, default: 30000)
+# PLEXUS_SHAPER_QUEUE_TIMEOUT_MS=30000
+#
+# Optional: Cleanup interval for stale queue entries (milliseconds, default: 60000).
+# This is consumed by the request shaper service at runtime.
+# PLEXUS_SHAPER_CLEANUP_INTERVAL_MS=60000
+#
+# Optional: Default RPM for providers that define rate_limit but omit
+# requests_per_minute (default: 60)
+# PLEXUS_SHAPER_DEFAULT_RPM=60

--- a/packages/backend/src/__tests__/config-shaper-env.test.ts
+++ b/packages/backend/src/__tests__/config-shaper-env.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { validateConfig } from '../config';
+
+const ENV_KEYS = [
+  'PLEXUS_SHAPER_QUEUE_TIMEOUT_MS',
+  'PLEXUS_SHAPER_CLEANUP_INTERVAL_MS',
+  'PLEXUS_SHAPER_DEFAULT_RPM',
+] as const;
+
+const makeConfigYaml = (rateLimitYaml?: string): string => `
+providers:
+  shaped-provider:
+    api_base_url: "https://api.example.com/v1"
+    api_key: "test-api-key"
+${rateLimitYaml ? rateLimitYaml : ''}
+models:
+  test-model:
+    targets:
+      - provider: shaped-provider
+        model: provider-model
+keys: {}
+adminKey: "admin-secret"
+`;
+
+const inlineRateLimit = (body: string): string => `    rate_limit:
+${body}`;
+
+const makeModelRateLimitYaml = (): string => `
+providers:
+  shaped-provider:
+    api_base_url: "https://api.example.com/v1"
+    api_key: "test-api-key"
+    models:
+      model-a:
+        rate_limit:
+          queue_depth: 4
+      model-b: {}
+models:
+  test-model:
+    targets:
+      - provider: shaped-provider
+        model: model-a
+keys: {}
+adminKey: "admin-secret"
+`;
+
+const makeAliasRateLimitYaml = (): string => `
+providers:
+  shaped-provider:
+    api_base_url: "https://api.example.com/v1"
+    api_key: "test-api-key"
+    models:
+      model-a: {}
+models:
+  coder:
+    rate_limit:
+      queue_depth: 2
+    targets:
+      - provider: shaped-provider
+        model: model-a
+keys: {}
+adminKey: "admin-secret"
+`;
+
+describe('config shaper env defaults', () => {
+  let envSnapshot: Record<(typeof ENV_KEYS)[number], string | undefined>;
+
+  beforeEach(() => {
+    envSnapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]])) as Record<
+      (typeof ENV_KEYS)[number],
+      string | undefined
+    >;
+
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = envSnapshot[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('keeps providers without rate_limit unchanged', () => {
+    process.env.PLEXUS_SHAPER_QUEUE_TIMEOUT_MS = '45000';
+    process.env.PLEXUS_SHAPER_DEFAULT_RPM = '25';
+
+    const config = validateConfig(makeConfigYaml());
+    const provider = config.providers['shaped-provider']!;
+
+    expect(provider.rate_limit).toBeUndefined();
+    expect(config.shaper).toMatchObject({
+      queueTimeoutMs: 45000,
+      cleanupIntervalMs: 60000,
+      defaultRpm: 25,
+    });
+  });
+
+  it('applies env defaults when rate_limit opts in with missing values', () => {
+    process.env.PLEXUS_SHAPER_QUEUE_TIMEOUT_MS = '45000';
+    process.env.PLEXUS_SHAPER_DEFAULT_RPM = '25';
+
+    const config = validateConfig(makeConfigYaml(inlineRateLimit('      queue_depth: 3\n')));
+    const provider = config.providers['shaped-provider']!;
+
+    expect(provider.rate_limit).toEqual({
+      requests_per_minute: 25,
+      queue_depth: 3,
+      queue_timeout_ms: 45000,
+    });
+  });
+
+  it('preserves explicit rate_limit values over env defaults', () => {
+    process.env.PLEXUS_SHAPER_QUEUE_TIMEOUT_MS = '45000';
+    process.env.PLEXUS_SHAPER_DEFAULT_RPM = '25';
+
+    const config = validateConfig(
+      makeConfigYaml(
+        inlineRateLimit(
+          '      requests_per_minute: 10\n      queue_depth: 2\n      queue_timeout_ms: 12000\n'
+        )
+      )
+    );
+    const provider = config.providers['shaped-provider']!;
+
+    expect(provider.rate_limit).toEqual({
+      requests_per_minute: 10,
+      queue_depth: 2,
+      queue_timeout_ms: 12000,
+    });
+  });
+
+  it('falls back safely when env values are invalid', () => {
+    process.env.PLEXUS_SHAPER_QUEUE_TIMEOUT_MS = 'invalid';
+    process.env.PLEXUS_SHAPER_CLEANUP_INTERVAL_MS = '0';
+    process.env.PLEXUS_SHAPER_DEFAULT_RPM = '-10';
+
+    const config = validateConfig(makeConfigYaml(inlineRateLimit('      queue_depth: 4\n')));
+    const provider = config.providers['shaped-provider']!;
+
+    expect(provider.rate_limit).toEqual({
+      requests_per_minute: 60,
+      queue_depth: 4,
+      queue_timeout_ms: 30000,
+    });
+    expect(config.shaper).toMatchObject({
+      queueTimeoutMs: 30000,
+      cleanupIntervalMs: 60000,
+      defaultRpm: 60,
+    });
+  });
+
+  it('hydrates model-level rate_limit values with env defaults', () => {
+    process.env.PLEXUS_SHAPER_QUEUE_TIMEOUT_MS = '9100';
+    process.env.PLEXUS_SHAPER_DEFAULT_RPM = '13';
+
+    const config = validateConfig(makeModelRateLimitYaml());
+    const provider = config.providers['shaped-provider']!;
+    const models = provider.models;
+
+    expect(models).not.toBeUndefined();
+    expect(Array.isArray(models)).toBe(false);
+
+    if (!models || Array.isArray(models)) {
+      throw new Error('Expected provider models to be a keyed model config record');
+    }
+
+    expect(models['model-a']).toMatchObject({
+      rate_limit: {
+        requests_per_minute: 13,
+        queue_depth: 4,
+        queue_timeout_ms: 9100,
+      },
+    });
+    expect(models['model-b']).toMatchObject({});
+    expect(models['model-b']?.rate_limit).toBeUndefined();
+  });
+
+  it('hydrates alias-level rate_limit values with env defaults', () => {
+    process.env.PLEXUS_SHAPER_QUEUE_TIMEOUT_MS = '9100';
+    process.env.PLEXUS_SHAPER_DEFAULT_RPM = '13';
+
+    const config = validateConfig(makeAliasRateLimitYaml());
+
+    expect(config.models['coder']).toMatchObject({
+      rate_limit: {
+        requests_per_minute: 13,
+        queue_depth: 2,
+        queue_timeout_ms: 9100,
+      },
+    });
+  });
+});

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -21,6 +21,22 @@ const FailoverPolicySchema = z.object({
   retryableErrors: z.array(z.string().min(1)).default(['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND']),
 });
 
+const RateLimitConfigSchema = z.object({
+  requests_per_minute: z.number().min(1).optional(),
+  queue_depth: z.number().min(1).optional(),
+  queue_timeout_ms: z.number().min(1).optional(),
+});
+
+const DEFAULT_SHAPER_QUEUE_TIMEOUT_MS = 30_000;
+const DEFAULT_SHAPER_CLEANUP_INTERVAL_MS = 60_000;
+const DEFAULT_SHAPER_DEFAULT_RPM = 60;
+
+const ShaperRuntimeConfigSchema = z.object({
+  queueTimeoutMs: z.number().int().min(1),
+  cleanupIntervalMs: z.number().int().min(1),
+  defaultRpm: z.number().int().min(1),
+});
+
 const PricingRangeSchema = z.object({
   // This strategy is used to define a range of pricing for a model
   // There can be multiple ranges defined for different usage levels
@@ -71,6 +87,7 @@ const ModelProviderConfigSchema = z.object({
   }),
   access_via: z.array(z.string()).optional(),
   type: z.enum(['chat', 'responses', 'embeddings', 'transcriptions', 'speech', 'image']).optional(),
+  rate_limit: RateLimitConfigSchema.optional(),
 });
 
 const OAuthProviderSchema = z.enum([
@@ -319,6 +336,7 @@ const ProviderConfigSchema = z
     headers: z.record(z.string()).optional(),
     extraBody: z.record(z.any()).optional(),
     estimateTokens: z.boolean().optional().default(false),
+    rate_limit: RateLimitConfigSchema.optional(),
     quota_checker: ProviderQuotaCheckerSchema.optional(),
   })
   .refine((data) => !!data.api_key || isOAuthProviderConfig(data), {
@@ -389,6 +407,7 @@ const ModelConfigSchema = z.object({
   additional_aliases: z.array(z.string()).optional(),
   use_image_fallthrough: z.boolean().default(false).optional(),
   type: z.enum(['chat', 'responses', 'embeddings', 'transcriptions', 'speech', 'image']).optional(),
+  rate_limit: RateLimitConfigSchema.optional(),
   advanced: z.array(ModelBehaviorSchema).optional(),
   metadata: ModelMetadataSchema.optional(),
 });
@@ -446,11 +465,13 @@ const RawPlexusConfigSchema = z
 
 export type FailoverPolicy = z.infer<typeof FailoverPolicySchema>;
 export type CooldownPolicy = z.infer<typeof CooldownPolicySchema>;
+export type ShaperRuntimeConfig = z.infer<typeof ShaperRuntimeConfigSchema>;
 export type PlexusConfig = z.infer<typeof RawPlexusConfigSchema> & {
   failover: FailoverPolicy;
   cooldown?: CooldownPolicy;
   quotas: QuotaConfig[];
   mcpServers?: Record<string, McpServerConfig>;
+  shaper?: ShaperRuntimeConfig;
 };
 export type DatabaseConfig = {
   connectionString: string;
@@ -601,12 +622,127 @@ export function validateConfig(yamlContent: string): PlexusConfig {
 }
 
 function hydrateConfig(config: z.infer<typeof RawPlexusConfigSchema>): PlexusConfig {
+  const shaper = getShaperRuntimeConfig();
+
   return {
     ...config,
+    providers: hydrateProviderRateLimits(config.providers, shaper),
+    models: hydrateAliasRateLimits(config.models, shaper),
     failover: FailoverPolicySchema.parse(config.failover ?? {}),
     cooldown: CooldownPolicySchema.parse(config.cooldown ?? {}),
     quotas: buildProviderQuotaConfigs(config),
     mcpServers: config.mcp_servers,
+    shaper,
+  };
+}
+
+function parsePositiveIntEnv(name: string, fallback: number): number {
+  const rawValue = process.env[name]?.trim();
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    logger.warn(`Ignoring invalid ${name} value '${rawValue}', using ${fallback}`);
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function getShaperRuntimeConfig(): ShaperRuntimeConfig {
+  return ShaperRuntimeConfigSchema.parse({
+    queueTimeoutMs: parsePositiveIntEnv(
+      'PLEXUS_SHAPER_QUEUE_TIMEOUT_MS',
+      DEFAULT_SHAPER_QUEUE_TIMEOUT_MS
+    ),
+    cleanupIntervalMs: parsePositiveIntEnv(
+      'PLEXUS_SHAPER_CLEANUP_INTERVAL_MS',
+      DEFAULT_SHAPER_CLEANUP_INTERVAL_MS
+    ),
+    defaultRpm: parsePositiveIntEnv('PLEXUS_SHAPER_DEFAULT_RPM', DEFAULT_SHAPER_DEFAULT_RPM),
+  });
+}
+
+function hydrateProviderRateLimits(
+  providers: z.infer<typeof RawPlexusConfigSchema>['providers'],
+  shaper: ShaperRuntimeConfig
+): z.infer<typeof RawPlexusConfigSchema>['providers'] {
+  const hydrateRateLimit = createRateLimitHydrator(shaper);
+
+  return Object.fromEntries(
+    Object.entries(providers).map(([providerId, providerConfig]) => {
+      const hydratedProviderRateLimit = hydrateRateLimit(providerConfig.rate_limit);
+
+      if (!providerConfig.models || Array.isArray(providerConfig.models)) {
+        if (!hydratedProviderRateLimit) {
+          return [providerId, providerConfig];
+        }
+
+        return [
+          providerId,
+          {
+            ...providerConfig,
+            rate_limit: hydratedProviderRateLimit,
+          },
+        ];
+      }
+
+      const hydratedModels = Object.fromEntries(
+        Object.entries(providerConfig.models).map(([modelId, modelConfig]) => [
+          modelId,
+          {
+            ...modelConfig,
+            rate_limit: hydrateRateLimit(modelConfig.rate_limit),
+          },
+        ])
+      );
+
+      return [
+        providerId,
+        {
+          ...providerConfig,
+          models: hydratedModels,
+          rate_limit: hydratedProviderRateLimit,
+        },
+      ];
+    })
+  );
+}
+
+function hydrateAliasRateLimits(
+  models: z.infer<typeof RawPlexusConfigSchema>['models'],
+  shaper: ShaperRuntimeConfig
+): z.infer<typeof RawPlexusConfigSchema>['models'] {
+  const hydrateRateLimit = createRateLimitHydrator(shaper);
+
+  return Object.fromEntries(
+    Object.entries(models).map(([aliasId, aliasConfig]) => [
+      aliasId,
+      {
+        ...aliasConfig,
+        rate_limit: hydrateRateLimit(aliasConfig.rate_limit),
+      },
+    ])
+  );
+}
+
+function createRateLimitHydrator(shaper: ShaperRuntimeConfig) {
+  return (rateLimit?: {
+    requests_per_minute?: number;
+    queue_depth?: number;
+    queue_timeout_ms?: number;
+  }) => {
+    if (!rateLimit) {
+      return undefined;
+    }
+
+    return {
+      ...rateLimit,
+      requests_per_minute: rateLimit.requests_per_minute ?? shaper.defaultRpm,
+      queue_timeout_ms: rateLimit.queue_timeout_ms ?? shaper.queueTimeoutMs,
+    };
   };
 }
 


### PR DESCRIPTION
## Summary

Adds environment variables and configuration schema for the low-RPM request shaper feature.

## Changes
- Environment variables for queue timeout, cleanup interval, and default RPM
- Zod schemas for validation
- Comprehensive test coverage

## Testing
- 6 tests pass
- Format check clean
- LSP diagnostics clean