### PR TITLE
feat: add per-alias enforce_limits toggle for pre-dispatch context check

### DIFF
--- a/packages/backend/drizzle/schema/postgres/model-aliases.ts
+++ b/packages/backend/drizzle/schema/postgres/model-aliases.ts
@@ -31,6 +31,7 @@ export const modelAliases = pgTable('model_aliases', {
   useImageFallthrough: boolean('use_image_fallthrough').notNull().default(false),
   // Model architecture override for inference energy calculation
   modelArchitecture: jsonb('model_architecture'), // override for total_params, active_params, layers, heads, kv_lora_rank, qk_rope_head_dim, context_length, dtype
+  enforceLimits: boolean('enforce_limits').notNull().default(false),
   createdAt: bigint('created_at', { mode: 'number' }).notNull(),
   updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
 });

--- a/packages/backend/drizzle/schema/sqlite/model-aliases.ts
+++ b/packages/backend/drizzle/schema/sqlite/model-aliases.ts
@@ -13,6 +13,7 @@ export const modelAliases = sqliteTable('model_aliases', {
   useImageFallthrough: integer('use_image_fallthrough').notNull().default(0),
   // Model architecture override for inference energy calculation
   modelArchitecture: text('model_architecture'), // JSON: override for total_params, active_params, layers, heads, kv_lora_rank, qk_rope_head_dim, context_length, dtype
+  enforceLimits: integer('enforce_limits').notNull().default(0),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -490,6 +490,7 @@ export const ModelConfigSchema = z.object({
   targets: z.array(ModelTargetSchema),
   additional_aliases: z.array(z.string()).optional(),
   use_image_fallthrough: z.boolean().default(false).optional(),
+  enforce_limits: z.boolean().default(false).optional(),
   type: z.enum(['chat', 'responses', 'embeddings', 'transcriptions', 'speech', 'image']).optional(),
   advanced: z.array(ModelBehaviorSchema).optional(),
   metadata: ModelMetadataSchema.optional(),

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -610,6 +610,7 @@ export class ConfigRepository {
       useImageFallthrough: fromBool(config.use_image_fallthrough === true),
       // Model architecture override for inference energy calculation
       modelArchitecture: config.model_architecture ? toJson(config.model_architecture) : null,
+      enforceLimits: fromBool(config.enforce_limits === true),
       updatedAt: timestamp,
     };
 
@@ -712,6 +713,7 @@ export class ConfigRepository {
       targets,
       priority: row.priority ?? 'selector',
       use_image_fallthrough: toBool(row.useImageFallthrough),
+      enforce_limits: toBool(row.enforceLimits),
       ...(row.selector ? { selector: row.selector } : {}),
       ...(row.modelType ? { type: row.modelType } : {}),
       ...(row.additionalAliases ? { additional_aliases: parseJson(row.additionalAliases) } : {}),

--- a/packages/backend/src/routes/inference/chat.ts
+++ b/packages/backend/src/routes/inference/chat.ts
@@ -141,8 +141,20 @@ export async function registerChatRoute(
 
       logger.error('Error processing OpenAI request', e);
       const statusCode = e.routingContext?.statusCode || 500;
-      const errorType = statusCode === 401 ? 'authentication_error' : 'api_error';
-      return reply.code(statusCode).send({ error: { message: e.message, type: errorType } });
+      const errorType =
+        statusCode === 401
+          ? 'authentication_error'
+          : statusCode === 400
+            ? 'invalid_request_error'
+            : 'api_error';
+      const errorCode = e.routingContext?.code;
+      return reply.code(statusCode).send({
+        error: {
+          message: e.message,
+          type: errorType,
+          ...(errorCode && { code: errorCode }),
+        },
+      });
     }
   });
 }

--- a/packages/backend/src/routes/inference/gemini.ts
+++ b/packages/backend/src/routes/inference/gemini.ts
@@ -150,11 +150,19 @@ export async function registerGeminiRoute(
 
       logger.error('Error processing Gemini request', e);
       const statusCode = e.routingContext?.statusCode || 500;
+      const errorReason = e.routingContext?.code;
+      const status =
+        statusCode === 401
+          ? 'UNAUTHENTICATED'
+          : statusCode === 400
+            ? 'INVALID_ARGUMENT'
+            : 'INTERNAL';
       return reply.code(statusCode).send({
         error: {
           message: e.message,
           code: statusCode,
-          status: statusCode === 401 ? 'UNAUTHENTICATED' : 'INTERNAL',
+          status,
+          ...(errorReason && { reason: errorReason }),
         },
       });
     }

--- a/packages/backend/src/routes/inference/messages.ts
+++ b/packages/backend/src/routes/inference/messages.ts
@@ -140,10 +140,21 @@ export async function registerMessagesRoute(
 
       logger.error('Error processing Anthropic request', e);
       const statusCode = e.routingContext?.statusCode || 500;
-      const errorType = statusCode === 401 ? 'authentication_error' : 'api_error';
-      return reply
-        .code(statusCode)
-        .send({ type: 'error', error: { type: errorType, message: e.message } });
+      const errorType =
+        statusCode === 401
+          ? 'authentication_error'
+          : statusCode === 400
+            ? 'invalid_request_error'
+            : 'api_error';
+      const errorCode = e.routingContext?.code;
+      return reply.code(statusCode).send({
+        type: 'error',
+        error: {
+          type: errorType,
+          message: e.message,
+          ...(errorCode && { code: errorCode }),
+        },
+      });
     }
   });
 }

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -239,10 +239,12 @@ export async function registerResponsesRoute(
       logger.error('Error processing Responses API request', e);
 
       const statusCode = e.routingContext?.statusCode || 500;
+      const errorCode = e.routingContext?.code;
       return reply.code(statusCode).send({
         error: {
           message: e.message || 'Internal server error',
           type: statusCode >= 500 ? 'server_error' : 'invalid_request_error',
+          ...(errorCode && { code: errorCode }),
           ...(e.routingContext && {
             routing_context: {
               provider: e.routingContext.provider,

--- a/packages/backend/src/services/__tests__/enforce-limits.test.ts
+++ b/packages/backend/src/services/__tests__/enforce-limits.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { ModelConfig } from '../../config';
 import type { UnifiedChatRequest } from '../../types/unified';
-import {
-  ContextLengthExceededError,
-  enforceContextLimit,
-} from '../enforce-limits';
+import { ContextLengthExceededError, enforceContextLimit } from '../enforce-limits';
 import { ModelMetadataManager } from '../model-metadata-manager';
 
 function makeRequest(overrides: Partial<UnifiedChatRequest> = {}): UnifiedChatRequest {
@@ -134,9 +131,9 @@ describe('enforceContextLimit', () => {
       originalBody: { messages: msgs },
     });
     // With max_completion_tokens=8000 reservation: 6600 + 8000 = 14600 > 10000 → reject
-    expect(() =>
-      enforceContextLimit(withMetadataReservation, config, 'test-alias')
-    ).toThrow(ContextLengthExceededError);
+    expect(() => enforceContextLimit(withMetadataReservation, config, 'test-alias')).toThrow(
+      ContextLengthExceededError
+    );
 
     // Same input, but caller requested max_tokens=10 → reservation becomes 10 → 6600 + 10 < 10000 → pass
     const withSmallMaxTokens = makeRequest({

--- a/packages/backend/src/services/__tests__/enforce-limits.test.ts
+++ b/packages/backend/src/services/__tests__/enforce-limits.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { ModelConfig } from '../../config';
+import type { UnifiedChatRequest } from '../../types/unified';
+import {
+  ContextLengthExceededError,
+  enforceContextLimit,
+} from '../enforce-limits';
+import { ModelMetadataManager } from '../model-metadata-manager';
+
+function makeRequest(overrides: Partial<UnifiedChatRequest> = {}): UnifiedChatRequest {
+  const messages = overrides.messages ?? [{ role: 'user' as const, content: 'hi there' }];
+  const originalBody = overrides.originalBody ?? { messages };
+  return {
+    messages,
+    model: 'test-alias',
+    incomingApiType: 'chat',
+    originalBody,
+    ...overrides,
+  } as UnifiedChatRequest;
+}
+
+function bigMessages(charCount: number): UnifiedChatRequest['messages'] {
+  return [{ role: 'user' as const, content: 'x'.repeat(charCount) }];
+}
+
+function aliasConfig(partial: Partial<ModelConfig> = {}): ModelConfig {
+  return {
+    targets: [{ provider: 'openai', model: 'gpt-4' }],
+    priority: 'selector',
+    ...partial,
+  } as ModelConfig;
+}
+
+describe('enforceContextLimit', () => {
+  beforeEach(() => {
+    ModelMetadataManager.resetForTesting();
+  });
+
+  afterEach(() => {
+    ModelMetadataManager.resetForTesting();
+  });
+
+  test('passes through when estimated input fits within context - reserved output', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 10_000,
+          top_provider: { context_length: 10_000, max_completion_tokens: 4096 },
+        },
+      },
+    });
+    const req = makeRequest({ messages: bigMessages(200) }); // ~50 tokens
+    expect(() => enforceContextLimit(req, config, 'test-alias')).not.toThrow();
+  });
+
+  test('throws ContextLengthExceededError when estimated input + reservation exceeds limit', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 1_000,
+          top_provider: { context_length: 1_000, max_completion_tokens: 256 },
+        },
+      },
+    });
+    // ~10,000 chars ≈ ~2,500 tokens, well over a 1000-token context.
+    const req = makeRequest({ messages: bigMessages(10_000) });
+    let caught: unknown;
+    try {
+      enforceContextLimit(req, config, 'test-alias');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ContextLengthExceededError);
+    const err = caught as ContextLengthExceededError;
+    expect(err.routingContext.statusCode).toBe(400);
+    expect(err.routingContext.code).toBe('context_length_exceeded');
+    expect(err.routingContext.contextLength).toBe(1_000);
+    expect(err.routingContext.aliasSlug).toBe('test-alias');
+    expect(err.routingContext.reservedOutputTokens).toBe(256);
+    expect(err.message).toContain('1000');
+  });
+
+  test('fails open with no throw when context_length is unknown', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      // No metadata at all.
+    });
+    const req = makeRequest({ messages: bigMessages(10_000) });
+    expect(() => enforceContextLimit(req, config, 'test-alias')).not.toThrow();
+  });
+
+  test('fails open when metadata exists but lacks context_length', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          // no context_length / top_provider.context_length
+          top_provider: { max_completion_tokens: 4096 },
+        },
+      },
+    });
+    const req = makeRequest({ messages: bigMessages(10_000) });
+    expect(() => enforceContextLimit(req, config, 'test-alias')).not.toThrow();
+  });
+
+  test('uses request.max_tokens reservation when smaller than metadata max_completion_tokens', () => {
+    // Small max_tokens leaves more budget for input; request that would be
+    // rejected with max_completion_tokens=8000 reservation should pass with
+    // max_tokens=10 reservation.
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 10_000,
+          top_provider: { context_length: 10_000, max_completion_tokens: 8_000 },
+        },
+      },
+    });
+    // ~6000 chars ≈ ~1500 tokens, * 1.1 = ~1650.
+    // With reservation 8000 → 9650 < 10000, still passes. Use bigger input:
+    const msgs = bigMessages(24_000); // ~6000 tokens * 1.1 = ~6600
+    const withMetadataReservation = makeRequest({
+      messages: msgs,
+      originalBody: { messages: msgs },
+    });
+    // With max_completion_tokens=8000 reservation: 6600 + 8000 = 14600 > 10000 → reject
+    expect(() =>
+      enforceContextLimit(withMetadataReservation, config, 'test-alias')
+    ).toThrow(ContextLengthExceededError);
+
+    // Same input, but caller requested max_tokens=10 → reservation becomes 10 → 6600 + 10 < 10000 → pass
+    const withSmallMaxTokens = makeRequest({
+      messages: msgs,
+      max_tokens: 10,
+      originalBody: { messages: msgs, max_tokens: 10 },
+    });
+    expect(() => enforceContextLimit(withSmallMaxTokens, config, 'test-alias')).not.toThrow();
+  });
+
+  test('uses metadata max_completion_tokens when request.max_tokens is larger', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 10_000,
+          top_provider: { context_length: 10_000, max_completion_tokens: 500 },
+        },
+      },
+    });
+    const msgs = bigMessages(32_000); // ~8000 tokens * 1.1 = ~8800
+    // With reservation=500 (metadata min): 8800 + 500 = 9300 < 10000 → pass
+    // With reservation=9999 (requested): 8800 + 9999 > 10000 → reject
+    // We use min(request, metadata) so it should pass.
+    const req = makeRequest({
+      messages: msgs,
+      max_tokens: 9999,
+      originalBody: { messages: msgs, max_tokens: 9999 },
+    });
+    expect(() => enforceContextLimit(req, config, 'test-alias')).not.toThrow();
+  });
+
+  test('prefers top_provider.context_length over root context_length', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 100_000, // broad
+          top_provider: { context_length: 1_000 }, // per-deployment narrower
+        },
+      },
+    });
+    const req = makeRequest({ messages: bigMessages(10_000) }); // ~2500 tokens
+    expect(() => enforceContextLimit(req, config, 'test-alias')).toThrow(
+      ContextLengthExceededError
+    );
+  });
+
+  test('falls back to root context_length when top_provider is absent', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 1_000,
+        },
+      },
+    });
+    const req = makeRequest({ messages: bigMessages(10_000) });
+    expect(() => enforceContextLimit(req, config, 'test-alias')).toThrow(
+      ContextLengthExceededError
+    );
+  });
+
+  test('works for anthropic messages API shape', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 1_000,
+        },
+      },
+    });
+    const longText = 'x'.repeat(10_000);
+    const req = makeRequest({
+      incomingApiType: 'messages',
+      messages: [{ role: 'user', content: longText }],
+      originalBody: {
+        messages: [{ role: 'user', content: longText }],
+        system: 'You are a helpful assistant.',
+      },
+    });
+    expect(() => enforceContextLimit(req, config, 'test-alias')).toThrow(
+      ContextLengthExceededError
+    );
+  });
+
+  test('works for gemini API shape', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 1_000,
+        },
+      },
+    });
+    const req = makeRequest({
+      incomingApiType: 'gemini',
+      messages: [{ role: 'user', content: 'x' }],
+      originalBody: {
+        contents: [{ role: 'user', parts: [{ text: 'x'.repeat(10_000) }] }],
+      },
+    });
+    expect(() => enforceContextLimit(req, config, 'test-alias')).toThrow(
+      ContextLengthExceededError
+    );
+  });
+
+  test('works for responses API shape (string input)', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 1_000,
+        },
+      },
+    });
+    const req = makeRequest({
+      incomingApiType: 'responses',
+      messages: [{ role: 'user', content: 'x' }],
+      originalBody: {
+        input: 'x'.repeat(10_000),
+      },
+    });
+    expect(() => enforceContextLimit(req, config, 'test-alias')).toThrow(
+      ContextLengthExceededError
+    );
+  });
+
+  test('returns error message with estimated tokens and context length', () => {
+    const config = aliasConfig({
+      enforce_limits: true,
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 1_000,
+          top_provider: { context_length: 1_000, max_completion_tokens: 256 },
+        },
+      },
+    });
+    const req = makeRequest({ messages: bigMessages(10_000) });
+    try {
+      enforceContextLimit(req, config, 'my-alias');
+      throw new Error('expected throw');
+    } catch (e) {
+      const err = e as ContextLengthExceededError;
+      expect(err.message).toMatch(/context window is 1000 tokens/);
+      expect(err.message).toMatch(/input tokens/);
+    }
+  });
+});

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -200,16 +200,6 @@ export class Dispatcher {
 
     candidates = this.applyKeyAccessPolicy(request, candidates, request.incomingApiType || 'chat');
 
-    // Pre-dispatch context limit enforcement (opt-in per alias). Runs before
-    // any upstream request so oversized prompts fail fast and don't burn
-    // quota / latency on a guaranteed-400 round trip. Throws
-    // ContextLengthExceededError on violation; returns silently otherwise.
-    const enforcementAlias = candidates[0]?.canonicalModel;
-    const enforcementConfig = enforcementAlias ? config.models?.[enforcementAlias] : undefined;
-    if (enforcementConfig?.enforce_limits) {
-      enforceContextLimit(request, enforcementConfig, enforcementAlias!);
-    }
-
     const targets = failoverEnabled ? candidates : [candidates[0]!];
     const attemptedProviders: string[] = [];
     const retryHistory: RetryAttemptRecord[] = [];
@@ -288,6 +278,17 @@ export class Dispatcher {
           `Provider ${route.provider}/${route.model} is on cooldown`
         );
         continue;
+      }
+
+      // Pre-dispatch context limit enforcement (opt-in per alias). Runs on
+      // the finalized per-target request — after any vision fallthrough has
+      // expanded the prompt and after cooldown has selected a live target —
+      // so we reject oversized prompts locally with a 400 instead of
+      // burning an upstream round trip on a guaranteed failure. A thrown
+      // ContextLengthExceededError escapes the loop (it's a client-side
+      // problem; failing over to another target won't help).
+      if (aliasConfig?.enforce_limits && route.canonicalModel) {
+        enforceContextLimit(currentRequest, aliasConfig, route.canonicalModel);
       }
 
       attemptedProviders.push(`${route.provider}/${route.model}`);

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -25,6 +25,7 @@ import { applyModelBehaviors } from './model-behaviors';
 import { getModels } from '@mariozechner/pi-ai';
 import { VisionDescriptorService } from './vision-descriptor-service';
 import { ModelMetadataManager } from './model-metadata-manager';
