### PR TITLE
feat(management): add rate-limits API for monitoring

### DIFF
--- a/packages/backend/src/routes/management/__tests__/rate-limits.test.ts
+++ b/packages/backend/src/routes/management/__tests__/rate-limits.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import Fastify from 'fastify';
+import { RequestShaper } from '../../../services/request-shaper';
+import {
+  rateLimitsResponseSchema,
+  rateLimitStatusSchema,
+  registerRateLimitRoutes,
+} from '../rate-limits';
+
+describe('Rate limits management routes', () => {
+  let fastify: ReturnType<typeof Fastify>;
+
+  beforeEach(async () => {
+    RequestShaper.resetInstance();
+    fastify = Fastify();
+    await registerRateLimitRoutes(fastify);
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+    RequestShaper.resetInstance();
+  });
+
+  it('returns a stable baseline payload', async () => {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/rate-limits',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('application/json');
+
+    const json = response.json() as {
+      rateLimits: unknown[];
+      summary: {
+        activeLimiters: number;
+        totalQueueDepth: number;
+        totalWaitersCount: number;
+        oldestWaitMs: number | null;
+        totalTimeoutCount: number;
+        totalDropCount: number;
+      };
+      timestamp: string;
+    };
+
+    expect(json).toEqual({
+      rateLimits: [],
+      summary: {
+        activeLimiters: 0,
+        totalQueueDepth: 0,
+        totalWaitersCount: 0,
+        oldestWaitMs: null,
+        totalTimeoutCount: 0,
+        totalDropCount: 0,
+      },
+      timestamp: json.timestamp,
+    });
+    expect(Number.isNaN(Date.parse(json.timestamp))).toBe(false);
+  });
+
+  it('exports a stable response schema for future shaper integration', () => {
+    expect(rateLimitsResponseSchema.required).toEqual(['rateLimits', 'summary', 'timestamp']);
+    expect(rateLimitStatusSchema.required).toEqual([
+      'provider',
+      'model',
+      'queueDepth',
+      'currentBudget',
+      'requestsPerMinute',
+      'oldestWaitMs',
+      'waitersCount',
+      'timeoutCount',
+      'dropCount',
+    ]);
+    expect(rateLimitsResponseSchema.properties.summary.required).toEqual([
+      'activeLimiters',
+      'totalQueueDepth',
+      'totalWaitersCount',
+      'oldestWaitMs',
+      'totalTimeoutCount',
+      'totalDropCount',
+    ]);
+  });
+
+  it('returns live request shaper state when shaping is active', async () => {
+    const shaper = RequestShaper.getInstance();
+    await shaper.initialize(
+      createTestConfig({
+        providers: {
+          'test-provider': {
+            api_base_url: 'https://example.com/v1',
+            api_key: 'test-key',
+            rate_limit: { requests_per_minute: 1, queue_depth: 5 },
+            models: ['test-model'],
+          },
+        },
+      })
+    );
+
+    await shaper.acquirePermit('test-provider', 'test-model');
+    const queuedRequest = shaper.acquirePermit('test-provider', 'test-model');
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/rate-limits',
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const json = response.json() as {
+      rateLimits: Array<{
+        provider: string;
+        model: string;
+        queueDepth: number;
+        currentBudget: number;
+        requestsPerMinute: number;
+        oldestWaitMs: number | null;
+        waitersCount: number;
+        timeoutCount: number;
+        dropCount: number;
+      }>;
+      summary: {
+        activeLimiters: number;
+        totalQueueDepth: number;
+        totalWaitersCount: number;
+        oldestWaitMs: number | null;
+        totalTimeoutCount: number;
+        totalDropCount: number;
+      };
+    };
+
+    const firstRateLimit = json.rateLimits[0];
+
+    expect(json.rateLimits).toHaveLength(1);
+    expect(firstRateLimit).toBeDefined();
+    expect(firstRateLimit).toMatchObject({
+      provider: 'test-provider',
+      model: 'test-model',
+      queueDepth: 1,
+      currentBudget: 0,
+      requestsPerMinute: 1,
+      waitersCount: 1,
+      timeoutCount: 0,
+      dropCount: 0,
+    });
+    expect(firstRateLimit?.oldestWaitMs).not.toBeNull();
+    expect(json.summary).toEqual({
+      activeLimiters: 1,
+      totalQueueDepth: 1,
+      totalWaitersCount: 1,
+      oldestWaitMs: json.summary.oldestWaitMs,
+      totalTimeoutCount: 0,
+      totalDropCount: 0,
+    });
+
+    shaper.releasePermit('test-provider', 'test-model');
+    await queuedRequest;
+  });
+
+  it('reports timeout and drop counters', async () => {
+    const shaper = RequestShaper.getInstance();
+    await shaper.initialize(
+      createTestConfig({
+        providers: {
+          'test-provider': {
+            api_base_url: 'https://example.com/v1',
+            api_key: 'test-key',
+            rate_limit: {
+              requests_per_minute: 1,
+              queue_depth: 1,
+              queue_timeout_ms: 50,
+            },
+            models: ['test-model'],
+          },
+        },
+      })
+    );
+
+    await shaper.acquirePermit('test-provider', 'test-model');
+    const queuedRequest = shaper.acquirePermit('test-provider', 'test-model');
+    let queueFullError: unknown;
+
+    try {
+      await shaper.acquirePermit('test-provider', 'test-model');
+    } catch (error) {
+      queueFullError = error;
+    }
+
+    expect(queueFullError).toBeInstanceOf(Error);
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    shaper.cleanupExpiredRequests();
+    await queuedRequest;
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/rate-limits',
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const json = response.json() as {
+      rateLimits: Array<{
+        queueDepth: number;
+        waitersCount: number;
+        timeoutCount: number;
+        dropCount: number;
+      }>;
+      summary: {
+        totalQueueDepth: number;
+        totalWaitersCount: number;
+        totalTimeoutCount: number;
+        totalDropCount: number;
+      };
+    };
+
+    expect(json.rateLimits[0]).toMatchObject({
+      queueDepth: 0,
+      waitersCount: 0,
+      timeoutCount: 1,
+      dropCount: 1,
+    });
+    expect(json.summary).toMatchObject({
+      totalQueueDepth: 0,
+      totalWaitersCount: 0,
+      totalTimeoutCount: 1,
+      totalDropCount: 1,
+    });
+  });
+
+  it('rejects unsupported mutation methods', async () => {
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE'] as const) {
+      const response = await fastify.inject({
+        method,
+        url: '/v0/management/rate-limits',
+      });
+
+      expect(response.statusCode).toBeGreaterThanOrEqual(400);
+    }
+  });
+
+  function createTestConfig(overrides: {
+    shaper?: Partial<{
+      queueTimeoutMs: number;
+      cleanupIntervalMs: number;
+      defaultRpm: number;
+    }>;
+    providers?: Record<string, unknown>;
+  }): any {
+    return {
+      providers: overrides.providers ?? {},
+      models: {},
+      keys: {},
+      adminKey: 'test-admin-key',
+      failover: {
+        enabled: false,
+        retryableStatusCodes: [],
+        retryableErrors: [],
+      },
+      quotas: [],
+      shaper: {
+        queueTimeoutMs: 30000,
+        cleanupIntervalMs: 60000,
+        defaultRpm: 60,
+        ...overrides.shaper,
+      },
+    };
+  }
+});

