### PR TITLE
Copilot/fix 401 error providers page

### DIFF
--- a/packages/backend/src/routes/management.ts
+++ b/packages/backend/src/routes/management.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { getConfig } from '../config';
+import { getConfig, VALID_QUOTA_CHECKER_TYPES } from '../config';
 import { logger } from '../utils/logger';
 import { UsageStorageService } from '../services/usage-storage';
 import { registerConfigRoutes } from './management/config';
@@ -54,6 +54,15 @@ export async function registerManagementRoutes(
       return reply.send({ ok: true });
     }
   );
+
+  // Public endpoint - no auth required; the Providers page fetches this before
+  // the user has entered an admin key, so it must not be inside the protected scope.
+  fastify.get('/v0/management/quota-checker-types', async (_request, reply) => {
+    return reply.send({
+      types: VALID_QUOTA_CHECKER_TYPES,
+      count: VALID_QUOTA_CHECKER_TYPES.length,
+    });
+  });
 
   // All other management routes are protected by the same admin key hook,
   // scoped inside this plugin so the v1 bearer-auth routes are unaffected.

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import yaml from 'yaml';
 import { logger } from '../../utils/logger';
-import { getConfigPath, validateConfig, loadConfig, VALID_QUOTA_CHECKER_TYPES } from '../../config';
+import { getConfigPath, validateConfig, loadConfig } from '../../config';
 
 export async function registerConfigRoutes(fastify: FastifyInstance) {
   fastify.get('/v0/management/config', async (request, reply) => {
@@ -362,14 +362,6 @@ export async function registerConfigRoutes(fastify: FastifyInstance) {
       logger.error(`Failed to delete MCP server '${serverName}'`, e);
       return reply.code(500).send({ error: e.message });
     }
-  });
-
-  // Quota checker types endpoint - single source of truth
-  fastify.get('/v0/management/quota-checker-types', async (_request, reply) => {
-    return reply.send({
-      types: VALID_QUOTA_CHECKER_TYPES,
-      count: VALID_QUOTA_CHECKER_TYPES.length,
-    });
   });
 
   // Restart endpoint - exits the process, relying on process manager to restart


### PR DESCRIPTION
When visiting providers page, it tries to call /v0/management/quota-checker-types which results in 401 unauthorized. This fixes the issue.