### PR TITLE
fix: use epoch ms for PostgreSQL bigint columns in quota_state

### DIFF
--- a/packages/backend/src/services/quota/quota-enforcer.ts
+++ b/packages/backend/src/services/quota/quota-enforcer.ts
@@ -3,6 +3,7 @@ import parseDuration from 'parse-duration';
 import { logger } from '../../utils/logger';
 import { getConfig, QuotaDefinition, KeyConfig } from '../../config';
 import { getDatabase, getCurrentDialect } from '../../db/client';
+import { toDbTimestampMs } from '../../utils/normalize';
 import * as sqliteSchema from '../../../drizzle/schema/sqlite';
 import * as postgresSchema from '../../../drizzle/schema/postgres';
 
@@ -27,9 +28,22 @@ export interface UsageRecord {
 
 export class QuotaEnforcer {
   private db: ReturnType<typeof getDatabase>;
+  private dialect: 'sqlite' | 'postgres';
 
   constructor() {
     this.db = getDatabase();
+    this.dialect = getCurrentDialect() === 'postgres' ? 'postgres' : 'sqlite';
+  }
+
+  /**
+   * Convert a DB-returned value for lastUpdated/windowStart to a Date.
+   * PostgreSQL bigint(mode:'number') returns epoch ms as a number.
+   * SQLite integer(mode:'timestamp_ms') returns a Date object.
+   */
+  private fromDbTimestamp(value: Date | number | null): Date | null {
+    if (value == null) return null;
+    if (value instanceof Date) return value;
+    return new Date(value as number);
   }
 
   /**
@@ -144,8 +158,8 @@ export class QuotaEnforcer {
       } else {
         // Quota definition unchanged, proceed normally
         currentUsage = state!.currentUsage;
-        lastUpdatedDate = state!.lastUpdated as Date;
-        windowStartDate = state!.windowStart as Date | null;
+        lastUpdatedDate = this.fromDbTimestamp(state!.lastUpdated)!;
+        windowStartDate = this.fromDbTimestamp(state!.windowStart);
 
         // Handle calendar quota reset
         if (
@@ -331,8 +345,8 @@ export class QuotaEnforcer {
         quotaName: keyConfig.quota,
         limitType: quotaDef.limitType,
         currentUsage: usageValue,
-        lastUpdated: nowDate,
-        windowStart: windowStartDate,
+        lastUpdated: toDbTimestampMs(nowDate, this.dialect)!,
+        windowStart: toDbTimestampMs(windowStartDate, this.dialect),
       });
     } else if (existingState[0]) {
       // Update existing state with leak calculation for rolling quotas
@@ -358,12 +372,12 @@ export class QuotaEnforcer {
         if (quotaDef.type === 'rolling') {
           const durationMs = parseDuration(quotaDef.duration);
           if (durationMs) {
-            const lastUpdatedDate = state.lastUpdated as Date;
+            const lastUpdatedDate = this.fromDbTimestamp(state.lastUpdated)!;
             const elapsedMs = nowMs - lastUpdatedDate.getTime();
 
             // Cost quotas use cumulative spending (no leak), reset when window expires
             if (quotaDef.limitType === 'cost') {
-              const windowStart = state.windowStart as Date | null;
+              const windowStart = this.fromDbTimestamp(state.windowStart);
               // Check if window has expired
               if (!windowStart || elapsedMs >= durationMs) {
                 // Window expired - start fresh with just this request's usage
@@ -395,20 +409,20 @@ export class QuotaEnforcer {
         quotaName: keyConfig.quota,
         limitType: quotaDef.limitType,
         currentUsage: newUsage,
-        lastUpdated: nowDate,
+        lastUpdated: toDbTimestampMs(nowDate, this.dialect)!,
       };
 
       // For rolling cost quotas, also update windowStart if needed
       if (quotaDef.type === 'rolling' && quotaDef.limitType === 'cost') {
         const durationMs = parseDuration(quotaDef.duration);
-        const lastUpdatedDate = state.lastUpdated as Date;
+        const lastUpdatedDate = this.fromDbTimestamp(state.lastUpdated)!;
         const elapsedMs = nowMs - lastUpdatedDate.getTime();
-        const windowStart = state.windowStart as Date | null;
+        const windowStart = this.fromDbTimestamp(state.windowStart);
 
         if (!windowStart || elapsedMs >= (durationMs || 0)) {
           // Window expired or not set - set new window start aligned to period
           const alignedStart = durationMs ? this.alignToPeriodStart(nowMs, durationMs) : nowMs;
-          updateValues.windowStart = new Date(alignedStart);
+          updateValues.windowStart = toDbTimestampMs(new Date(alignedStart), this.dialect);
         }
       }
 
@@ -434,7 +448,7 @@ export class QuotaEnforcer {
       .update(schema.quotaState)
       .set({
         currentUsage: 0,
-        lastUpdated: nowDate,
+        lastUpdated: toDbTimestampMs(nowDate, this.dialect)!,
       })
       .where(eq(schema.quotaState.keyName, keyName));
 


### PR DESCRIPTION
Fixes #166

The quota_state table uses bigint columns for last_updated and window_start in PostgreSQL, but quota-enforcer.ts was passing Date objects instead of epoch millisecond numbers. This caused PostgresError: "column is of type bigint but expression is of type timestamp with time zone".

Fix by using toDbTimestampMs() for writes and fromDbTimestamp() for reads to properly handle the type difference between PostgreSQL (number) and SQLite (Date).

Generated with [Claude Code](https://claude.ai/code)