+import { enforceContextLimit } from './enforce-limits';
 import { DEFAULT_VISION_DESCRIPTION_PROMPT } from '../utils/constants';
 import { UsageRecord } from '../types/usage';
 import { calculateCosts } from '../utils/calculate-costs';
@@ -198,6 +199,16 @@ export class Dispatcher {
     }
 
     candidates = this.applyKeyAccessPolicy(request, candidates, request.incomingApiType || 'chat');
+
+    // Pre-dispatch context limit enforcement (opt-in per alias). Runs before
+    // any upstream request so oversized prompts fail fast and don't burn
+    // quota / latency on a guaranteed-400 round trip. Throws
+    // ContextLengthExceededError on violation; returns silently otherwise.
+    const enforcementAlias = candidates[0]?.canonicalModel;
+    const enforcementConfig = enforcementAlias ? config.models?.[enforcementAlias] : undefined;
+    if (enforcementConfig?.enforce_limits) {
+      enforceContextLimit(request, enforcementConfig, enforcementAlias!);
+    }
 
     const targets = failoverEnabled ? candidates : [candidates[0]!];
     const attemptedProviders: string[] = [];

--- a/packages/backend/src/services/enforce-limits.ts
+++ b/packages/backend/src/services/enforce-limits.ts
@@ -96,7 +96,12 @@ export function enforceContextLimit(
   }
 
   const apiType = request.incomingApiType || 'chat';
