### PR TITLE
feat: Support the new Synthetic quota system

### DIFF
--- a/packages/backend/src/services/quota/checkers/__tests__/synthetic-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/synthetic-checker.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { QuotaCheckerConfig } from '../../../../types/quota';
+import { SyntheticQuotaChecker } from '../synthetic-checker';
+import { QuotaCheckerFactory } from '../../quota-checker-factory';
+
+const makeConfig = (options: Record<string, unknown> = {}): QuotaCheckerConfig => ({
+  id: 'synthetic-test',
+  provider: 'synthetic',
+  type: 'synthetic',
+  enabled: true,
+  intervalMinutes: 30,
+  options: {
+    apiKey: 'synthetic-api-key',
+    ...options,
+  },
+});
+
+describe('SyntheticQuotaChecker', () => {
+  const setFetchMock = (impl: (...args: any[]) => Promise<Response>): void => {
+    global.fetch = mock(impl) as unknown as typeof fetch;
+  };
+
+  beforeEach(() => {
+    mock.restore();
+  });
+
+  it('is registered under synthetic', () => {
+    expect(QuotaCheckerFactory.isRegistered('synthetic')).toBe(true);
+  });
+
+  it('maps rollingFiveHourLimit to rolling_five_hour window', async () => {
+    setFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          rollingFiveHourLimit: { remaining: 30, max: 100, nextTickAt: '2026-04-10T12:00:00Z' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const result = await new SyntheticQuotaChecker(makeConfig()).checkQuota();
+
+    expect(result.success).toBe(true);
+    const w = result.windows?.find((w) => w.windowType === 'rolling_five_hour');
+    expect(w).toBeDefined();
+    expect(w?.remaining).toBe(30);
+    expect(w?.limit).toBe(100);
+    expect(w?.used).toBe(70);
+    expect(w?.unit).toBe('requests');
+    expect(w?.description).toBe('Rolling 5-hour limit');
+  });
+
+  it('maps weeklyTokenLimit dollar strings to rolling_weekly window', async () => {
+    setFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          weeklyTokenLimit: {
+            maxCredits: '$50.00',
+            remainingCredits: '$20.00',
+            nextRegenAt: '2026-04-17T00:00:00Z',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const result = await new SyntheticQuotaChecker(makeConfig()).checkQuota();
+
+    expect(result.success).toBe(true);
+    const w = result.windows?.find((w) => w.windowType === 'rolling_weekly');
+    expect(w).toBeDefined();
+    expect(w?.limit).toBeCloseTo(50);
+    expect(w?.remaining).toBeCloseTo(20);
+    expect(w?.used).toBeCloseTo(30);
+    expect(w?.unit).toBe('dollars');
+    expect(w?.description).toBe('Weekly token credits');
+  });
+
+  it('handles weeklyTokenLimit with dollar-sign-less credit strings', async () => {
+    setFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          weeklyTokenLimit: { maxCredits: '100', remainingCredits: '40' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const result = await new SyntheticQuotaChecker(makeConfig()).checkQuota();
+    const w = result.windows?.find((w) => w.windowType === 'rolling_weekly');
+    expect(w?.limit).toBeCloseTo(100);
+    expect(w?.remaining).toBeCloseTo(40);
+    expect(w?.used).toBeCloseTo(60);
+  });
+
+  it('omits rolling_weekly window when credit strings are unparseable', async () => {
+    setFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          weeklyTokenLimit: { maxCredits: 'N/A', remainingCredits: 'N/A' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const result = await new SyntheticQuotaChecker(makeConfig()).checkQuota();
+    // Window is created but limit/used are undefined — treated as no useful data
+    const w = result.windows?.find((w) => w.windowType === 'rolling_weekly');
+    expect(w?.limit).toBeUndefined();
+    expect(w?.used).toBeUndefined();
+  });
+
+  it('maps search hourly window when present', async () => {
+    setFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          search: {
+            hourly: { limit: 50, requests: 10, remaining: 40, renewsAt: '2026-04-10T13:00:00Z' },
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const result = await new SyntheticQuotaChecker(makeConfig()).checkQuota();
+    const w = result.windows?.find((w) => w.windowType === 'search');
+    expect(w).toBeDefined();
+    expect(w?.limit).toBe(50);
+    expect(w?.remaining).toBe(40);
+    expect(w?.unit).toBe('requests');
+  });
+
+  it('returns success with empty windows when response has no known fields', async () => {
+    setFetchMock(async () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await new SyntheticQuotaChecker(makeConfig()).checkQuota();
+    expect(result.success).toBe(true);
+    expect(result.windows).toHaveLength(0);
+  });
+
+  it('returns error for non-200 response', async () => {
+    setFetchMock(
+      async () => new Response('unauthorized', { status: 401, statusText: 'Unauthorized' })
+    );
+
+    const result = await new SyntheticQuotaChecker(makeConfig()).checkQuota();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('HTTP 401: Unauthorized');
+  });
+
+  it('sends Authorization header with api key', async () => {
+    let capturedAuth: string | undefined;
+
+    setFetchMock(async (_input, init) => {
+      capturedAuth = new Headers(init?.headers).get('Authorization') ?? undefined;
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    await new SyntheticQuotaChecker(makeConfig()).checkQuota();
+    expect(capturedAuth).toBe('Bearer synthetic-api-key');
+  });
+});

--- a/packages/backend/src/services/quota/checkers/synthetic-checker.ts
+++ b/packages/backend/src/services/quota/checkers/synthetic-checker.ts
@@ -22,6 +22,20 @@ interface SyntheticQuotaResponse {
     remaining?: number;
     renewsAt?: string;
   };
+  weeklyTokenLimit?: {
+    nextRegenAt?: string;
+    percentRemaining?: number;
+    maxCredits?: string;
+    remainingCredits?: string;
+    nextRegenCredits?: string;
+  };
+  rollingFiveHourLimit?: {
+    nextTickAt?: string;
+    tickPercent?: number;
+    remaining?: number;
+    max?: number;
+    limited?: boolean;
+  };
 }
 
 export class SyntheticQuotaChecker extends QuotaChecker {
@@ -52,16 +66,17 @@ export class SyntheticQuotaChecker extends QuotaChecker {
       const data: SyntheticQuotaResponse = await response.json();
       const windows: QuotaWindow[] = [];
 
-      if (data.subscription) {
+      if (data.rollingFiveHourLimit) {
+        const { remaining, max, nextTickAt } = data.rollingFiveHourLimit;
         windows.push(
           this.createWindow(
-            'five_hour',
-            data.subscription.limit,
-            data.subscription.requests,
-            data.subscription.remaining,
+            'rolling_five_hour',
+            max,
+            max !== undefined && remaining !== undefined ? max - remaining : undefined,
+            remaining,
             'requests',
-            data.subscription.renewsAt ? new Date(data.subscription.renewsAt) : undefined,
-            '5-hour request quota'
+            nextTickAt ? new Date(nextTickAt) : undefined,
+            'Rolling 5-hour limit'
           )
         );
       }
@@ -80,16 +95,24 @@ export class SyntheticQuotaChecker extends QuotaChecker {
         );
       }
 
-      if (data.freeToolCalls) {
+      if (data.weeklyTokenLimit) {
+        const { maxCredits, remainingCredits, nextRegenAt } = data.weeklyTokenLimit;
+        const parseCredits = (val?: string) => {
+          if (!val) return undefined;
+          const num = parseFloat(val.replace('$', ''));
+          return isNaN(num) ? undefined : num;
+        };
         windows.push(
           this.createWindow(
-            'toolcalls',
-            data.freeToolCalls.limit,
-            data.freeToolCalls.requests,
-            data.freeToolCalls.remaining,
-            'requests',
-            data.freeToolCalls.renewsAt ? new Date(data.freeToolCalls.renewsAt) : undefined,
-            'Free tool calls (5-hour)'
+            'rolling_weekly',
+            parseCredits(maxCredits),
+            parseCredits(maxCredits) !== undefined && parseCredits(remainingCredits) !== undefined
+              ? parseCredits(maxCredits)! - parseCredits(remainingCredits)!
+              : undefined,
+            parseCredits(remainingCredits),
+            'dollars',
+            nextRegenAt ? new Date(nextRegenAt) : undefined,
+            'Weekly token credits'
           )
         );
       }

--- a/packages/backend/src/services/quota/checkers/synthetic-checker.ts
+++ b/packages/backend/src/services/quota/checkers/synthetic-checker.ts
@@ -102,14 +102,16 @@ export class SyntheticQuotaChecker extends QuotaChecker {
           const num = parseFloat(val.replace('$', ''));
           return isNaN(num) ? undefined : num;
         };
+        const parsedMax = parseCredits(maxCredits);
+        const parsedRemaining = parseCredits(remainingCredits);
         windows.push(
           this.createWindow(
             'rolling_weekly',
-            parseCredits(maxCredits),
-            parseCredits(maxCredits) !== undefined && parseCredits(remainingCredits) !== undefined
-              ? parseCredits(maxCredits)! - parseCredits(remainingCredits)!
+            parsedMax,
+            parsedMax !== undefined && parsedRemaining !== undefined
+              ? parsedMax - parsedRemaining
               : undefined,
-            parseCredits(remainingCredits),
+            parsedRemaining,
             'dollars',
             nextRegenAt ? new Date(nextRegenAt) : undefined,
             'Weekly token credits'

--- a/packages/backend/src/types/quota.ts
+++ b/packages/backend/src/types/quota.ts
@@ -2,10 +2,12 @@ export type QuotaWindowType =
   | 'subscription'
   | 'hourly'
   | 'five_hour'
+  | 'rolling_five_hour'
   | 'toolcalls'
   | 'search'
   | 'daily'
   | 'weekly'
+  | 'rolling_weekly'
   | 'monthly'
   | 'custom';
 

--- a/packages/frontend/src/components/quota/CompactQuotasCard.tsx
+++ b/packages/frontend/src/components/quota/CompactQuotasCard.tsx
@@ -26,10 +26,12 @@ interface CompactQuotasCardProps {
 // Window type priority for display order (lower = shown first)
 export const WINDOW_PRIORITY: Record<string, number> = {
   five_hour: 1,
+  rolling_five_hour: 1,
   daily: 2,
   toolcalls: 3,
   search: 4,
   weekly: 5,
+  rolling_weekly: 5,
   monthly: 6,
 };
 
@@ -162,7 +164,7 @@ export const getTrackedWindowsForChecker = (category: string, windows: any[]): s
 
   switch (category) {
     case 'synthetic':
-      return ['five_hour', 'toolcalls'].filter((t) => availableTypes.has(t));
+      return ['rolling_weekly', 'rolling_five_hour'].filter((t) => availableTypes.has(t));
     case 'claude':
     case 'codex':
       return ['five_hour', 'weekly'].filter((t) => availableTypes.has(t));

--- a/packages/frontend/src/components/quota/QuotaHistoryModal.tsx
+++ b/packages/frontend/src/components/quota/QuotaHistoryModal.tsx
@@ -95,13 +95,37 @@ export const QuotaHistoryModal: React.FC<QuotaHistoryModalProps> = ({
   // Colors for different window types
   const WINDOW_COLORS: Record<string, string> = {
     five_hour: '#3b82f6', // blue
+    rolling_five_hour: '#60a5fa', // light blue
     toolcalls: '#06b6d4', // cyan
     search: '#8b5cf6', // violet
     daily: '#10b981', // emerald
     weekly: '#a855f7', // purple
+    rolling_weekly: '#c084fc', // light purple
     monthly: '#f59e0b', // amber
     subscription: '#ec4899', // pink
     custom: '#6b7280', // gray
+  };
+
+  // Synthetic-specific display names for window types
+  const SYNTHETIC_DISPLAY_NAMES: Record<string, string> = {
+    five_hour: 'Five Hour (old)',
+    rolling_five_hour: 'Five Hour',
+    toolcalls: 'Tool Calls (old)',
+    rolling_weekly: 'Weekly',
+  };
+
+  // Check if this is a Synthetic checker
+  const isSynthetic = quota
+    ? (quota.checkerType || quota.checkerId).toLowerCase().includes('synthetic')
+    : false;
+
+  // Format window type for display
+  const formatWindowType = (windowType: string): string => {
+    const defaultName = windowType.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
+
+    if (!isSynthetic) return defaultName;
+
+    return SYNTHETIC_DISPLAY_NAMES[windowType] || defaultName;
   };
 
   // Process history data for the chart - group by window type
@@ -186,10 +210,12 @@ export const QuotaHistoryModal: React.FC<QuotaHistoryModalProps> = ({
     // Sort window types by priority
     const priorityOrder = [
       'five_hour',
+      'rolling_five_hour',
       'toolcalls',
       'search',
       'daily',
       'weekly',
+      'rolling_weekly',
       'monthly',
       'subscription',
       'custom',
@@ -461,9 +487,7 @@ export const QuotaHistoryModal: React.FC<QuotaHistoryModalProps> = ({
                                   .filter((p) => p.value !== null && p.value !== undefined)
                                   .map((p) => {
                                     const windowType = p.dataKey;
-                                    const displayName = windowType
-                                      .replace(/_/g, ' ')
-                                      .replace(/\b\w/g, (l) => l.toUpperCase());
+                                    const displayName = formatWindowType(windowType);
                                     return (
                                       <div key={windowType} className="flex items-center gap-2">
                                         <div
@@ -523,9 +547,7 @@ export const QuotaHistoryModal: React.FC<QuotaHistoryModalProps> = ({
                         strokeWidth={2}
                         fillOpacity={1}
                         fill={`url(#color${windowType})`}
-                        name={windowType
-                          .replace(/_/g, ' ')
-                          .replace(/\b\w/g, (l) => l.toUpperCase())}
+                        name={formatWindowType(windowType)}
                         connectNulls={false}
                       />
                     ))}
@@ -540,7 +562,7 @@ export const QuotaHistoryModal: React.FC<QuotaHistoryModalProps> = ({
                         style={{ backgroundColor: WINDOW_COLORS[windowType] || '#6b7280' }}
                       />
                       <span className="text-xs text-text-secondary">
-                        {windowType.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase())}
+                        {formatWindowType(windowType)}
                       </span>
                     </div>
                   ))}

--- a/packages/frontend/src/components/quota/SyntheticQuotaDisplay.tsx
+++ b/packages/frontend/src/components/quota/SyntheticQuotaDisplay.tsx
@@ -1,13 +1,80 @@
 import React from 'react';
 import { clsx } from 'clsx';
-import { Zap, AlertTriangle, CheckCircle2 } from 'lucide-react';
-import { formatDuration } from '../../lib/format';
-import type { QuotaCheckResult, QuotaStatus } from '../../types/quota';
+import { Zap, AlertTriangle, CheckCircle2, Wallet } from 'lucide-react';
+import { formatDuration, formatCost } from '../../lib/format';
+import type { QuotaCheckResult, QuotaWindow } from '../../types/quota';
 
 interface SyntheticQuotaDisplayProps {
   result: QuotaCheckResult;
   isCollapsed: boolean;
 }
+
+interface ProgressBarProps {
+  window: QuotaWindow;
+  label: string;
+  barColor: string;
+  textColor: string;
+  infoText?: string;
+  dollarCost?: number;
+  dollarLimit?: number;
+  showWalletIcon?: boolean;
+  showDollarUsedLabel?: boolean;
+}
+
+const ProgressBar: React.FC<ProgressBarProps> = ({
+  window,
+  label,
+  barColor,
+  textColor,
+  infoText,
+  dollarCost,
+  dollarLimit,
+  showWalletIcon,
+  showDollarUsedLabel,
+}) => {
+  if (!window.limit) return null;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline gap-2">
+        {showWalletIcon && <Wallet size={12} className={textColor} />}
+        <span className="text-xs font-semibold text-text-secondary">{label}</span>
+        {dollarCost !== undefined && (
+          <>
+            <span className={clsx('text-xs font-semibold', textColor)}>
+              {formatCost(dollarCost)}
+            </span>
+            {dollarLimit !== undefined && (
+              <span className="text-[10px] text-text-muted">
+                / {formatCost(dollarLimit)}
+                {showDollarUsedLabel && ' used'}
+              </span>
+            )}
+          </>
+        )}
+        {infoText && <span className="text-[10px] text-text-muted">{infoText}</span>}
+      </div>
+      <div className="relative h-2">
+        <div className="h-2 rounded-md bg-bg-hover overflow-hidden mr-7">
+          <div
+            className={clsx('h-full rounded-md transition-all duration-500 ease-out', barColor)}
+            style={{
+              width: `${Math.min(100, Math.max(0, window.utilizationPercent))}%`,
+            }}
+          />
+        </div>
+        <div
+          className={clsx(
+            'absolute inset-y-0 right-0 flex items-center text-[10px] font-semibold',
+            textColor
+          )}
+        >
+          {Math.round(window.utilizationPercent)}%
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export const SyntheticQuotaDisplay: React.FC<SyntheticQuotaDisplayProps> = ({
   result,
@@ -28,24 +95,16 @@ export const SyntheticQuotaDisplay: React.FC<SyntheticQuotaDisplayProps> = ({
 
   const windows = result.windows || [];
 
-  // Find windows by type
-  const fiveHourWindow = windows.find((w) => w.windowType === 'five_hour');
-  const toolcallsWindow = windows.find((w) => w.windowType === 'toolcalls');
+  const fiveHourWindow =
+    windows.find((w) => w.windowType === 'rolling_five_hour') ||
+    windows.find((w) => w.windowType === 'five_hour');
   const searchWindow = windows.find((w) => w.windowType === 'search');
+  const weeklyWindow =
+    windows.find((w) => w.windowType === 'rolling_weekly') ||
+    windows.find((w) => w.windowType === 'weekly');
 
-  // Get overall status (prioritize five_hour, then toolcalls, then search)
   const overallStatus =
-    fiveHourWindow?.status || toolcallsWindow?.status || searchWindow?.status || 'ok';
-
-  const statusColors: Record<QuotaStatus, string> = {
-    ok: 'bg-success',
-    warning: 'bg-warning',
-    critical: 'bg-danger',
-    exhausted: 'bg-danger',
-  };
-
-  const barColorForStatus = (status?: QuotaStatus, fallback = 'bg-emerald-400') =>
-    status ? statusColors[status] : fallback;
+    fiveHourWindow?.status || weeklyWindow?.status || searchWindow?.status || 'ok';
 
   if (isCollapsed) {
     return (
@@ -61,9 +120,19 @@ export const SyntheticQuotaDisplay: React.FC<SyntheticQuotaDisplayProps> = ({
     );
   }
 
+  const fiveHourUsed = fiveHourWindow?.used ?? 0;
+  const fiveHourLimit = fiveHourWindow?.limit ?? 0;
+  const fiveHourInfo = `${fiveHourUsed.toFixed(1)}/${fiveHourLimit.toFixed(1)} used`;
+
+  const searchUsed = searchWindow?.used ?? 0;
+  const searchLimit = searchWindow?.limit ?? 0;
+  const searchReset = searchWindow?.resetInSeconds
+    ? formatDuration(searchWindow.resetInSeconds)
+    : '?';
+  const searchInfo = `${searchUsed.toFixed(1)}/${searchLimit.toFixed(1)} used, resets in ${searchReset}`;
+
   return (
     <div className="px-2 py-1 space-y-1">
-      {/* Header */}
       <div className="flex items-center gap-2 min-w-0">
         <Zap size={14} className="text-info" />
         <span className="text-xs font-semibold text-text whitespace-nowrap">Synthetic</span>
@@ -72,73 +141,37 @@ export const SyntheticQuotaDisplay: React.FC<SyntheticQuotaDisplayProps> = ({
         )}
       </div>
 
-      {/* 5-hour request quota */}
-      {fiveHourWindow && fiveHourWindow.limit && (
-        <div className="space-y-1">
-          <div className="flex items-baseline gap-2">
-            <span className="text-xs font-semibold text-text-secondary">5h:</span>
-            <span className="text-[10px] text-text-muted">
-              {fiveHourWindow.resetInSeconds !== undefined && fiveHourWindow.resetInSeconds !== null
-                ? formatDuration(fiveHourWindow.resetInSeconds)
-                : '?'}
-            </span>
-          </div>
-          <div className="relative h-2">
-            <div className="h-2 rounded-md bg-bg-hover overflow-hidden mr-7">
-              <div
-                className={clsx(
-                  'h-full rounded-md transition-all duration-500 ease-out',
-                  barColorForStatus(fiveHourWindow.status, 'bg-emerald-400')
-                )}
-                style={{
-                  width: `${Math.min(100, Math.max(0, fiveHourWindow.utilizationPercent))}%`,
-                }}
-              />
-            </div>
-            <div className="absolute inset-y-0 right-0 flex items-center text-[10px] font-semibold text-emerald-400">
-              {Math.round(fiveHourWindow.utilizationPercent)}%
-            </div>
-          </div>
-        </div>
+      {weeklyWindow && (
+        <ProgressBar
+          window={weeklyWindow}
+          label="Weekly"
+          barColor="bg-info"
+          textColor="text-info"
+          dollarCost={weeklyWindow.used}
+          dollarLimit={weeklyWindow.limit}
+          showWalletIcon
+          showDollarUsedLabel
+        />
       )}
 
-      {(toolcallsWindow || searchWindow) && (
-        <div className="flex items-center gap-3 text-[10px] text-text-secondary">
-          {toolcallsWindow && toolcallsWindow.limit && (
-            <div className="flex items-center gap-2 flex-1 min-w-0">
-              <span className="text-text-secondary">Tool Calls</span>
-              <div className="relative flex-1 h-1.5 rounded-full bg-bg-hover overflow-hidden">
-                <div
-                  className={clsx(
-                    'absolute inset-y-0 left-0 rounded-full transition-all duration-500 ease-out',
-                    barColorForStatus(toolcallsWindow.status, 'bg-cyan-400')
-                  )}
-                  style={{
-                    width: `${Math.min(100, Math.max(0, toolcallsWindow.utilizationPercent))}%`,
-                  }}
-                />
-              </div>
-              <span className="text-text">{Math.round(toolcallsWindow.utilizationPercent)}%</span>
-            </div>
-          )}
-          {searchWindow && searchWindow.limit && (
-            <div className="flex items-center gap-2 flex-1 min-w-0">
-              <span className="text-text-secondary">Search</span>
-              <div className="relative flex-1 h-1.5 rounded-full bg-bg-hover overflow-hidden">
-                <div
-                  className={clsx(
-                    'absolute inset-y-0 left-0 rounded-full transition-all duration-500 ease-out',
-                    barColorForStatus(searchWindow.status, 'bg-violet-400')
-                  )}
-                  style={{
-                    width: `${Math.min(100, Math.max(0, searchWindow.utilizationPercent))}%`,
-                  }}
-                />
-              </div>
-              <span className="text-text">{Math.round(searchWindow.utilizationPercent)}%</span>
-            </div>
-          )}
-        </div>
+      {fiveHourWindow && (
+        <ProgressBar
+          window={fiveHourWindow}
+          label="5h"
+          barColor="bg-emerald-400"
+          textColor="text-emerald-400"
+          infoText={fiveHourInfo}
+        />
+      )}
+
+      {searchWindow && (
+        <ProgressBar
+          window={searchWindow}
+          label="Search"
+          barColor="bg-violet-400"
+          textColor="text-violet-400"
+          infoText={searchInfo}
+        />
       )}
     </div>
   );

--- a/packages/frontend/src/components/quota/SyntheticQuotaDisplay.tsx
+++ b/packages/frontend/src/components/quota/SyntheticQuotaDisplay.tsx
@@ -2,18 +2,32 @@ import React from 'react';
 import { clsx } from 'clsx';
 import { Zap, AlertTriangle, CheckCircle2, Wallet } from 'lucide-react';
 import { formatDuration, formatCost } from '../../lib/format';
-import type { QuotaCheckResult, QuotaWindow } from '../../types/quota';
+import type { QuotaCheckResult, QuotaStatus, QuotaWindow } from '../../types/quota';
 
 interface SyntheticQuotaDisplayProps {
   result: QuotaCheckResult;
   isCollapsed: boolean;
 }
 
+const STATUS_BAR_COLOR: Record<QuotaStatus, string> = {
+  ok: 'bg-success',
+  warning: 'bg-warning',
+  critical: 'bg-danger',
+  exhausted: 'bg-danger',
+};
+
+const STATUS_TEXT_COLOR: Record<QuotaStatus, string> = {
+  ok: 'text-success',
+  warning: 'text-warning',
+  critical: 'text-danger',
+  exhausted: 'text-danger',
+};
+
 interface ProgressBarProps {
   window: QuotaWindow;
   label: string;
-  barColor: string;
-  textColor: string;
+  defaultBarColor: string;
+  defaultTextColor: string;
   infoText?: string;
   dollarCost?: number;
   dollarLimit?: number;
@@ -24,14 +38,16 @@ interface ProgressBarProps {
 const ProgressBar: React.FC<ProgressBarProps> = ({
   window,
   label,
-  barColor,
-  textColor,
+  defaultBarColor,
+  defaultTextColor,
   infoText,
   dollarCost,
   dollarLimit,
   showWalletIcon,
   showDollarUsedLabel,
 }) => {
+  const barColor = window.status ? STATUS_BAR_COLOR[window.status] : defaultBarColor;
+  const textColor = window.status ? STATUS_TEXT_COLOR[window.status] : defaultTextColor;
   if (!window.limit) return null;
 
   return (
@@ -145,8 +161,8 @@ export const SyntheticQuotaDisplay: React.FC<SyntheticQuotaDisplayProps> = ({
         <ProgressBar
           window={weeklyWindow}
           label="Weekly"
-          barColor="bg-info"
-          textColor="text-info"
+          defaultBarColor="bg-info"
+          defaultTextColor="text-info"
           dollarCost={weeklyWindow.used}
           dollarLimit={weeklyWindow.limit}
           showWalletIcon
@@ -158,8 +174,8 @@ export const SyntheticQuotaDisplay: React.FC<SyntheticQuotaDisplayProps> = ({
         <ProgressBar
           window={fiveHourWindow}
           label="5h"
-          barColor="bg-emerald-400"
-          textColor="text-emerald-400"
+          defaultBarColor="bg-emerald-400"
+          defaultTextColor="text-emerald-400"
           infoText={fiveHourInfo}
         />
       )}
@@ -168,8 +184,8 @@ export const SyntheticQuotaDisplay: React.FC<SyntheticQuotaDisplayProps> = ({
         <ProgressBar
           window={searchWindow}
           label="Search"
-          barColor="bg-violet-400"
-          textColor="text-violet-400"
+          defaultBarColor="bg-violet-400"
+          defaultTextColor="text-violet-400"
           infoText={searchInfo}
         />
       )}

--- a/packages/frontend/src/types/quota.ts
+++ b/packages/frontend/src/types/quota.ts
@@ -2,10 +2,12 @@ export type QuotaWindowType =
   | 'subscription'
   | 'hourly'
   | 'five_hour'
+  | 'rolling_five_hour'
   | 'toolcalls'
   | 'search'
   | 'daily'
   | 'weekly'
+  | 'rolling_weekly'
   | 'monthly'
   | 'custom';
 


### PR DESCRIPTION
Also improve the quota card display to show more information. The quota graphs support both the new and old system, so historical data can be viewed.

<img width="1405" height="263" alt="image" src="https://github.com/user-attachments/assets/db939bcf-1a9e-44ad-aeef-e00639eb0a20" />
<img width="1160" height="906" alt="image" src="https://github.com/user-attachments/assets/8465aea2-a630-42ab-ac6f-761125b3cfea" />

fixes: https://github.com/mcowger/plexus/issues/150