### PR TITLE
feat: forward cache routing headers for Responses API prompt caching

### DIFF
--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -127,6 +127,17 @@ export async function registerResponsesRoute(
       unifiedRequest.incomingApiType = 'responses';
       unifiedRequest.originalBody = body;
       unifiedRequest.requestId = requestId;
+
+      // Forward cache routing headers for prompt caching support.
+      // These headers enable server-side cache routing at the upstream provider.
+      const sessionId = request.headers['session_id'] as string | undefined;
+      const clientRequestId = request.headers['x-client-request-id'] as string | undefined;
+      if (sessionId || clientRequestId || body.prompt_cache_key) {
+        unifiedRequest.cacheRoutingHeaders = {
+          session_id: sessionId || body.prompt_cache_key,
+          'x-client-request-id': clientRequestId || body.prompt_cache_key,
+        };
+      }
       unifiedRequest = attachKeyAccessPolicy(request, unifiedRequest);
       const xAppHeader = Array.isArray(request.headers['x-app'])
         ? request.headers['x-app'][0]

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -31,7 +31,8 @@ export async function registerResponsesRoute(
    * This enables true stateless multi-turn conversations where the client only sends the
    * new input and the previous_response_id, without needing to re-send all history.
    */
-  fastify.post('/v1/responses', async (request: FastifyRequest, reply: FastifyReply) => {
+  // Handler for Responses API requests (shared between /v1/responses and /v1/codex/responses)
+  const responsesHandler = async (request: FastifyRequest, reply: FastifyReply) => {
     const requestId = crypto.randomUUID();
     const startTime = Date.now();
     let usageRecord: Partial<UsageRecord> = {
@@ -252,7 +253,11 @@ export async function registerResponsesRoute(
         },
       });
     }
-  });
+  };
+
+  fastify.post('/v1/responses', responsesHandler);
+  // Codex CLI sends requests to /v1/codex/responses — alias to the same handler
+  fastify.post('/v1/codex/responses', responsesHandler);
 
   /**
    * GET /v1/responses/:response_id

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -969,6 +969,20 @@ export class Dispatcher {
     if (route.config.headers) {
       Object.assign(headers, route.config.headers);
     }
+
+    // Forward cache routing headers for Responses API prompt caching.
+    // These headers enable server-side cache routing at the upstream provider
+    // (e.g. theclawbay, OpenAI). Without them, each request may land on a
+    // different backend server, causing cache misses.
+    if (request.cacheRoutingHeaders) {
+      if (request.cacheRoutingHeaders.session_id) {
+        headers['session_id'] = request.cacheRoutingHeaders.session_id;
+      }
+      if (request.cacheRoutingHeaders['x-client-request-id']) {
+        headers['x-client-request-id'] = request.cacheRoutingHeaders['x-client-request-id'];
+      }
+    }
+
     return headers;
   }
 

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -119,6 +119,10 @@ export interface UnifiedChatRequest {
     type: 'text' | 'json_object' | 'json_schema';
     json_schema?: any;
   };
+  cacheRoutingHeaders?: {
+    session_id?: string;
+    'x-client-request-id'?: string;
+  };
   incomingApiType?: string;
   originalBody?: any;
   metadata?: {


### PR DESCRIPTION
## Summary
- forward `session_id` and `x-client-request-id` headers from incoming Responses API requests to upstream providers for prompt cache routing
- add `/v1/codex/responses` route alias so Codex CLI and pi-agent clients can connect through plexus without URL mismatch
- fall back to `prompt_cache_key` from the request body when client headers are absent

## Details
- OpenAI's Codex backend uses `session_id` and `x-client-request-id` headers to route requests to the same backend server that holds cached prompt prefixes. Without these headers, `prompt_cache_key` in the body is ineffective and every request is a full-price cache miss.
- The official Codex CLI (`codex-rs/codex-api/src/requests/headers.rs`) sends these headers unconditionally. Third-party clients (pi-agent, hermes-agent) also send them. Plexus was silently dropping them in `setupHeaders()`.
- Cache routing headers are captured in `responses.ts` route handler, attached to `UnifiedChatRequest.cacheRoutingHeaders`, and forwarded by `dispatcher.ts` `setupHeaders()`. When client headers are absent, `prompt_cache_key` from the body is used as fallback.
- The `/v1/codex/responses` alias is needed because pi-agent's `openai-codex-responses` wire API appends `/codex/responses` to the base URL. The handler is shared -- no code duplication.

## Files changed

| File | Change |
|------|--------|
| `packages/backend/src/types/unified.ts` | add `cacheRoutingHeaders` to `UnifiedChatRequest` interface |
| `packages/backend/src/routes/inference/responses.ts` | capture incoming `session_id`/`x-client-request-id` headers with `prompt_cache_key` fallback; extract handler for dual-route registration; add `/v1/codex/responses` alias |
| `packages/backend/src/services/dispatcher.ts` | forward `cacheRoutingHeaders` to upstream in `setupHeaders()` |

## Configuration note

No config schema changes needed. Providers that support the Responses API can already be configured using the existing `api_base_url` record format:

```yaml
clawbay-direct:
  api_key: "ca_v1.YOUR_TOKEN"
  api_base_url:
    responses: "https://api.theclawbay.com/backend-api/codex"
  models:
    gpt-5.4:
      access_via: ["responses"]
```

This makes `getProviderTypes()` return `['responses']`, the incoming type matches directly, pass-through optimization activates, and the cache routing headers are forwarded.

OAuth-based providers (`api_base_url: oauth://`) also work -- the OAuth path handles codex responses natively.

## Verification
- `bun run typecheck` -- zero type errors from changed files (all errors are pre-existing in test files, frontend, and `index.ts` bundle types)
- `cd packages/backend && bun test src/routes/inference/__tests__/auth.test.ts src/services/__tests__/dispatcher-failover.test.ts` -- 35 tests pass, 0 failures
- deployed to local plexus instance at `192.168.66.12:4000` against live config/SQLite:
  - `/v1/codex/responses` accepts requests and returns responses correctly
  - pi-agent with `openai-codex-responses` wire API (baseUrl `http://192.168.66.12:4000/v1`) successfully connects through plexus to theclawbay OAuth provider
  - `session_id` and `x-client-request-id` headers forwarded to upstream
  - no regression on existing `/v1/responses` endpoint -- pass-through optimization active for responses-to-responses routing