### PR TITLE
feat(frontend): add rate limit config editors to Providers and Models

### DIFF
--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -182,6 +182,19 @@ export interface ProviderPerformanceData {
   last_updated: number;
 }
 
+export interface RateLimitConfig {
+  requestsPerMinute?: number;
+  queueDepth?: number;
+  queueTimeoutMs?: number;
+}
+
+export interface ProviderModelConfig {
+  pricing?: Record<string, any>;
+  access_via?: string[];
+  type?: 'chat' | 'responses' | 'embeddings' | 'transcriptions' | 'speech' | 'image';
+  rateLimit?: RateLimitConfig;
+}
+
 export interface Provider {
   id: string;
   name: string;
@@ -196,7 +209,8 @@ export interface Provider {
   discount?: number;
   headers?: Record<string, string>;
   extraBody?: Record<string, any>;
-  models?: string[] | Record<string, any>;
+  models?: string[] | Record<string, ProviderModelConfig>;
+  rateLimit?: RateLimitConfig;
   quotaChecker?: {
     type?: string;
     enabled: boolean;
@@ -244,6 +258,119 @@ export interface Model {
   providerId: string;
   pricingSource?: string;
   type?: 'chat' | 'embeddings' | 'transcriptions' | 'speech' | 'image' | 'responses';
+  rateLimit?: RateLimitConfig;
+}
+
+export interface ShaperRateLimitStatus {
+  provider: string;
+  model: string;
+  queueDepth: number;
+  currentBudget: number;
+  requestsPerMinute: number;
+  oldestWaitMs: number | null;
+  waitersCount: number;
+  timeoutCount: number;
+  dropCount: number;
+}
+
+export interface ShaperRateLimitSummary {
+  activeLimiters: number;
+  totalQueueDepth: number;
+  totalWaitersCount: number;
+  oldestWaitMs: number | null;
+  totalTimeoutCount: number;
+  totalDropCount: number;
+}
+
+export interface ShaperRateLimitsResponse {
+  rateLimits: ShaperRateLimitStatus[];
+  summary: ShaperRateLimitSummary;
+  timestamp: string;
+}
+
+function normalizeRateLimitConfig(rateLimit?: any): RateLimitConfig | undefined {
+  if (!rateLimit || typeof rateLimit !== 'object') return undefined;
+
+  return {
+    requestsPerMinute:
+      typeof rateLimit.requests_per_minute === 'number' ? rateLimit.requests_per_minute : undefined,
+    queueDepth: typeof rateLimit.queue_depth === 'number' ? rateLimit.queue_depth : undefined,
+    queueTimeoutMs:
+      typeof rateLimit.queue_timeout_ms === 'number' ? rateLimit.queue_timeout_ms : undefined,
+  };
+}
+
+function serializeRateLimitConfig(rateLimit?: RateLimitConfig): Record<string, number> | undefined {
+  if (!rateLimit) return undefined;
+
+  const serialized: Record<string, number> = {};
+
+  if (
+    typeof rateLimit.requestsPerMinute === 'number' &&
+    Number.isFinite(rateLimit.requestsPerMinute)
+  ) {
+    serialized.requests_per_minute = rateLimit.requestsPerMinute;
+  }
+  if (typeof rateLimit.queueDepth === 'number' && Number.isFinite(rateLimit.queueDepth)) {
+    serialized.queue_depth = rateLimit.queueDepth;
+  }
+  if (typeof rateLimit.queueTimeoutMs === 'number' && Number.isFinite(rateLimit.queueTimeoutMs)) {
+    serialized.queue_timeout_ms = rateLimit.queueTimeoutMs;
+  }
+
+  return Object.keys(serialized).length > 0 ? serialized : undefined;
+}
+
+function normalizeProviderModels(
+  models?: string[] | Record<string, any>
+): Record<string, ProviderModelConfig> | undefined {
+  if (!models) return undefined;
+
+  if (Array.isArray(models)) {
+    return models.reduce(
+      (acc, modelName) => {
+        acc[modelName] = {};
+        return acc;
+      },
+      {} as Record<string, ProviderModelConfig>
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(models).map(([modelName, modelConfig]) => [
+      modelName,
+      {
+        ...modelConfig,
+        rateLimit: normalizeRateLimitConfig(modelConfig?.rate_limit),
+      },
+    ])
+  );
+}
+
+function serializeProviderModels(
+  models?: string[] | Record<string, ProviderModelConfig>
+): Record<string, any> | undefined {
+  if (!models) return undefined;
+
+  if (Array.isArray(models)) {
+    return models.reduce(
+      (acc, modelName) => {
+        acc[modelName] = {};
+        return acc;
+      },
+      {} as Record<string, any>
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(models).map(([modelName, modelConfig]) => [
+      modelName,
+      {
+        ...modelConfig,
+        rate_limit: serializeRateLimitConfig(modelConfig?.rateLimit),
+      },
+    ])
+  );
 }
 
 // ─── Alias advanced behaviors ────────────────────────────────
@@ -636,7 +763,9 @@ const formatBucketLabel = (range: 'hour' | 'day' | 'week' | 'month', date: Date)
 };
 
 const buildSummarySeries = (summary: UsageSummaryResponse, now: Date): UsageData[] => {
-  const { buckets, step } = getUsageRangeConfig(summary.range, now);
+  const normalizedRange: 'hour' | 'day' | 'week' | 'month' =
+    summary.range === 'custom' ? 'day' : summary.range;
+  const { buckets, step } = getUsageRangeConfig(normalizedRange, now);
   const grouped: Record<string, UsageData> = {};
   const stepMs = step;
   const alignedNowMs = Math.floor(now.getTime() / stepMs) * stepMs;
@@ -646,7 +775,7 @@ const buildSummarySeries = (summary: UsageSummaryResponse, now: Date): UsageData
   for (let i = 0; i <= buckets; i++) {
     const bucketStartMs = startMs + i * stepMs;
     const bucketDate = new Date(bucketStartMs);
-    const label = formatBucketLabel(summary.range, bucketDate);
+    const label = formatBucketLabel(normalizedRange, bucketDate);
     const point = byBucket.get(bucketStartMs);
     const inputTokens = point?.inputTokens || 0;
     const outputTokens = point?.outputTokens || 0;
@@ -803,6 +932,11 @@ interface PlexusConfig {
       discount?: number;
       headers?: Record<string, string>;
       extraBody?: Record<string, any>;
+      rate_limit?: {
+        requests_per_minute?: number;
+        queue_depth?: number;
+        queue_timeout_ms?: number;
+      };
       quota_checker?: {
         type?: string;
         enabled?: boolean;
@@ -1505,17 +1639,7 @@ export const api = {
       if (!config.providers) return [];
 
       return Object.entries(config.providers).map(([key, val]) => {
-        // Normalize models array format to object format
-        let normalizedModels = val.models;
-        if (Array.isArray(val.models)) {
-          normalizedModels = val.models.reduce(
-            (acc, modelName) => {
-              acc[modelName] = {};
-              return acc;
-            },
-            {} as Record<string, any>
-          );
-        }
+        const normalizedModels = normalizeProviderModels(val.models);
 
         // Infer type from api_base_url if not explicitly provided
         const inferredTypes = val.type || inferProviderTypes(val.api_base_url);
@@ -1535,6 +1659,7 @@ export const api = {
           headers: val.headers,
           extraBody: val.extraBody,
           models: normalizedModels,
+          rateLimit: normalizeRateLimitConfig(val.rate_limit),
           quotaChecker: normalizeProviderQuotaChecker(val.quota_checker),
         };
       });
@@ -1579,7 +1704,8 @@ export const api = {
         disable_cooldown: p.disableCooldown === true ? true : undefined,
         headers: p.headers,
         extraBody: p.extraBody,
-        models: p.models,
+        models: serializeProviderModels(p.models),
+        rate_limit: serializeRateLimitConfig(p.rateLimit),
         quota_checker: p.quotaChecker?.type
           ? {
               type: p.quotaChecker.type,
@@ -1633,7 +1759,8 @@ export const api = {
       discount: provider.discount,
       headers: provider.headers,
       extraBody: provider.extraBody,
-      models: provider.models,
+      models: serializeProviderModels(provider.models),
+      rate_limit: serializeRateLimitConfig(provider.rateLimit),
       enabled: provider.enabled,
       quota_checker: provider.quotaChecker?.type
         ? {
@@ -1782,6 +1909,7 @@ export const api = {
                   providerId: pKey,
                   pricingSource: mVal.pricing?.source,
                   type: mVal.type,
+                  rateLimit: normalizeRateLimitConfig(mVal.rate_limit),
                 });
               });
             }
@@ -1849,6 +1977,17 @@ export const api = {
       console.error('API Error getAliases', e);
       return [];
     }
+  },
+
+  getRateLimits: async (): Promise<ShaperRateLimitsResponse> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/rate-limits`);
+    if (!res.ok) throw new Error('Failed to fetch request shaper status');
+
+    const data = (await res.json()) as ShaperRateLimitsResponse;
+    return {
+      ...data,
+      timestamp: toIsoString(data.timestamp) ?? new Date(0).toISOString(),
+    };
   },
 
   getDebugLogs: async (

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -2,12 +2,14 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { api, Alias, AliasMetadata, AliasBehavior, Provider, Model } from '../lib/api';
 import { useModels } from '../hooks/useModels';
+import { formatDuration } from '../lib/format';
 import { AliasTableRow } from '../components/models/AliasTableRow';
 import { Input } from '../components/ui/Input';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
 import { Switch } from '../components/ui/Switch';
+import { Tooltip } from '../components/ui/Tooltip';
 import {
   Search,
   Plus,
@@ -23,6 +25,7 @@ import {
   GripVertical,
   Save,
   Eye,
+  Info,
 } from 'lucide-react';
 
 export const Models = () => {
@@ -188,6 +191,34 @@ export const Models = () => {
     const newTargets = [...editingAlias.targets];
     newTargets.splice(index, 1);
     setEditingAlias({ ...editingAlias, targets: newTargets });
+  };
+
+  const describeTrafficLimit = (providerId: string, modelId: string) => {
+    const provider = providers.find((entry) => entry.id === providerId);
+    if (!provider || !modelId || !provider.models || Array.isArray(provider.models)) return null;
+
+    const modelConfig = provider.models[modelId];
+    const effectiveRateLimit = modelConfig?.rateLimit ?? provider.rateLimit;
+    if (!effectiveRateLimit?.requestsPerMinute) return null;
+
+    const parts = [`${effectiveRateLimit.requestsPerMinute} request(s) each minute`];
+
+    if (effectiveRateLimit.queueDepth) {
+      parts.push(`${effectiveRateLimit.queueDepth} can wait in line`);
+    }
+
+    if (effectiveRateLimit.queueTimeoutMs) {
+      parts.push(
+        `waiting up to ${formatDuration(Math.round(effectiveRateLimit.queueTimeoutMs / 1000))}`
+      );
+    }
+
+    return {
+      source: modelConfig?.rateLimit
+        ? 'This target has its own traffic limit.'
+        : 'This target uses the provider default traffic limit.',
+      summary: parts.join(' - '),
+    };
   };
 
   const handleOpenAutoAdd = () => {
@@ -934,6 +965,7 @@ export const Models = () => {
               {editingAlias.targets.map((target, idx) => {
                 const isDragging = dragSourceIndex === idx;
                 const isDragOver = dragOverIndex === idx && !isDragging;
+                const trafficLimit = describeTrafficLimit(target.provider, target.model);
 
                 return (
                   <div
@@ -945,9 +977,10 @@ export const Models = () => {
                     onDrop={(e) => handleDrop(e, idx)}
                     style={{
                       display: 'flex',
+                      flexDirection: 'column',
                       gap: '6px',
-                      alignItems: 'center',
-                      padding: '4px 8px',
+                      alignItems: 'stretch',
+                      padding: '6px 8px',
                       backgroundColor: isDragging
                         ? 'transparent'
                         : isDragOver
@@ -986,121 +1019,151 @@ export const Models = () => {
                         }}
                       />
                     )}
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '4px',
-                        color: 'var(--color-text-secondary)',
-                        opacity: 0.8,
-                        marginRight: '4px',
-                        visibility: isDragging ? 'hidden' : 'visible',
-                      }}
-                    >
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          moveTarget(idx, 'up');
-                        }}
-                        disabled={idx === 0}
-                        className="hover:scale-110 hover:text-primary disabled:opacity-30 disabled:hover:scale-100 transition-all duration-200"
+                    <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                      <div
                         style={{
-                          background: 'none',
-                          border: 'none',
-                          padding: '4px',
-                          cursor: idx === 0 ? 'default' : 'pointer',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '4px',
+                          color: 'var(--color-text-secondary)',
+                          opacity: 0.8,
+                          marginRight: '4px',
+                          visibility: isDragging ? 'hidden' : 'visible',
                         }}
-                        title="Move Up"
                       >
-                        <ChevronUp size={16} />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          moveTarget(idx, 'down');
-                        }}
-                        disabled={idx === editingAlias.targets.length - 1}
-                        className="hover:scale-110 hover:text-primary disabled:opacity-30 disabled:hover:scale-100 transition-all duration-200"
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            moveTarget(idx, 'up');
+                          }}
+                          disabled={idx === 0}
+                          className="hover:scale-110 hover:text-primary disabled:opacity-30 disabled:hover:scale-100 transition-all duration-200"
+                          style={{
+                            background: 'none',
+                            border: 'none',
+                            padding: '4px',
+                            cursor: idx === 0 ? 'default' : 'pointer',
+                          }}
+                          title="Move Up"
+                        >
+                          <ChevronUp size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            moveTarget(idx, 'down');
+                          }}
+                          disabled={idx === editingAlias.targets.length - 1}
+                          className="hover:scale-110 hover:text-primary disabled:opacity-30 disabled:hover:scale-100 transition-all duration-200"
+                          style={{
+                            background: 'none',
+                            border: 'none',
+                            padding: '4px',
+                            cursor: idx === editingAlias.targets.length - 1 ? 'default' : 'pointer',
+                          }}
+                          title="Move Down"
+                        >
+                          <ChevronDown size={16} />
+                        </button>
+                      </div>
+                      <div
                         style={{
-                          background: 'none',
-                          border: 'none',
-                          padding: '4px',
-                          cursor: idx === editingAlias.targets.length - 1 ? 'default' : 'pointer',
+                          cursor: 'grab',
+                          color: 'var(--color-text-secondary)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          visibility: isDragging ? 'hidden' : 'visible',
                         }}
-                        title="Move Down"
                       >
-                        <ChevronDown size={16} />
-                      </button>
-                    </div>
-                    <div
-                      style={{
-                        cursor: 'grab',
-                        color: 'var(--color-text-secondary)',
-                        display: 'flex',
-                        alignItems: 'center',
-                        visibility: isDragging ? 'hidden' : 'visible',
-                      }}
-                    >
-                      <GripVertical size={16} />
-                    </div>
-                    <div
-                      style={{
-                        flex: '0 0 120px',
-                        maxWidth: '120px',
-                        visibility: isDragging ? 'hidden' : 'visible',
-                      }}
-                    >
-                      <select
-                        className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                        style={{ padding: '4px 8px', height: '28px' }}
-                        value={target.provider}
-                        onChange={(e) => updateTarget(idx, 'provider', e.target.value)}
+                        <GripVertical size={16} />
+                      </div>
+                      <div
+                        style={{
+                          flex: '0 0 120px',
+                          maxWidth: '120px',
+                          visibility: isDragging ? 'hidden' : 'visible',
+                        }}
                       >
-                        <option value="">Select Provider...</option>
-                        {providers.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.name}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div style={{ flex: 1, visibility: isDragging ? 'hidden' : 'visible' }}>
-                      <select
-                        className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                        style={{ padding: '4px 8px', height: '28px' }}
-                        value={target.model}
-                        onChange={(e) => updateTarget(idx, 'model', e.target.value)}
-                        disabled={!target.provider}
-                      >
-                        <option value="">Select Model...</option>
-                        {availableModels
-                          .filter((m) => m.providerId === target.provider)
-                          .map((m) => (
-                            <option key={m.id} value={m.id}>
-                              {m.name}
+                        <select
+                          className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                          style={{ padding: '4px 8px', height: '28px' }}
+                          value={target.provider}
+                          onChange={(e) => updateTarget(idx, 'provider', e.target.value)}
+                        >
+                          <option value="">Select Provider...</option>
+                          {providers.map((p) => (
+                            <option key={p.id} value={p.id}>
+                              {p.name}
                             </option>
                           ))}
-                      </select>
+                        </select>
+                      </div>
+                      <div style={{ flex: 1, visibility: isDragging ? 'hidden' : 'visible' }}>
+                        <select
+                          className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                          style={{ padding: '4px 8px', height: '28px' }}
+                          value={target.model}
+                          onChange={(e) => updateTarget(idx, 'model', e.target.value)}
+                          disabled={!target.provider}
+                        >
+                          <option value="">Select Model...</option>
+                          {availableModels
+                            .filter((m) => m.providerId === target.provider)
+                            .map((m) => (
+                              <option key={m.id} value={m.id}>
+                                {m.name}
+                              </option>
+                            ))}
+                        </select>
+                      </div>
+                      <div style={{ visibility: isDragging ? 'hidden' : 'visible' }}>
+                        <Switch
+                          checked={target.enabled !== false}
+                          onChange={(val) => updateTarget(idx, 'enabled', val)}
+                          size="sm"
+                        />
+                      </div>
+                      <div style={{ visibility: isDragging ? 'hidden' : 'visible' }}>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => removeTarget(idx)}
+                          style={{
+                            color: 'var(--color-danger)',
+                            padding: '4px',
+                            minHeight: 'auto',
+                          }}
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </div>
                     </div>
-                    <div style={{ visibility: isDragging ? 'hidden' : 'visible' }}>
-                      <Switch
-                        checked={target.enabled !== false}
-                        onChange={(val) => updateTarget(idx, 'enabled', val)}
-                        size="sm"
-                      />
-                    </div>
-                    <div style={{ visibility: isDragging ? 'hidden' : 'visible' }}>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => removeTarget(idx)}
-                        style={{ color: 'var(--color-danger)', padding: '4px', minHeight: 'auto' }}
+                    {trafficLimit && !isDragging && (
+                      <div
+                        className="font-body text-[11px] text-text-secondary"
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '6px',
+                          paddingLeft: '68px',
+                        }}
                       >
-                        <Trash2 size={14} />
-                      </Button>
-                    </div>
+                        <Tooltip content={trafficLimit.source} position="bottom">
+                          <span
+                            style={{
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              color: 'var(--color-primary)',
+                            }}
+                          >
+                            <Info size={12} />
+                          </span>
+                        </Tooltip>
+                        <span>Traffic limit: {trafficLimit.summary}</span>
+                      </div>
+                    )}
                   </div>
                 );
               })}

--- a/packages/frontend/src/pages/Providers.tsx
+++ b/packages/frontend/src/pages/Providers.tsx
@@ -3,6 +3,7 @@ import {
   api,
   Provider,
   OAuthSession,
+  RateLimitConfig,
   initQuotaCheckerTypes,
   getQuotaCheckerTypes,
 } from '../lib/api';
@@ -150,6 +151,24 @@ const EMPTY_PROVIDER: Provider = {
   headers: {},
   extraBody: {},
   models: {},
+};
+
+const updateRateLimitField = (
+  current: RateLimitConfig | undefined,
+  field: keyof RateLimitConfig,
+  rawValue: string,
+  multiplier: number = 1
+): RateLimitConfig | undefined => {
+  const next = { ...(current || {}) };
+
+  if (rawValue.trim() === '') {
+    delete next[field];
+  } else {
+    const parsed = Math.max(1, parseInt(rawValue, 10) || 1) * multiplier;
+    next[field] = parsed;
+  }
+
+  return Object.keys(next).length > 0 ? next : undefined;
 };
 
 interface FetchedModel {
@@ -749,6 +768,25 @@ export const Providers = () => {
   const updateModelConfig = (modelId: string, updates: any) => {
     const models = { ...(editingProvider.models as Record<string, any>) };
     models[modelId] = { ...models[modelId], ...updates };
+    setEditingProvider({ ...editingProvider, models });
+  };
+
+  const updateProviderRateLimit = (field: keyof RateLimitConfig, value: string) => {
+    setEditingProvider({
+      ...editingProvider,
+      rateLimit: updateRateLimitField(editingProvider.rateLimit, field, value),
+    });
+  };
+
+  const updateModelRateLimit = (modelId: string, field: keyof RateLimitConfig, value: string) => {
+    const models = { ...(editingProvider.models as Record<string, any>) };
+    const currentModel = models[modelId] || {};
+
+    models[modelId] = {
+      ...currentModel,
+      rateLimit: updateRateLimitField(currentModel.rateLimit, field, value),
+    };
+
     setEditingProvider({ ...editingProvider, models });
   };
 
@@ -1436,6 +1474,59 @@ export const Providers = () => {
                   )}
                 </div>
               )}
+            </div>
+
+            <div className="flex flex-col gap-1 border border-border-glass rounded-md p-3 bg-bg-subtle">
+              <label className="font-body text-[13px] font-medium text-text-secondary">
+                Traffic Limits (Provider Defaults)
+              </label>
+              <div className="text-[11px] text-text-secondary italic mt-1">
+                Use these only for slower providers. Plexus will spread requests over time instead
+                of sending too many at once. Model-specific settings below win when both are set.
+              </div>
+              <div className="grid gap-3 grid-cols-3 mt-3">
+                <Input
+                  label="Requests allowed each minute"
+                  type="number"
+                  min={1}
+                  step={1}
+                  placeholder="leave blank for none"
+                  value={editingProvider.rateLimit?.requestsPerMinute ?? ''}
+                  onChange={(e) => updateProviderRateLimit('requestsPerMinute', e.target.value)}
+                />
+                <Input
+                  label="How many can wait in line"
+                  type="number"
+                  min={1}
+                  step={1}
+                  placeholder="leave blank for default"
+                  value={editingProvider.rateLimit?.queueDepth ?? ''}
+                  onChange={(e) => updateProviderRateLimit('queueDepth', e.target.value)}
+                />
+                <Input
+                  label="How long one can wait in line (seconds)"
+                  type="number"
+                  min={1}
+                  step={1}
+                  placeholder="30"
+                  value={
+                    editingProvider.rateLimit?.queueTimeoutMs
+                      ? Math.round(editingProvider.rateLimit.queueTimeoutMs / 1000)
+                      : ''
+                  }
+                  onChange={(e) =>
+                    setEditingProvider({
+                      ...editingProvider,
+                      rateLimit: updateRateLimitField(
+                        editingProvider.rateLimit,
+                        'queueTimeoutMs',
+                        e.target.value,
+                        1000
+                      ),
+                    })
+                  }
+                />
+              </div>
             </div>
 
             {/* Right: Quota Checker */}
@@ -2297,6 +2388,71 @@ export const Providers = () => {
                                   <option value="defined">Ranges (Complex)</option>
                                   <option value="per_request">Per Request (Flat Fee)</option>
                                 </select>
+                              </div>
+                              <div
+                                className="grid gap-4 grid-cols-3"
+                                style={{
+                                  background: 'var(--color-bg-subtle)',
+                                  padding: '12px',
+                                  borderRadius: 'var(--radius-sm)',
+                                }}
+                              >
+                                <Input
+                                  label="Requests allowed each minute"
+                                  type="number"
+                                  min={1}
+                                  step={1}
+                                  placeholder={
+                                    editingProvider.rateLimit?.requestsPerMinute
+                                      ? 'uses provider default'
+                                      : 'leave blank for none'
+                                  }
+                                  value={mCfg.rateLimit?.requestsPerMinute ?? ''}
+                                  onChange={(e) =>
+                                    updateModelRateLimit(mId, 'requestsPerMinute', e.target.value)
+                                  }
+                                />
+                                <Input
+                                  label="How many can wait in line"
+                                  type="number"
+                                  min={1}
+                                  step={1}
+                                  placeholder={
+                                    editingProvider.rateLimit?.queueDepth
+                                      ? 'uses provider default'
+                                      : 'leave blank for default'
+                                  }
+                                  value={mCfg.rateLimit?.queueDepth ?? ''}
+                                  onChange={(e) =>
+                                    updateModelRateLimit(mId, 'queueDepth', e.target.value)
+                                  }
+                                />
+                                <Input
+                                  label="How long one can wait in line (seconds)"
+                                  type="number"
+                                  min={1}
+                                  step={1}
+                                  placeholder={
+                                    editingProvider.rateLimit?.queueTimeoutMs
+                                      ? 'uses provider default'
+                                      : '30'
+                                  }
+                                  value={
+                                    mCfg.rateLimit?.queueTimeoutMs
+                                      ? Math.round(mCfg.rateLimit.queueTimeoutMs / 1000)
+                                      : ''
+                                  }
+                                  onChange={(e) =>
+                                    updateModelConfig(mId, {
+                                      rateLimit: updateRateLimitField(
+                                        mCfg.rateLimit,
+                                        'queueTimeoutMs',
+                                        e.target.value,
+                                        1000
+                                      ),
+                                    })
+                                  }
+                                />
                               </div>
                               {mCfg.type !== 'embeddings' &&
                                 mCfg.type !== 'transcriptions' &&


### PR DESCRIPTION
## Summary

Adds UI controls for configuring provider rate limits in the frontend.

## Changes
- Rate limiting section in provider/model edit modals
- RPM, queue depth, and timeout inputs
- Validation and help text

## Testing
- Format check passes

Depends on #94