### PR TITLE
fix(quota): show weekly input tokens for NanoGPT

### DIFF
--- a/packages/frontend/src/components/quota/CompactQuotasCard.tsx
+++ b/packages/frontend/src/components/quota/CompactQuotasCard.tsx
@@ -154,7 +154,7 @@ const getTrackedWindowsForChecker = (category: string, windows: any[]): string[]
     case 'zai':
       return ['five_hour', 'monthly'].filter((t) => availableTypes.has(t));
     case 'nanogpt':
-      return ['daily', 'monthly'].filter((t) => availableTypes.has(t));
+      return ['weekly', 'monthly'].filter((t) => availableTypes.has(t));
     case 'naga':
       return Array.from(availableTypes)
         .filter((t) => t !== 'subscription')

--- a/packages/frontend/src/components/quota/NanoGPTQuotaDisplay.tsx
+++ b/packages/frontend/src/components/quota/NanoGPTQuotaDisplay.tsx
@@ -27,7 +27,7 @@ export const NanoGPTQuotaDisplay: React.FC<NanoGPTQuotaDisplayProps> = ({
   }
 
   const windows = result.windows || [];
-  const dailyWindow = windows.find((window) => window.windowType === 'daily');
+  const weeklyWindow = windows.find((window) => window.windowType === 'weekly');
   const monthlyWindow = windows.find((window) => window.windowType === 'monthly');
 
   const statusRank: Record<string, number> = {
@@ -73,13 +73,13 @@ export const NanoGPTQuotaDisplay: React.FC<NanoGPTQuotaDisplayProps> = ({
         <span className="text-xs font-semibold text-text whitespace-nowrap">NanoGPT</span>
       </div>
 
-      {dailyWindow && (
+      {weeklyWindow && (
         <div className="space-y-1">
           <div className="flex items-baseline gap-2">
-            <span className="text-xs font-semibold text-text-secondary">Daily</span>
-            {dailyWindow.resetInSeconds !== undefined && dailyWindow.resetInSeconds !== null && (
+            <span className="text-xs font-semibold text-text-secondary">Weekly</span>
+            {weeklyWindow.resetInSeconds !== undefined && weeklyWindow.resetInSeconds !== null && (
               <span className="text-[10px] text-text-muted">
-                {formatDuration(dailyWindow.resetInSeconds)}
+                {formatDuration(weeklyWindow.resetInSeconds)}
               </span>
             )}
           </div>
@@ -88,13 +88,13 @@ export const NanoGPTQuotaDisplay: React.FC<NanoGPTQuotaDisplayProps> = ({
               <div
                 className={clsx(
                   'h-full rounded-md transition-all duration-500 ease-out',
-                  barColorForStatus(dailyWindow.status)
+                  barColorForStatus(weeklyWindow.status)
                 )}
-                style={{ width: `${Math.min(100, Math.max(0, dailyWindow.utilizationPercent))}%` }}
+                style={{ width: `${Math.min(100, Math.max(0, weeklyWindow.utilizationPercent))}%` }}
               />
             </div>
             <div className="absolute inset-y-0 right-0 flex items-center text-[10px] font-semibold text-cyan-400">
-              {Math.round(dailyWindow.utilizationPercent)}%
+              {Math.round(weeklyWindow.utilizationPercent)}%
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Updates the NanoGPT quota display to show **weekly input token usage** instead of daily tokens.

## Background

NanoGPT recently introduced a weekly input token limit of **60M tokens** as the primary quota metric for their API. This replaces the previous daily quota structure.

## Changes

- **CompactQuotasCard.tsx**: Changed tracked window types from daily/monthly to weekly/monthly for NanoGPT
- **NanoGPTQuotaDisplay.tsx**: Updated all references from dailyWindow to weeklyWindow, including:
  - Window type filter (daily → weekly)
  - Label text (Daily → Weekly)
  - Progress bar and percentage display

## Rationale

This change aligns the UI display with the actual data structure returned by the NanoGPT quota checker. The API now provides:
- : tokens consumed in the current week (out of 60M)
- : tokens available until weekly reset
- : when the weekly window resets

Previously the UI was incorrectly showing daily tokens which didn't match the backend data or NanoGPT's current quota structure.