-  const rawEstimate = estimateInputTokens(request.originalBody ?? request, apiType);
+  // Defensive fallback: all inference routes set originalBody, but if it's
+  // missing (e.g. a programmatic caller), hand the estimator a minimal
+  // messages-only body rather than the full UnifiedChatRequest — whose
+  // model/tools/metadata fields would inflate the token estimate.
+  const bodyForEstimate = request.originalBody ?? { messages: request.messages };
+  const rawEstimate = estimateInputTokens(bodyForEstimate, apiType);
   const estimated = Math.ceil(rawEstimate * ESTIMATE_SAFETY_MULTIPLIER);
 
   if (estimated + reservedOutput > contextLength) {

--- a/packages/backend/src/services/enforce-limits.ts
+++ b/packages/backend/src/services/enforce-limits.ts
@@ -1,0 +1,116 @@
+import type { ModelConfig } from '../config';
+import type { UnifiedChatRequest } from '../types/unified';
+import { estimateInputTokens } from '../utils/estimate-tokens';
+import { logger } from '../utils/logger';
+import { ModelMetadataManager, mergeOverrides } from './model-metadata-manager';
+
+// Heuristic estimator has ±20–30% variance; inflate the estimate by 10% so we
+// err on the side of rejecting a borderline-oversized request rather than
+// shipping it upstream and getting an opaque 400.
+const ESTIMATE_SAFETY_MULTIPLIER = 1.1;
+
+// Fallback reservation when we have no metadata max_completion_tokens and the
+// caller didn't specify max_tokens. Matches a common default completion budget.
+const DEFAULT_OUTPUT_RESERVATION = 4096;
+
+export interface ContextLengthExceededDetails {
+  statusCode: 400;
+  code: 'context_length_exceeded';
+  estimatedInputTokens: number;
+  reservedOutputTokens: number;
+  contextLength: number;
+  aliasSlug: string;
+}
+
+/**
+ * Error thrown when the estimated prompt tokens plus the reserved output
+ * budget would exceed the model's declared context window. Route handlers
+ * read `routingContext` to build the reply envelope.
+ */
+export class ContextLengthExceededError extends Error {
+  readonly routingContext: ContextLengthExceededDetails;
+
+  constructor(message: string, details: ContextLengthExceededDetails) {
+    super(message);
+    this.name = 'ContextLengthExceededError';
+    this.routingContext = details;
+  }
+}
+
+/**
+ * Resolve the effective context window for an alias by merging metadata
+ * overrides on top of the catalog entry. Returns undefined when no context
+ * length is known from either source — callers should fail open.
+ */
+function resolveMetadata(aliasConfig: ModelConfig) {
+  const metadata = aliasConfig.metadata;
+  if (!metadata) return undefined;
+
+  let base;
+  if (metadata.source !== 'custom') {
+    base = ModelMetadataManager.getInstance().getMetadata(metadata.source, metadata.source_path);
+  }
+  return mergeOverrides(base, metadata.overrides);
+}
+
+/**
+ * Enforces the incoming-context-size limit for an alias that has
+ * `enforce_limits` enabled. Fast path: one JSON.stringify + one linear
+ * heuristic scan + an in-memory Map lookup. Throws
+ * `ContextLengthExceededError` on violation; returns silently otherwise.
+ *
+ * Fail-open behavior: when no context_length can be determined, we log at
+ * debug level and let the request through — we can't enforce what we don't
+ * know.
+ */
+export function enforceContextLimit(
+  request: UnifiedChatRequest,
+  aliasConfig: ModelConfig,
+  aliasSlug: string
+): void {
+  const merged = resolveMetadata(aliasConfig);
+
+  // Prefer top_provider.context_length (per-deployment) over the model-wide
+  // context_length when both are present.
+  const contextLength = merged?.top_provider?.context_length ?? merged?.context_length;
+  if (!contextLength || contextLength <= 0) {
+    logger.debug(
+      `[enforce-limits] Skipping '${aliasSlug}': no context_length known (no override, no catalog entry).`
+    );
+    return;
+  }
+
+  // Reserve output space: prefer the caller's max_tokens if specified and
+  // smaller than the model's max_completion_tokens — otherwise reserve the
+  // model's max. Falls back to a conservative constant when neither is set.
+  const metadataMaxOutput = merged?.top_provider?.max_completion_tokens;
+  const requestedMaxTokens =
+    typeof request.max_tokens === 'number' && request.max_tokens > 0
+      ? request.max_tokens
+      : undefined;
+  let reservedOutput: number;
+  if (requestedMaxTokens !== undefined && metadataMaxOutput !== undefined) {
+    reservedOutput = Math.min(requestedMaxTokens, metadataMaxOutput);
+  } else {
+    reservedOutput = requestedMaxTokens ?? metadataMaxOutput ?? DEFAULT_OUTPUT_RESERVATION;
+  }
+
+  const apiType = request.incomingApiType || 'chat';
+  const rawEstimate = estimateInputTokens(request.originalBody ?? request, apiType);
+  const estimated = Math.ceil(rawEstimate * ESTIMATE_SAFETY_MULTIPLIER);
+
+  if (estimated + reservedOutput > contextLength) {
+    const message =
+      `This model's context window is ${contextLength} tokens. ` +
+      `Your request is estimated at ~${estimated} input tokens with ${reservedOutput} reserved for the response, ` +
+      `which exceeds the limit. Please shorten the prompt or lower max_tokens.`;
+    throw new ContextLengthExceededError(message, {
+      statusCode: 400,
+      code: 'context_length_exceeded',
+      estimatedInputTokens: estimated,
+      reservedOutputTokens: reservedOutput,
+      contextLength,
+      aliasSlug,
+    });
+  }
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -390,6 +390,7 @@ export interface Alias {
     context_length?: number;
     dtype?: 'fp16' | 'bf16' | 'fp8' | 'fp8_e4m3' | 'fp8_e5m2' | 'nvfp4' | 'int4' | 'int8';
   };
+  enforce_limits?: boolean;
 }
 
 export interface InferenceError {
@@ -1837,6 +1838,7 @@ export const api = {
       priority: alias.priority || 'selector',
       additional_aliases: alias.aliases,
       use_image_fallthrough: alias.use_image_fallthrough || false,
+      enforce_limits: alias.enforce_limits || false,
       ...(alias.type && { type: alias.type }),
       ...(alias.advanced && alias.advanced.length > 0 && { advanced: alias.advanced }),
       ...(alias.metadata && { metadata: alias.metadata }),
@@ -1953,6 +1955,7 @@ export const api = {
           priority: val.priority,
           type: val.type,
           use_image_fallthrough: val.use_image_fallthrough || false,
+          enforce_limits: val.enforce_limits || false,
           advanced: val.advanced || [],
           targets,
           metadata: val.metadata,

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -1448,8 +1448,9 @@ export const Models = () => {
                       <p className="font-body text-[11px] text-text-muted mt-0.5">
                         Reject oversized prompts locally (400 context_length_exceeded) before
                         dispatch. Uses a fast heuristic estimator with a 10% safety margin, and
-                        reserves max_tokens (or the model's max completion) for the response.
-                        Requires a known context_length in metadata (override or catalog).
+                        reserves the smaller of max_tokens and the model's max completion for the
+                        response. Requires a known context_length in metadata (override or
+                        catalog).
                       </p>
                     </div>
                     <Switch

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -34,6 +34,7 @@ import {
   GripVertical,
   Save,
   Eye,
+  AlertTriangle,
 } from 'lucide-react';
 
 export const Models = () => {
@@ -1449,15 +1450,24 @@ export const Models = () => {
                         Reject oversized prompts locally (400 context_length_exceeded) before
                         dispatch. Uses a fast heuristic estimator with a 10% safety margin, and
                         reserves the smaller of max_tokens and the model's max completion for the
-                        response. Requires a known context_length in metadata (override or
-                        catalog).
+                        response. Requires a known context_length in metadata (override or catalog).
                       </p>
+                      {editingAlias.enforce_limits &&
+                        !editingAlias.metadata?.overrides?.context_length &&
+                        !editingAlias.metadata?.overrides?.top_provider?.context_length && (
+                          <p
+                            className="font-body text-[11px] mt-1 flex items-center gap-1"
+                            style={{ color: 'var(--color-warning)' }}
+                          >
+                            <AlertTriangle size={12} />
+                            No context_length found in metadata — this toggle will have no effect
+                            until a metadata source with a known context_length is configured.
+                          </p>
+                        )}
                     </div>
                     <Switch
                       checked={editingAlias.enforce_limits || false}
-                      onChange={(val) =>
-                        setEditingAlias({ ...editingAlias, enforce_limits: val })
-                      }
+                      onChange={(val) => setEditingAlias({ ...editingAlias, enforce_limits: val })}
                       size="sm"
                     />
                   </div>

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -1441,6 +1441,25 @@ export const Models = () => {
                       size="sm"
                     />
                   </div>
+
+                  <div className="flex items-center justify-between py-1">
+                    <div>
+                      <span className="font-body text-[13px] text-text">Enforce Limits</span>
+                      <p className="font-body text-[11px] text-text-muted mt-0.5">
+                        Reject oversized prompts locally (400 context_length_exceeded) before
+                        dispatch. Uses a fast heuristic estimator with a 10% safety margin, and
+                        reserves max_tokens (or the model's max completion) for the response.
+                        Requires a known context_length in metadata (override or catalog).
+                      </p>
+                    </div>
+                    <Switch
+                      checked={editingAlias.enforce_limits || false}
+                      onChange={(val) =>
+                        setEditingAlias({ ...editingAlias, enforce_limits: val })
+                      }
+                      size="sm"
+                    />
+                  </div>
                 </div>
 
                 <div className="h-px bg-border-glass"></div>


### PR DESCRIPTION
Adds an opt-in boolean on model aliases that runs a fast token-estimation
check before dispatching to the upstream provider. When enabled, the
dispatcher rejects locally with a 400 context_length_exceeded error if the
estimated input tokens plus reserved output tokens exceed the model's
context window — avoiding a wasted upstream round-trip and an opaque
provider-side 400.

Behavior:
- Toggle lives on ModelConfig alongside use_image_fallthrough (not in
  metadata.overrides) — it is routing policy, not catalog data.
- Reservation uses min(request.max_tokens, metadata.max_completion_tokens)
  to minimize false rejections when the caller asked for a small
  completion.
- Fails open (with a debug log) when no context_length is known — can't
  enforce what we don't know.
- Reuses existing estimateInputTokens() heuristic (microseconds, no WASM)
  with a 10% safety multiplier to cover the estimator's ±20–30% variance.
- The context_length_exceeded code propagates through each endpoint's
  native error envelope (chat/messages/responses/gemini).

Includes 12 new tests covering toggle on/off, oversized/under-limit,
missing metadata (fail-open), max_tokens-vs-metadata precedence, and all
four API shapes (chat, messages, gemini, responses).