### PR TITLE
Test: Claude Code Review workflow

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -1,3 +1,4 @@
+// Plexus - Unified API Gateway for LLMs
 import { z } from 'zod';
 import yaml from 'yaml';
 import { logger } from './utils/logger';


### PR DESCRIPTION
Trivial change to test that the claude-code-review workflow works with `pull_request_target` and `github.token` instead of OIDC.