--- a/packages/backend/src/routes/management/rate-limits.ts
+++ b/packages/backend/src/routes/management/rate-limits.ts
@@ -1,0 +1,200 @@
+import { FastifyInstance } from 'fastify';
+import { RequestShaper } from '../../services/request-shaper';
+import { logger } from '../../utils/logger';
+
+/**
+ * Rate limit status read model for shaper observability.
+ * Provides read-only access to rate-limit state, queue depth, waiters, and timeout counters.
+ */
+
+interface RateLimitStatus {
+  provider: string;
+  model: string;
+  queueDepth: number;
+  currentBudget: number;
+  requestsPerMinute: number;
+  oldestWaitMs: number | null;
+  waitersCount: number;
+  timeoutCount: number;
+  dropCount: number;
+}
+
+interface RateLimitSummary {
+  activeLimiters: number;
+  totalQueueDepth: number;
+  totalWaitersCount: number;
+  oldestWaitMs: number | null;
+  totalTimeoutCount: number;
+  totalDropCount: number;
+}
+
+interface RateLimitsResponse {
+  rateLimits: RateLimitStatus[];
+  summary: RateLimitSummary;
+  timestamp: string;
+}
+
+export const rateLimitStatusSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'provider',
+    'model',
+    'queueDepth',
+    'currentBudget',
+    'requestsPerMinute',
+    'oldestWaitMs',
+    'waitersCount',
+    'timeoutCount',
+    'dropCount',
+  ],
+  properties: {
+    provider: { type: 'string' },
+    model: { type: 'string' },
+    queueDepth: { type: 'number' },
+    currentBudget: { type: 'number' },
+    requestsPerMinute: { type: 'number' },
+    oldestWaitMs: { anyOf: [{ type: 'number' }, { type: 'null' }] },
+    waitersCount: { type: 'number' },
+    timeoutCount: { type: 'number' },
+    dropCount: { type: 'number' },
+  },
+} as const;
+
+export const rateLimitsResponseSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['rateLimits', 'summary', 'timestamp'],
+  properties: {
+    rateLimits: {
+      type: 'array',
+      items: rateLimitStatusSchema,
+    },
+    summary: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'activeLimiters',
+        'totalQueueDepth',
+        'totalWaitersCount',
+        'oldestWaitMs',
+        'totalTimeoutCount',
+        'totalDropCount',
+      ],
+      properties: {
+        activeLimiters: { type: 'number' },
+        totalQueueDepth: { type: 'number' },
+        totalWaitersCount: { type: 'number' },
+        oldestWaitMs: { anyOf: [{ type: 'number' }, { type: 'null' }] },
+        totalTimeoutCount: { type: 'number' },
+        totalDropCount: { type: 'number' },
+      },
+    },
+    timestamp: { type: 'string' },
+  },
+} as const;
+
+const rateLimitsErrorSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['error'],
+  properties: {
+    error: { type: 'string' },
+  },
+} as const;
+
+function buildEmptyRateLimitsResponse(): RateLimitsResponse {
+  return {
+    rateLimits: [],
+    summary: {
+      activeLimiters: 0,
+      totalQueueDepth: 0,
+      totalWaitersCount: 0,
+      oldestWaitMs: null,
+      totalTimeoutCount: 0,
+      totalDropCount: 0,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function buildRateLimitsResponse(): RateLimitsResponse {
+  const shaper = RequestShaper.getInstance();
+  const status = shaper.getAllStatus();
+
+  if (status.targets.length === 0) {
+    return buildEmptyRateLimitsResponse();
+  }
+
+  const rateLimits: RateLimitStatus[] = status.targets.map((target) => ({
+    provider: target.provider,
+    model: target.model,
+    queueDepth: target.currentQueueDepth,
+    currentBudget: target.currentBudget,
+    requestsPerMinute: target.requestsPerMinute,
+    oldestWaitMs: target.oldestWaitMs,
+    waitersCount: target.queueWaiters,
+    timeoutCount: target.timeoutCount,
+    dropCount: target.dropCount,
+  }));
+
+  const oldestWaitMs = rateLimits.reduce<number | null>((oldest, target) => {
+    if (target.oldestWaitMs === null) {
+      return oldest;
+    }
+
+    return oldest === null ? target.oldestWaitMs : Math.max(oldest, target.oldestWaitMs);
+  }, null);
+
+  return {
+    rateLimits,
+    summary: {
+      activeLimiters: rateLimits.length,
+      totalQueueDepth: rateLimits.reduce((sum, target) => sum + target.queueDepth, 0),
+      totalWaitersCount: rateLimits.reduce((sum, target) => sum + target.waitersCount, 0),
+      oldestWaitMs,
+      totalTimeoutCount: rateLimits.reduce((sum, target) => sum + target.timeoutCount, 0),
+      totalDropCount: rateLimits.reduce((sum, target) => sum + target.dropCount, 0),
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Register rate-limits management routes.
+ *
+ * @param fastify - Fastify instance
+ */
+export async function registerRateLimitRoutes(fastify: FastifyInstance) {
+  /**
+   * GET /v0/management/rate-limits
+   *
+   * Returns current rate-limit state for all configured provider/model combinations.
+   * Returns empty/zero values when no shaper state exists.
+   */
+  fastify.get(
+    '/v0/management/rate-limits',
+    {
+      schema: {
+        response: {
+          200: rateLimitsResponseSchema,
+          500: rateLimitsErrorSchema,
+        },
+      },
+    },
+    async (_request, reply) => {
+      void _request;
+
+      try {
+        const response = buildRateLimitsResponse();
+
+        logger.debug('[RateLimits API] Retrieved rate-limit status');
+        return reply.send(response);
+      } catch (error) {
+        logger.error(`[RateLimits API] Failed to get rate-limits: ${error}`);
+        reply.statusCode = 500;
+        return reply.send({ error: 'Failed to retrieve rate-limit status' });
+      }
+    }
+  );
+}


### PR DESCRIPTION
## Summary

Adds management API endpoint for viewing provider rate limit status.

## Changes
- GET /v0/rate-limits endpoint
- ShaperTargetStatus response type
- API tests

## Testing
- Format check passes

Depends on #93