### PR TITLE
feat: add metadata overrides and custom source for model aliases

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -491,7 +491,7 @@ This section defines virtual model aliases that clients use in the `model` field
   The metadata catalog is loaded at startup from:
   - OpenRouter: `https://openrouter.ai/api/v1/models`
   - models.dev: `https://models.dev/api.json`
-  - Catwalk: `https://catwalk.charm.sh/providers`
+  - Catwalk: `https://catwalk.charm.sh/v2/providers`
 
   Metadata loading is non-fatal — if a source is unavailable, Plexus continues operating and returns base model information for aliases that reference that source.
 

--- a/packages/backend/drizzle/migrations/0029_simple_skullbuster.sql
+++ b/packages/backend/drizzle/migrations/0029_simple_skullbuster.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `alias_metadata_overrides` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`alias_id` integer NOT NULL,
+	`name` text,
+	`description` text,
+	`context_length` integer,
+	`pricing_prompt` text,
+	`pricing_completion` text,
+	`pricing_input_cache_read` text,
+	`pricing_input_cache_write` text,
+	`architecture_input_modalities` text,
+	`architecture_output_modalities` text,
+	`architecture_tokenizer` text,
+	`supported_parameters` text,
+	`top_provider_context_length` integer,
+	`top_provider_max_completion_tokens` integer,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`alias_id`) REFERENCES `model_aliases`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_alias_metadata_overrides` ON `alias_metadata_overrides` (`alias_id`);--> statement-breakpoint
+ALTER TABLE `request_usage` ADD `provider_reported_cost` real;

--- a/packages/backend/drizzle/migrations/meta/0029_snapshot.json
+++ b/packages/backend/drizzle/migrations/meta/0029_snapshot.json
@@ -1,0 +1,2609 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "160da8c7-763b-45fe-8473-f8c36880012f",
+  "prevId": "29e95ea2-8d40-4c6a-a0ec-b4e884976d55",
+  "tables": {
+    "request_usage": {
+      "name": "request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            "api_key",
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            "expiry"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "columns": [
+            "provider",
+            "model"
+          ],
+          "name": "provider_cooldowns_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debug_logs": {
+      "name": "debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inference_errors": {
+      "name": "inference_errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_performance": {
+      "name": "provider_performance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            "provider",
+            "model",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_snapshots": {
+      "name": "quota_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            "checker_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            "group_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "response_items": {
+      "name": "response_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            "response_id",
+            "item_index"
+          ],
+          "isUnique": false
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "responses": {
+      "name": "responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            "previous_response_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            "server_name"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_state": {
+      "name": "quota_state",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_models": {
+      "name": "provider_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "columns": [
+            "provider_id",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_aliases": {
+      "name": "model_aliases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_alias_targets": {
+      "name": "model_alias_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "columns": [
+            "alias_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "columns": [
+            "secret"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "columns": [
+            "secret_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_settings": {
+      "name": "system_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_credentials": {
+      "name": "oauth_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/backend/drizzle/migrations/meta/_journal.json
+++ b/packages/backend/drizzle/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1776284938798,
       "tag": "0028_dapper_pestilence",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1776289140163,
+      "tag": "0029_simple_skullbuster",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/migrations_pg/0033_colossal_exiles.sql
+++ b/packages/backend/drizzle/migrations_pg/0033_colossal_exiles.sql
@@ -1,0 +1,23 @@
+ALTER TYPE "public"."metadata_source" ADD VALUE 'custom';--> statement-breakpoint
+CREATE TABLE "alias_metadata_overrides" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"alias_id" integer NOT NULL,
+	"name" text,
+	"description" text,
+	"context_length" integer,
+	"pricing_prompt" text,
+	"pricing_completion" text,
+	"pricing_input_cache_read" text,
+	"pricing_input_cache_write" text,
+	"architecture_input_modalities" jsonb,
+	"architecture_output_modalities" jsonb,
+	"architecture_tokenizer" text,
+	"supported_parameters" jsonb,
+	"top_provider_context_length" integer,
+	"top_provider_max_completion_tokens" integer,
+	"updated_at" bigint NOT NULL,
+	CONSTRAINT "uq_alias_metadata_overrides" UNIQUE("alias_id")
+);
+--> statement-breakpoint
+ALTER TABLE "request_usage" ADD COLUMN "provider_reported_cost" real;--> statement-breakpoint
+ALTER TABLE "alias_metadata_overrides" ADD CONSTRAINT "alias_metadata_overrides_alias_id_model_aliases_id_fk" FOREIGN KEY ("alias_id") REFERENCES "public"."model_aliases"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/backend/drizzle/migrations_pg/meta/0033_snapshot.json
+++ b/packages/backend/drizzle/migrations_pg/meta/0033_snapshot.json
@@ -1,0 +1,2772 @@
+{
+  "id": "7129653d-e547-4e89-bfb0-049a2ad1f0b9",
+  "prevId": "8cc6f615-7b70-4151-81b7-ff1233166e94",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.request_usage": {
+      "name": "request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            {
+              "expression": "expiry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "name": "provider_cooldowns_provider_model_pk",
+          "columns": [
+            "provider",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_errors": {
+      "name": "inference_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_performance": {
+      "name": "provider_performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_snapshots": {
+      "name": "quota_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_items": {
+      "name": "response_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.responses": {
+      "name": "responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            {
+              "expression": "previous_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            {
+              "expression": "server_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_state": {
+      "name": "quota_state",
+      "schema": "",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "quota_checker_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_models": {
+      "name": "provider_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "model_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_aliases": {
+      "name": "model_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "selector_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "alias_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "metadata_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_alias_targets": {
+      "name": "model_alias_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret"
+          ]
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "quota_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "limit_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.oauth_provider_type": {
+      "name": "oauth_provider_type",
+      "schema": "public",
+      "values": [
+        "anthropic",
+        "openai-codex",
+        "github-copilot",
+        "google-gemini-cli",
+        "google-antigravity"
+      ]
+    },
+    "public.quota_checker_type": {
+      "name": "quota_checker_type",
+      "schema": "public",
+      "values": [
+        "naga",
+        "synthetic",
+        "nanogpt",
+        "zai",
+        "moonshot",
+        "minimax",
+        "minimax-coding",
+        "openrouter",
+        "kilo",
+        "openai-codex",
+        "claude-code",
+        "kimi-code",
+        "copilot",
+        "wisdomgate",
+        "apertis",
+        "apertis-coding-plan",
+        "poe",
+        "gemini-cli",
+        "antigravity",
+        "novita",
+        "ollama"
+      ]
+    },
+    "public.model_type": {
+      "name": "model_type",
+      "schema": "public",
+      "values": [
+        "chat",
+        "embeddings",
+        "transcriptions",
+        "speech",
+        "image",
+        "responses"
+      ]
+    },
+    "public.alias_priority": {
+      "name": "alias_priority",
+      "schema": "public",
+      "values": [
+        "selector",
+        "api_match"
+      ]
+    },
+    "public.metadata_source": {
+      "name": "metadata_source",
+      "schema": "public",
+      "values": [
+        "openrouter",
+        "models.dev",
+        "catwalk",
+        "custom"
+      ]
+    },
+    "public.selector_strategy": {
+      "name": "selector_strategy",
+      "schema": "public",
+      "values": [
+        "random",
+        "in_order",
+        "cost",
+        "latency",
+        "usage",
+        "performance"
+      ]
+    },
+    "public.limit_type": {
+      "name": "limit_type",
+      "schema": "public",
+      "values": [
+        "requests",
+        "tokens",
+        "cost"
+      ]
+    },
+    "public.quota_type": {
+      "name": "quota_type",
+      "schema": "public",
+      "values": [
+        "rolling",
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/migrations_pg/meta/_journal.json
+++ b/packages/backend/drizzle/migrations_pg/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1776284939165,
       "tag": "0032_fast_lethal_legion",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1776289140510,
+      "tag": "0033_colossal_exiles",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/schema/index.ts
+++ b/packages/backend/drizzle/schema/index.ts
@@ -37,6 +37,7 @@ export * from './sqlite/providers';
 export * from './sqlite/provider-models';
 export * from './sqlite/model-aliases';
 export * from './sqlite/model-alias-targets';
+export * from './sqlite/alias-metadata-overrides';
 export * from './sqlite/api-keys';
 export * from './sqlite/user-quota-definitions';
 export * from './sqlite/mcp-servers';
@@ -47,6 +48,7 @@ export {
   providerModelsRelations,
   modelAliasesRelations,
   modelAliasTargetsRelations,
+  aliasMetadataOverridesRelations,
 } from './sqlite/config-relations';
 
 // Config tables (PostgreSQL exports)
@@ -54,6 +56,7 @@ export { providers as pgProviders } from './postgres/providers';
 export { providerModels as pgProviderModels } from './postgres/provider-models';
 export { modelAliases as pgModelAliases } from './postgres/model-aliases';
 export { modelAliasTargets as pgModelAliasTargets } from './postgres/model-alias-targets';
+export { aliasMetadataOverrides as pgAliasMetadataOverrides } from './postgres/alias-metadata-overrides';
 export { apiKeys as pgApiKeys } from './postgres/api-keys';
 export { userQuotaDefinitions as pgUserQuotaDefinitions } from './postgres/user-quota-definitions';
 export { mcpServers as pgMcpServers } from './postgres/mcp-servers';

--- a/packages/backend/drizzle/schema/postgres/alias-metadata-overrides.ts
+++ b/packages/backend/drizzle/schema/postgres/alias-metadata-overrides.ts
@@ -1,0 +1,29 @@
+import { pgTable, serial, text, integer, bigint, jsonb, unique } from 'drizzle-orm/pg-core';
+import { modelAliases } from './model-aliases';
+
+export const aliasMetadataOverrides = pgTable(
+  'alias_metadata_overrides',
+  {
+    id: serial('id').primaryKey(),
+    aliasId: integer('alias_id')
+      .notNull()
+      .references(() => modelAliases.id, { onDelete: 'cascade' }),
+    name: text('name'),
+    description: text('description'),
+    contextLength: integer('context_length'),
+    pricingPrompt: text('pricing_prompt'),
+    pricingCompletion: text('pricing_completion'),
+    pricingInputCacheRead: text('pricing_input_cache_read'),
+    pricingInputCacheWrite: text('pricing_input_cache_write'),
+    architectureInputModalities: jsonb('architecture_input_modalities'), // string[]
+    architectureOutputModalities: jsonb('architecture_output_modalities'), // string[]
+    architectureTokenizer: text('architecture_tokenizer'),
+    supportedParameters: jsonb('supported_parameters'), // string[]
+    topProviderContextLength: integer('top_provider_context_length'),
+    topProviderMaxCompletionTokens: integer('top_provider_max_completion_tokens'),
+    updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+  },
+  (table) => ({
+    aliasUnique: unique('uq_alias_metadata_overrides').on(table.aliasId),
+  })
+);

--- a/packages/backend/drizzle/schema/postgres/alias-metadata-overrides.ts
+++ b/packages/backend/drizzle/schema/postgres/alias-metadata-overrides.ts
@@ -15,10 +15,10 @@ export const aliasMetadataOverrides = pgTable(
     pricingCompletion: text('pricing_completion'),
     pricingInputCacheRead: text('pricing_input_cache_read'),
     pricingInputCacheWrite: text('pricing_input_cache_write'),
-    architectureInputModalities: jsonb('architecture_input_modalities'), // string[]
-    architectureOutputModalities: jsonb('architecture_output_modalities'), // string[]
+    architectureInputModalities: jsonb('architecture_input_modalities').$type<string[]>(),
+    architectureOutputModalities: jsonb('architecture_output_modalities').$type<string[]>(),
     architectureTokenizer: text('architecture_tokenizer'),
-    supportedParameters: jsonb('supported_parameters'), // string[]
+    supportedParameters: jsonb('supported_parameters').$type<string[]>(),
     topProviderContextLength: integer('top_provider_context_length'),
     topProviderMaxCompletionTokens: integer('top_provider_max_completion_tokens'),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),

--- a/packages/backend/drizzle/schema/postgres/index.ts
+++ b/packages/backend/drizzle/schema/postgres/index.ts
@@ -13,6 +13,7 @@ export * from './providers';
 export * from './provider-models';
 export * from './model-aliases';
 export * from './model-alias-targets';
+export * from './alias-metadata-overrides';
 export * from './api-keys';
 export * from './user-quota-definitions';
 export * from './mcp-servers';

--- a/packages/backend/drizzle/schema/postgres/model-aliases.ts
+++ b/packages/backend/drizzle/schema/postgres/model-aliases.ts
@@ -15,6 +15,7 @@ export const metadataSourceEnum = pgEnum('metadata_source', [
   'openrouter',
   'models.dev',
   'catwalk',
+  'custom',
 ]);
 
 export const modelAliases = pgTable('model_aliases', {

--- a/packages/backend/drizzle/schema/sqlite/alias-metadata-overrides.ts
+++ b/packages/backend/drizzle/schema/sqlite/alias-metadata-overrides.ts
@@ -1,0 +1,29 @@
+import { sqliteTable, integer, text, unique } from 'drizzle-orm/sqlite-core';
+import { modelAliases } from './model-aliases';
+
+export const aliasMetadataOverrides = sqliteTable(
+  'alias_metadata_overrides',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    aliasId: integer('alias_id')
+      .notNull()
+      .references(() => modelAliases.id, { onDelete: 'cascade' }),
+    name: text('name'),
+    description: text('description'),
+    contextLength: integer('context_length'),
+    pricingPrompt: text('pricing_prompt'),
+    pricingCompletion: text('pricing_completion'),
+    pricingInputCacheRead: text('pricing_input_cache_read'),
+    pricingInputCacheWrite: text('pricing_input_cache_write'),
+    architectureInputModalities: text('architecture_input_modalities'), // JSON: string[]
+    architectureOutputModalities: text('architecture_output_modalities'), // JSON: string[]
+    architectureTokenizer: text('architecture_tokenizer'),
+    supportedParameters: text('supported_parameters'), // JSON: string[]
+    topProviderContextLength: integer('top_provider_context_length'),
+    topProviderMaxCompletionTokens: integer('top_provider_max_completion_tokens'),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => ({
+    aliasUnique: unique('uq_alias_metadata_overrides').on(table.aliasId),
+  })
+);

--- a/packages/backend/drizzle/schema/sqlite/config-relations.ts
+++ b/packages/backend/drizzle/schema/sqlite/config-relations.ts
@@ -3,6 +3,7 @@ import { providers } from './providers';
 import { providerModels } from './provider-models';
 import { modelAliases } from './model-aliases';
 import { modelAliasTargets } from './model-alias-targets';
+import { aliasMetadataOverrides } from './alias-metadata-overrides';
 import { oauthCredentials } from './oauth-credentials';
 
 export const providersRelations = relations(providers, ({ many, one }) => ({
@@ -20,13 +21,24 @@ export const providerModelsRelations = relations(providerModels, ({ one }) => ({
   }),
 }));
 
-export const modelAliasesRelations = relations(modelAliases, ({ many }) => ({
+export const modelAliasesRelations = relations(modelAliases, ({ many, one }) => ({
   targets: many(modelAliasTargets),
+  metadataOverride: one(aliasMetadataOverrides, {
+    fields: [modelAliases.id],
+    references: [aliasMetadataOverrides.aliasId],
+  }),
 }));
 
 export const modelAliasTargetsRelations = relations(modelAliasTargets, ({ one }) => ({
   alias: one(modelAliases, {
     fields: [modelAliasTargets.aliasId],
+    references: [modelAliases.id],
+  }),
+}));
+
+export const aliasMetadataOverridesRelations = relations(aliasMetadataOverrides, ({ one }) => ({
+  alias: one(modelAliases, {
+    fields: [aliasMetadataOverrides.aliasId],
     references: [modelAliases.id],
   }),
 }));

--- a/packages/backend/drizzle/schema/sqlite/index.ts
+++ b/packages/backend/drizzle/schema/sqlite/index.ts
@@ -13,6 +13,7 @@ export * from './providers';
 export * from './provider-models';
 export * from './model-aliases';
 export * from './model-alias-targets';
+export * from './alias-metadata-overrides';
 export * from './api-keys';
 export * from './user-quota-definitions';
 export * from './mcp-servers';

--- a/packages/backend/drizzle/schema/sqlite/model-aliases.ts
+++ b/packages/backend/drizzle/schema/sqlite/model-aliases.ts
@@ -8,7 +8,7 @@ export const modelAliases = sqliteTable('model_aliases', {
   modelType: text('model_type'), // 'chat' | 'embeddings' | 'transcriptions' | 'speech' | 'image' | 'responses'
   additionalAliases: text('additional_aliases'), // JSON: string[]
   advanced: text('advanced'), // JSON: behavior objects array
-  metadataSource: text('metadata_source'), // 'openrouter' | 'models.dev' | 'catwalk'
+  metadataSource: text('metadata_source'), // 'openrouter' | 'models.dev' | 'catwalk' | 'custom'
   metadataSourcePath: text('metadata_source_path'),
   useImageFallthrough: integer('use_image_fallthrough').notNull().default(0),
   createdAt: integer('created_at').notNull(),

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -405,14 +405,71 @@ const ModelBehaviorSchema = z.discriminatedUnion('type', [StripAdaptiveThinkingB
 // ─── Model Metadata ──────────────────────
 // Optional reference to an external model catalog entry. When configured,
 // Plexus fetches metadata at startup and includes it in GET /v1/models.
-const ModelMetadataSchema = z.object({
-  source: z.enum(['openrouter', 'models.dev', 'catwalk']),
-  // Path within the source catalog:
-  //   openrouter:  "openai/gpt-4.1-nano"
-  //   models.dev:  "anthropic.claude-3-5-haiku-20241022"
-  //   catwalk:     "anthropic.claude-3-5-haiku-20241022"
-  source_path: z.string().min(1),
+//
+// `overrides` lets users override individual fields per alias. Overridden
+// fields win over catalog values; untouched fields still track the catalog.
+// When `source === 'custom'`, all data comes from overrides (no catalog lookup).
+const MetadataPricingOverridesSchema = z
+  .object({
+    prompt: z.string().optional(),
+    completion: z.string().optional(),
+    input_cache_read: z.string().optional(),
+    input_cache_write: z.string().optional(),
+  })
+  .partial();
+
+const MetadataArchitectureOverridesSchema = z
+  .object({
+    input_modalities: z.array(z.string()).optional(),
+    output_modalities: z.array(z.string()).optional(),
+    tokenizer: z.string().optional(),
+  })
+  .partial();
+
+const MetadataTopProviderOverridesSchema = z
+  .object({
+    context_length: z.number().int().positive().optional(),
+    max_completion_tokens: z.number().int().positive().optional(),
+  })
+  .partial();
+
+const MetadataOverridesSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().optional(),
+  context_length: z.number().int().positive().optional(),
+  pricing: MetadataPricingOverridesSchema.optional(),
+  architecture: MetadataArchitectureOverridesSchema.optional(),
+  supported_parameters: z.array(z.string()).optional(),
+  top_provider: MetadataTopProviderOverridesSchema.optional(),
 });
+
+const ModelMetadataSchema = z.discriminatedUnion('source', [
+  z.object({
+    source: z.literal('openrouter'),
+    // Path within the source catalog (e.g., "openai/gpt-4.1-nano")
+    source_path: z.string().min(1),
+    overrides: MetadataOverridesSchema.optional(),
+  }),
+  z.object({
+    source: z.literal('models.dev'),
+    // e.g., "anthropic.claude-3-5-haiku-20241022"
+    source_path: z.string().min(1),
+    overrides: MetadataOverridesSchema.optional(),
+  }),
+  z.object({
+    source: z.literal('catwalk'),
+    // e.g., "anthropic.claude-3-5-haiku-20241022"
+    source_path: z.string().min(1),
+    overrides: MetadataOverridesSchema.optional(),
+  }),
+  z.object({
+    source: z.literal('custom'),
+    // Optional free-form label; not used for any catalog lookup.
+    source_path: z.string().optional(),
+    // All metadata for custom sources lives in overrides.
+    overrides: MetadataOverridesSchema,
+  }),
+]);
 
 export const ModelConfigSchema = z.object({
   selector: z.enum(['random', 'in_order', 'cost', 'latency', 'usage', 'performance']).optional(),
@@ -428,6 +485,7 @@ export const ModelConfigSchema = z.object({
 export type ModelBehavior = z.infer<typeof ModelBehaviorSchema>;
 export type StripAdaptiveThinkingBehavior = z.infer<typeof StripAdaptiveThinkingBehaviorSchema>;
 export type ModelMetadata = z.infer<typeof ModelMetadataSchema>;
+export type MetadataOverrides = z.infer<typeof MetadataOverridesSchema>;
 
 export const KeyConfigSchema = z.object({
   secret: z.string(),

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -466,8 +466,11 @@ const ModelMetadataSchema = z.discriminatedUnion('source', [
     source: z.literal('custom'),
     // Optional free-form label; not used for any catalog lookup.
     source_path: z.string().optional(),
-    // All metadata for custom sources lives in overrides.
-    overrides: MetadataOverridesSchema,
+    // All metadata for custom sources lives in overrides. A non-empty `name`
+    // is required because there is no catalog fallback.
+    overrides: MetadataOverridesSchema.extend({
+      name: z.string().min(1),
+    }),
   }),
 ]);
 

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -18,6 +18,7 @@ import type {
   McpServerConfig,
   FailoverPolicy,
   CooldownPolicy,
+  MetadataOverrides,
 } from '../config';
 
 // Helper to parse JSON from SQLite text columns (PG jsonb auto-deserializes)
@@ -74,6 +75,56 @@ function decryptJsonField<T>(value: unknown): T | null {
   }
   if (typeof value === 'object') return value as T;
   return null;
+}
+
+function hasAnyOverrideField(o: MetadataOverrides): boolean {
+  if (o.name !== undefined) return true;
+  if (o.description !== undefined) return true;
+  if (o.context_length !== undefined) return true;
+  if (o.pricing && Object.values(o.pricing).some((v) => v !== undefined)) return true;
+  if (o.architecture) {
+    if (o.architecture.tokenizer !== undefined) return true;
+    if (o.architecture.input_modalities !== undefined) return true;
+    if (o.architecture.output_modalities !== undefined) return true;
+  }
+  if (o.supported_parameters !== undefined) return true;
+  if (o.top_provider && Object.values(o.top_provider).some((v) => v !== undefined)) return true;
+  return false;
+}
+
+function overrideRowToOverrides(row: any): MetadataOverrides {
+  const overrides: MetadataOverrides = {};
+  if (row.name != null) overrides.name = row.name;
+  if (row.description != null) overrides.description = row.description;
+  if (row.contextLength != null) overrides.context_length = row.contextLength;
+
+  const pricing: MetadataOverrides['pricing'] = {};
+  if (row.pricingPrompt != null) pricing.prompt = row.pricingPrompt;
+  if (row.pricingCompletion != null) pricing.completion = row.pricingCompletion;
+  if (row.pricingInputCacheRead != null) pricing.input_cache_read = row.pricingInputCacheRead;
+  if (row.pricingInputCacheWrite != null) pricing.input_cache_write = row.pricingInputCacheWrite;
+  if (Object.keys(pricing).length > 0) overrides.pricing = pricing;
+
+  const architecture: MetadataOverrides['architecture'] = {};
+  const inputMods = parseJson<string[]>(row.architectureInputModalities);
+  const outputMods = parseJson<string[]>(row.architectureOutputModalities);
+  if (inputMods && Array.isArray(inputMods)) architecture.input_modalities = inputMods;
+  if (outputMods && Array.isArray(outputMods)) architecture.output_modalities = outputMods;
+  if (row.architectureTokenizer != null) architecture.tokenizer = row.architectureTokenizer;
+  if (Object.keys(architecture).length > 0) overrides.architecture = architecture;
+
+  const supportedParams = parseJson<string[]>(row.supportedParameters);
+  if (supportedParams && Array.isArray(supportedParams))
+    overrides.supported_parameters = supportedParams;
+
+  const topProvider: MetadataOverrides['top_provider'] = {};
+  if (row.topProviderContextLength != null)
+    topProvider.context_length = row.topProviderContextLength;
+  if (row.topProviderMaxCompletionTokens != null)
+    topProvider.max_completion_tokens = row.topProviderMaxCompletionTokens;
+  if (Object.keys(topProvider).length > 0) overrides.top_provider = topProvider;
+
+  return overrides;
 }
 
 function toBool(value: unknown): boolean {
@@ -429,7 +480,8 @@ export class ConfigRepository {
         .where(eq(schema.modelAliasTargets.aliasId, row.id))
         .orderBy(schema.modelAliasTargets.sortOrder);
 
-      result[row.slug] = this.rowToModelConfig(row, targets);
+      const overrideRow = await this.getMetadataOverrideRow(row.id);
+      result[row.slug] = this.rowToModelConfig(row, targets, overrideRow);
     }
 
     return result;
@@ -452,7 +504,18 @@ export class ConfigRepository {
       .where(eq(schema.modelAliasTargets.aliasId, row.id))
       .orderBy(schema.modelAliasTargets.sortOrder);
 
-    return this.rowToModelConfig(row, targets);
+    const overrideRow = await this.getMetadataOverrideRow(row.id);
+    return this.rowToModelConfig(row, targets, overrideRow);
+  }
+
+  private async getMetadataOverrideRow(aliasId: number): Promise<any | null> {
+    const schema = this.schema();
+    const rows = await this.db()
+      .select()
+      .from(schema.aliasMetadataOverrides)
+      .where(eq(schema.aliasMetadataOverrides.aliasId, aliasId))
+      .limit(1);
+    return rows.length > 0 ? rows[0] : null;
   }
 
   async saveAlias(slug: string, config: ModelConfig): Promise<void> {
@@ -509,6 +572,40 @@ export class ConfigRepository {
       }));
       await this.db().insert(schema.modelAliasTargets).values(targetRows);
     }
+
+    // Replace metadata overrides
+    await this.db()
+      .delete(schema.aliasMetadataOverrides)
+      .where(eq(schema.aliasMetadataOverrides.aliasId, aliasId));
+
+    const overrides = config.metadata?.overrides;
+    if (overrides && hasAnyOverrideField(overrides)) {
+      await this.db()
+        .insert(schema.aliasMetadataOverrides)
+        .values({
+          aliasId,
+          name: overrides.name ?? null,
+          description: overrides.description ?? null,
+          contextLength: overrides.context_length ?? null,
+          pricingPrompt: overrides.pricing?.prompt ?? null,
+          pricingCompletion: overrides.pricing?.completion ?? null,
+          pricingInputCacheRead: overrides.pricing?.input_cache_read ?? null,
+          pricingInputCacheWrite: overrides.pricing?.input_cache_write ?? null,
+          architectureInputModalities: overrides.architecture?.input_modalities
+            ? toJson(overrides.architecture.input_modalities)
+            : null,
+          architectureOutputModalities: overrides.architecture?.output_modalities
+            ? toJson(overrides.architecture.output_modalities)
+            : null,
+          architectureTokenizer: overrides.architecture?.tokenizer ?? null,
+          supportedParameters: overrides.supported_parameters
+            ? toJson(overrides.supported_parameters)
+            : null,
+          topProviderContextLength: overrides.top_provider?.context_length ?? null,
+          topProviderMaxCompletionTokens: overrides.top_provider?.max_completion_tokens ?? null,
+          updatedAt: timestamp,
+        });
+    }
   }
 
   async deleteAlias(slug: string): Promise<void> {
@@ -524,7 +621,7 @@ export class ConfigRepository {
     return count.length;
   }
 
-  private rowToModelConfig(row: any, targetRows: any[]): ModelConfig {
+  private rowToModelConfig(row: any, targetRows: any[], overrideRow?: any | null): ModelConfig {
     const targets = targetRows.map((t: any) => ({
       provider: t.providerSlug,
       model: t.modelName,
@@ -539,15 +636,25 @@ export class ConfigRepository {
       ...(row.modelType ? { type: row.modelType } : {}),
       ...(row.additionalAliases ? { additional_aliases: parseJson(row.additionalAliases) } : {}),
       ...(row.advanced ? { advanced: parseJson(row.advanced) } : {}),
-      ...(row.metadataSource
-        ? {
-            metadata: {
-              source: row.metadataSource,
-              source_path: row.metadataSourcePath,
-            },
-          }
-        : {}),
     };
+
+    if (row.metadataSource) {
+      const overrides = overrideRow ? overrideRowToOverrides(overrideRow) : undefined;
+      if (row.metadataSource === 'custom') {
+        // Custom sources always carry overrides (possibly empty if no row found).
+        result.metadata = {
+          source: 'custom',
+          ...(row.metadataSourcePath ? { source_path: row.metadataSourcePath } : {}),
+          overrides: overrides ?? {},
+        };
+      } else {
+        result.metadata = {
+          source: row.metadataSource,
+          source_path: row.metadataSourcePath,
+          ...(overrides && Object.keys(overrides).length > 0 ? { overrides } : {}),
+        };
+      }
+    }
 
     return result as ModelConfig;
   }

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and, sql, inArray } from 'drizzle-orm';
 import { getDatabase, getSchema, getCurrentDialect } from './client';
 import { logger } from '../utils/logger';
 import {
@@ -473,14 +473,37 @@ export class ConfigRepository {
     const rows = await this.db().select().from(schema.modelAliases);
     const result: Record<string, ModelConfig> = {};
 
-    for (const row of rows) {
-      const targets = await this.db()
+    if (rows.length === 0) return result;
+
+    const aliasIds = rows.map((r: any) => r.id);
+
+    // Batch-fetch targets and override rows in parallel, keyed by aliasId —
+    // avoids the 1+2N round-trips a per-alias loop would incur.
+    const [allTargets, allOverrides] = await Promise.all([
+      this.db()
         .select()
         .from(schema.modelAliasTargets)
-        .where(eq(schema.modelAliasTargets.aliasId, row.id))
-        .orderBy(schema.modelAliasTargets.sortOrder);
+        .where(inArray(schema.modelAliasTargets.aliasId, aliasIds))
+        .orderBy(schema.modelAliasTargets.sortOrder),
+      this.db()
+        .select()
+        .from(schema.aliasMetadataOverrides)
+        .where(inArray(schema.aliasMetadataOverrides.aliasId, aliasIds)),
+    ]);
 
-      const overrideRow = await this.getMetadataOverrideRow(row.id);
+    const targetsByAliasId = new Map<number, any[]>();
+    for (const t of allTargets) {
+      const list = targetsByAliasId.get(t.aliasId);
+      if (list) list.push(t);
+      else targetsByAliasId.set(t.aliasId, [t]);
+    }
+
+    const overrideByAliasId = new Map<number, any>();
+    for (const o of allOverrides) overrideByAliasId.set(o.aliasId, o);
+
+    for (const row of rows) {
+      const targets = targetsByAliasId.get(row.id) ?? [];
+      const overrideRow = overrideByAliasId.get(row.id) ?? null;
       result[row.slug] = this.rowToModelConfig(row, targets, overrideRow);
     }
 

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -535,54 +535,55 @@ export class ConfigRepository {
       updatedAt: timestamp,
     };
 
-    const existing = await this.db()
-      .select()
-      .from(schema.modelAliases)
-      .where(eq(schema.modelAliases.slug, slug))
-      .limit(1);
+    // Wrap the whole save — alias upsert, target replace, override replace —
+    // in one transaction so partial failures don't leave the row inconsistent.
+    await this.db().transaction(async (tx: any) => {
+      const existing = await tx
+        .select()
+        .from(schema.modelAliases)
+        .where(eq(schema.modelAliases.slug, slug))
+        .limit(1);
 
-    let aliasId: number;
+      let aliasId: number;
 
-    if (existing.length > 0) {
-      aliasId = existing[0]!.id;
-      await this.db()
-        .update(schema.modelAliases)
-        .set(aliasData)
-        .where(eq(schema.modelAliases.id, aliasId));
-    } else {
-      const inserted = await this.db()
-        .insert(schema.modelAliases)
-        .values({ ...aliasData, createdAt: timestamp })
-        .returning({ id: schema.modelAliases.id });
-      aliasId = inserted[0]!.id;
-    }
+      if (existing.length > 0) {
+        aliasId = existing[0]!.id;
+        await tx
+          .update(schema.modelAliases)
+          .set(aliasData)
+          .where(eq(schema.modelAliases.id, aliasId));
+      } else {
+        const inserted = await tx
+          .insert(schema.modelAliases)
+          .values({ ...aliasData, createdAt: timestamp })
+          .returning({ id: schema.modelAliases.id });
+        aliasId = inserted[0]!.id;
+      }
 
-    // Replace targets
-    await this.db()
-      .delete(schema.modelAliasTargets)
-      .where(eq(schema.modelAliasTargets.aliasId, aliasId));
+      // Replace targets
+      await tx
+        .delete(schema.modelAliasTargets)
+        .where(eq(schema.modelAliasTargets.aliasId, aliasId));
 
-    if (config.targets && config.targets.length > 0) {
-      const targetRows = config.targets.map((t, idx) => ({
-        aliasId,
-        providerSlug: t.provider,
-        modelName: t.model,
-        enabled: fromBool(t.enabled !== false),
-        sortOrder: idx,
-      }));
-      await this.db().insert(schema.modelAliasTargets).values(targetRows);
-    }
+      if (config.targets && config.targets.length > 0) {
+        const targetRows = config.targets.map((t, idx) => ({
+          aliasId,
+          providerSlug: t.provider,
+          modelName: t.model,
+          enabled: fromBool(t.enabled !== false),
+          sortOrder: idx,
+        }));
+        await tx.insert(schema.modelAliasTargets).values(targetRows);
+      }
 
-    // Replace metadata overrides
-    await this.db()
-      .delete(schema.aliasMetadataOverrides)
-      .where(eq(schema.aliasMetadataOverrides.aliasId, aliasId));
+      // Replace metadata overrides
+      await tx
+        .delete(schema.aliasMetadataOverrides)
+        .where(eq(schema.aliasMetadataOverrides.aliasId, aliasId));
 
-    const overrides = config.metadata?.overrides;
-    if (overrides && hasAnyOverrideField(overrides)) {
-      await this.db()
-        .insert(schema.aliasMetadataOverrides)
-        .values({
+      const overrides = config.metadata?.overrides;
+      if (overrides && hasAnyOverrideField(overrides)) {
+        await tx.insert(schema.aliasMetadataOverrides).values({
           aliasId,
           name: overrides.name ?? null,
           description: overrides.description ?? null,
@@ -605,7 +606,8 @@ export class ConfigRepository {
           topProviderMaxCompletionTokens: overrides.top_provider?.max_completion_tokens ?? null,
           updatedAt: timestamp,
         });
-    }
+      }
+    });
   }
 
   async deleteAlias(slug: string): Promise<void> {

--- a/packages/backend/src/routes/inference/__tests__/models.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/models.test.ts
@@ -357,3 +357,93 @@ describe('GET /v1/metadata/search', () => {
     expect(response.json().data.length).toBe(1);
   });
 });
+
+// ─── GET /v1/metadata/lookup ──────────────────────────────
+
+describe('GET /v1/metadata/lookup', () => {
+  it('should return 400 when source param is missing', async () => {
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+    setConfigForTesting({ models: {} } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v1/metadata/lookup?source_path=anthropic/claude-3.5-sonnet',
+    });
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toContain('source');
+  });
+
+  it('should return 400 when source_path param is missing', async () => {
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+    setConfigForTesting({ models: {} } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v1/metadata/lookup?source=openrouter',
+    });
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toContain('source_path');
+  });
+
+  it('should return 503 when source is not yet initialized', async () => {
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+    setConfigForTesting({ models: {} } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v1/metadata/lookup?source=openrouter&source_path=anthropic/claude-3.5-sonnet',
+    });
+    expect(response.statusCode).toBe(503);
+  });
+
+  it('should return 404 when source_path is not found', async () => {
+    const mgr = ModelMetadataManager.getInstance();
+    await mgr.loadAll({
+      openrouter: openrouterMetadataFixture,
+      modelsDev: '/nonexistent',
+      catwalk: '/nonexistent',
+    });
+
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+    setConfigForTesting({ models: {} } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v1/metadata/lookup?source=openrouter&source_path=does/not-exist',
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('should return full normalized metadata for a known model', async () => {
+    const mgr = ModelMetadataManager.getInstance();
+    await mgr.loadAll({
+      openrouter: openrouterMetadataFixture,
+      modelsDev: '/nonexistent',
+      catwalk: '/nonexistent',
+    });
+
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+    setConfigForTesting({ models: {} } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v1/metadata/lookup?source=openrouter&source_path=anthropic/claude-3.5-sonnet',
+    });
+    expect(response.statusCode).toBe(200);
+
+    const meta = response.json().data;
+    expect(meta.id).toBe('anthropic/claude-3.5-sonnet');
+    expect(meta.name).toBe('Anthropic: Claude 3.5 Sonnet');
+    expect(meta.context_length).toBe(200000);
+    expect(meta.pricing.prompt).toBe('0.000003');
+    expect(meta.pricing.completion).toBe('0.000015');
+    expect(meta.architecture.input_modalities).toContain('image');
+    expect(meta.supported_parameters).toContain('tools');
+    expect(meta.top_provider.max_completion_tokens).toBe(8192);
+  });
+});

--- a/packages/backend/src/routes/inference/models.ts
+++ b/packages/backend/src/routes/inference/models.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { getConfig } from '../../config';
 import { PricingManager } from '../../services/pricing-manager';
-import { ModelMetadataManager } from '../../services/model-metadata-manager';
+import { ModelMetadataManager, mergeOverrides } from '../../services/model-metadata-manager';
 
 export async function registerModelsRoute(fastify: FastifyInstance) {
   /**
@@ -36,8 +36,13 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
         return base;
       }
 
-      // Look up enriched metadata from the appropriate source
-      const enriched = metadataManager.getMetadata(metaConfig.source, metaConfig.source_path);
+      // Look up enriched metadata from the appropriate source. Custom sources
+      // skip the catalog entirely and derive everything from overrides.
+      let catalog: ReturnType<typeof metadataManager.getMetadata> = undefined;
+      if (metaConfig.source !== 'custom') {
+        catalog = metadataManager.getMetadata(metaConfig.source, metaConfig.source_path);
+      }
+      const enriched = mergeOverrides(catalog, metaConfig.overrides);
       if (!enriched) {
         return base;
       }
@@ -80,6 +85,7 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
 
     const source = query.source as 'openrouter' | 'models.dev' | 'catwalk' | undefined;
     if (!source || !['openrouter', 'models.dev', 'catwalk'].includes(source)) {
+      // Note: 'custom' is intentionally rejected — there's no catalog to search.
       return reply.status(400).send({
         error: `Missing or invalid 'source' parameter. Must be one of: openrouter, models.dev, catwalk`,
       });

--- a/packages/backend/src/routes/inference/models.ts
+++ b/packages/backend/src/routes/inference/models.ts
@@ -115,6 +115,50 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
   });
 
   /**
+   * GET /v1/metadata/lookup
+   * Return the full normalized metadata for a single model in a catalog source.
+   * Used by the frontend to auto-populate the override form when a user enables
+   * "Override catalog fields" — so the user sees the current values and can
+   * tweak them rather than starting blank.
+   *
+   * Query parameters:
+   *   - source (required): "openrouter" | "models.dev" | "catwalk"
+   *   - source_path (required): the model id within the source
+   *
+   * Returns: the NormalizedModelMetadata record, or 404 if not found.
+   */
+  fastify.get('/v1/metadata/lookup', async (request, reply) => {
+    const metadataManager = ModelMetadataManager.getInstance();
+    const query = request.query as { source?: string; source_path?: string };
+
+    const source = query.source as 'openrouter' | 'models.dev' | 'catwalk' | undefined;
+    if (!source || !['openrouter', 'models.dev', 'catwalk'].includes(source)) {
+      return reply.status(400).send({
+        error: `Missing or invalid 'source' parameter. Must be one of: openrouter, models.dev, catwalk`,
+      });
+    }
+
+    if (!query.source_path) {
+      return reply.status(400).send({ error: `Missing 'source_path' parameter` });
+    }
+
+    if (!metadataManager.isInitialized(source)) {
+      return reply.status(503).send({
+        error: `Metadata source '${source}' is not yet loaded or failed to load`,
+      });
+    }
+
+    const metadata = metadataManager.getMetadata(source, query.source_path);
+    if (!metadata) {
+      return reply.status(404).send({
+        error: `No metadata found for '${query.source_path}' in source '${source}'`,
+      });
+    }
+
+    return reply.send({ data: metadata });
+  });
+
+  /**
    * GET /v1/openrouter/models
    * Returns a list of OpenRouter model slugs, optionally filtered by a search query.
    * Query parameter: ?q=search-term

--- a/packages/backend/src/routes/inference/models.ts
+++ b/packages/backend/src/routes/inference/models.ts
@@ -37,12 +37,19 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
       }
 
       // Look up enriched metadata from the appropriate source. Custom sources
-      // skip the catalog entirely and derive everything from overrides.
-      let catalog: ReturnType<typeof metadataManager.getMetadata> = undefined;
-      if (metaConfig.source !== 'custom') {
-        catalog = metadataManager.getMetadata(metaConfig.source, metaConfig.source_path);
+      // skip the catalog entirely and derive everything from overrides. For
+      // catalog-backed sources, a missing catalog hit is treated as a miss —
+      // we don't silently synthesize a partial record from overrides alone,
+      // because that would hide typos in source_path or unloaded sources.
+      let enriched: ReturnType<typeof mergeOverrides> = undefined;
+      if (metaConfig.source === 'custom') {
+        enriched = mergeOverrides(undefined, metaConfig.overrides);
+      } else {
+        const catalog = metadataManager.getMetadata(metaConfig.source, metaConfig.source_path);
+        if (catalog) {
+          enriched = mergeOverrides(catalog, metaConfig.overrides);
+        }
       }
-      const enriched = mergeOverrides(catalog, metaConfig.overrides);
       if (!enriched) {
         return base;
       }

--- a/packages/backend/src/routes/management.ts
+++ b/packages/backend/src/routes/management.ts
@@ -18,7 +18,7 @@ import { registerRestartRoutes } from './management/restart';
 import { registerProviderRoutes } from './management/providers';
 import { registerMetricsRoutes } from './management/metrics';
 import { registerSelfRoutes } from './management/self';
-import { authenticate, requireAdmin } from './management/_principal';
+import { authenticate, requireAdmin, ManagementAuthError } from './management/_principal';
 import { Dispatcher } from '../services/dispatcher';
 import { QuotaScheduler } from '../services/quota/quota-scheduler';
 import { QuotaEnforcer } from '../services/quota/quota-enforcer';
@@ -32,6 +32,16 @@ export async function registerManagementRoutes(
   mcpUsageStorage?: McpUsageStorageService,
   quotaEnforcer?: QuotaEnforcer
 ) {
+  // Translate ManagementAuthError throws (from authenticate / requireAdmin) into
+  // correctly-shaped 401/403 responses. In Fastify v5, async hooks must throw
+  // rather than calling reply.send() to abort the hook chain.
+  fastify.setErrorHandler(async (error, _request, reply) => {
+    if (error instanceof ManagementAuthError) {
+      return reply.code(error.statusCode).send(error.authBody);
+    }
+    throw error;
+  });
+
   // Verify endpoint runs the authentication hook but has no further checks,
   // so the login page can call it with a candidate credential. Returns
   // principal info (role + key metadata for limited users) on success.

--- a/packages/backend/src/routes/management/_principal.ts
+++ b/packages/backend/src/routes/management/_principal.ts
@@ -4,6 +4,21 @@ import { logger } from '../../utils/logger';
 import { getConfig } from '../../config';
 
 /**
+ * Sentinel error thrown by authenticate/requireAdmin so that Fastify's error
+ * handler can send the correctly-shaped management auth response. In Fastify v5
+ * async hooks must throw (not call reply.send) to abort the hook chain.
+ */
+export class ManagementAuthError extends Error {
+  statusCode: number;
+  authBody: object;
+  constructor(statusCode: number, message: string, type: string) {
+    super(message);
+    this.statusCode = statusCode;
+    this.authBody = { error: { message, type, code: statusCode } };
+  }
+}
+
+/**
  * Authenticated identity for a management-API request.
  *
  * - admin   → full access (the ADMIN_KEY was presented)
@@ -100,12 +115,11 @@ export async function resolvePrincipal(request: FastifyRequest): Promise<Princip
  * Fastify preHandler that authenticates a request and attaches the principal.
  * 401 if the credential is missing/invalid.
  */
-export async function authenticate(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+export async function authenticate(request: FastifyRequest, _reply: FastifyReply): Promise<void> {
   const principal = await resolvePrincipal(request);
   if (!principal) {
     logger.silly(`[ADMIN AUTH] Rejected request to ${request.url} - invalid or missing credential`);
-    reply.code(401).send({ error: { message: 'Unauthorized', type: 'auth_error', code: 401 } });
-    return;
+    throw new ManagementAuthError(401, 'Unauthorized', 'auth_error');
   }
   request.principal = principal;
   logger.silly(
@@ -119,20 +133,12 @@ export async function authenticate(request: FastifyRequest, reply: FastifyReply)
  * Fastify preHandler that requires the authenticated principal to be admin.
  * Must run AFTER `authenticate`. Returns 403 for limited users.
  */
-export async function requireAdmin(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+export async function requireAdmin(request: FastifyRequest, _reply: FastifyReply): Promise<void> {
   if (!request.principal) {
-    reply.code(401).send({ error: { message: 'Unauthorized', type: 'auth_error', code: 401 } });
-    return;
+    throw new ManagementAuthError(401, 'Unauthorized', 'auth_error');
   }
   if (request.principal.role !== 'admin') {
-    reply.code(403).send({
-      error: {
-        message: 'Admin privileges required',
-        type: 'forbidden',
-        code: 403,
-      },
-    });
-    return;
+    throw new ManagementAuthError(403, 'Admin privileges required', 'forbidden');
   }
 }
 

--- a/packages/backend/src/routes/management/cooldowns.ts
+++ b/packages/backend/src/routes/management/cooldowns.ts
@@ -15,15 +15,11 @@ export async function registerCooldownRoutes(fastify: FastifyInstance) {
   // cooldowns to steer away from providers with real failure signals (rate
   // limits, outages, quota exhaustion), so forcing a retry has system-wide
   // blast radius and is not a safe self-service action for a key holder.
-  fastify.delete(
-    '/v0/management/cooldowns',
-    { preHandler: requireAdmin },
-    (_request, reply) => {
-      CooldownManager.getInstance().clearCooldown();
-      logger.info('[AUDIT] admin cleared all cooldowns');
-      return reply.send({ success: true });
-    }
-  );
+  fastify.delete('/v0/management/cooldowns', { preHandler: requireAdmin }, (_request, reply) => {
+    CooldownManager.getInstance().clearCooldown();
+    logger.info('[AUDIT] admin cleared all cooldowns');
+    return reply.send({ success: true });
+  });
 
   fastify.delete(
     '/v0/management/cooldowns/:provider',

--- a/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
+++ b/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test, beforeAll, afterEach } from 'bun:test';
 import path from 'path';
-import { ModelMetadataManager } from '../model-metadata-manager';
+import { ModelMetadataManager, mergeOverrides } from '../model-metadata-manager';
+import type { NormalizedModelMetadata } from '../model-metadata-manager';
+import type { MetadataOverrides } from '../../config';
 
 const FIXTURES = path.join(__dirname, '../../utils/__tests__/fixtures');
 
@@ -346,5 +348,97 @@ describe('ModelMetadataManager – singleton', () => {
     const mgr2 = ModelMetadataManager.getInstance();
     expect(mgr2.isInitialized('openrouter')).toBe(false);
     expect(mgr2).not.toBe(mgr);
+  });
+});
+
+// ─── mergeOverrides ─────────────────────────────────────────────
+
+describe('mergeOverrides', () => {
+  const base: NormalizedModelMetadata = {
+    id: 'openai/gpt-4',
+    name: 'GPT-4',
+    description: 'Catalog description',
+    context_length: 8192,
+    pricing: {
+      prompt: '0.00003',
+      completion: '0.00006',
+      input_cache_read: '0.0000015',
+    },
+    architecture: {
+      input_modalities: ['text'],
+      output_modalities: ['text'],
+      tokenizer: 'cl100k_base',
+    },
+    supported_parameters: ['temperature', 'tools'],
+    top_provider: { context_length: 8192, max_completion_tokens: 4096 },
+  };
+
+  test('returns base unchanged when overrides is undefined', () => {
+    expect(mergeOverrides(base, undefined)).toEqual(base);
+  });
+
+  test('scalar overrides replace catalog values', () => {
+    const out = mergeOverrides(base, { name: 'My GPT-4', context_length: 16384 })!;
+    expect(out.name).toBe('My GPT-4');
+    expect(out.context_length).toBe(16384);
+    // Untouched fields still come from catalog
+    expect(out.description).toBe('Catalog description');
+  });
+
+  test('partial pricing override merges with catalog pricing', () => {
+    const out = mergeOverrides(base, { pricing: { prompt: '0.00001' } })!;
+    expect(out.pricing?.prompt).toBe('0.00001');
+    // Siblings preserved
+    expect(out.pricing?.completion).toBe('0.00006');
+    expect(out.pricing?.input_cache_read).toBe('0.0000015');
+  });
+
+  test('partial architecture override merges with catalog architecture', () => {
+    const out = mergeOverrides(base, { architecture: { tokenizer: 'custom-bpe' } })!;
+    expect(out.architecture?.tokenizer).toBe('custom-bpe');
+    expect(out.architecture?.input_modalities).toEqual(['text']);
+  });
+
+  test('supported_parameters array replaces entirely', () => {
+    const out = mergeOverrides(base, { supported_parameters: ['reasoning'] })!;
+    expect(out.supported_parameters).toEqual(['reasoning']);
+  });
+
+  test('modality arrays replace entirely when present', () => {
+    const out = mergeOverrides(base, {
+      architecture: { input_modalities: ['text', 'image', 'audio'] },
+    })!;
+    expect(out.architecture?.input_modalities).toEqual(['text', 'image', 'audio']);
+    // Output modalities untouched
+    expect(out.architecture?.output_modalities).toEqual(['text']);
+  });
+
+  test('custom source — undefined base + full overrides builds result from overrides alone', () => {
+    const overrides: MetadataOverrides = {
+      name: 'My Custom',
+      context_length: 2048,
+      pricing: { prompt: '0', completion: '0' },
+      architecture: { input_modalities: ['text'], output_modalities: ['text'] },
+      supported_parameters: [],
+      top_provider: { max_completion_tokens: 1024 },
+    };
+    const out = mergeOverrides(undefined, overrides)!;
+    expect(out.name).toBe('My Custom');
+    expect(out.context_length).toBe(2048);
+    expect(out.pricing?.prompt).toBe('0');
+    expect(out.top_provider?.max_completion_tokens).toBe(1024);
+  });
+
+  test('undefined base with empty overrides returns undefined', () => {
+    expect(mergeOverrides(undefined, {})).toBeUndefined();
+  });
+
+  test('overrides do not mutate the base object', () => {
+    const snapshot = JSON.parse(JSON.stringify(base));
+    mergeOverrides(base, {
+      pricing: { prompt: '0.5' },
+      architecture: { tokenizer: 'custom' },
+    });
+    expect(base).toEqual(snapshot);
   });
 });

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger';
+import type { MetadataOverrides } from '../config';
 
 // ─── Normalized model metadata (OpenRouter-style) ──────────────────────────
 // All three sources are normalized into this shape.
@@ -445,4 +446,68 @@ export class ModelMetadataManager {
   public getAllIds(source: 'openrouter' | 'models.dev' | 'catwalk'): string[] {
     return Array.from(this.getMap(source).keys());
   }
+}
+
+/**
+ * Merge per-field metadata overrides on top of a catalog entry.
+ *
+ * - Scalars (name, description, context_length) replace.
+ * - Nested objects (pricing, architecture, top_provider) are spread-merged so
+ *   partial overrides don't wipe untouched sibling keys.
+ * - Arrays (supported_parameters, *_modalities) fully replace when present.
+ *
+ * When `base` is undefined (e.g. `source === 'custom'`), the overrides form the
+ * entire result. When both `base` and `overrides` are empty/undefined, returns
+ * undefined so callers can treat the alias as having no enriched metadata.
+ */
+export function mergeOverrides(
+  base: NormalizedModelMetadata | undefined,
+  overrides: MetadataOverrides | undefined
+): NormalizedModelMetadata | undefined {
+  if (!overrides) return base;
+
+  const merged: NormalizedModelMetadata = {
+    id: base?.id ?? '',
+    name: base?.name ?? '',
+    ...(base?.description !== undefined && { description: base.description }),
+    ...(base?.context_length !== undefined && { context_length: base.context_length }),
+    ...(base?.architecture !== undefined && { architecture: { ...base.architecture } }),
+    ...(base?.pricing !== undefined && { pricing: { ...base.pricing } }),
+    ...(base?.supported_parameters !== undefined && {
+      supported_parameters: [...base.supported_parameters],
+    }),
+    ...(base?.top_provider !== undefined && { top_provider: { ...base.top_provider } }),
+  };
+
+  if (overrides.name !== undefined) merged.name = overrides.name;
+  if (overrides.description !== undefined) merged.description = overrides.description;
+  if (overrides.context_length !== undefined) merged.context_length = overrides.context_length;
+
+  if (overrides.pricing) {
+    merged.pricing = { ...(merged.pricing ?? {}), ...overrides.pricing };
+  }
+  if (overrides.architecture) {
+    merged.architecture = { ...(merged.architecture ?? {}), ...overrides.architecture };
+  }
+  if (overrides.top_provider) {
+    merged.top_provider = { ...(merged.top_provider ?? {}), ...overrides.top_provider };
+  }
+  if (overrides.supported_parameters !== undefined) {
+    merged.supported_parameters = overrides.supported_parameters;
+  }
+
+  // If nothing meaningful ended up in merged, signal "no metadata".
+  if (
+    !merged.name &&
+    merged.description === undefined &&
+    merged.context_length === undefined &&
+    merged.pricing === undefined &&
+    merged.architecture === undefined &&
+    merged.supported_parameters === undefined &&
+    merged.top_provider === undefined
+  ) {
+    return undefined;
+  }
+
+  return merged;
 }

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -258,7 +258,7 @@ export class ModelMetadataManager {
     const {
       openrouter = 'https://openrouter.ai/api/v1/models',
       modelsDev = 'https://models.dev/api.json',
-      catwalk = 'https://catwalk.charm.sh/providers',
+      catwalk = 'https://catwalk.charm.sh/v2/providers',
     } = sources ?? {};
 
     await Promise.all([

--- a/packages/backend/src/services/usage-storage.ts
+++ b/packages/backend/src/services/usage-storage.ts
@@ -314,8 +314,9 @@ export class UsageStorageService extends EventEmitter {
 
   async getErrors(limit: number = 50, offset: number = 0, apiKey?: string): Promise<any[]> {
     try {
+      const db = this.ensureDb();
       const where = apiKey ? eq(this.schema.inferenceErrors.apiKey, apiKey) : undefined;
-      const query = this.ensureDb()
+      const query = db
         .select()
         .from(this.schema.inferenceErrors)
         .orderBy(desc(this.schema.inferenceErrors.createdAt))
@@ -386,8 +387,9 @@ export class UsageStorageService extends EventEmitter {
     apiKey?: string
   ): Promise<{ requestId: string; createdAt: number }[]> {
     try {
+      const db = this.ensureDb();
       const where = apiKey ? eq(this.schema.debugLogs.apiKey, apiKey) : undefined;
-      const query = this.ensureDb()
+      const query = db
         .select({
           requestId: this.schema.debugLogs.requestId,
           createdAt: this.schema.debugLogs.createdAt,

--- a/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
@@ -318,8 +318,8 @@ export const OverallTab: React.FC = () => {
             <div className="flex items-start gap-2 text-sm text-warning">
               <AlertTriangle size={14} className="mt-0.5 flex-shrink-0" />
               <span>
-                Could not load quota status. If this key has a quota assigned, its current
-                usage is not shown here — try refreshing.
+                Could not load quota status. If this key has a quota assigned, its current usage is
+                not shown here — try refreshing.
               </span>
             </div>
           ) : !quota || !quota.quotaName ? (

--- a/packages/frontend/src/components/models/MetadataOverrideForm.tsx
+++ b/packages/frontend/src/components/models/MetadataOverrideForm.tsx
@@ -1,0 +1,248 @@
+import type { MetadataOverrides } from '../../lib/api';
+import { Input } from '../ui/Input';
+
+interface Props {
+  overrides: MetadataOverrides;
+  isCustom: boolean;
+  onSetField: <K extends keyof MetadataOverrides>(
+    key: K,
+    value: MetadataOverrides[K] | undefined
+  ) => void;
+  onSetPricing: (
+    key: keyof NonNullable<MetadataOverrides['pricing']>,
+    value: string | undefined
+  ) => void;
+  onSetArchitecture: (
+    key: keyof NonNullable<MetadataOverrides['architecture']>,
+    value: string | string[] | undefined
+  ) => void;
+  onSetTopProvider: (
+    key: keyof NonNullable<MetadataOverrides['top_provider']>,
+    value: number | undefined
+  ) => void;
+}
+
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <div
+    className="font-body text-[11px] font-semibold uppercase tracking-wide text-text-muted"
+    style={{ marginBottom: '4px' }}
+  >
+    {children}
+  </div>
+);
+
+const FieldLabel = ({ children }: { children: React.ReactNode }) => (
+  <label
+    className="font-body text-[11px] font-medium text-text-secondary"
+    style={{ display: 'block', marginBottom: '2px' }}
+  >
+    {children}
+  </label>
+);
+
+const parseCsv = (s: string): string[] =>
+  s
+    .split(',')
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0);
+
+const parseIntOrUndef = (s: string): number | undefined => {
+  const trimmed = s.trim();
+  if (!trimmed) return undefined;
+  const n = parseInt(trimmed, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+};
+
+export function MetadataOverrideForm({
+  overrides,
+  isCustom,
+  onSetField,
+  onSetPricing,
+  onSetArchitecture,
+  onSetTopProvider,
+}: Props) {
+  const helperText = isCustom
+    ? 'All fields below come from your manual entry — no catalog is consulted.'
+    : 'Fields left blank fall back to the catalog value.';
+
+  return (
+    <div
+      className="rounded-sm border border-border-glass bg-bg-subtle"
+      style={{ padding: '10px', display: 'flex', flexDirection: 'column', gap: '12px' }}
+    >
+      <p className="font-body text-[11px] text-text-muted" style={{ marginBottom: 0 }}>
+        {helperText}
+      </p>
+
+      {/* Basic */}
+      <div>
+        <SectionLabel>Basic</SectionLabel>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+          <div>
+            <FieldLabel>Name</FieldLabel>
+            <Input
+              value={overrides.name ?? ''}
+              onChange={(e) =>
+                onSetField('name', e.target.value === '' ? undefined : e.target.value)
+              }
+              placeholder="Display name"
+            />
+          </div>
+          <div>
+            <FieldLabel>Context length (tokens)</FieldLabel>
+            <Input
+              type="number"
+              min={1}
+              value={overrides.context_length ?? ''}
+              onChange={(e) => onSetField('context_length', parseIntOrUndef(e.target.value))}
+              placeholder="e.g. 128000"
+            />
+          </div>
+        </div>
+        <div style={{ marginTop: '6px' }}>
+          <FieldLabel>Description</FieldLabel>
+          <Input
+            value={overrides.description ?? ''}
+            onChange={(e) =>
+              onSetField('description', e.target.value === '' ? undefined : e.target.value)
+            }
+            placeholder="Short description"
+          />
+        </div>
+      </div>
+
+      {/* Pricing */}
+      <div>
+        <SectionLabel>Pricing ($/token)</SectionLabel>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+          <div>
+            <FieldLabel>Prompt</FieldLabel>
+            <Input
+              value={overrides.pricing?.prompt ?? ''}
+              onChange={(e) =>
+                onSetPricing('prompt', e.target.value === '' ? undefined : e.target.value)
+              }
+              placeholder="0.000003"
+            />
+          </div>
+          <div>
+            <FieldLabel>Completion</FieldLabel>
+            <Input
+              value={overrides.pricing?.completion ?? ''}
+              onChange={(e) =>
+                onSetPricing('completion', e.target.value === '' ? undefined : e.target.value)
+              }
+              placeholder="0.000015"
+            />
+          </div>
+          <div>
+            <FieldLabel>Input cache read</FieldLabel>
+            <Input
+              value={overrides.pricing?.input_cache_read ?? ''}
+              onChange={(e) =>
+                onSetPricing('input_cache_read', e.target.value === '' ? undefined : e.target.value)
+              }
+              placeholder="0.0000003"
+            />
+          </div>
+          <div>
+            <FieldLabel>Input cache write</FieldLabel>
+            <Input
+              value={overrides.pricing?.input_cache_write ?? ''}
+              onChange={(e) =>
+                onSetPricing(
+                  'input_cache_write',
+                  e.target.value === '' ? undefined : e.target.value
+                )
+              }
+              placeholder="0.00000375"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Architecture */}
+      <div>
+        <SectionLabel>Architecture</SectionLabel>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+          <div>
+            <FieldLabel>Input modalities (comma-separated)</FieldLabel>
+            <Input
+              value={(overrides.architecture?.input_modalities ?? []).join(', ')}
+              onChange={(e) => {
+                const list = parseCsv(e.target.value);
+                onSetArchitecture('input_modalities', list.length > 0 ? list : undefined);
+              }}
+              placeholder="text, image"
+            />
+          </div>
+          <div>
+            <FieldLabel>Output modalities (comma-separated)</FieldLabel>
+            <Input
+              value={(overrides.architecture?.output_modalities ?? []).join(', ')}
+              onChange={(e) => {
+                const list = parseCsv(e.target.value);
+                onSetArchitecture('output_modalities', list.length > 0 ? list : undefined);
+              }}
+              placeholder="text"
+            />
+          </div>
+          <div style={{ gridColumn: 'span 2' }}>
+            <FieldLabel>Tokenizer</FieldLabel>
+            <Input
+              value={overrides.architecture?.tokenizer ?? ''}
+              onChange={(e) =>
+                onSetArchitecture('tokenizer', e.target.value === '' ? undefined : e.target.value)
+              }
+              placeholder="e.g. cl100k_base"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Capabilities */}
+      <div>
+        <SectionLabel>Capabilities</SectionLabel>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '6px' }}>
+          <div>
+            <FieldLabel>Supported parameters (comma-separated)</FieldLabel>
+            <Input
+              value={(overrides.supported_parameters ?? []).join(', ')}
+              onChange={(e) => {
+                const list = parseCsv(e.target.value);
+                onSetField('supported_parameters', list.length > 0 ? list : undefined);
+              }}
+              placeholder="tools, temperature, reasoning"
+            />
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+            <div>
+              <FieldLabel>Top provider context length</FieldLabel>
+              <Input
+                type="number"
+                min={1}
+                value={overrides.top_provider?.context_length ?? ''}
+                onChange={(e) =>
+                  onSetTopProvider('context_length', parseIntOrUndef(e.target.value))
+                }
+                placeholder="e.g. 128000"
+              />
+            </div>
+            <div>
+              <FieldLabel>Max completion tokens</FieldLabel>
+              <Input
+                type="number"
+                min={1}
+                value={overrides.top_provider?.max_completion_tokens ?? ''}
+                onChange={(e) =>
+                  onSetTopProvider('max_completion_tokens', parseIntOrUndef(e.target.value))
+                }
+                placeholder="e.g. 16384"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/models/MetadataOverrideForm.tsx
+++ b/packages/frontend/src/components/models/MetadataOverrideForm.tsx
@@ -1,5 +1,33 @@
 import type { MetadataOverrides } from '../../lib/api';
 import { Input } from '../ui/Input';
+import { TagSelect } from '../ui/TagSelect';
+
+// Suggested values shown in the TagSelect dropdowns. Users can still enter
+// arbitrary strings via `allowCustom`; these are just hints for the common case.
+const MODALITY_SUGGESTIONS = ['text', 'image', 'audio', 'video', 'file'];
+const SUPPORTED_PARAM_SUGGESTIONS = [
+  'temperature',
+  'top_p',
+  'top_k',
+  'min_p',
+  'top_a',
+  'frequency_penalty',
+  'presence_penalty',
+  'repetition_penalty',
+  'seed',
+  'max_tokens',
+  'logit_bias',
+  'logprobs',
+  'top_logprobs',
+  'response_format',
+  'structured_outputs',
+  'stop',
+  'tools',
+  'tool_choice',
+  'reasoning',
+  'include_reasoning',
+  'web_search_options',
+];
 
 interface Props {
   overrides: MetadataOverrides;
@@ -39,12 +67,6 @@ const FieldLabel = ({ children }: { children: React.ReactNode }) => (
     {children}
   </label>
 );
-
-const parseCsv = (s: string): string[] =>
-  s
-    .split(',')
-    .map((x) => x.trim())
-    .filter((x) => x.length > 0);
 
 const parseIntOrUndef = (s: string): number | undefined => {
   const trimmed = s.trim();
@@ -166,25 +188,27 @@ export function MetadataOverrideForm({
         <SectionLabel>Architecture</SectionLabel>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
           <div>
-            <FieldLabel>Input modalities (comma-separated)</FieldLabel>
-            <Input
-              value={(overrides.architecture?.input_modalities ?? []).join(', ')}
-              onChange={(e) => {
-                const list = parseCsv(e.target.value);
-                onSetArchitecture('input_modalities', list.length > 0 ? list : undefined);
-              }}
-              placeholder="text, image"
+            <FieldLabel>Input modalities</FieldLabel>
+            <TagSelect
+              placeholder="Add modalities..."
+              options={MODALITY_SUGGESTIONS}
+              selected={overrides.architecture?.input_modalities ?? []}
+              allowCustom
+              onChange={(list) =>
+                onSetArchitecture('input_modalities', list.length > 0 ? list : undefined)
+              }
             />
           </div>
           <div>
-            <FieldLabel>Output modalities (comma-separated)</FieldLabel>
-            <Input
-              value={(overrides.architecture?.output_modalities ?? []).join(', ')}
-              onChange={(e) => {
-                const list = parseCsv(e.target.value);
-                onSetArchitecture('output_modalities', list.length > 0 ? list : undefined);
-              }}
-              placeholder="text"
+            <FieldLabel>Output modalities</FieldLabel>
+            <TagSelect
+              placeholder="Add modalities..."
+              options={MODALITY_SUGGESTIONS}
+              selected={overrides.architecture?.output_modalities ?? []}
+              allowCustom
+              onChange={(list) =>
+                onSetArchitecture('output_modalities', list.length > 0 ? list : undefined)
+              }
             />
           </div>
           <div style={{ gridColumn: 'span 2' }}>
@@ -205,14 +229,15 @@ export function MetadataOverrideForm({
         <SectionLabel>Capabilities</SectionLabel>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '6px' }}>
           <div>
-            <FieldLabel>Supported parameters (comma-separated)</FieldLabel>
-            <Input
-              value={(overrides.supported_parameters ?? []).join(', ')}
-              onChange={(e) => {
-                const list = parseCsv(e.target.value);
-                onSetField('supported_parameters', list.length > 0 ? list : undefined);
-              }}
-              placeholder="tools, temperature, reasoning"
+            <FieldLabel>Supported parameters</FieldLabel>
+            <TagSelect
+              placeholder="Add parameters..."
+              options={SUPPORTED_PARAM_SUGGESTIONS}
+              selected={overrides.supported_parameters ?? []}
+              allowCustom
+              onChange={(list) =>
+                onSetField('supported_parameters', list.length > 0 ? list : undefined)
+              }
             />
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>

--- a/packages/frontend/src/components/ui/TagSelect.tsx
+++ b/packages/frontend/src/components/ui/TagSelect.tsx
@@ -9,6 +9,12 @@ interface TagSelectProps {
   selected: string[];
   onChange: (selected: string[]) => void;
   className?: string;
+  /**
+   * When true, users can add free-form values that aren't in `options`.
+   * Pressing Enter or typing a comma commits the current search text as a
+   * new tag, and the dropdown shows a "Create '<search>'" affordance.
+   */
+  allowCustom?: boolean;
 }
 
 export const TagSelect: React.FC<TagSelectProps> = ({
@@ -18,6 +24,7 @@ export const TagSelect: React.FC<TagSelectProps> = ({
   selected,
   onChange,
   className,
+  allowCustom = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState('');
@@ -64,6 +71,50 @@ export const TagSelect: React.FC<TagSelectProps> = ({
     setIsOpen(true);
   };
 
+  // Commit the current search text as a new free-form tag. No-ops if the
+  // value is empty (after trim) or already selected.
+  const commitCustom = (raw: string) => {
+    const value = raw.trim();
+    if (!value) return;
+    if (selected.includes(value)) {
+      setSearch('');
+      return;
+    }
+    onChange([...selected, value]);
+    setSearch('');
+  };
+
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!allowCustom) return;
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      commitCustom(search);
+    } else if (e.key === 'Backspace' && search === '' && selected.length > 0) {
+      // Quality-of-life: backspace on empty input peels off the last tag.
+      onChange(selected.slice(0, -1));
+    }
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.value;
+    // Commit on comma even inside onChange (handles paste of "a, b, c").
+    if (allowCustom && next.includes(',')) {
+      const parts = next.split(',');
+      const tail = parts.pop() ?? '';
+      parts.forEach((p) => commitCustom(p));
+      setSearch(tail);
+      return;
+    }
+    setSearch(next);
+  };
+
+  const searchTrimmed = search.trim();
+  const showCreateOption =
+    allowCustom &&
+    searchTrimmed.length > 0 &&
+    !selected.includes(searchTrimmed) &&
+    !options.some((o) => o.toLowerCase() === searchTrimmed.toLowerCase());
+
   return (
     <div className={clsx('flex flex-col gap-2', className)} ref={containerRef}>
       {label && (
@@ -101,8 +152,14 @@ export const TagSelect: React.FC<TagSelectProps> = ({
             ref={searchInputRef}
             className="flex-1 min-w-[80px] bg-transparent border-0 outline-none text-text text-sm p-0 placeholder:text-text-muted"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder={selected.length === 0 ? placeholder : 'Search...'}
+            onChange={handleSearchChange}
+            onKeyDown={handleSearchKeyDown}
+            onBlur={() => {
+              if (allowCustom) commitCustom(search);
+            }}
+            placeholder={
+              selected.length === 0 ? placeholder : allowCustom ? 'Type to add...' : 'Search...'
+            }
           />
         ) : (
           <span className="text-text-muted text-sm flex-1">
@@ -121,9 +178,13 @@ export const TagSelect: React.FC<TagSelectProps> = ({
       {isOpen && (
         <div className="relative -mt-1">
           <div className="absolute z-50 w-full max-h-52 overflow-y-auto bg-bg-surface border border-border-glass rounded-sm shadow-lg">
-            {filteredOptions.length === 0 && (
+            {filteredOptions.length === 0 && !showCreateOption && (
               <div className="px-3.5 py-2.5 text-xs text-text-muted">
-                {search ? 'No matches found' : 'All items selected'}
+                {search
+                  ? 'No matches found'
+                  : allowCustom
+                    ? 'Type to add a new tag'
+                    : 'All items selected'}
               </div>
             )}
             {filteredOptions.map((option) => (
@@ -139,6 +200,22 @@ export const TagSelect: React.FC<TagSelectProps> = ({
                 {option}
               </button>
             ))}
+            {showCreateOption && (
+              <button
+                type="button"
+                key={`__create__${searchTrimmed}`}
+                className="w-full text-left px-3.5 py-2 text-sm font-body cursor-pointer transition-colors hover:bg-bg-hover text-text border-t border-border-glass"
+                onMouseDown={(e) => {
+                  // Use onMouseDown so the click registers before the input
+                  // blur handler fires and closes the dropdown.
+                  e.preventDefault();
+                  commitCustom(searchTrimmed);
+                }}
+              >
+                <span className="text-text-muted">Create </span>
+                <span className="font-medium">&quot;{searchTrimmed}&quot;</span>
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/packages/frontend/src/components/ui/TagSelect.tsx
+++ b/packages/frontend/src/components/ui/TagSelect.tsx
@@ -71,16 +71,25 @@ export const TagSelect: React.FC<TagSelectProps> = ({
     setIsOpen(true);
   };
 
+  // Add one or more free-form tags in a single onChange call. Skips empty,
+  // duplicate, and already-selected values. Does NOT touch `search` — callers
+  // decide whether to clear the input.
+  const addCustomTags = (raws: string[]) => {
+    const seen = new Set(selected);
+    const toAdd: string[] = [];
+    for (const raw of raws) {
+      const value = raw.trim();
+      if (!value || seen.has(value)) continue;
+      seen.add(value);
+      toAdd.push(value);
+    }
+    if (toAdd.length > 0) onChange([...selected, ...toAdd]);
+  };
+
   // Commit the current search text as a new free-form tag. No-ops if the
   // value is empty (after trim) or already selected.
   const commitCustom = (raw: string) => {
-    const value = raw.trim();
-    if (!value) return;
-    if (selected.includes(value)) {
-      setSearch('');
-      return;
-    }
-    onChange([...selected, value]);
+    addCustomTags([raw]);
     setSearch('');
   };
 
@@ -97,11 +106,13 @@ export const TagSelect: React.FC<TagSelectProps> = ({
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const next = e.target.value;
-    // Commit on comma even inside onChange (handles paste of "a, b, c").
+    // Commit on comma even inside onChange (handles paste of "a, b, c"). Batch
+    // all new tags into a single onChange so later calls don't overwrite
+    // earlier ones via the stale `selected` snapshot.
     if (allowCustom && next.includes(',')) {
       const parts = next.split(',');
       const tail = parts.pop() ?? '';
-      parts.forEach((p) => commitCustom(p));
+      addCustomTags(parts);
       setSearch(tail);
       return;
     }
@@ -195,7 +206,14 @@ export const TagSelect: React.FC<TagSelectProps> = ({
                   'w-full text-left px-3.5 py-2 text-sm font-body cursor-pointer transition-colors',
                   'hover:bg-bg-hover text-text'
                 )}
-                onClick={() => handleToggle(option)}
+                onMouseDown={(e) => {
+                  // Use onMouseDown so the click registers before the input
+                  // blur handler fires. Otherwise, onBlur's commitCustom(search)
+                  // would add the partial search text as a new tag before the
+                  // suggestion is selected.
+                  e.preventDefault();
+                  handleToggle(option);
+                }}
               >
                 {option}
               </button>

--- a/packages/frontend/src/components/ui/TagSelect.tsx
+++ b/packages/frontend/src/components/ui/TagSelect.tsx
@@ -50,8 +50,16 @@ export const TagSelect: React.FC<TagSelectProps> = ({
     }
   }, [isOpen]);
 
+  // Single source of truth for tag identity: duplicate detection across
+  // filteredOptions / showCreateOption / addCustomTags must agree, otherwise
+  // the dropdown can hide a "Create" option while keyboard/blur/paste still
+  // commits it (or vice versa).
+  const normalize = (s: string) => s.trim().toLowerCase();
+
   const filteredOptions = options.filter(
-    (opt) => opt.toLowerCase().includes(search.toLowerCase()) && !selected.includes(opt)
+    (opt) =>
+      normalize(opt).includes(normalize(search)) &&
+      !selected.some((s) => normalize(s) === normalize(opt))
   );
 
   const handleToggle = (option: string) => {
@@ -72,15 +80,18 @@ export const TagSelect: React.FC<TagSelectProps> = ({
   };
 
   // Add one or more free-form tags in a single onChange call. Skips empty,
-  // duplicate, and already-selected values. Does NOT touch `search` — callers
-  // decide whether to clear the input.
+  // duplicate, and already-selected values (case-insensitive). Preserves the
+  // user-typed casing in the committed value. Does NOT touch `search` —
+  // callers decide whether to clear the input.
   const addCustomTags = (raws: string[]) => {
-    const seen = new Set(selected);
+    const seen = new Set(selected.map(normalize));
     const toAdd: string[] = [];
     for (const raw of raws) {
       const value = raw.trim();
-      if (!value || seen.has(value)) continue;
-      seen.add(value);
+      if (!value) continue;
+      const key = normalize(value);
+      if (seen.has(key)) continue;
+      seen.add(key);
       toAdd.push(value);
     }
     if (toAdd.length > 0) onChange([...selected, ...toAdd]);
@@ -120,11 +131,12 @@ export const TagSelect: React.FC<TagSelectProps> = ({
   };
 
   const searchTrimmed = search.trim();
+  const searchKey = normalize(searchTrimmed);
   const showCreateOption =
     allowCustom &&
     searchTrimmed.length > 0 &&
-    !selected.includes(searchTrimmed) &&
-    !options.some((o) => o.toLowerCase() === searchTrimmed.toLowerCase());
+    !selected.some((s) => normalize(s) === searchKey) &&
+    !options.some((o) => normalize(o) === searchKey);
 
   return (
     <div className={clsx('flex flex-col gap-2', className)} ref={containerRef}>
@@ -165,8 +177,15 @@ export const TagSelect: React.FC<TagSelectProps> = ({
             value={search}
             onChange={handleSearchChange}
             onKeyDown={handleSearchKeyDown}
-            onBlur={() => {
-              if (allowCustom) commitCustom(search);
+            onBlur={(e) => {
+              if (!allowCustom) return;
+              // Only commit when focus leaves the component entirely. A blur
+              // to another element inside the container (e.g. clicking a
+              // dropdown item) would otherwise commit the partial search text
+              // as a new tag before the item's click handler fires.
+              const related = e.relatedTarget as Node | null;
+              if (related && containerRef.current?.contains(related)) return;
+              commitCustom(search);
             }}
             placeholder={
               selected.length === 0 ? placeholder : allowCustom ? 'Type to add...' : 'Search...'
@@ -206,14 +225,7 @@ export const TagSelect: React.FC<TagSelectProps> = ({
                   'w-full text-left px-3.5 py-2 text-sm font-body cursor-pointer transition-colors',
                   'hover:bg-bg-hover text-text'
                 )}
-                onMouseDown={(e) => {
-                  // Use onMouseDown so the click registers before the input
-                  // blur handler fires. Otherwise, onBlur's commitCustom(search)
-                  // would add the partial search text as a new tag before the
-                  // suggestion is selected.
-                  e.preventDefault();
-                  handleToggle(option);
-                }}
+                onClick={() => handleToggle(option)}
               >
                 {option}
               </button>
@@ -223,12 +235,7 @@ export const TagSelect: React.FC<TagSelectProps> = ({
                 type="button"
                 key={`__create__${searchTrimmed}`}
                 className="w-full text-left px-3.5 py-2 text-sm font-body cursor-pointer transition-colors hover:bg-bg-hover text-text border-t border-border-glass"
-                onMouseDown={(e) => {
-                  // Use onMouseDown so the click registers before the input
-                  // blur handler fires and closes the dropdown.
-                  e.preventDefault();
-                  commitCustom(searchTrimmed);
-                }}
+                onClick={() => commitCustom(searchTrimmed)}
               >
                 <span className="text-text-muted">Create </span>
                 <span className="font-medium">&quot;{searchTrimmed}&quot;</span>

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -296,9 +296,35 @@ export interface StripAdaptiveThinkingBehavior {
 
 export type AliasBehavior = StripAdaptiveThinkingBehavior; // | NextBehavior | ...
 
+export type MetadataSource = 'openrouter' | 'models.dev' | 'catwalk' | 'custom';
+
+export interface MetadataOverrides {
+  name?: string;
+  description?: string;
+  context_length?: number;
+  pricing?: {
+    prompt?: string;
+    completion?: string;
+    input_cache_read?: string;
+    input_cache_write?: string;
+  };
+  architecture?: {
+    input_modalities?: string[];
+    output_modalities?: string[];
+    tokenizer?: string;
+  };
+  supported_parameters?: string[];
+  top_provider?: {
+    context_length?: number;
+    max_completion_tokens?: number;
+  };
+}
+
 export interface AliasMetadata {
-  source: 'openrouter' | 'models.dev' | 'catwalk';
-  source_path: string;
+  source: MetadataSource;
+  // Required for openrouter/models.dev/catwalk; optional for 'custom'.
+  source_path?: string;
+  overrides?: MetadataOverrides;
 }
 
 export interface Alias {
@@ -2306,7 +2332,7 @@ export const api = {
    * @param limit  - max results (default 50)
    */
   searchModelMetadata: async (
-    source: 'openrouter' | 'models.dev' | 'catwalk',
+    source: Exclude<MetadataSource, 'custom'>,
     query?: string,
     limit?: number
   ): Promise<{ data: { id: string; name: string }[]; count: number }> => {

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -349,7 +349,8 @@ export interface NormalizedModelMetadata {
 }
 
 // Discriminated union mirrors backend validation: catalog-backed sources
-// must carry a non-empty source_path; 'custom' may omit it.
+// must carry a non-empty source_path; 'custom' may omit it but MUST carry
+// an overrides blob with a non-empty `name` (there is no catalog fallback).
 export type AliasMetadata =
   | {
       source: Exclude<MetadataSource, 'custom'>;
@@ -359,7 +360,7 @@ export type AliasMetadata =
   | {
       source: 'custom';
       source_path?: string;
-      overrides?: MetadataOverrides;
+      overrides: MetadataOverrides & { name: string };
     };
 
 export interface Alias {

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -320,12 +320,19 @@ export interface MetadataOverrides {
   };
 }
 
-export interface AliasMetadata {
-  source: MetadataSource;
-  // Required for openrouter/models.dev/catwalk; optional for 'custom'.
-  source_path?: string;
-  overrides?: MetadataOverrides;
-}
+// Discriminated union mirrors backend validation: catalog-backed sources
+// must carry a non-empty source_path; 'custom' may omit it.
+export type AliasMetadata =
+  | {
+      source: Exclude<MetadataSource, 'custom'>;
+      source_path: string;
+      overrides?: MetadataOverrides;
+    }
+  | {
+      source: 'custom';
+      source_path?: string;
+      overrides?: MetadataOverrides;
+    };
 
 export interface Alias {
   id: string;

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -320,6 +320,34 @@ export interface MetadataOverrides {
   };
 }
 
+/**
+ * Mirror of the backend `NormalizedModelMetadata` shape. Returned by
+ * `GET /v1/metadata/lookup` and used to pre-fill the override form.
+ */
+export interface NormalizedModelMetadata {
+  id: string;
+  name: string;
+  description?: string;
+  context_length?: number;
+  architecture?: {
+    input_modalities?: string[];
+    output_modalities?: string[];
+    tokenizer?: string;
+    instruct_type?: string | null;
+  };
+  pricing?: {
+    prompt?: string;
+    completion?: string;
+    input_cache_read?: string;
+    input_cache_write?: string;
+  };
+  supported_parameters?: string[];
+  top_provider?: {
+    context_length?: number;
+    max_completion_tokens?: number;
+  };
+}
+
 // Discriminated union mirrors backend validation: catalog-backed sources
 // must carry a non-empty source_path; 'custom' may omit it.
 export type AliasMetadata =
@@ -2353,6 +2381,25 @@ export const api = {
       throw new Error(`Failed to search model metadata: ${res.statusText}`);
     }
     return res.json();
+  },
+
+  /**
+   * Look up full catalog metadata for a specific model. Returns null when the
+   * source has not loaded (503) or the source_path is not found (404) so callers
+   * can gracefully fall back to leaving the form blank.
+   */
+  getModelMetadata: async (
+    source: Exclude<MetadataSource, 'custom'>,
+    sourcePath: string
+  ): Promise<NormalizedModelMetadata | null> => {
+    const params = new URLSearchParams({ source, source_path: sourcePath });
+    const res = await fetch(`${API_BASE}/v1/metadata/lookup?${params}`);
+    if (res.status === 404 || res.status === 503) return null;
+    if (!res.ok) {
+      throw new Error(`Failed to look up model metadata: ${res.statusText}`);
+    }
+    const json = (await res.json()) as { data: NormalizedModelMetadata };
+    return json.data;
   },
 
   getOAuthProviderModels: async (

--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -37,7 +37,7 @@ interface DebugLogDetail extends DebugLogMeta {
 
 export const Debug: React.FC = () => {
   const location = useLocation();
-  const { isAdmin, isLimited, principal } = useAuth();
+  const { isAdmin, principal } = useAuth();
   const [logs, setLogs] = useState<DebugLogMeta[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<DebugLogDetail | null>(null);
@@ -266,7 +266,7 @@ export const Debug: React.FC = () => {
         <div>
           <h1 className="font-heading text-3xl font-bold text-text m-0 mb-2">Debug Traces</h1>
           <p className="text-[15px] text-text-secondary m-0">
-            {isLimited && principal?.keyName
+            {principal?.role === 'limited' && principal.keyName
               ? `Traces for key "${principal.keyName}" only. Toggle capture in My Key.`
               : 'Inspect full request/response lifecycles'}
           </p>

--- a/packages/frontend/src/pages/Errors.tsx
+++ b/packages/frontend/src/pages/Errors.tsx
@@ -19,7 +19,7 @@ import { useAuth } from '../contexts/AuthContext';
 
 export const Errors: React.FC = () => {
   const location = useLocation();
-  const { isAdmin, isLimited, principal } = useAuth();
+  const { isAdmin, principal } = useAuth();
   const [errors, setErrors] = useState<InferenceError[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedError, setSelectedError] = useState<InferenceError | null>(null);
@@ -146,7 +146,7 @@ export const Errors: React.FC = () => {
             Inference Errors
           </h1>
           <p className="text-[15px] text-text-secondary m-0">
-            {isLimited && principal?.keyName
+            {principal?.role === 'limited' && principal.keyName
               ? `Errors for key "${principal.keyName}" only.`
               : 'Investigate failed requests and exceptions'}
           </p>

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -388,7 +388,7 @@ export const Logs = () => {
     <div className="min-h-screen p-6 transition-all duration-300 bg-linear-to-br from-bg-deep to-bg-surface">
       <div className="mb-4">
         <h1 className="font-heading text-3xl font-bold text-text m-0">Logs</h1>
-        {isLimited && principal?.keyName && (
+        {principal?.role === 'limited' && principal.keyName && (
           <p className="text-sm text-text-muted mt-1">Scoped to key "{principal.keyName}".</p>
         )}
       </div>

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -1,8 +1,18 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { api, Alias, AliasMetadata, AliasBehavior, Provider, Model } from '../lib/api';
+import {
+  api,
+  Alias,
+  AliasMetadata,
+  AliasBehavior,
+  MetadataOverrides,
+  MetadataSource,
+  Provider,
+  Model,
+} from '../lib/api';
 import { useModels } from '../hooks/useModels';
 import { AliasTableRow } from '../components/models/AliasTableRow';
+import { MetadataOverrideForm } from '../components/models/MetadataOverrideForm';
 import { Input } from '../components/ui/Input';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
@@ -52,6 +62,9 @@ export const Models = () => {
   // Modal State
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
   const [isMetadataOpen, setIsMetadataOpen] = useState(false);
+  // "Override" toggle for non-custom sources. When on, the editable field
+  // grid is shown so the user can override individual enriched fields.
+  const [isOverrideOpen, setIsOverrideOpen] = useState(false);
 
   // Metadata search state
   const [metadataQuery, setMetadataQuery] = useState('');
@@ -102,6 +115,19 @@ export const Models = () => {
     };
     fetchVFConfig();
   }, []);
+
+  // When the modal opens, sync override panel state + search query with the
+  // current alias's metadata block.
+  useEffect(() => {
+    if (!isModalOpen) return;
+    const meta = editingAlias.metadata;
+    setIsOverrideOpen(!!meta && (meta.source === 'custom' || !!meta.overrides));
+    setMetadataQuery(meta?.source_path ?? '');
+    setShowMetadataDropdown(false);
+    setMetadataResults([]);
+    // Only re-run when the modal transitions open (or editingAlias.id changes).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isModalOpen, editingAlias.id]);
 
   const handleSaveDescriptor = async () => {
     setIsSavingDescriptor(true);
@@ -301,7 +327,14 @@ export const Models = () => {
   };
 
   /** Search metadata catalog for autocomplete */
-  const handleMetadataSearch = useCallback((query: string, source: AliasMetadata['source']) => {
+  const handleMetadataSearch = useCallback((query: string, source: MetadataSource) => {
+    if (source === 'custom') {
+      // Custom has no catalog to search against.
+      setMetadataQuery(query);
+      setMetadataResults([]);
+      setShowMetadataDropdown(false);
+      return;
+    }
     setMetadataQuery(query);
     if (metadataSearchRef.current) clearTimeout(metadataSearchRef.current);
     if (!query.trim()) {
@@ -323,12 +356,18 @@ export const Models = () => {
     }, 250);
   }, []);
 
-  /** Select a metadata result and set it on the alias */
+  /** Select a metadata result and set it on the alias (preserves existing overrides). */
   const selectMetadataResult = (result: { id: string; name: string }) => {
-    const source = editingAlias.metadata?.source ?? 'openrouter';
+    const current = editingAlias.metadata;
+    const source: MetadataSource =
+      current?.source && current.source !== 'custom' ? current.source : 'openrouter';
     setEditingAlias({
       ...editingAlias,
-      metadata: { source, source_path: result.id },
+      metadata: {
+        source,
+        source_path: result.id,
+        ...(current?.overrides ? { overrides: current.overrides } : {}),
+      },
     });
     setMetadataQuery(result.name);
     setShowMetadataDropdown(false);
@@ -341,6 +380,95 @@ export const Models = () => {
     setEditingAlias(rest as Alias);
     setMetadataQuery('');
     setShowMetadataDropdown(false);
+  };
+
+  /** Seed defaults when a user first picks the 'custom' source. */
+  const buildCustomDefaults = (aliasId: string): MetadataOverrides => ({
+    name: aliasId || 'Custom Model',
+    context_length: 4096,
+    architecture: { input_modalities: ['text'], output_modalities: ['text'] },
+    pricing: { prompt: '0', completion: '0' },
+    supported_parameters: [],
+  });
+
+  /** Patch a single field in the override blob. `undefined` removes the key. */
+  const setOverrideField = <K extends keyof MetadataOverrides>(
+    key: K,
+    value: MetadataOverrides[K] | undefined
+  ) => {
+    const current = editingAlias.metadata;
+    if (!current) return;
+    const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
+    if (value === undefined) delete nextOverrides[key];
+    else nextOverrides[key] = value;
+    setEditingAlias({
+      ...editingAlias,
+      metadata: { ...current, overrides: nextOverrides },
+    });
+  };
+
+  const setPricingField = (
+    key: keyof NonNullable<MetadataOverrides['pricing']>,
+    value: string | undefined
+  ) => {
+    const current = editingAlias.metadata;
+    if (!current) return;
+    const pricing = { ...(current.overrides?.pricing ?? {}) };
+    if (value === undefined || value === '') delete pricing[key];
+    else pricing[key] = value;
+    const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
+    if (Object.keys(pricing).length === 0) delete nextOverrides.pricing;
+    else nextOverrides.pricing = pricing;
+    setEditingAlias({ ...editingAlias, metadata: { ...current, overrides: nextOverrides } });
+  };
+
+  const setArchitectureField = (
+    key: keyof NonNullable<MetadataOverrides['architecture']>,
+    value: string | string[] | undefined
+  ) => {
+    const current = editingAlias.metadata;
+    if (!current) return;
+    const arch = { ...(current.overrides?.architecture ?? {}) };
+    if (value === undefined || (Array.isArray(value) && value.length === 0) || value === '')
+      delete arch[key];
+    else (arch as any)[key] = value;
+    const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
+    if (Object.keys(arch).length === 0) delete nextOverrides.architecture;
+    else nextOverrides.architecture = arch;
+    setEditingAlias({ ...editingAlias, metadata: { ...current, overrides: nextOverrides } });
+  };
+
+  const setTopProviderField = (
+    key: keyof NonNullable<MetadataOverrides['top_provider']>,
+    value: number | undefined
+  ) => {
+    const current = editingAlias.metadata;
+    if (!current) return;
+    const tp = { ...(current.overrides?.top_provider ?? {}) };
+    if (value === undefined) delete tp[key];
+    else tp[key] = value;
+    const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
+    if (Object.keys(tp).length === 0) delete nextOverrides.top_provider;
+    else nextOverrides.top_provider = tp;
+    setEditingAlias({ ...editingAlias, metadata: { ...current, overrides: nextOverrides } });
+  };
+
+  /** Count the number of overridden fields for the preview strip. */
+  const countOverrides = (o?: MetadataOverrides): number => {
+    if (!o) return 0;
+    let n = 0;
+    if (o.name !== undefined) n++;
+    if (o.description !== undefined) n++;
+    if (o.context_length !== undefined) n++;
+    if (o.pricing) n += Object.values(o.pricing).filter((v) => v !== undefined).length;
+    if (o.architecture) {
+      if (o.architecture.input_modalities !== undefined) n++;
+      if (o.architecture.output_modalities !== undefined) n++;
+      if (o.architecture.tokenizer !== undefined) n++;
+    }
+    if (o.supported_parameters !== undefined) n++;
+    if (o.top_provider) n += Object.values(o.top_provider).filter((v) => v !== undefined).length;
+    return n;
   };
 
   const handleDragStart = (e: React.DragEvent<HTMLDivElement>, index: number) => {
@@ -792,103 +920,210 @@ export const Models = () => {
                     style={{ padding: '5px 8px', height: '30px' }}
                     value={editingAlias.metadata?.source ?? 'openrouter'}
                     onChange={(e) => {
-                      const source = e.target.value as AliasMetadata['source'];
-                      setEditingAlias({
-                        ...editingAlias,
-                        metadata: { source, source_path: editingAlias.metadata?.source_path ?? '' },
-                      });
+                      const source = e.target.value as MetadataSource;
+                      const existingOverrides = editingAlias.metadata?.overrides;
+                      let next: AliasMetadata;
+                      if (source === 'custom') {
+                        next = {
+                          source: 'custom',
+                          overrides: existingOverrides ?? buildCustomDefaults(editingAlias.id),
+                        };
+                        setIsOverrideOpen(true);
+                      } else {
+                        next = {
+                          source,
+                          source_path: editingAlias.metadata?.source_path ?? '',
+                          ...(existingOverrides ? { overrides: existingOverrides } : {}),
+                        };
+                      }
+                      setEditingAlias({ ...editingAlias, metadata: next });
                       // Re-run search with new source if there's a query
-                      if (metadataQuery) handleMetadataSearch(metadataQuery, source);
+                      if (metadataQuery && source !== 'custom')
+                        handleMetadataSearch(metadataQuery, source);
                     }}
                   >
                     <option value="openrouter">OpenRouter</option>
                     <option value="models.dev">models.dev</option>
                     <option value="catwalk">Catwalk (Charm)</option>
+                    <option value="custom">Custom (manual entry)</option>
                   </select>
                 </div>
 
-                {/* Search / source_path */}
-                <div style={{ position: 'relative' }}>
-                  <label
-                    className="font-body text-[12px] font-medium text-text-secondary"
-                    style={{ display: 'block', marginBottom: '4px' }}
-                  >
-                    Model
-                    {editingAlias.metadata?.source_path && (
-                      <span className="ml-2 font-normal text-text-muted">
-                        ({editingAlias.metadata.source_path})
-                      </span>
-                    )}
-                  </label>
-                  <div style={{ position: 'relative', display: 'flex', gap: '4px' }}>
-                    <div ref={metadataInputWrapperRef} style={{ position: 'relative', flex: 1 }}>
-                      <Input
-                        value={metadataQuery}
-                        onChange={(e) => {
-                          const source = editingAlias.metadata?.source ?? 'openrouter';
-                          handleMetadataSearch(e.target.value, source);
-                          // Update rect so portal dropdown follows the input
-                          if (metadataInputWrapperRef.current) {
-                            const r = metadataInputWrapperRef.current.getBoundingClientRect();
-                            setDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width });
-                          }
-                        }}
-                        onFocus={() => {
-                          if (metadataResults.length > 0) {
+                {/* Search / source_path — hidden for 'custom' (no catalog) */}
+                {editingAlias.metadata?.source !== 'custom' && (
+                  <div style={{ position: 'relative' }}>
+                    <label
+                      className="font-body text-[12px] font-medium text-text-secondary"
+                      style={{ display: 'block', marginBottom: '4px' }}
+                    >
+                      Model
+                      {editingAlias.metadata?.source_path && (
+                        <span className="ml-2 font-normal text-text-muted">
+                          ({editingAlias.metadata.source_path})
+                        </span>
+                      )}
+                    </label>
+                    <div style={{ position: 'relative', display: 'flex', gap: '4px' }}>
+                      <div ref={metadataInputWrapperRef} style={{ position: 'relative', flex: 1 }}>
+                        <Input
+                          value={metadataQuery}
+                          onChange={(e) => {
+                            const source = editingAlias.metadata?.source ?? 'openrouter';
+                            handleMetadataSearch(e.target.value, source);
+                            // Update rect so portal dropdown follows the input
                             if (metadataInputWrapperRef.current) {
                               const r = metadataInputWrapperRef.current.getBoundingClientRect();
                               setDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width });
                             }
-                            setShowMetadataDropdown(true);
-                          }
-                        }}
-                        placeholder={`Search ${editingAlias.metadata?.source ?? 'openrouter'} catalog...`}
-                        style={{
-                          width: '100%',
-                          paddingRight: isMetadataSearching ? '28px' : undefined,
-                        }}
-                        onBlur={() => setShowMetadataDropdown(false)}
-                      />
-                      {isMetadataSearching && (
-                        <Loader2
-                          size={14}
-                          className="animate-spin text-text-muted"
-                          style={{
-                            position: 'absolute',
-                            right: '8px',
-                            top: '50%',
-                            transform: 'translateY(-50%)',
                           }}
+                          onFocus={() => {
+                            if (metadataResults.length > 0) {
+                              if (metadataInputWrapperRef.current) {
+                                const r = metadataInputWrapperRef.current.getBoundingClientRect();
+                                setDropdownRect({
+                                  top: r.bottom + 2,
+                                  left: r.left,
+                                  width: r.width,
+                                });
+                              }
+                              setShowMetadataDropdown(true);
+                            }
+                          }}
+                          placeholder={`Search ${editingAlias.metadata?.source ?? 'openrouter'} catalog...`}
+                          style={{
+                            width: '100%',
+                            paddingRight: isMetadataSearching ? '28px' : undefined,
+                          }}
+                          onBlur={() => setShowMetadataDropdown(false)}
                         />
+                        {isMetadataSearching && (
+                          <Loader2
+                            size={14}
+                            className="animate-spin text-text-muted"
+                            style={{
+                              position: 'absolute',
+                              right: '8px',
+                              top: '50%',
+                              transform: 'translateY(-50%)',
+                            }}
+                          />
+                        )}
+                      </div>
+                      {editingAlias.metadata && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={clearMetadata}
+                          style={{
+                            color: 'var(--color-danger)',
+                            padding: '4px',
+                            minHeight: 'auto',
+                          }}
+                          title="Remove metadata"
+                        >
+                          <X size={14} />
+                        </Button>
                       )}
                     </div>
-                    {editingAlias.metadata && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={clearMetadata}
-                        style={{ color: 'var(--color-danger)', padding: '4px', minHeight: 'auto' }}
-                        title="Remove metadata"
-                      >
-                        <X size={14} />
-                      </Button>
-                    )}
                   </div>
-                </div>
+                )}
 
                 {/* Selected metadata preview */}
-                {editingAlias.metadata?.source_path && (
-                  <div
-                    className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-2"
-                    style={{ fontSize: '11px', color: 'var(--color-text-secondary)' }}
-                  >
-                    <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                      <CheckCircle size={12} className="text-success" />
-                      <span>
-                        Metadata assigned from <strong>{editingAlias.metadata.source}</strong>:{' '}
-                        <code className="text-primary">{editingAlias.metadata.source_path}</code>
-                      </span>
+                {editingAlias.metadata &&
+                  (editingAlias.metadata.source === 'custom' ||
+                    editingAlias.metadata.source_path ||
+                    editingAlias.metadata.overrides) && (
+                    <div
+                      className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-2"
+                      style={{ fontSize: '11px', color: 'var(--color-text-secondary)' }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                        <CheckCircle size={12} className="text-success" />
+                        <span>
+                          {editingAlias.metadata.source === 'custom' ? (
+                            <>
+                              Custom metadata
+                              {editingAlias.metadata.source_path && (
+                                <>
+                                  :{' '}
+                                  <code className="text-primary">
+                                    {editingAlias.metadata.source_path}
+                                  </code>
+                                </>
+                              )}
+                            </>
+                          ) : (
+                            <>
+                              Metadata assigned from <strong>{editingAlias.metadata.source}</strong>
+                              {editingAlias.metadata.source_path && (
+                                <>
+                                  :{' '}
+                                  <code className="text-primary">
+                                    {editingAlias.metadata.source_path}
+                                  </code>
+                                </>
+                              )}
+                            </>
+                          )}
+                          {countOverrides(editingAlias.metadata.overrides) > 0 && (
+                            <span className="ml-2 text-text-muted">
+                              + {countOverrides(editingAlias.metadata.overrides)} field
+                              {countOverrides(editingAlias.metadata.overrides) === 1 ? '' : 's'}{' '}
+                              overridden
+                            </span>
+                          )}
+                        </span>
+                      </div>
                     </div>
+                  )}
+
+                {/* Override toggle + editable form */}
+                {editingAlias.metadata && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                    {editingAlias.metadata.source !== 'custom' && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                        }}
+                      >
+                        <label
+                          className="font-body text-[12px] font-medium text-text-secondary"
+                          style={{ marginBottom: 0 }}
+                        >
+                          Override catalog fields
+                        </label>
+                        <Switch
+                          checked={isOverrideOpen}
+                          onChange={(v) => {
+                            setIsOverrideOpen(v);
+                            if (!v) {
+                              // Flipping override off clears any existing overrides.
+                              const current = editingAlias.metadata;
+                              if (current) {
+                                const { overrides: _o, ...rest } = current;
+                                setEditingAlias({
+                                  ...editingAlias,
+                                  metadata: rest as AliasMetadata,
+                                });
+                              }
+                            }
+                          }}
+                        />
+                      </div>
+                    )}
+
+                    {(isOverrideOpen || editingAlias.metadata.source === 'custom') && (
+                      <MetadataOverrideForm
+                        overrides={editingAlias.metadata.overrides ?? {}}
+                        isCustom={editingAlias.metadata.source === 'custom'}
+                        onSetField={setOverrideField}
+                        onSetPricing={setPricingField}
+                        onSetArchitecture={setArchitectureField}
+                        onSetTopProvider={setTopProviderField}
+                      />
+                    )}
                   </div>
                 )}
               </div>

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -130,11 +130,15 @@ export const Models = () => {
   // current alias's metadata block.
   useEffect(() => {
     if (!isModalOpen) return;
+    // Cancel any debounce left over from the previous modal session so it
+    // can't land results against the newly-loaded alias.
+    cancelMetadataDebounce();
     const meta = editingAlias.metadata;
     setIsOverrideOpen(!!meta && (meta.source === 'custom' || !!meta.overrides));
     setMetadataQuery(meta?.source_path ?? '');
     setShowMetadataDropdown(false);
     setMetadataResults([]);
+    setIsMetadataSearching(false);
     // Only re-run when the modal transitions open (or editingAlias.id changes).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isModalOpen, editingAlias.id]);
@@ -346,20 +350,37 @@ export const Models = () => {
     setEditingAlias({ ...editingAlias, advanced: next });
   };
 
+  /**
+   * Cancel any pending debounced metadata search so a stale response cannot
+   * later overwrite `metadataResults` after the source/query has moved on.
+   * Callers that change `metadata.source` or clear the query must invoke this
+   * before mutating state.
+   */
+  const cancelMetadataDebounce = () => {
+    if (metadataSearchRef.current) {
+      clearTimeout(metadataSearchRef.current);
+      metadataSearchRef.current = null;
+    }
+  };
+
   /** Search metadata catalog for autocomplete */
   const handleMetadataSearch = useCallback((query: string, source: MetadataSource) => {
     if (source === 'custom') {
-      // Custom has no catalog to search against.
+      // Custom has no catalog to search against — also kill any pending debounce
+      // from the prior catalog source so it can't land stale results.
+      cancelMetadataDebounce();
       setMetadataQuery(query);
       setMetadataResults([]);
       setShowMetadataDropdown(false);
+      setIsMetadataSearching(false);
       return;
     }
     setMetadataQuery(query);
-    if (metadataSearchRef.current) clearTimeout(metadataSearchRef.current);
+    cancelMetadataDebounce();
     if (!query.trim()) {
       setMetadataResults([]);
       setShowMetadataDropdown(false);
+      setIsMetadataSearching(false);
       return;
     }
     setIsMetadataSearching(true);
@@ -401,10 +422,18 @@ export const Models = () => {
 
   /** Clear metadata from the alias */
   const clearMetadata = () => {
+    // Drop any in-flight debounced search so it can't repopulate results
+    // against an alias that no longer has metadata attached.
+    cancelMetadataDebounce();
     const { metadata: _removed, ...rest } = editingAlias;
     setEditingAlias(rest as Alias);
     setMetadataQuery('');
+    setMetadataResults([]);
     setShowMetadataDropdown(false);
+    setIsMetadataSearching(false);
+    // Without this, re-adding a source would reopen the override form with
+    // stale `isOverrideOpen` state from the cleared metadata.
+    setIsOverrideOpen(false);
   };
 
   /** Seed defaults when a user first picks the 'custom' source. */
@@ -1287,6 +1316,16 @@ export const Models = () => {
                         };
                       }
                       setEditingAlias({ ...editingAlias, metadata: next });
+                      // Changing catalogs (or switching to custom) can leave
+                      // a pending debounced search from the prior source that
+                      // would overwrite `metadataResults` with stale data; kill
+                      // it before any conditional re-run below.
+                      if (prevSource !== source) {
+                        cancelMetadataDebounce();
+                        setMetadataResults([]);
+                        setShowMetadataDropdown(false);
+                        setIsMetadataSearching(false);
+                      }
                       // When we dropped the path, also clear the visible model
                       // query input so it doesn't show a stale value that no
                       // longer matches metadata.source_path.

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -7,6 +7,7 @@ import {
   AliasBehavior,
   MetadataOverrides,
   MetadataSource,
+  NormalizedModelMetadata,
   Provider,
   Model,
 } from '../lib/api';
@@ -101,6 +102,15 @@ export const Models = () => {
   // Global Descriptor State
   const [globalDescriptorModel, setGlobalDescriptorModel] = useState('');
   const [isSavingDescriptor, setIsSavingDescriptor] = useState(false);
+
+  // Reference values used by `countOverrides` to distinguish genuine overrides
+  // from fields that merely mirror the auto-populated catalog values.
+  //   undefined -> catalog lookup hasn't resolved yet (or not applicable)
+  //   null      -> lookup failed / no catalog record (treat as empty reference)
+  //   object    -> loaded catalog values, converted to the overrides shape
+  const [catalogReference, setCatalogReference] = useState<MetadataOverrides | null | undefined>(
+    undefined
+  );
 
   useEffect(() => {
     const fetchVFConfig = async () => {
@@ -369,7 +379,7 @@ export const Models = () => {
   /** Select a metadata result and set it on the alias (preserves existing overrides). */
   const selectMetadataResult = (result: { id: string; name: string }) => {
     const current = editingAlias.metadata;
-    const source: MetadataSource =
+    const source: Exclude<MetadataSource, 'custom'> =
       current?.source && current.source !== 'custom' ? current.source : 'openrouter';
     setEditingAlias({
       ...editingAlias,
@@ -382,6 +392,11 @@ export const Models = () => {
     setMetadataQuery(result.name);
     setShowMetadataDropdown(false);
     setMetadataResults([]);
+    // If override is already on, refresh the form with the newly-selected
+    // model's catalog values (still preserving any fields the user typed).
+    if (isOverrideOpen) {
+      populateOverridesFromCatalog(source, result.id);
+    }
   };
 
   /** Clear metadata from the alias */
@@ -400,6 +415,136 @@ export const Models = () => {
     pricing: { prompt: '0', completion: '0' },
     supported_parameters: [],
   });
+
+  /**
+   * Convert a catalog metadata record into the `MetadataOverrides` shape,
+   * keeping only defined fields so no spurious empty keys land in the config.
+   */
+  const metadataToOverrides = (meta: NormalizedModelMetadata): MetadataOverrides => {
+    const out: MetadataOverrides = {};
+    if (meta.name) out.name = meta.name;
+    if (meta.description !== undefined) out.description = meta.description;
+    if (meta.context_length !== undefined) out.context_length = meta.context_length;
+    if (meta.pricing) {
+      const p: NonNullable<MetadataOverrides['pricing']> = {};
+      if (meta.pricing.prompt !== undefined) p.prompt = meta.pricing.prompt;
+      if (meta.pricing.completion !== undefined) p.completion = meta.pricing.completion;
+      if (meta.pricing.input_cache_read !== undefined)
+        p.input_cache_read = meta.pricing.input_cache_read;
+      if (meta.pricing.input_cache_write !== undefined)
+        p.input_cache_write = meta.pricing.input_cache_write;
+      if (Object.keys(p).length > 0) out.pricing = p;
+    }
+    if (meta.architecture) {
+      const a: NonNullable<MetadataOverrides['architecture']> = {};
+      if (meta.architecture.input_modalities && meta.architecture.input_modalities.length > 0)
+        a.input_modalities = [...meta.architecture.input_modalities];
+      if (meta.architecture.output_modalities && meta.architecture.output_modalities.length > 0)
+        a.output_modalities = [...meta.architecture.output_modalities];
+      if (meta.architecture.tokenizer !== undefined) a.tokenizer = meta.architecture.tokenizer;
+      if (Object.keys(a).length > 0) out.architecture = a;
+    }
+    if (meta.supported_parameters && meta.supported_parameters.length > 0)
+      out.supported_parameters = [...meta.supported_parameters];
+    if (meta.top_provider) {
+      const tp: NonNullable<MetadataOverrides['top_provider']> = {};
+      if (meta.top_provider.context_length !== undefined)
+        tp.context_length = meta.top_provider.context_length;
+      if (meta.top_provider.max_completion_tokens !== undefined)
+        tp.max_completion_tokens = meta.top_provider.max_completion_tokens;
+      if (Object.keys(tp).length > 0) out.top_provider = tp;
+    }
+    return out;
+  };
+
+  /**
+   * Fetch catalog metadata for (source, sourcePath) and populate the override
+   * form with those values, preserving any overrides the user has already
+   * typed (user-entered values win on conflict).
+   *
+   * Silently no-ops when source is custom, source_path is unset, or the lookup
+   * fails — in those cases the form simply stays empty.
+   *
+   * Caller must pass explicit (source, sourcePath) rather than reading
+   * `editingAlias` here, because we're often invoked right after a state
+   * update that hasn't flushed — e.g. when the user selects a new catalog
+   * model while override is already on.
+   */
+  const populateOverridesFromCatalog = async (
+    source: Exclude<MetadataSource, 'custom'>,
+    sourcePath: string
+  ) => {
+    if (!sourcePath) return;
+    try {
+      const catalog = await api.getModelMetadata(source, sourcePath);
+      if (!catalog) return;
+      const catalogOverrides = metadataToOverrides(catalog);
+      setEditingAlias((prev) => {
+        // Bail if the alias's metadata pointer changed while we were fetching
+        // (e.g. user toggled off, or picked a different model).
+        if (!prev.metadata || prev.metadata.source === 'custom') return prev;
+        if (prev.metadata.source !== source || prev.metadata.source_path !== sourcePath)
+          return prev;
+        // Merge so anything the user already typed takes precedence over the
+        // freshly-fetched catalog values.
+        const existing = prev.metadata.overrides ?? {};
+        const merged: MetadataOverrides = {
+          ...catalogOverrides,
+          ...existing,
+          ...(catalogOverrides.pricing || existing.pricing
+            ? { pricing: { ...(catalogOverrides.pricing ?? {}), ...(existing.pricing ?? {}) } }
+            : {}),
+          ...(catalogOverrides.architecture || existing.architecture
+            ? {
+                architecture: {
+                  ...(catalogOverrides.architecture ?? {}),
+                  ...(existing.architecture ?? {}),
+                },
+              }
+            : {}),
+          ...(catalogOverrides.top_provider || existing.top_provider
+            ? {
+                top_provider: {
+                  ...(catalogOverrides.top_provider ?? {}),
+                  ...(existing.top_provider ?? {}),
+                },
+              }
+            : {}),
+        };
+        return { ...prev, metadata: { ...prev.metadata, overrides: merged } };
+      });
+    } catch {
+      // Leave the form blank on error; existing helper text tells the user
+      // blank fields fall back to the catalog value.
+    }
+  };
+
+  // Keep `catalogReference` in sync with the currently selected catalog
+  // (source, source_path). Used by `countOverrides` to decide which fields
+  // actually differ from the auto-populated values.
+  useEffect(() => {
+    const meta = editingAlias.metadata;
+    if (!meta || meta.source === 'custom' || !meta.source_path) {
+      setCatalogReference(undefined);
+      return;
+    }
+    const { source, source_path } = meta;
+    let cancelled = false;
+    (async () => {
+      try {
+        const catalog = await api.getModelMetadata(source, source_path);
+        if (cancelled) return;
+        setCatalogReference(catalog ? metadataToOverrides(catalog) : null);
+      } catch {
+        if (!cancelled) setCatalogReference(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // metadataToOverrides is a stable local helper that doesn't close over state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingAlias.metadata?.source, editingAlias.metadata?.source_path]);
 
   /**
    * Patch a single field in the override blob. `undefined` removes the key
@@ -476,21 +621,75 @@ export const Models = () => {
     setEditingAlias({ ...editingAlias, metadata: { ...current, overrides: nextOverrides } });
   };
 
-  /** Count the number of overridden fields for the preview strip. */
-  const countOverrides = (o?: MetadataOverrides): number => {
-    if (!o) return 0;
-    let n = 0;
-    if (o.name !== undefined) n++;
-    if (o.description !== undefined) n++;
-    if (o.context_length !== undefined) n++;
-    if (o.pricing) n += Object.values(o.pricing).filter((v) => v !== undefined).length;
-    if (o.architecture) {
-      if (o.architecture.input_modalities !== undefined) n++;
-      if (o.architecture.output_modalities !== undefined) n++;
-      if (o.architecture.tokenizer !== undefined) n++;
+  /**
+   * Count the number of overridden fields for the preview strip. Only fields
+   * whose values *differ* from the reference are counted:
+   *   - custom source: compared against `buildCustomDefaults(aliasId)`
+   *   - catalog source: compared against the auto-populated catalog values
+   * While the catalog lookup is still in flight for a catalog-backed source
+   * we report 0 so the strip doesn't flash a spurious "all fields overridden"
+   * count on open.
+   */
+  const countOverrides = (metadata?: AliasMetadata): number => {
+    if (!metadata?.overrides) return 0;
+    const o = metadata.overrides;
+    let ref: MetadataOverrides;
+    if (metadata.source === 'custom') {
+      ref = buildCustomDefaults(editingAlias.id);
+    } else if (catalogReference === undefined) {
+      // Catalog still loading — avoid flashing a spurious count.
+      return 0;
+    } else {
+      ref = catalogReference ?? {};
     }
-    if (o.supported_parameters !== undefined) n++;
-    if (o.top_provider) n += Object.values(o.top_provider).filter((v) => v !== undefined).length;
+    const arrayEq = (a?: string[], b?: string[]): boolean => {
+      if (a === b) return true;
+      if (!a || !b) return false;
+      if (a.length !== b.length) return false;
+      return a.every((v, i) => v === b[i]);
+    };
+    let n = 0;
+    if (o.name !== undefined && o.name !== ref.name) n++;
+    if (o.description !== undefined && o.description !== ref.description) n++;
+    if (o.context_length !== undefined && o.context_length !== ref.context_length) n++;
+    if (o.pricing) {
+      const r = ref.pricing ?? {};
+      if (o.pricing.prompt !== undefined && o.pricing.prompt !== r.prompt) n++;
+      if (o.pricing.completion !== undefined && o.pricing.completion !== r.completion) n++;
+      if (o.pricing.input_cache_read !== undefined && o.pricing.input_cache_read !== r.input_cache_read)
+        n++;
+      if (
+        o.pricing.input_cache_write !== undefined &&
+        o.pricing.input_cache_write !== r.input_cache_write
+      )
+        n++;
+    }
+    if (o.architecture) {
+      const r = ref.architecture ?? {};
+      if (
+        o.architecture.input_modalities !== undefined &&
+        !arrayEq(o.architecture.input_modalities, r.input_modalities)
+      )
+        n++;
+      if (
+        o.architecture.output_modalities !== undefined &&
+        !arrayEq(o.architecture.output_modalities, r.output_modalities)
+      )
+        n++;
+      if (o.architecture.tokenizer !== undefined && o.architecture.tokenizer !== r.tokenizer) n++;
+    }
+    if (o.supported_parameters !== undefined && !arrayEq(o.supported_parameters, ref.supported_parameters))
+      n++;
+    if (o.top_provider) {
+      const r = ref.top_provider ?? {};
+      if (o.top_provider.context_length !== undefined && o.top_provider.context_length !== r.context_length)
+        n++;
+      if (
+        o.top_provider.max_completion_tokens !== undefined &&
+        o.top_provider.max_completion_tokens !== r.max_completion_tokens
+      )
+        n++;
+    }
     return n;
   };
 
@@ -1097,11 +1296,10 @@ export const Models = () => {
                               )}
                             </>
                           )}
-                          {countOverrides(editingAlias.metadata.overrides) > 0 && (
+                          {countOverrides(editingAlias.metadata) > 0 && (
                             <span className="ml-2 text-text-muted">
-                              + {countOverrides(editingAlias.metadata.overrides)} field
-                              {countOverrides(editingAlias.metadata.overrides) === 1 ? '' : 's'}{' '}
-                              overridden
+                              + {countOverrides(editingAlias.metadata)} field
+                              {countOverrides(editingAlias.metadata) === 1 ? '' : 's'} overridden
                             </span>
                           )}
                         </span>
@@ -1139,6 +1337,14 @@ export const Models = () => {
                                   ...editingAlias,
                                   metadata: rest as AliasMetadata,
                                 });
+                              }
+                            } else {
+                              // Flipping override on auto-populates the form with
+                              // the catalog's current values so the user sees what
+                              // they're overriding instead of a blank form.
+                              const cur = editingAlias.metadata;
+                              if (cur && cur.source !== 'custom' && cur.source_path) {
+                                populateOverridesFromCatalog(cur.source, cur.source_path);
                               }
                             }
                           }}

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -493,10 +493,7 @@ export const Models = () => {
    * runtime code path that substitutes an empty string; this helper keeps
    * that guarantee visible to TypeScript.
    */
-  const withOverrides = (
-    current: AliasMetadata,
-    overrides: MetadataOverrides
-  ): AliasMetadata => {
+  const withOverrides = (current: AliasMetadata, overrides: MetadataOverrides): AliasMetadata => {
     if (current.source === 'custom') {
       return {
         ...current,
@@ -765,7 +762,10 @@ export const Models = () => {
       const r = ref.pricing ?? {};
       if (o.pricing.prompt !== undefined && o.pricing.prompt !== r.prompt) n++;
       if (o.pricing.completion !== undefined && o.pricing.completion !== r.completion) n++;
-      if (o.pricing.input_cache_read !== undefined && o.pricing.input_cache_read !== r.input_cache_read)
+      if (
+        o.pricing.input_cache_read !== undefined &&
+        o.pricing.input_cache_read !== r.input_cache_read
+      )
         n++;
       if (
         o.pricing.input_cache_write !== undefined &&
@@ -787,11 +787,17 @@ export const Models = () => {
         n++;
       if (o.architecture.tokenizer !== undefined && o.architecture.tokenizer !== r.tokenizer) n++;
     }
-    if (o.supported_parameters !== undefined && !arrayEq(o.supported_parameters, ref.supported_parameters))
+    if (
+      o.supported_parameters !== undefined &&
+      !arrayEq(o.supported_parameters, ref.supported_parameters)
+    )
       n++;
     if (o.top_provider) {
       const r = ref.top_provider ?? {};
-      if (o.top_provider.context_length !== undefined && o.top_provider.context_length !== r.context_length)
+      if (
+        o.top_provider.context_length !== undefined &&
+        o.top_provider.context_length !== r.context_length
+      )
         n++;
       if (
         o.top_provider.max_completion_tokens !== undefined &&

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -144,6 +144,16 @@ export const Models = () => {
 
   const handleSave = async () => {
     if (!editingAlias.id) return;
+    // Custom metadata requires a non-empty name — the backend Zod schema will
+    // reject it otherwise. Surface a clear error here instead of letting the
+    // save API call fail generically.
+    if (editingAlias.metadata?.source === 'custom') {
+      const name = editingAlias.metadata.overrides?.name;
+      if (!name || name.trim() === '') {
+        alert('Custom metadata requires a non-empty Name.');
+        return;
+      }
+    }
     await hookSave(editingAlias, originalId);
   };
 
@@ -391,7 +401,13 @@ export const Models = () => {
     supported_parameters: [],
   });
 
-  /** Patch a single field in the override blob. `undefined` removes the key. */
+  /**
+   * Patch a single field in the override blob. `undefined` removes the key
+   * so the field falls back to the catalog value — except for the `name`
+   * field in custom mode, which has no catalog fallback and is required by
+   * the backend schema. In that case we store an empty string instead of
+   * deleting, letting the save-time validator surface the error clearly.
+   */
   const setOverrideField = <K extends keyof MetadataOverrides>(
     key: K,
     value: MetadataOverrides[K] | undefined
@@ -399,8 +415,15 @@ export const Models = () => {
     const current = editingAlias.metadata;
     if (!current) return;
     const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
-    if (value === undefined) delete nextOverrides[key];
-    else nextOverrides[key] = value;
+    if (value === undefined) {
+      if (current.source === 'custom' && key === 'name') {
+        nextOverrides.name = '';
+      } else {
+        delete nextOverrides[key];
+      }
+    } else {
+      nextOverrides[key] = value;
+    }
     setEditingAlias({
       ...editingAlias,
       metadata: { ...current, overrides: nextOverrides },
@@ -922,17 +945,26 @@ export const Models = () => {
                     onChange={(e) => {
                       const source = e.target.value as MetadataSource;
                       const existingOverrides = editingAlias.metadata?.overrides;
+                      const existingSourcePath = editingAlias.metadata?.source_path;
                       let next: AliasMetadata;
                       if (source === 'custom') {
+                        // Seed defaults, then layer any existing overrides on top so
+                        // user-typed values take precedence while missing required
+                        // fields (e.g., name) still have a sensible default.
+                        const mergedOverrides = {
+                          ...buildCustomDefaults(editingAlias.id),
+                          ...(existingOverrides ?? {}),
+                        };
                         next = {
                           source: 'custom',
-                          overrides: existingOverrides ?? buildCustomDefaults(editingAlias.id),
+                          ...(existingSourcePath ? { source_path: existingSourcePath } : {}),
+                          overrides: mergedOverrides,
                         };
                         setIsOverrideOpen(true);
                       } else {
                         next = {
                           source,
-                          source_path: editingAlias.metadata?.source_path ?? '',
+                          source_path: existingSourcePath ?? '',
                           ...(existingOverrides ? { overrides: existingOverrides } : {}),
                         };
                       }

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -458,6 +458,77 @@ export const Models = () => {
   };
 
   /**
+   * Return `current` with its overrides replaced by `overrides`, preserving
+   * the 'custom' variant's `name: string` invariant for the type system.
+   * Callers that delete `name` for a custom source are relying on the
+   * runtime code path that substitutes an empty string; this helper keeps
+   * that guarantee visible to TypeScript.
+   */
+  const withOverrides = (
+    current: AliasMetadata,
+    overrides: MetadataOverrides
+  ): AliasMetadata => {
+    if (current.source === 'custom') {
+      return {
+        ...current,
+        overrides: {
+          ...overrides,
+          name: overrides.name ?? current.overrides.name,
+        },
+      };
+    }
+    return { ...current, overrides };
+  };
+
+  /**
+   * Return the subset of `existing` that differs from `reference`. Used to
+   * strip auto-populated-from-catalog values out of an overrides blob so that
+   * only genuine user-edits remain. Top-level fields are compared by identity
+   * (or element-wise for arrays); nested objects (pricing/architecture/
+   * top_provider) are compared field-by-field one level deep.
+   */
+  const diffOverrides = (
+    existing: MetadataOverrides,
+    reference: MetadataOverrides
+  ): MetadataOverrides => {
+    const valuesEqual = (a: unknown, b: unknown): boolean => {
+      if (a === b) return true;
+      if (Array.isArray(a) && Array.isArray(b)) {
+        return a.length === b.length && a.every((v, i) => v === b[i]);
+      }
+      return false;
+    };
+    const out: MetadataOverrides = {};
+    for (const key of Object.keys(existing) as (keyof MetadataOverrides)[]) {
+      const ev = existing[key];
+      const rv = reference[key];
+      if (ev === undefined) continue;
+      if (
+        ev !== null &&
+        typeof ev === 'object' &&
+        !Array.isArray(ev) &&
+        rv !== null &&
+        typeof rv === 'object' &&
+        !Array.isArray(rv)
+      ) {
+        // Nested object (pricing/architecture/top_provider): recurse one level.
+        const nested: Record<string, unknown> = {};
+        for (const sub of Object.keys(ev as object)) {
+          const sev = (ev as Record<string, unknown>)[sub];
+          const srv = (rv as Record<string, unknown>)[sub];
+          if (sev !== undefined && !valuesEqual(sev, srv)) nested[sub] = sev;
+        }
+        if (Object.keys(nested).length > 0) {
+          (out as Record<string, unknown>)[key] = nested;
+        }
+      } else if (!valuesEqual(ev, rv)) {
+        (out as Record<string, unknown>)[key] = ev;
+      }
+    }
+    return out;
+  };
+
+  /**
    * Fetch catalog metadata for (source, sourcePath) and populate the override
    * form with those values, preserving any overrides the user has already
    * typed (user-entered values win on conflict).
@@ -475,6 +546,11 @@ export const Models = () => {
     sourcePath: string
   ) => {
     if (!sourcePath) return;
+    // Capture the current catalog snapshot BEFORE the async fetch. When the
+    // caller (e.g. selectMetadataResult) has just switched catalog models,
+    // this is still the prior catalog — exactly what we need to distinguish
+    // true user edits from values that were auto-populated last time.
+    const priorCatalog = catalogReference ?? null;
     try {
       const catalog = await api.getModelMetadata(source, sourcePath);
       if (!catalog) return;
@@ -485,28 +561,32 @@ export const Models = () => {
         if (!prev.metadata || prev.metadata.source === 'custom') return prev;
         if (prev.metadata.source !== source || prev.metadata.source_path !== sourcePath)
           return prev;
-        // Merge so anything the user already typed takes precedence over the
-        // freshly-fetched catalog values.
+        // `existing` may hold values that were auto-populated from the prior
+        // catalog rather than typed by the user. Strip anything matching the
+        // prior snapshot so only real user-edits layer over the new catalog.
+        // When we have no prior snapshot (first populate), treat `existing`
+        // as all user-edits.
         const existing = prev.metadata.overrides ?? {};
+        const userEdits = priorCatalog ? diffOverrides(existing, priorCatalog) : existing;
         const merged: MetadataOverrides = {
           ...catalogOverrides,
-          ...existing,
-          ...(catalogOverrides.pricing || existing.pricing
-            ? { pricing: { ...(catalogOverrides.pricing ?? {}), ...(existing.pricing ?? {}) } }
+          ...userEdits,
+          ...(catalogOverrides.pricing || userEdits.pricing
+            ? { pricing: { ...(catalogOverrides.pricing ?? {}), ...(userEdits.pricing ?? {}) } }
             : {}),
-          ...(catalogOverrides.architecture || existing.architecture
+          ...(catalogOverrides.architecture || userEdits.architecture
             ? {
                 architecture: {
                   ...(catalogOverrides.architecture ?? {}),
-                  ...(existing.architecture ?? {}),
+                  ...(userEdits.architecture ?? {}),
                 },
               }
             : {}),
-          ...(catalogOverrides.top_provider || existing.top_provider
+          ...(catalogOverrides.top_provider || userEdits.top_provider
             ? {
                 top_provider: {
                   ...(catalogOverrides.top_provider ?? {}),
-                  ...(existing.top_provider ?? {}),
+                  ...(userEdits.top_provider ?? {}),
                 },
               }
             : {}),
@@ -571,7 +651,7 @@ export const Models = () => {
     }
     setEditingAlias({
       ...editingAlias,
-      metadata: { ...current, overrides: nextOverrides },
+      metadata: withOverrides(current, nextOverrides),
     });
   };
 
@@ -587,7 +667,7 @@ export const Models = () => {
     const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
     if (Object.keys(pricing).length === 0) delete nextOverrides.pricing;
     else nextOverrides.pricing = pricing;
-    setEditingAlias({ ...editingAlias, metadata: { ...current, overrides: nextOverrides } });
+    setEditingAlias({ ...editingAlias, metadata: withOverrides(current, nextOverrides) });
   };
 
   const setArchitectureField = (
@@ -603,7 +683,7 @@ export const Models = () => {
     const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
     if (Object.keys(arch).length === 0) delete nextOverrides.architecture;
     else nextOverrides.architecture = arch;
-    setEditingAlias({ ...editingAlias, metadata: { ...current, overrides: nextOverrides } });
+    setEditingAlias({ ...editingAlias, metadata: withOverrides(current, nextOverrides) });
   };
 
   const setTopProviderField = (
@@ -618,7 +698,7 @@ export const Models = () => {
     const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
     if (Object.keys(tp).length === 0) delete nextOverrides.top_provider;
     else nextOverrides.top_provider = tp;
-    setEditingAlias({ ...editingAlias, metadata: { ...current, overrides: nextOverrides } });
+    setEditingAlias({ ...editingAlias, metadata: withOverrides(current, nextOverrides) });
   };
 
   /**
@@ -1143,8 +1223,17 @@ export const Models = () => {
                     value={editingAlias.metadata?.source ?? 'openrouter'}
                     onChange={(e) => {
                       const source = e.target.value as MetadataSource;
+                      const prevSource = editingAlias.metadata?.source;
                       const existingOverrides = editingAlias.metadata?.overrides;
                       const existingSourcePath = editingAlias.metadata?.source_path;
+                      // Different catalogs use different path formats (e.g.
+                      // openrouter's "openai/gpt-4.1-nano" ≠ models.dev's
+                      // "openai.gpt-4.1-nano"), so a path from the old catalog
+                      // is always wrong under a new one. Only carry the path
+                      // when the source is unchanged or switching to 'custom'
+                      // (where source_path is a free-form label).
+                      const carryPath = prevSource === source || source === 'custom';
+                      const carriedSourcePath = carryPath ? existingSourcePath : undefined;
                       let next: AliasMetadata;
                       if (source === 'custom') {
                         // Seed defaults, then layer any existing overrides on top so
@@ -1153,23 +1242,27 @@ export const Models = () => {
                         const mergedOverrides = {
                           ...buildCustomDefaults(editingAlias.id),
                           ...(existingOverrides ?? {}),
-                        };
+                        } as MetadataOverrides & { name: string };
                         next = {
                           source: 'custom',
-                          ...(existingSourcePath ? { source_path: existingSourcePath } : {}),
+                          ...(carriedSourcePath ? { source_path: carriedSourcePath } : {}),
                           overrides: mergedOverrides,
                         };
                         setIsOverrideOpen(true);
                       } else {
                         next = {
                           source,
-                          source_path: existingSourcePath ?? '',
+                          source_path: carriedSourcePath ?? '',
                           ...(existingOverrides ? { overrides: existingOverrides } : {}),
                         };
                       }
                       setEditingAlias({ ...editingAlias, metadata: next });
-                      // Re-run search with new source if there's a query
-                      if (metadataQuery && source !== 'custom')
+                      // When we dropped the path, also clear the visible model
+                      // query input so it doesn't show a stale value that no
+                      // longer matches metadata.source_path.
+                      if (!carryPath) setMetadataQuery('');
+                      // Re-run search only when we kept the query (same catalog).
+                      if (carryPath && source !== 'custom' && metadataQuery)
                         handleMetadataSearch(metadataQuery, source);
                     }}
                   >

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -1238,10 +1238,40 @@ export const Models = () => {
                       if (source === 'custom') {
                         // Seed defaults, then layer any existing overrides on top so
                         // user-typed values take precedence while missing required
-                        // fields (e.g., name) still have a sensible default.
+                        // fields (e.g., name) still have a sensible default. Nested
+                        // objects (architecture/pricing/top_provider) are merged
+                        // field-by-field so a partial user override (e.g. only
+                        // input_modalities) doesn't wipe default sibling fields
+                        // (e.g. output_modalities).
+                        const defaults = buildCustomDefaults(editingAlias.id);
+                        const existing = existingOverrides ?? {};
                         const mergedOverrides = {
-                          ...buildCustomDefaults(editingAlias.id),
-                          ...(existingOverrides ?? {}),
+                          ...defaults,
+                          ...existing,
+                          ...(defaults.pricing || existing.pricing
+                            ? {
+                                pricing: {
+                                  ...(defaults.pricing ?? {}),
+                                  ...(existing.pricing ?? {}),
+                                },
+                              }
+                            : {}),
+                          ...(defaults.architecture || existing.architecture
+                            ? {
+                                architecture: {
+                                  ...(defaults.architecture ?? {}),
+                                  ...(existing.architecture ?? {}),
+                                },
+                              }
+                            : {}),
+                          ...(defaults.top_provider || existing.top_provider
+                            ? {
+                                top_provider: {
+                                  ...(defaults.top_provider ?? {}),
+                                  ...(existing.top_provider ?? {}),
+                                },
+                              }
+                            : {}),
                         } as MetadataOverrides & { name: string };
                         next = {
                           source: 'custom',

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -40,7 +40,9 @@ async function main() {
     console.log(`  bun scripts/release.ts [options]`);
     console.log('\nOptions:');
     console.log(`  ${pc.cyan('--help, -h')} Show this help message`);
-    console.log('\nThis script tags the repo and pushes the tag. Release notes are handled by GitHub Actions.\n');
+    console.log(
+      '\nThis script tags the repo and pushes the tag. Release notes are handled by GitHub Actions.\n'
+    );
     process.exit(0);
   }
 
@@ -98,7 +100,9 @@ async function main() {
     console.log(pc.dim('⬆️  Pushing tag...'));
     await run(['git', 'push', 'origin', version]);
     console.log(`${pc.green('✅ Pushed tag')} ${pc.bold(version)}\n`);
-    console.log(`${pc.bold(pc.magenta('🎊 Release tag created! GitHub Actions will handle the rest.'))}\n`);
+    console.log(
+      `${pc.bold(pc.magenta('🎊 Release tag created! GitHub Actions will handle the rest.'))}\n`
+    );
   } catch (e) {
     console.error(`\n${pc.red('❌ Git operation failed:')}`, e);
     process.exit(1);


### PR DESCRIPTION
Lets users override individual fields (name, description, context length,
pricing, architecture, supported parameters, top provider limits) on top of
models.dev / OpenRouter / Catwalk catalog data, and adds a new 'custom'
metadata source where users supply everything themselves — seeded with
sensible defaults.