### PR TITLE
ci: verify PR test workflow

### DIFF
--- a/packages/backend/src/__tests__/getProviderTypes.test.ts
+++ b/packages/backend/src/__tests__/getProviderTypes.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 import { getProviderTypes, ProviderConfig } from '../config';
 
+// CI test PR — verifying pr-tests workflow
+
 describe('getProviderTypes', () => {
   describe('string URL inference', () => {
     it('returns ["chat"] for OpenAI-compatible URLs', () => {


### PR DESCRIPTION
Trivial change to confirm the **PR Tests** workflow () triggers correctly on pull requests and all jobs pass (typecheck, frontend build, bun test).