### PR TITLE
fix: auto-run search when opening auto-add modal

### DIFF
--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -190,20 +190,14 @@ export const Models = () => {
     setEditingAlias({ ...editingAlias, targets: newTargets });
   };
 
-  const handleOpenAutoAdd = () => {
-    setSubstring(editingAlias.id || '');
-    setFilteredModels([]);
-    setSelectedModels(new Set());
-    setIsAutoAddModalOpen(true);
-  };
-
-  const handleSearchModels = () => {
-    if (!substring.trim()) {
+  const handleSearchModels = (query?: string) => {
+    const searchTerm = query !== undefined ? query : substring;
+    if (!searchTerm.trim()) {
       setFilteredModels([]);
       return;
     }
 
-    const searchLower = substring.toLowerCase();
+    const searchLower = searchTerm.toLowerCase();
 
     const matches: Array<{ model: Model; provider: Provider }> = [];
     availableModels.forEach((model) => {
@@ -218,6 +212,16 @@ export const Models = () => {
     });
 
     setFilteredModels(matches);
+  };
+
+  const handleOpenAutoAdd = () => {
+    const query = editingAlias.id || '';
+    setSubstring(query);
+    setSelectedModels(new Set());
+    setIsAutoAddModalOpen(true);
+    // Run search immediately with the pre-filled query so results appear
+    // without requiring a manual button click (fixes #148).
+    handleSearchModels(query);
   };
 
   const handleToggleModelSelection = (modelId: string, providerId: string) => {


### PR DESCRIPTION
Fixes #148

## Problem

When clicking the auto-add target button, the modal opens with the alias ID pre-filled in the search input, but no results are shown. The user has to manually click the Search button to get results, which is not obvious.

Root cause: `handleOpenAutoAdd()` called `setSubstring()` and `setIsAutoAddModalOpen(true)` but never executed the search. Calling `handleSearchModels()` immediately after `setSubstring()` would also not work since React state updates are batched — `substring` still holds the old value at that point.

## Fix

- `handleSearchModels` now accepts an optional `query` parameter. When supplied it uses that value directly instead of reading from the (potentially stale) `substring` state. Existing callsites (Enter key, Search button) are unaffected — they still call it with no args.
- `handleOpenAutoAdd` captures the query in a local variable, sets state, then calls `handleSearchModels(query)` directly — no timing issues, no duplicated logic.
- Moved `handleSearchModels` above `handleOpenAutoAdd` so the `const` reference is valid at the call site.

## Behaviour after fix

Opening the auto-add modal immediately shows matching models for the pre-filled alias ID. The Search button and Enter key continue to work as before.