### PR TITLE
feat: responsive frontend revamp

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { Login } from './pages/Login';
 import { MyKey } from './pages/MyKey';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { SidebarProvider } from './contexts/SidebarContext';
+import { ToastProvider } from './contexts/ToastContext';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -128,11 +129,13 @@ const AppRoutes = () => {
 
 const App = () => {
   return (
-    <AuthProvider>
-      <SidebarProvider>
-        <AppRoutes />
-      </SidebarProvider>
-    </AuthProvider>
+    <ToastProvider>
+      <AuthProvider>
+        <SidebarProvider>
+          <AppRoutes />
+        </SidebarProvider>
+      </AuthProvider>
+    </ToastProvider>
   );
 };
 

--- a/packages/frontend/src/components/dashboard/MetricsOverviewCard.tsx
+++ b/packages/frontend/src/components/dashboard/MetricsOverviewCard.tsx
@@ -23,7 +23,7 @@ export const MetricsOverviewCard: React.FC<MetricsOverviewCardProps> = ({
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 200px), 1fr))',
           gap: '16px',
         }}
       >

--- a/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
@@ -105,6 +105,7 @@ import {
   formatTPS,
 } from '../../../lib/format';
 import { useAuth } from '../../../contexts/AuthContext';
+import { useToast } from '../../../contexts/ToastContext';
 
 //
 // LOCAL TYPES
@@ -591,6 +592,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
   onLiveWindowPeriodChange,
 }) => {
   const { isAdmin, principal } = useAuth();
+  const toast = useToast();
   const limitedAllowedProviders =
     principal?.role === 'limited' ? (principal.allowedProviders ?? []) : null;
   // ---------------------------------------------------------------------------
@@ -1535,54 +1537,47 @@ export const LiveTab: React.FC<LiveTabProps> = ({
 
   /** Prompts the user to confirm, then clears all active cooldowns via the API */
   const handleClearCooldowns = async () => {
-    if (
-      !confirm(
-        'Clear ALL provider cooldowns?\n\n' +
-          'Cooldowns are shared across all API keys. Clearing them affects traffic ' +
-          "for every key using those providers. If the underlying problem hasn't " +
-          'been resolved, cooldowns will simply re-establish on the next failure.'
-      )
-    ) {
-      return;
-    }
+    const ok = await toast.confirm({
+      title: 'Clear ALL provider cooldowns?',
+      message:
+        "Cooldowns are shared across all API keys. Clearing them affects traffic for every key using those providers. If the underlying problem hasn't been resolved, cooldowns will simply re-establish on the next failure.",
+      confirmLabel: 'Clear all',
+      variant: 'danger',
+    });
+    if (!ok) return;
 
     try {
       await api.clearCooldown();
       await loadData();
     } catch (e) {
-      alert('Failed to clear cooldowns');
+      toast.error('Failed to clear cooldowns');
       console.error('Failed to clear cooldowns', e);
     }
   };
 
   /** Clears a specific provider/model cooldown */
   const handleClearSingleCooldown = async (provider: string, model?: string) => {
-    // Limited users whose allowedProviders list is set may only clear a
-    // cooldown for a provider they're permitted to use. The backend also
-    // enforces this; the client-side check is UX — surface a clear message.
     if (
       limitedAllowedProviders &&
       limitedAllowedProviders.length > 0 &&
       !limitedAllowedProviders.includes(provider)
     ) {
-      alert(`Your API key is not permitted to clear cooldowns for provider '${provider}'.`);
+      toast.error(`Your API key is not permitted to clear cooldowns for provider '${provider}'.`);
       return;
     }
-    if (
-      !confirm(
-        `Clear cooldown for ${provider}${model ? ':' + model : ''}?\n\n` +
-          'This affects traffic for every API key using that provider. The ' +
-          "cooldown will re-establish on the next failure if the issue isn't " +
-          'resolved.'
-      )
-    ) {
-      return;
-    }
+    const ok = await toast.confirm({
+      title: `Clear cooldown for ${provider}${model ? ':' + model : ''}?`,
+      message:
+        "This affects traffic for every API key using that provider. The cooldown will re-establish on the next failure if the issue isn't resolved.",
+      confirmLabel: 'Clear',
+      variant: 'danger',
+    });
+    if (!ok) return;
     try {
       await api.clearCooldown(provider, model);
       await loadData();
     } catch (e) {
-      alert('Failed to clear cooldown');
+      toast.error('Failed to clear cooldown');
       console.error('Failed to clear cooldown', e);
     }
   };

--- a/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
@@ -286,7 +286,7 @@ export const OverallTab: React.FC = () => {
       {/* -------- Row 1: Identity + Quota ------------------------------- */}
       <div
         className="grid gap-4"
-        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))' }}
+        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))' }}
       >
         <Card title="Key" extra={<Key size={16} className="text-text-muted" />} className="min-w-0">
           <dl className="grid grid-cols-1 gap-3 text-sm">
@@ -373,7 +373,7 @@ export const OverallTab: React.FC = () => {
       {/* -------- Row 2: Access (providers / models) -------------------- */}
       <div
         className="grid gap-4"
-        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))' }}
+        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))' }}
       >
         <Card
           title="Allowed providers"
@@ -435,7 +435,7 @@ export const OverallTab: React.FC = () => {
         ) : (
           <div
             className="grid gap-6"
-            style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))' }}
+            style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 140px), 1fr))' }}
           >
             <Metric label="Requests" value={formatNumber(summary.totalRequests, 0)} />
             <Metric label="Total tokens" value={formatTokens(summary.totalTokens)} />
@@ -463,7 +463,7 @@ export const OverallTab: React.FC = () => {
       {/* -------- Row 4: Per-provider + per-model breakdown ------------- */}
       <div
         className="grid gap-4"
-        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))' }}
+        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))' }}
       >
         <Card title="Requests by provider" className="min-w-0">
           {loading && !providerData.length ? (

--- a/packages/frontend/src/components/dashboard/tabs/PerformanceTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/PerformanceTab.tsx
@@ -5,6 +5,7 @@ import { api, type ProviderPerformanceData } from '../../../lib/api';
 import { formatMs, formatNumber } from '../../../lib/format';
 import { Card } from '../../ui/Card';
 import { Button } from '../../ui/Button';
+import { useToast } from '../../../contexts/ToastContext';
 
 const BAR_COLORS = [
   '#c26134',
@@ -124,6 +125,7 @@ const PerformanceBarChart = ({
 };
 
 export const PerformanceTab = () => {
+  const toast = useToast();
   const [rows, setRows] = useState<ProviderPerformanceData[]>([]);
   const [selectedModel, setSelectedModel] = useState('');
   const [loading, setLoading] = useState(false);
@@ -138,8 +140,13 @@ export const PerformanceTab = () => {
 
   const clearPerformance = async () => {
     if (!selectedModel) return;
-    if (!confirm(`Are you sure you want to clear all performance data for "${selectedModel}"?`))
-      return;
+    const ok = await toast.confirm({
+      title: 'Clear performance data?',
+      message: `Are you sure you want to clear all performance data for "${selectedModel}"?`,
+      confirmLabel: 'Clear',
+      variant: 'danger',
+    });
+    if (!ok) return;
 
     setClearing(true);
     const success = await api.clearProviderPerformance(selectedModel);
@@ -236,13 +243,9 @@ export const PerformanceTab = () => {
         </div>
       </Card>
 
-      <div
-        className="grid gap-4"
-        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(350px, 1fr))' }}
-      >
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
         <Card
           className="min-w-0"
-          style={{ minWidth: '350px' }}
           title="Fastest Providers (tok/s)"
           extra={<Gauge size={16} className="text-primary" />}
         >
@@ -268,7 +271,6 @@ export const PerformanceTab = () => {
 
         <Card
           className="min-w-0"
-          style={{ minWidth: '350px' }}
           title="Fastest First Token (TTFT)"
           extra={<TimerReset size={16} className="text-primary" />}
         >
@@ -292,7 +294,6 @@ export const PerformanceTab = () => {
 
         <Card
           className="min-w-0"
-          style={{ minWidth: '350px' }}
           title="Selected Model"
           extra={<BarChart3 size={16} className="text-primary" />}
         >

--- a/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
@@ -425,12 +425,9 @@ export const UsageTab: React.FC<UsageTabProps> = ({
       </div>
 
       {/* All Charts in 4-Column Grid */}
-      <div
-        className="grid gap-4"
-        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(350px, 1fr))' }}
-      >
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
         {/* Time Series - Requests */}
-        <Card className="min-w-0" style={{ minWidth: '350px' }} title="Requests over Time">
+        <Card className="min-w-0" title="Requests over Time">
           <div style={{ height: 300, marginTop: '12px' }}>
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={data}>
@@ -481,7 +478,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
          * The x-axis uses the pre-formatted `label` field ("HH:MM") rather
          * than raw timestamps to keep tick labels compact.
          */}
-        <Card className="min-w-0" style={{ minWidth: '350px' }} title="Concurrency by Provider">
+        <Card className="min-w-0" title="Concurrency by Provider">
           <div style={{ height: 300, marginTop: '12px' }}>
             {concurrencyByProviderTimeline.length === 0 ? (
               <div className="h-full flex items-center justify-center text-text-secondary text-sm">
@@ -535,7 +532,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
          * highest-traffic model at the bottom of the stack (matching the
          * sort order from `modelKeys`).
          */}
-        <Card className="min-w-0" style={{ minWidth: '350px' }} title="Concurrency by Model">
+        <Card className="min-w-0" title="Concurrency by Model">
           <div style={{ height: 300, marginTop: '12px' }}>
             {concurrencyByModelTimeline.length === 0 ? (
               <div className="h-full flex items-center justify-center text-text-secondary text-sm">
@@ -574,7 +571,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
         </Card>
 
         {/* Time Series - Tokens */}
-        <Card className="min-w-0" style={{ minWidth: '350px' }} title="Token Usage">
+        <Card className="min-w-0" title="Token Usage">
           <div style={{ height: 300, marginTop: '12px' }}>
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={data}>
@@ -638,7 +635,6 @@ export const UsageTab: React.FC<UsageTabProps> = ({
         {/* Model Distribution - Requests */}
         <Card
           className="min-w-0"
-          style={{ minWidth: '350px' }}
           title="Usage by Model Alias (Requests)"
         >
           <div style={{ height: 300, marginTop: '12px' }}>
@@ -649,7 +645,6 @@ export const UsageTab: React.FC<UsageTabProps> = ({
         {/* Model Distribution - Tokens */}
         <Card
           className="min-w-0"
-          style={{ minWidth: '350px' }}
           title="Usage by Model Alias (Tokens)"
         >
           <div style={{ height: 300, marginTop: '12px' }}>
@@ -660,7 +655,6 @@ export const UsageTab: React.FC<UsageTabProps> = ({
         {/* Provider Distribution - Requests */}
         <Card
           className="min-w-0"
-          style={{ minWidth: '350px' }}
           title="Usage by Provider (Requests)"
         >
           <div style={{ height: 300, marginTop: '12px' }}>
@@ -669,25 +663,25 @@ export const UsageTab: React.FC<UsageTabProps> = ({
         </Card>
 
         {/* Provider Distribution - Tokens */}
-        <Card className="min-w-0" style={{ minWidth: '350px' }} title="Usage by Provider (Tokens)">
+        <Card className="min-w-0" title="Usage by Provider (Tokens)">
           <div style={{ height: 300, marginTop: '12px' }}>
             {renderPieChart('tokens', providerData)}
           </div>
         </Card>
 
         {/* API Key Distribution - Requests */}
-        <Card className="min-w-0" style={{ minWidth: '350px' }} title="Usage by API Key (Requests)">
+        <Card className="min-w-0" title="Usage by API Key (Requests)">
           <div style={{ height: 300, marginTop: '12px' }}>
             {renderPieChart('requests', keyData)}
           </div>
         </Card>
 
         {/* API Key Distribution - Tokens */}
-        <Card className="min-w-0" style={{ minWidth: '350px' }} title="Usage by API Key (Tokens)">
+        <Card className="min-w-0" title="Usage by API Key (Tokens)">
           <div style={{ height: 300, marginTop: '12px' }}>{renderPieChart('tokens', keyData)}</div>
         </Card>
 
-        <Card className="min-w-0" style={{ minWidth: '350px' }} title="Energy Comparisons">
+        <Card className="min-w-0" title="Energy Comparisons">
           <div style={{ marginTop: '12px', height: 300 }}>
             <TotalEnergyComparison totalKwh={energySummary?.totalKwhUsed} />
           </div>

--- a/packages/frontend/src/components/layout/AppBar.tsx
+++ b/packages/frontend/src/components/layout/AppBar.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Menu } from 'lucide-react';
+import { useSidebar } from '../../contexts/SidebarContext';
+import logo from '../../assets/plexus_logo_transparent.png';
+
+export const AppBar: React.FC = () => {
+  const { openMobile } = useSidebar();
+
+  return (
+    <header className="md:hidden sticky top-0 z-sidebar h-14 flex items-center gap-3 px-4 bg-bg-surface/90 backdrop-blur-md border-b border-border">
+      <button
+        type="button"
+        onClick={openMobile}
+        aria-label="Open navigation"
+        className="p-2 -ml-2 rounded-md text-text-secondary hover:bg-bg-hover hover:text-text transition-colors duration-fast focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
+      >
+        <Menu size={22} />
+      </button>
+      <div className="flex items-center gap-2">
+        <img src={logo} alt="" className="w-6 h-6" />
+        <span className="font-heading text-lg font-bold bg-clip-text text-transparent bg-gradient-to-br from-primary to-secondary">
+          Plexus
+        </span>
+      </div>
+    </header>
+  );
+};

--- a/packages/frontend/src/components/layout/MainLayout.tsx
+++ b/packages/frontend/src/components/layout/MainLayout.tsx
@@ -1,21 +1,32 @@
 import React from 'react';
 import { clsx } from 'clsx';
 import { Sidebar } from './Sidebar';
+import { AppBar } from './AppBar';
+import { Drawer } from '../ui/Drawer';
 import { useSidebar } from '../../contexts/SidebarContext';
 
 export const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { isCollapsed } = useSidebar();
+  const { isCollapsed, isMobileOpen, closeMobile } = useSidebar();
 
   return (
-    <div className="flex min-h-screen bg-bg-deep">
-      <Sidebar />
+    <div className="min-h-screen bg-bg-deep">
+      <AppBar />
+
+      {/* Desktop fixed sidebar. Hidden below md. */}
+      <Sidebar mode="desktop" />
+
+      {/* Mobile drawer — only mounted while open. */}
+      <Drawer open={isMobileOpen} onClose={closeMobile} aria-label="Main navigation">
+        <Sidebar mode="drawer" />
+      </Drawer>
+
       <main
         className={clsx(
-          'flex-1 min-h-screen p-8 transition-[margin] duration-300',
-          isCollapsed ? 'ml-[64px]' : 'ml-[200px]'
+          'min-h-screen p-4 sm:p-6 lg:p-8 transition-[margin] duration-300',
+          isCollapsed ? 'md:ml-[64px]' : 'md:ml-[200px]'
         )}
       >
-        <div className="main-content-inner">{children}</div>
+        {children}
       </main>
     </div>
   );

--- a/packages/frontend/src/components/layout/PageContainer.tsx
+++ b/packages/frontend/src/components/layout/PageContainer.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+interface PageContainerProps {
+  children: React.ReactNode;
+  /** Constrain content width. Defaults to wide. */
+  width?: 'narrow' | 'standard' | 'wide' | 'full';
+  className?: string;
+}
+
+const widthClasses: Record<NonNullable<PageContainerProps['width']>, string> = {
+  narrow: 'max-w-3xl',
+  standard: 'max-w-5xl',
+  wide: 'max-w-7xl',
+  full: 'max-w-none',
+};
+
+export const PageContainer: React.FC<PageContainerProps> = ({
+  children,
+  width = 'wide',
+  className,
+}) => {
+  return <div className={clsx('mx-auto w-full', widthClasses[width], className)}>{children}</div>;
+};

--- a/packages/frontend/src/components/layout/PageHeader.tsx
+++ b/packages/frontend/src/components/layout/PageHeader.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+interface PageHeaderProps {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export const PageHeader: React.FC<PageHeaderProps> = ({ title, subtitle, actions, className }) => {
+  return (
+    <div
+      className={clsx(
+        'mb-6 sm:mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between',
+        className
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <h1 className="font-heading text-h1 font-bold text-text m-0 leading-tight">{title}</h1>
+        {subtitle && (
+          <p className="mt-1 font-body text-sm text-text-secondary">{subtitle}</p>
+        )}
+      </div>
+      {actions && <div className="flex flex-wrap items-center gap-2 sm:gap-3 sm:flex-shrink-0">{actions}</div>}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { NavLink } from 'react-router-dom';
+import React, { useState, useEffect, useRef } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 import {
   LayoutDashboard,
   Settings,
@@ -30,31 +30,36 @@ import { toBoolean, toIsoString } from '../../lib/normalize';
 
 import logo from '../../assets/plexus_logo_transparent.png';
 
+interface SidebarProps {
+  /** desktop = fixed aside with collapse rail; drawer = flush content rendered inside a Drawer. */
+  mode?: 'desktop' | 'drawer';
+}
+
 interface NavItemProps {
   to: string;
   icon: React.ComponentType<{ size: number }>;
   label: string;
-  isCollapsed: boolean;
+  collapsed: boolean;
 }
 
-const NavItem: React.FC<NavItemProps> = ({ to, icon: Icon, label, isCollapsed }) => {
+const NavItem: React.FC<NavItemProps> = ({ to, icon: Icon, label, collapsed }) => {
   const navLink = (
     <NavLink
       to={to}
       className={({ isActive }) =>
         clsx(
-          'flex items-center gap-3 py-1.5 px-2 rounded-md font-body text-sm font-medium text-text-secondary no-underline cursor-pointer transition-all duration-200 border border-transparent hover:bg-bg-hover hover:text-text',
-          isCollapsed && 'justify-center',
+          'flex items-center gap-3 py-1.5 px-2 rounded-md font-body text-sm font-medium text-text-secondary no-underline cursor-pointer transition-all duration-fast border border-transparent hover:bg-bg-hover hover:text-text',
+          collapsed && 'justify-center',
           isActive &&
-            'bg-bg-glass text-primary border-border-glass shadow-sm backdrop-blur-md shadow-[0_2px_8px_rgba(245,158,11,0.15)]'
+            'bg-bg-glass text-primary border-border-glass backdrop-blur-md shadow-nav-active'
         )
       }
     >
       <Icon size={20} />
       <span
         className={clsx(
-          'transition-opacity duration-200',
-          isCollapsed && 'opacity-0 w-0 overflow-hidden'
+          'transition-opacity duration-fast',
+          collapsed && 'opacity-0 w-0 overflow-hidden'
         )}
       >
         {label}
@@ -62,7 +67,7 @@ const NavItem: React.FC<NavItemProps> = ({ to, icon: Icon, label, isCollapsed })
     </NavLink>
   );
 
-  return isCollapsed ? (
+  return collapsed ? (
     <Tooltip content={label} position="right">
       {navLink}
     </Tooltip>
@@ -71,8 +76,7 @@ const NavItem: React.FC<NavItemProps> = ({ to, icon: Icon, label, isCollapsed })
   );
 };
 
-export const Sidebar: React.FC = () => {
-  // process.env.APP_VERSION is replaced at build time by the bundler
+export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
   // biome-ignore lint/security/noGlobalAssign: build-time constant injected by bundler
   const appVersion: string =
     // @ts-expect-error — replaced at build time by build.ts
@@ -88,20 +92,34 @@ export const Sidebar: React.FC = () => {
   const [devToolsExpanded, setDevToolsExpanded] = useState(false);
   const [quotas, setQuotas] = useState<QuotaCheckerInfo[]>([]);
   const { logout, isAdmin, isLimited, principal } = useAuth();
-  const { isCollapsed, toggleSidebar } = useSidebar();
+  const { isCollapsed, toggleSidebar, isMobileOpen, closeMobile } = useSidebar();
+  const location = useLocation();
+
+  // Drawer mode always renders expanded; desktop respects user preference.
+  const collapsed = mode === 'desktop' && isCollapsed;
+
+  // Auto-close drawer on navigation. Only fires on pathname *changes*, not on
+  // initial mount — otherwise opening the drawer would immediately close it,
+  // since the drawer-mode Sidebar mounts with location.pathname already set.
+  const lastPathnameRef = useRef(location.pathname);
+  useEffect(() => {
+    const pathChanged = lastPathnameRef.current !== location.pathname;
+    lastPathnameRef.current = location.pathname;
+    if (pathChanged && mode === 'drawer' && isMobileOpen) {
+      closeMobile();
+    }
+  }, [location.pathname, mode, isMobileOpen, closeMobile]);
 
   useEffect(() => {
     api.getDebugMode().then((result) => setDebugMode(result.enabled));
   }, []);
 
-  // Fetch quotas
   useEffect(() => {
     const fetchQuotas = async () => {
       const data = await api.getQuotas();
       setQuotas(data);
     };
     fetchQuotas();
-    // Refresh quotas every 60 seconds
     const interval = setInterval(fetchQuotas, 60000);
     return () => clearInterval(interval);
   }, []);
@@ -116,7 +134,6 @@ export const Sidebar: React.FC = () => {
     const parsedA = parseSemverTag(a);
     const parsedB = parseSemverTag(b);
     if (!parsedA || !parsedB) return 0;
-
     for (let i = 0; i < 3; i++) {
       if (parsedA[i]! !== parsedB[i]!) {
         return parsedA[i]! - parsedB[i]!;
@@ -127,23 +144,16 @@ export const Sidebar: React.FC = () => {
 
   useEffect(() => {
     const controller = new AbortController();
-
     const fetchLatestVersion = async () => {
       try {
         const response = await fetch(
           'https://api.github.com/repos/mcowger/plexus/releases/latest',
           {
             signal: controller.signal,
-            headers: {
-              Accept: 'application/vnd.github+json',
-            },
+            headers: { Accept: 'application/vnd.github+json' },
           }
         );
-
-        if (!response.ok) {
-          return;
-        }
-
+        if (!response.ok) return;
         const latestRelease = (await response.json()) as { tag_name?: string };
         if (latestRelease.tag_name && parseSemverTag(latestRelease.tag_name)) {
           setLatestVersion(latestRelease.tag_name);
@@ -154,21 +164,15 @@ export const Sidebar: React.FC = () => {
         }
       }
     };
-
     fetchLatestVersion();
-
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
   const isOutdated = Boolean(
     latestVersion && parseSemverTag(appVersion) && compareSemverTags(appVersion, latestVersion) < 0
   );
 
-  const handleToggleClick = () => {
-    setShowConfirm(true);
-  };
+  const handleToggleClick = () => setShowConfirm(true);
 
   const confirmToggle = async () => {
     try {
@@ -186,7 +190,6 @@ export const Sidebar: React.FC = () => {
     window.location.href = '/ui/login';
   };
 
-  // Convert QuotaSnapshot to QuotaCheckResult format for display
   const getQuotaResult = (quota: QuotaCheckerInfo) => {
     if (!quota.latest || quota.latest.length === 0) {
       return {
@@ -200,8 +203,6 @@ export const Sidebar: React.FC = () => {
         windows: [],
       };
     }
-
-    // Get unique windows; key on windowType+description to preserve multiple windows of the same type
     const windowsByType = new Map<string, (typeof quota.latest)[0]>();
     for (const snapshot of quota.latest) {
       const key = snapshot.description
@@ -212,7 +213,6 @@ export const Sidebar: React.FC = () => {
         windowsByType.set(key, snapshot);
       }
     }
-
     const windows = Array.from(windowsByType.values()).map((snapshot) => ({
       windowType: snapshot.windowType as any,
       windowLabel: snapshot.description || snapshot.windowType,
@@ -228,7 +228,6 @@ export const Sidebar: React.FC = () => {
           : undefined,
       status: (snapshot.status as any) || 'ok',
     }));
-
     const firstSnapshot = quota.latest[0];
     const errorFromSnapshots =
       quota.latest.find((snapshot) => snapshot.errorMessage)?.errorMessage || undefined;
@@ -244,9 +243,6 @@ export const Sidebar: React.FC = () => {
     };
   };
 
-  // Filter using the authoritative checkerCategory field from the backend.
-  // Balance checkers that also have rate-limit windows (e.g. neuralwatt has
-  // both a $ balance and a kWh quota) appear in both sections.
   const BALANCE_CHECKERS_WITH_RATE_LIMIT = new Set(['neuralwatt']);
   const balanceQuotas = quotas.filter((quota) => quota.checkerCategory === 'balance');
   const rateLimitQuotas = quotas.filter(
@@ -255,33 +251,36 @@ export const Sidebar: React.FC = () => {
       BALANCE_CHECKERS_WITH_RATE_LIMIT.has(quota.checkerType || quota.checkerId)
   );
 
+  const isDrawer = mode === 'drawer';
+
   return (
     <aside
+      data-collapsed={collapsed}
       className={clsx(
-        'h-screen fixed left-0 top-0 bg-bg-surface flex flex-col overflow-y-auto overflow-x-hidden z-50 transition-all duration-300 border-r border-border',
-        isCollapsed ? 'w-[64px]' : 'w-[200px]'
+        'bg-bg-surface flex flex-col overflow-y-auto overflow-x-hidden border-r border-border',
+        isDrawer
+          ? 'h-full w-full border-r-0'
+          : 'hidden md:flex fixed left-0 top-0 h-screen z-sidebar transition-[width] duration-300',
+        !isDrawer && (collapsed ? 'w-[64px]' : 'w-[200px]')
       )}
     >
-      <div className="px-5 py-3 border-b border-border flex items-center justify-between">
+      <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-2">
         <div
           className={clsx(
-            'flex items-center gap-2 transition-opacity duration-200',
-            isCollapsed && 'opacity-0 w-0 overflow-hidden'
+            'flex items-center gap-2 min-w-0 transition-opacity duration-fast',
+            collapsed && 'opacity-0 w-0 overflow-hidden'
           )}
         >
-          <img src={logo} alt="Plexus" className="w-6 h-6" />
-          <div className="flex flex-col">
-            <h1 className="font-heading text-lg font-bold m-0 bg-clip-text text-transparent bg-gradient-to-br from-primary to-secondary">
+          <img src={logo} alt="" className="w-6 h-6 flex-shrink-0" />
+          <div className="flex flex-col min-w-0">
+            <h1 className="font-heading text-lg font-bold m-0 bg-clip-text text-transparent bg-gradient-to-br from-primary to-secondary truncate">
               Plexus
             </h1>
             <div className="flex items-center gap-1 text-[10px] leading-none text-text-muted">
               <span>{appVersion}</span>
               {isOutdated && (
                 <Tooltip content={`Update available: ${latestVersion}`} position="bottom">
-                  <span
-                    className="inline-flex text-primary"
-                    aria-label={`Outdated version. Latest is ${latestVersion}`}
-                  >
+                  <span className="inline-flex text-primary" aria-label={`Outdated version. Latest is ${latestVersion}`}>
                     <AlertTriangle size={11} />
                   </span>
                 </Tooltip>
@@ -289,14 +288,24 @@ export const Sidebar: React.FC = () => {
             </div>
           </div>
         </div>
-
-        <button
-          onClick={toggleSidebar}
-          className="p-2 rounded-md hover:bg-bg-hover transition-colors duration-200 text-text-secondary hover:text-text flex-shrink-0"
-          aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        >
-          {isCollapsed ? <PanelLeftOpen size={20} /> : <PanelLeftClose size={20} />}
-        </button>
+        {!isDrawer && (
+          <button
+            onClick={toggleSidebar}
+            className="p-1.5 rounded-md hover:bg-bg-hover transition-colors duration-fast text-text-secondary hover:text-text flex-shrink-0 focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            {collapsed ? <PanelLeftOpen size={18} /> : <PanelLeftClose size={18} />}
+          </button>
+        )}
+        {isDrawer && (
+          <button
+            onClick={closeMobile}
+            className="p-1.5 rounded-md hover:bg-bg-hover transition-colors duration-fast text-text-secondary hover:text-text flex-shrink-0 focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
+            aria-label="Close navigation"
+          >
+            <PanelLeftClose size={18} />
+          </button>
+        )}
       </div>
 
       <nav className="flex-1 py-2 px-2 flex flex-col gap-1">
@@ -307,37 +316,32 @@ export const Sidebar: React.FC = () => {
           >
             <h3
               className={clsx(
-                'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-200',
-                isCollapsed && 'opacity-0 h-0 overflow-hidden'
+                'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
+                collapsed && 'opacity-0 h-0 overflow-hidden'
               )}
             >
               Main
             </h3>
-            {!isCollapsed && (
+            {!collapsed && (
               <ChevronRight
                 size={14}
                 className={clsx(
-                  'text-text-muted transition-transform duration-200 group-hover:text-text',
+                  'text-text-muted transition-transform duration-fast group-hover:text-text',
                   mainExpanded && 'rotate-90'
                 )}
               />
             )}
           </button>
-          {(mainExpanded || isCollapsed) && (
+          {(mainExpanded || collapsed) && (
             <>
-              <NavItem to="/" icon={LayoutDashboard} label="Dashboard" isCollapsed={isCollapsed} />
-              <NavItem to="/logs" icon={FileText} label="Logs" isCollapsed={isCollapsed} />
-              {isAdmin && (
-                <NavItem to="/quotas" icon={PieChart} label="Quotas" isCollapsed={isCollapsed} />
-              )}
-              {isLimited && (
-                <NavItem to="/me" icon={UserCircle2} label="My Key" isCollapsed={isCollapsed} />
-              )}
+              <NavItem to="/" icon={LayoutDashboard} label="Dashboard" collapsed={collapsed} />
+              <NavItem to="/logs" icon={FileText} label="Logs" collapsed={collapsed} />
+              {isAdmin && <NavItem to="/quotas" icon={PieChart} label="Quotas" collapsed={collapsed} />}
+              {isLimited && <NavItem to="/me" icon={UserCircle2} label="My Key" collapsed={collapsed} />}
             </>
           )}
         </div>
 
-        {/* Balances Section */}
         {isAdmin && balanceQuotas.length > 0 && (
           <div className="mt-4 px-2">
             <button
@@ -346,39 +350,35 @@ export const Sidebar: React.FC = () => {
             >
               <h3
                 className={clsx(
-                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-200',
-                  isCollapsed && 'opacity-0 h-0 overflow-hidden'
+                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
+                  collapsed && 'opacity-0 h-0 overflow-hidden'
                 )}
               >
                 Balances
               </h3>
-              {!isCollapsed && (
+              {!collapsed && (
                 <ChevronRight
                   size={14}
                   className={clsx(
-                    'text-text-muted transition-transform duration-200 group-hover:text-text',
+                    'text-text-muted transition-transform duration-fast group-hover:text-text',
                     balancesExpanded && 'rotate-90'
                   )}
                 />
               )}
             </button>
-            {(balancesExpanded || isCollapsed) && (
+            {(balancesExpanded || collapsed) && (
               <div
                 className={clsx(
-                  'rounded-md bg-bg-card border border-border overflow-hidden transition-opacity duration-200',
-                  isCollapsed && 'opacity-0 h-0 overflow-hidden'
+                  'rounded-md bg-bg-card border border-border overflow-hidden transition-opacity duration-fast',
+                  collapsed && 'opacity-0 h-0 overflow-hidden'
                 )}
               >
-                <CompactBalancesCard
-                  balanceQuotas={balanceQuotas}
-                  getQuotaResult={getQuotaResult}
-                />
+                <CompactBalancesCard balanceQuotas={balanceQuotas} getQuotaResult={getQuotaResult} />
               </div>
             )}
           </div>
         )}
 
-        {/* Rate Limits Section */}
         {isAdmin && rateLimitQuotas.length > 0 && (
           <div className="mt-4 px-2">
             <button
@@ -387,33 +387,30 @@ export const Sidebar: React.FC = () => {
             >
               <h3
                 className={clsx(
-                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-200',
-                  isCollapsed && 'opacity-0 h-0 overflow-hidden'
+                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
+                  collapsed && 'opacity-0 h-0 overflow-hidden'
                 )}
               >
                 Quotas
               </h3>
-              {!isCollapsed && (
+              {!collapsed && (
                 <ChevronRight
                   size={14}
                   className={clsx(
-                    'text-text-muted transition-transform duration-200 group-hover:text-text',
+                    'text-text-muted transition-transform duration-fast group-hover:text-text',
                     quotasExpanded && 'rotate-90'
                   )}
                 />
               )}
             </button>
-            {(quotasExpanded || isCollapsed) && (
+            {(quotasExpanded || collapsed) && (
               <div
                 className={clsx(
-                  'rounded-md bg-bg-card border border-border overflow-hidden transition-opacity duration-200',
-                  isCollapsed && 'opacity-0 h-0 overflow-hidden'
+                  'rounded-md bg-bg-card border border-border overflow-hidden transition-opacity duration-fast',
+                  collapsed && 'opacity-0 h-0 overflow-hidden'
                 )}
               >
-                <CompactQuotasCard
-                  rateLimitQuotas={rateLimitQuotas}
-                  getQuotaResult={getQuotaResult}
-                />
+                <CompactQuotasCard rateLimitQuotas={rateLimitQuotas} getQuotaResult={getQuotaResult} />
               </div>
             )}
           </div>
@@ -427,34 +424,29 @@ export const Sidebar: React.FC = () => {
             >
               <h3
                 className={clsx(
-                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-200',
-                  isCollapsed && 'opacity-0 h-0 overflow-hidden'
+                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
+                  collapsed && 'opacity-0 h-0 overflow-hidden'
                 )}
               >
                 Configuration
               </h3>
-              {!isCollapsed && (
+              {!collapsed && (
                 <ChevronRight
                   size={14}
                   className={clsx(
-                    'text-text-muted transition-transform duration-200 group-hover:text-text',
+                    'text-text-muted transition-transform duration-fast group-hover:text-text',
                     configExpanded && 'rotate-90'
                   )}
                 />
               )}
             </button>
-            {(configExpanded || isCollapsed) && (
+            {(configExpanded || collapsed) && (
               <>
-                <NavItem
-                  to="/providers"
-                  icon={Server}
-                  label="Providers"
-                  isCollapsed={isCollapsed}
-                />
-                <NavItem to="/models" icon={Box} label="Models" isCollapsed={isCollapsed} />
-                <NavItem to="/keys" icon={Key} label="Keys" isCollapsed={isCollapsed} />
-                <NavItem to="/mcp" icon={Plug} label="MCP" isCollapsed={isCollapsed} />
-                <NavItem to="/config" icon={Settings} label="Settings" isCollapsed={isCollapsed} />
+                <NavItem to="/providers" icon={Server} label="Providers" collapsed={collapsed} />
+                <NavItem to="/models" icon={Box} label="Models" collapsed={collapsed} />
+                <NavItem to="/keys" icon={Key} label="Keys" collapsed={collapsed} />
+                <NavItem to="/mcp" icon={Plug} label="MCP" collapsed={collapsed} />
+                <NavItem to="/config" icon={Settings} label="Settings" collapsed={collapsed} />
               </>
             )}
           </div>
@@ -467,33 +459,31 @@ export const Sidebar: React.FC = () => {
           >
             <h3
               className={clsx(
-                'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-200',
-                isCollapsed && 'opacity-0 h-0 overflow-hidden'
+                'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
+                collapsed && 'opacity-0 h-0 overflow-hidden'
               )}
             >
               Dev Tools
             </h3>
-            {!isCollapsed && (
+            {!collapsed && (
               <ChevronRight
                 size={14}
                 className={clsx(
-                  'text-text-muted transition-transform duration-200 group-hover:text-text',
+                  'text-text-muted transition-transform duration-fast group-hover:text-text',
                   devToolsExpanded && 'rotate-90'
                 )}
               />
             )}
           </button>
-          {(devToolsExpanded || isCollapsed) && (
+          {(devToolsExpanded || collapsed) && (
             <>
               <div className="flex items-center justify-between">
-                <NavItem to="/debug" icon={Database} label="Traces" isCollapsed={isCollapsed} />
-                {/* Global debug toggle is admin-only. Limited users manage their
-                    own key's trace capture via the My Key page. */}
-                {isAdmin && !isCollapsed && (
+                <NavItem to="/debug" icon={Database} label="Traces" collapsed={collapsed} />
+                {isAdmin && !collapsed && (
                   <button
                     onClick={handleToggleClick}
                     className={clsx(
-                      'ml-2 px-1.5 py-0.5 rounded text-[10px] font-semibold transition-all duration-200 flex-shrink-0',
+                      'ml-2 px-1.5 py-0.5 rounded text-[10px] font-semibold transition-all duration-fast flex-shrink-0',
                       debugMode
                         ? 'bg-danger text-white hover:bg-danger/80'
                         : 'bg-text-muted/20 text-text-muted hover:bg-text-muted/30'
@@ -503,18 +493,13 @@ export const Sidebar: React.FC = () => {
                   </button>
                 )}
               </div>
-              <NavItem to="/errors" icon={AlertTriangle} label="Errors" isCollapsed={isCollapsed} />
+              <NavItem to="/errors" icon={AlertTriangle} label="Errors" collapsed={collapsed} />
               {isAdmin && (
-                <NavItem
-                  to="/system-logs"
-                  icon={FileText}
-                  label="System Logs"
-                  isCollapsed={isCollapsed}
-                />
+                <NavItem to="/system-logs" icon={FileText} label="System Logs" collapsed={collapsed} />
               )}
             </>
           )}
-          {principal && !isCollapsed && (
+          {principal && !collapsed && (
             <div className="mt-3 mx-1 px-2 py-1.5 rounded-md bg-bg-card border border-border flex items-center gap-2">
               <UserCircle2 size={16} className="text-text-muted flex-shrink-0" />
               <div className="flex-1 min-w-0">
@@ -537,23 +522,17 @@ export const Sidebar: React.FC = () => {
               <button
                 onClick={handleLogout}
                 className={clsx(
-                  'flex items-center gap-3 py-2 px-2 rounded-md font-body text-sm font-medium text-danger no-underline cursor-pointer transition-all duration-200 border border-transparent w-full bg-transparent border-transparent hover:text-danger hover:border-danger/30 hover:bg-red-500/10 mt-3',
-                  isCollapsed && 'justify-center'
+                  'flex items-center gap-3 py-2 px-2 rounded-md font-body text-sm font-medium text-danger cursor-pointer transition-all duration-fast border border-transparent w-full bg-transparent hover:text-danger hover:border-danger/30 hover:bg-red-500/10 mt-3',
+                  collapsed && 'justify-center'
                 )}
               >
                 <LogOut size={20} />
-                <span
-                  className={clsx(
-                    'transition-opacity duration-200',
-                    isCollapsed && 'opacity-0 w-0 overflow-hidden'
-                  )}
-                >
+                <span className={clsx('transition-opacity duration-fast', collapsed && 'opacity-0 w-0 overflow-hidden')}>
                   Logout
                 </span>
               </button>
             );
-
-            return isCollapsed ? (
+            return collapsed ? (
               <Tooltip content="Logout" position="right">
                 {logoutButton}
               </Tooltip>

--- a/packages/frontend/src/components/ui/Badge.tsx
+++ b/packages/frontend/src/components/ui/Badge.tsx
@@ -1,22 +1,31 @@
 import React from 'react';
 import { clsx } from 'clsx';
 
+type BadgeStatus = 'connected' | 'disconnected' | 'connecting' | 'error' | 'neutral' | 'warning';
+
 interface BadgeProps {
-  status: 'connected' | 'disconnected' | 'connecting' | 'error' | 'neutral' | 'warning';
+  status: BadgeStatus;
   children: React.ReactNode;
   secondaryText?: string;
   className?: string;
-  style?: React.CSSProperties;
   onClick?: (e: React.MouseEvent) => void;
   title?: string;
 }
+
+const statusClasses: Record<BadgeStatus, string> = {
+  connected: 'text-success border-success/30 bg-success/15',
+  connecting: 'text-info border-info/30 bg-info/15',
+  disconnected: 'text-danger border-danger/30 bg-danger/15',
+  error: 'text-danger border-danger/30 bg-danger/15',
+  warning: 'text-secondary border-secondary/30 bg-secondary/15',
+  neutral: 'text-text-secondary border-border bg-bg-hover',
+};
 
 export const Badge: React.FC<BadgeProps> = ({
   status,
   children,
   secondaryText,
   className,
-  style,
   onClick,
   title,
 }) => {
@@ -25,34 +34,17 @@ export const Badge: React.FC<BadgeProps> = ({
       onClick={onClick}
       title={title}
       className={clsx(
-        'inline-flex items-center gap-2 py-1.5 px-3 rounded-xl text-xs font-medium',
-        {
-          'text-success border border-success/30 bg-emerald-500/15': status === 'connected',
-          'text-danger border border-danger/30 bg-red-500/15':
-            status === 'disconnected' || status === 'error',
-          'text-secondary border border-secondary/30 bg-amber-500/15': status === 'warning',
-        },
+        'inline-flex items-center gap-2 rounded-full border text-xs font-medium whitespace-nowrap',
+        secondaryText ? 'px-3 py-1' : 'px-3 py-1.5',
+        onClick && 'cursor-pointer hover:opacity-80 transition-opacity duration-fast',
+        statusClasses[status],
         className
       )}
-      style={{
-        ...style,
-        height: secondaryText ? 'auto' : undefined,
-        padding: secondaryText ? '4px 12px' : undefined,
-      }}
     >
-      <span className="connection-dot w-1.5 h-1.5 rounded-full bg-current" />
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-start',
-          lineHeight: 1.1,
-        }}
-      >
-        <span style={{ fontWeight: 600 }}>{children}</span>
-        {secondaryText && (
-          <span style={{ fontSize: '9px', opacity: 0.7, marginTop: '2px' }}>{secondaryText}</span>
-        )}
+      <span className="w-1.5 h-1.5 rounded-full bg-current flex-shrink-0" />
+      <div className="flex flex-col items-start leading-tight">
+        <span className="font-semibold">{children}</span>
+        {secondaryText && <span className="text-[9px] opacity-70 mt-0.5">{secondaryText}</span>}
       </div>
     </div>
   );

--- a/packages/frontend/src/components/ui/Button.tsx
+++ b/packages/frontend/src/components/ui/Button.tsx
@@ -4,7 +4,7 @@ import { Loader2 } from 'lucide-react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | 'icon';
   isLoading?: boolean;
   leftIcon?: React.ReactNode;
 }
@@ -22,16 +22,19 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <button
       className={clsx(
-        'inline-flex items-center justify-center gap-2 py-2.5 px-5 font-body text-sm font-medium leading-normal border-0 rounded-md cursor-pointer transition-all duration-200 whitespace-nowrap select-none outline-none disabled:opacity-50 disabled:cursor-not-allowed',
+        'inline-flex items-center justify-center gap-2 font-body font-medium leading-normal border-0 rounded-md cursor-pointer transition-all duration-fast whitespace-nowrap select-none outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg-deep disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0',
         {
-          'text-black shadow-md bg-gradient-to-br from-primary to-secondary shadow-[0_4px_12px_rgba(245,158,11,0.3)] hover:disabled:transform-none hover:-translate-y-0.5 hover:shadow-[0_6px_20px_rgba(245,158,11,0.4)]':
+          'text-black bg-gradient-to-br from-primary to-secondary shadow-glow-primary-sm hover:-translate-y-0.5 hover:shadow-glow-primary':
             variant === 'primary',
           'bg-bg-glass text-text border border-border-glass backdrop-blur-md hover:bg-bg-hover hover:border-primary':
             variant === 'secondary',
-          'bg-transparent text-text border-0 hover:bg-amber-500/10': variant === 'ghost',
-          'bg-danger text-white shadow-md shadow-[0_4px_12px_rgba(239,68,68,0.3)] hover:bg-red-700 hover:-translate-y-0.5':
+          'bg-transparent text-text hover:bg-amber-500/10': variant === 'ghost',
+          'bg-danger text-white shadow-glow-danger hover:bg-red-700 hover:-translate-y-0.5':
             variant === 'danger',
-          '!py-1.5 !px-3.5 !text-xs': size === 'sm',
+          'py-1.5 px-3.5 text-xs': size === 'sm',
+          'py-2.5 px-5 text-sm': size === 'md',
+          'py-3 px-6 text-base': size === 'lg',
+          'h-9 w-9 p-0': size === 'icon',
         },
         className
       )}

--- a/packages/frontend/src/components/ui/Card.tsx
+++ b/packages/frontend/src/components/ui/Card.tsx
@@ -4,24 +4,44 @@ import { clsx } from 'clsx';
 interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string;
   extra?: React.ReactNode;
+  /** Use a minimal variant with less padding. */
+  dense?: boolean;
+  /** Remove default body padding so caller can control layout. */
+  flush?: boolean;
 }
 
-export const Card: React.FC<CardProps> = ({ title, extra, children, className, ...props }) => {
+export const Card: React.FC<CardProps> = ({
+  title,
+  extra,
+  children,
+  className,
+  dense,
+  flush,
+  ...props
+}) => {
   return (
     <div
       className={clsx(
-        'glass-bg backdrop-blur-md border border-white/10 rounded-lg shadow-xl overflow-hidden transition-all duration-300 max-w-full shadow-[0_8px_32px_rgba(0,0,0,0.3)]',
+        'glass-bg backdrop-blur-md rounded-lg overflow-hidden transition-all duration-fast max-w-full shadow-[0_8px_32px_rgba(0,0,0,0.25)]',
         className
       )}
       {...props}
     >
       {(title || extra) && (
-        <div className="flex items-center justify-between px-6 py-5 border-b border-border-glass">
-          {title && <h3 className="font-heading text-lg font-semibold text-text m-0">{title}</h3>}
-          {extra && <div className="card-extra">{extra}</div>}
+        <div
+          className={clsx(
+            'flex items-center justify-between gap-3 border-b border-border-glass',
+            dense ? 'px-4 py-3' : 'px-4 py-4 sm:px-5 sm:py-4'
+          )}
+        >
+          {title && (
+            <h3 className="font-heading text-h3 font-semibold text-text m-0 truncate">{title}</h3>
+          )}
+          {extra && <div className="flex-shrink-0">{extra}</div>}
         </div>
       )}
-      <div className="p-6 max-w-full">{children}</div>
+      {!flush && <div className={clsx('max-w-full', dense ? 'p-3 sm:p-4' : 'p-4 sm:p-5 md:p-6')}>{children}</div>}
+      {flush && <div className="max-w-full">{children}</div>}
     </div>
   );
 };

--- a/packages/frontend/src/components/ui/CopyButton.tsx
+++ b/packages/frontend/src/components/ui/CopyButton.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+import { clsx } from 'clsx';
+
+interface CopyButtonProps {
+  value: string;
+  label?: string;
+  size?: 'sm' | 'md';
+  className?: string;
+  variant?: 'icon' | 'button';
+}
+
+export const CopyButton: React.FC<CopyButtonProps> = ({
+  value,
+  label = 'Copy',
+  size = 'md',
+  className,
+  variant = 'icon',
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  };
+
+  const iconSize = size === 'sm' ? 12 : 14;
+
+  if (variant === 'icon') {
+    return (
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? 'Copied' : label}
+        className={clsx(
+          'inline-flex items-center justify-center rounded-md text-text-muted hover:text-text hover:bg-bg-hover transition-colors duration-fast focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2',
+          size === 'sm' ? 'h-6 w-6' : 'h-7 w-7',
+          className
+        )}
+      >
+        {copied ? <Check size={iconSize} className="text-success" /> : <Copy size={iconSize} />}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={clsx(
+        'inline-flex items-center gap-1.5 rounded-md border border-border-glass bg-bg-glass px-2.5 py-1 text-xs font-medium text-text-secondary hover:text-text hover:border-primary transition-all duration-fast focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2',
+        className
+      )}
+    >
+      {copied ? <Check size={iconSize} className="text-success" /> : <Copy size={iconSize} />}
+      {copied ? 'Copied' : label}
+    </button>
+  );
+};

--- a/packages/frontend/src/components/ui/DataTable.tsx
+++ b/packages/frontend/src/components/ui/DataTable.tsx
@@ -1,0 +1,170 @@
+import React, { useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight, ArrowUp, ArrowDown } from 'lucide-react';
+import { clsx } from 'clsx';
+import { ResponsiveTable, type ResponsiveTableColumn } from './ResponsiveTable';
+import { Button } from './Button';
+import { EmptyState } from './EmptyState';
+import { Skeleton } from './Skeleton';
+
+export interface DataTableColumn<T> extends ResponsiveTableColumn<T> {
+  sortable?: boolean;
+  sortKey?: (row: T) => string | number;
+}
+
+interface DataTableProps<T> {
+  columns: DataTableColumn<T>[];
+  data: T[];
+  getRowKey: (row: T, index: number) => string | number;
+  onRowClick?: (row: T, index: number) => void;
+  loading?: boolean;
+  error?: React.ReactNode;
+  emptyTitle?: React.ReactNode;
+  emptyDescription?: React.ReactNode;
+  emptyAction?: React.ReactNode;
+  /** Number of rows per page. Set to 0 to disable pagination. */
+  pageSize?: number;
+  className?: string;
+  noMobileCards?: boolean;
+}
+
+type SortState = { key: string; direction: 'asc' | 'desc' } | null;
+
+export function DataTable<T>({
+  columns,
+  data,
+  getRowKey,
+  onRowClick,
+  loading,
+  error,
+  emptyTitle = 'Nothing here yet',
+  emptyDescription,
+  emptyAction,
+  pageSize = 0,
+  className,
+  noMobileCards,
+}: DataTableProps<T>) {
+  const [sort, setSort] = useState<SortState>(null);
+  const [page, setPage] = useState(0);
+
+  const sortedData = useMemo(() => {
+    if (!sort) return data;
+    const col = columns.find((c) => c.key === sort.key);
+    if (!col || !col.sortable) return data;
+    const getKey = col.sortKey;
+    if (!getKey) return data;
+    const copy = [...data];
+    copy.sort((a, b) => {
+      const ka = getKey(a);
+      const kb = getKey(b);
+      if (ka < kb) return sort.direction === 'asc' ? -1 : 1;
+      if (ka > kb) return sort.direction === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return copy;
+  }, [data, sort, columns]);
+
+  const paged = useMemo(() => {
+    if (pageSize <= 0) return sortedData;
+    const start = page * pageSize;
+    return sortedData.slice(start, start + pageSize);
+  }, [sortedData, page, pageSize]);
+
+  const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(sortedData.length / pageSize)) : 1;
+
+  const handleSort = (key: string) => {
+    setSort((prev) => {
+      if (!prev || prev.key !== key) return { key, direction: 'asc' };
+      if (prev.direction === 'asc') return { key, direction: 'desc' };
+      return null;
+    });
+  };
+
+  if (loading && data.length === 0) {
+    return (
+      <div className={clsx('flex flex-col gap-2', className)}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} height={48} />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className={clsx(
+          'p-4 sm:p-6 rounded-lg border border-danger/40 bg-danger/10 text-danger font-body text-sm',
+          className
+        )}
+      >
+        {error}
+      </div>
+    );
+  }
+
+  const columnsWithSort: ResponsiveTableColumn<T>[] = columns.map((col) => {
+    if (!col.sortable) return col;
+    const isSorted = sort?.key === col.key;
+    return {
+      ...col,
+      header: (
+        <button
+          type="button"
+          onClick={() => handleSort(col.key)}
+          className="inline-flex items-center gap-1 hover:text-text transition-colors duration-fast"
+        >
+          {col.header}
+          {isSorted && sort?.direction === 'asc' && <ArrowUp size={12} />}
+          {isSorted && sort?.direction === 'desc' && <ArrowDown size={12} />}
+        </button>
+      ),
+    };
+  });
+
+  return (
+    <div className={clsx('flex flex-col gap-4', className)}>
+      <ResponsiveTable<T>
+        columns={columnsWithSort}
+        data={paged}
+        getRowKey={getRowKey}
+        onRowClick={onRowClick}
+        noMobileCards={noMobileCards}
+        emptyState={
+          <EmptyState
+            title={emptyTitle}
+            description={emptyDescription}
+            action={emptyAction}
+            dense
+          />
+        }
+      />
+      {pageSize > 0 && sortedData.length > pageSize && (
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-xs text-text-muted">
+            Page {page + 1} of {totalPages} · {sortedData.length} items
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              leftIcon={<ChevronLeft size={14} />}
+            >
+              Prev
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+            >
+              Next
+              <ChevronRight size={14} />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/Disclosure.tsx
+++ b/packages/frontend/src/components/ui/Disclosure.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { clsx } from 'clsx';
+
+interface DisclosureProps {
+  title: React.ReactNode;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  extra?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Disclosure: React.FC<DisclosureProps> = ({
+  title,
+  defaultOpen = false,
+  open: controlledOpen,
+  onOpenChange,
+  extra,
+  children,
+  className,
+}) => {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+
+  const toggle = () => {
+    const next = !open;
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
+
+  return (
+    <div className={clsx('border border-border-glass rounded-md bg-bg-glass/50 overflow-hidden', className)}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors duration-fast hover:bg-bg-hover focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:-outline-offset-2"
+      >
+        <ChevronRight
+          size={14}
+          className={clsx(
+            'text-text-muted flex-shrink-0 transition-transform duration-fast',
+            open && 'rotate-90'
+          )}
+        />
+        <span className="flex-1 font-heading text-sm font-medium text-text">{title}</span>
+        {extra && <span onClick={(e) => e.stopPropagation()}>{extra}</span>}
+      </button>
+      {open && (
+        <div className="px-4 pb-4 pt-2 border-t border-border-glass animate-[fadeIn_0.15s_ease]">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/ui/Drawer.tsx
+++ b/packages/frontend/src/components/ui/Drawer.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { clsx } from 'clsx';
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
+
+interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  side?: 'left' | 'right';
+  children: React.ReactNode;
+  className?: string;
+  /** Aria label for the off-canvas region. */
+  'aria-label'?: string;
+}
+
+export const Drawer: React.FC<DrawerProps> = ({
+  open,
+  onClose,
+  side = 'left',
+  children,
+  className,
+  'aria-label': ariaLabel = 'Navigation',
+}) => {
+  useBodyScrollLock(open);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-drawer-backdrop" role="dialog" aria-modal="true" aria-label={ariaLabel}>
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm animate-[fadeIn_0.2s_ease]"
+        onClick={onClose}
+      />
+      <div
+        className={clsx(
+          'absolute top-0 bottom-0 z-drawer flex w-[280px] max-w-[85vw] flex-col bg-bg-surface border-border shadow-modal outline-none',
+          side === 'left' && 'left-0 border-r animate-[drawerSlideLeft_250ms_cubic-bezier(0.22,1,0.36,1)]',
+          side === 'right' && 'right-0 border-l animate-[drawerSlideRight_250ms_cubic-bezier(0.22,1,0.36,1)]',
+          className
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/packages/frontend/src/components/ui/EmptyState.tsx
+++ b/packages/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+  dense?: boolean;
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  icon,
+  title,
+  description,
+  action,
+  className,
+  dense,
+}) => {
+  return (
+    <div
+      className={clsx(
+        'flex flex-col items-center justify-center text-center',
+        dense ? 'py-8 px-4' : 'py-12 sm:py-16 px-6',
+        className
+      )}
+    >
+      {icon && (
+        <div className="mb-4 text-text-muted [&>svg]:h-10 [&>svg]:w-10 [&>svg]:sm:h-12 [&>svg]:sm:w-12">
+          {icon}
+        </div>
+      )}
+      <h3 className="font-heading text-h3 font-semibold text-text m-0">{title}</h3>
+      {description && (
+        <p className="mt-2 max-w-md font-body text-sm text-text-secondary">{description}</p>
+      )}
+      {action && <div className="mt-6">{action}</div>}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/ui/FormField.tsx
+++ b/packages/frontend/src/components/ui/FormField.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+interface FormFieldProps {
+  label?: React.ReactNode;
+  hint?: React.ReactNode;
+  error?: React.ReactNode;
+  children: React.ReactNode;
+  htmlFor?: string;
+  /** Render label & control horizontally (label left, control right). */
+  inline?: boolean;
+  className?: string;
+}
+
+export const FormField: React.FC<FormFieldProps> = ({
+  label,
+  hint,
+  error,
+  children,
+  htmlFor,
+  inline,
+  className,
+}) => {
+  return (
+    <div
+      className={clsx(
+        'flex gap-2',
+        inline ? 'flex-row items-center justify-between' : 'flex-col',
+        className
+      )}
+    >
+      {label && (
+        <label
+          htmlFor={htmlFor}
+          className={clsx(
+            'font-body text-xs font-medium text-text-secondary',
+            inline && 'flex-shrink-0'
+          )}
+        >
+          {label}
+        </label>
+      )}
+      <div className={clsx('flex flex-col gap-1', inline && 'min-w-0 flex-1')}>
+        {children}
+        {error && <span className="text-xs text-danger">{error}</span>}
+        {!error && hint && <span className="text-xs text-text-muted">{hint}</span>}
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/ui/Input.tsx
+++ b/packages/frontend/src/components/ui/Input.tsx
@@ -4,30 +4,60 @@ import { clsx } from 'clsx';
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  hint?: string;
+  leadingIcon?: React.ReactNode;
+  trailingAction?: React.ReactNode;
 }
 
-export const Input: React.FC<InputProps> = ({ label, error, className, id, ...props }) => {
-  const inputId = id || props.name || Math.random().toString(36).substr(2, 9);
+export const Input: React.FC<InputProps> = ({
+  label,
+  error,
+  hint,
+  leadingIcon,
+  trailingAction,
+  className,
+  id,
+  ...props
+}) => {
+  const generatedId = React.useId();
+  const inputId = id || props.name || generatedId;
 
   return (
-    <div className={clsx('flex flex-col gap-2', { 'input-has-error': !!error })}>
+    <div className="flex flex-col gap-1.5">
       {label && (
         <label
           htmlFor={inputId}
-          className="font-body text-[13px] font-medium text-text-secondary whitespace-nowrap"
+          className="font-body text-xs font-medium text-text-secondary"
         >
           {label}
         </label>
       )}
-      <input
-        id={inputId}
-        className={clsx(
-          'w-full py-2.5 px-3.5 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]',
-          className
+      <div className="relative flex items-center">
+        {leadingIcon && (
+          <span className="pointer-events-none absolute left-3 flex items-center text-text-muted">
+            {leadingIcon}
+          </span>
         )}
-        {...props}
-      />
-      {error && <span className="text-danger text-xs mt-1">{error}</span>}
+        <input
+          id={inputId}
+          aria-invalid={!!error}
+          className={clsx(
+            'w-full py-2.5 font-body text-sm text-text bg-bg-glass border rounded-md outline-none transition-all duration-fast backdrop-blur-md placeholder:text-text-muted',
+            'focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25',
+            'disabled:opacity-50 disabled:cursor-not-allowed',
+            leadingIcon ? 'pl-10' : 'pl-3.5',
+            trailingAction ? 'pr-10' : 'pr-3.5',
+            error ? 'border-danger' : 'border-border-glass',
+            className
+          )}
+          {...props}
+        />
+        {trailingAction && (
+          <span className="absolute right-2 flex items-center">{trailingAction}</span>
+        )}
+      </div>
+      {error && <span className="text-danger text-xs">{error}</span>}
+      {!error && hint && <span className="text-text-muted text-xs">{hint}</span>}
     </div>
   );
 };

--- a/packages/frontend/src/components/ui/KeyValueEditor.tsx
+++ b/packages/frontend/src/components/ui/KeyValueEditor.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { Input } from './Input';
+import { Button } from './Button';
+
+type Entries = Record<string, string>;
+
+interface KeyValueEditorProps {
+  entries: Entries;
+  onChange: (entries: Entries) => void;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  addLabel?: string;
+  /** Render value as a textarea instead of a single-line input. */
+  multilineValue?: boolean;
+  emptyText?: string;
+}
+
+export const KeyValueEditor: React.FC<KeyValueEditorProps> = ({
+  entries,
+  onChange,
+  keyPlaceholder = 'Key',
+  valuePlaceholder = 'Value',
+  addLabel = 'Add',
+  multilineValue,
+  emptyText,
+}) => {
+  const keys = Object.keys(entries);
+
+  const updateKey = (oldKey: string, newKey: string) => {
+    if (newKey === oldKey) return;
+    const next: Entries = {};
+    for (const k of keys) {
+      next[k === oldKey ? newKey : k] = entries[k] ?? '';
+    }
+    onChange(next);
+  };
+
+  const updateValue = (key: string, value: string) => {
+    onChange({ ...entries, [key]: value });
+  };
+
+  const removeEntry = (key: string) => {
+    const next = { ...entries };
+    delete next[key];
+    onChange(next);
+  };
+
+  const addEntry = () => {
+    let i = 1;
+    let candidate = 'key';
+    while (candidate in entries) {
+      candidate = `key${i++}`;
+    }
+    onChange({ ...entries, [candidate]: '' });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {keys.length === 0 && emptyText && (
+        <p className="text-xs text-text-muted italic">{emptyText}</p>
+      )}
+      {keys.map((key) => (
+        <div key={key} className="flex flex-col sm:flex-row items-stretch sm:items-start gap-2">
+          <div className="flex-1 min-w-0">
+            <Input
+              defaultValue={key}
+              onBlur={(e) => updateKey(key, e.target.value)}
+              placeholder={keyPlaceholder}
+            />
+          </div>
+          <div className="flex-[2] min-w-0">
+            {multilineValue ? (
+              <textarea
+                value={entries[key] ?? ''}
+                onChange={(e) => updateValue(key, e.target.value)}
+                placeholder={valuePlaceholder}
+                rows={2}
+                className="w-full py-2.5 px-3.5 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-md outline-none transition-all duration-fast backdrop-blur-md placeholder:text-text-muted focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25 resize-y"
+              />
+            ) : (
+              <Input
+                value={entries[key] ?? ''}
+                onChange={(e) => updateValue(key, e.target.value)}
+                placeholder={valuePlaceholder}
+              />
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => removeEntry(key)}
+            aria-label={`Remove ${key}`}
+            className="inline-flex items-center justify-center h-10 w-10 flex-shrink-0 rounded-md text-text-muted hover:text-danger hover:bg-red-500/10 transition-colors duration-fast focus-visible:outline-2 focus-visible:outline focus-visible:outline-danger focus-visible:outline-offset-2"
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      ))}
+      <Button type="button" variant="secondary" size="sm" leftIcon={<Plus size={14} />} onClick={addEntry}>
+        {addLabel}
+      </Button>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/ui/Modal.tsx
+++ b/packages/frontend/src/components/ui/Modal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { clsx } from 'clsx';
 import { X } from 'lucide-react';
+import { useBodyScrollLock } from '../../hooks/useBodyScrollLock';
 
 interface ModalProps {
   isOpen: boolean;
@@ -20,50 +21,52 @@ export const Modal: React.FC<ModalProps> = ({
   footer,
   size = 'md',
 }) => {
+  useBodyScrollLock(isOpen);
+
   useEffect(() => {
+    if (!isOpen) return;
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
-    if (isOpen) {
-      document.addEventListener('keydown', handleEsc);
-      document.body.style.overflow = 'hidden';
-    }
-    return () => {
-      document.removeEventListener('keydown', handleEsc);
-      document.body.style.overflow = 'unset';
-    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 
   return createPortal(
     <div
-      className="fixed inset-0 flex items-center justify-center z-[1000] p-5 bg-black/70 backdrop-blur-md animate-[fadeIn_0.2s_ease]"
+      className="fixed inset-0 z-modal flex items-center justify-center p-4 sm:p-5 bg-black/70 backdrop-blur-md animate-[fadeIn_0.2s_ease]"
       onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
     >
       <div
         className={clsx(
-          'bg-bg-surface border border-border-glass rounded-xl max-w-full max-h-[90vh] overflow-hidden flex flex-col shadow-[0_20px_60px_rgba(0,0,0,0.5)] animate-[slideUp_0.3s_ease]',
+          'bg-bg-surface border border-border-glass rounded-xl w-full max-h-[90vh] overflow-hidden flex flex-col shadow-modal animate-[slideUp_0.3s_ease]',
           {
-            'w-[400px]': size === 'sm',
-            'w-[600px]': size === 'md',
-            'w-[800px]': size === 'lg',
+            'max-w-[420px]': size === 'sm',
+            'max-w-[640px]': size === 'md',
+            'max-w-[960px]': size === 'lg',
           }
         )}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between p-6 border-b border-border-glass">
-          <h2 className="font-heading text-xl font-semibold text-text m-0">{title}</h2>
+        <div className="flex items-center justify-between gap-4 p-4 sm:p-5 md:p-6 border-b border-border-glass">
+          <h2 className="font-heading text-h2 font-semibold text-text m-0 truncate">{title}</h2>
           <button
-            className="bg-transparent border-0 text-text-muted cursor-pointer hover:text-text"
+            type="button"
+            className="flex-shrink-0 bg-transparent border-0 text-text-muted cursor-pointer rounded-md p-1 transition-colors duration-fast hover:text-text focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
             onClick={onClose}
+            aria-label="Close"
           >
             <X size={20} />
           </button>
         </div>
-        <div className="p-8 overflow-y-auto flex-1">{children}</div>
+        <div className="p-4 sm:p-5 md:p-6 lg:p-8 overflow-y-auto flex-1">{children}</div>
         {footer && (
-          <div className="flex items-center justify-end gap-3 px-6 py-5 border-t border-border-glass">
+          <div className="flex flex-wrap items-center justify-end gap-3 px-4 py-4 sm:px-5 sm:py-5 md:px-6 border-t border-border-glass">
             {footer}
           </div>
         )}

--- a/packages/frontend/src/components/ui/ResponsiveTable.tsx
+++ b/packages/frontend/src/components/ui/ResponsiveTable.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+export interface ResponsiveTableColumn<T> {
+  key: string;
+  header: React.ReactNode;
+  render: (row: T, index: number) => React.ReactNode;
+  /** Column priority controls mobile visibility. `high` always shows; `low` hidden on mobile. */
+  priority?: 'high' | 'medium' | 'low';
+  align?: 'left' | 'center' | 'right';
+  width?: string;
+  /** Label shown above the value in mobile card mode. Defaults to `header`. */
+  mobileLabel?: React.ReactNode;
+  /** Override: show as the main title of the mobile card. */
+  mobileTitle?: boolean;
+}
+
+interface ResponsiveTableProps<T> {
+  columns: ResponsiveTableColumn<T>[];
+  data: T[];
+  getRowKey: (row: T, index: number) => string | number;
+  onRowClick?: (row: T, index: number) => void;
+  emptyState?: React.ReactNode;
+  className?: string;
+  /** Disable the mobile card layout and use horizontal scroll instead. */
+  noMobileCards?: boolean;
+}
+
+const alignClass: Record<NonNullable<ResponsiveTableColumn<unknown>['align']>, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+};
+
+export function ResponsiveTable<T>({
+  columns,
+  data,
+  getRowKey,
+  onRowClick,
+  emptyState,
+  className,
+  noMobileCards,
+}: ResponsiveTableProps<T>) {
+  if (data.length === 0 && emptyState) {
+    return <>{emptyState}</>;
+  }
+
+  return (
+    <div className={className}>
+      {/* Desktop / tablet table */}
+      <div
+        className={clsx(
+          'overflow-x-auto border border-border-glass rounded-lg',
+          noMobileCards ? 'block' : 'hidden md:block'
+        )}
+      >
+        <table className="w-full border-collapse font-body text-sm">
+          <thead>
+            <tr className="bg-bg-glass/40">
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  style={col.width ? { width: col.width } : undefined}
+                  className={clsx(
+                    'px-4 py-3 text-xs font-semibold uppercase tracking-wider text-text-muted border-b border-border-glass',
+                    alignClass[col.align ?? 'left'],
+                    col.priority === 'low' && 'hidden lg:table-cell',
+                    col.priority === 'medium' && 'hidden md:table-cell'
+                  )}
+                >
+                  {col.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((row, rowIdx) => (
+              <tr
+                key={getRowKey(row, rowIdx)}
+                onClick={onRowClick ? () => onRowClick(row, rowIdx) : undefined}
+                className={clsx(
+                  'border-b border-border-glass/50 last:border-b-0 transition-colors duration-fast',
+                  onRowClick && 'cursor-pointer hover:bg-bg-hover'
+                )}
+              >
+                {columns.map((col) => (
+                  <td
+                    key={col.key}
+                    className={clsx(
+                      'px-4 py-3 text-text',
+                      alignClass[col.align ?? 'left'],
+                      col.priority === 'low' && 'hidden lg:table-cell',
+                      col.priority === 'medium' && 'hidden md:table-cell'
+                    )}
+                  >
+                    {col.render(row, rowIdx)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile card layout */}
+      {!noMobileCards && (
+        <div className="md:hidden flex flex-col gap-3">
+          {data.map((row, rowIdx) => {
+            const titleCol = columns.find((c) => c.mobileTitle);
+            const detailCols = columns.filter((c) => !c.mobileTitle && c.priority !== 'low');
+            return (
+              <div
+                key={getRowKey(row, rowIdx)}
+                onClick={onRowClick ? () => onRowClick(row, rowIdx) : undefined}
+                className={clsx(
+                  'glass-bg rounded-lg p-4 border border-border-glass flex flex-col gap-2',
+                  onRowClick && 'cursor-pointer hover:border-primary/40 transition-colors duration-fast'
+                )}
+              >
+                {titleCol && (
+                  <div className="font-heading text-sm font-semibold text-text break-words">
+                    {titleCol.render(row, rowIdx)}
+                  </div>
+                )}
+                <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+                  {detailCols.map((col) => (
+                    <React.Fragment key={col.key}>
+                      <dt className="text-text-muted font-medium uppercase tracking-wider text-[10px] self-center">
+                        {col.mobileLabel ?? col.header}
+                      </dt>
+                      <dd className="text-text break-words">{col.render(row, rowIdx)}</dd>
+                    </React.Fragment>
+                  ))}
+                </dl>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/SearchInput.tsx
+++ b/packages/frontend/src/components/ui/SearchInput.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Search, X } from 'lucide-react';
+import { Input } from './Input';
+
+interface SearchInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {
+  value: string;
+  onChange: (value: string) => void;
+  onClear?: () => void;
+  placeholder?: string;
+}
+
+export const SearchInput: React.FC<SearchInputProps> = ({
+  value,
+  onChange,
+  onClear,
+  placeholder = 'Search...',
+  ...rest
+}) => {
+  const handleClear = () => {
+    onChange('');
+    onClear?.();
+  };
+
+  return (
+    <Input
+      type="search"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      leadingIcon={<Search size={16} />}
+      trailingAction={
+        value ? (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="Clear search"
+            className="flex items-center justify-center h-7 w-7 rounded-md text-text-muted hover:text-text hover:bg-bg-hover transition-colors duration-fast"
+          >
+            <X size={14} />
+          </button>
+        ) : null
+      }
+      {...rest}
+    />
+  );
+};

--- a/packages/frontend/src/components/ui/Select.tsx
+++ b/packages/frontend/src/components/ui/Select.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { ChevronDown } from 'lucide-react';
+import { clsx } from 'clsx';
+
+interface SelectOption<V extends string = string> {
+  value: V;
+  label: string;
+  disabled?: boolean;
+}
+
+interface SelectProps<V extends string = string>
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'value' | 'onChange'> {
+  value: V;
+  onChange: (value: V) => void;
+  options: SelectOption<V>[];
+  label?: string;
+  error?: string;
+  placeholder?: string;
+}
+
+export function Select<V extends string = string>({
+  value,
+  onChange,
+  options,
+  label,
+  error,
+  placeholder,
+  className,
+  id,
+  ...rest
+}: SelectProps<V>) {
+  const generatedId = React.useId();
+  const selectId = id || generatedId;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label && (
+        <label htmlFor={selectId} className="font-body text-xs font-medium text-text-secondary">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <select
+          id={selectId}
+          value={value}
+          onChange={(e) => onChange(e.target.value as V)}
+          aria-invalid={!!error}
+          className={clsx(
+            'w-full appearance-none py-2.5 pl-3.5 pr-10 font-body text-sm text-text bg-bg-glass border rounded-md outline-none transition-all duration-fast backdrop-blur-md cursor-pointer',
+            'focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25',
+            'disabled:opacity-50 disabled:cursor-not-allowed',
+            error ? 'border-danger' : 'border-border-glass',
+            className
+          )}
+          {...rest}
+        >
+          {placeholder && (
+            <option value="" disabled>
+              {placeholder}
+            </option>
+          )}
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value} disabled={opt.disabled}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          size={16}
+          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-muted"
+        />
+      </div>
+      {error && <span className="text-danger text-xs">{error}</span>}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/Skeleton.tsx
+++ b/packages/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+interface SkeletonProps {
+  className?: string;
+  height?: number | string;
+  width?: number | string;
+  rounded?: 'sm' | 'md' | 'lg' | 'full';
+}
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  className,
+  height,
+  width,
+  rounded = 'md',
+}) => {
+  const style: React.CSSProperties = {};
+  if (height !== undefined) style.height = typeof height === 'number' ? `${height}px` : height;
+  if (width !== undefined) style.width = typeof width === 'number' ? `${width}px` : width;
+
+  return (
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      style={style}
+      className={clsx(
+        'animate-pulse bg-bg-hover/60',
+        {
+          'rounded-sm': rounded === 'sm',
+          'rounded-md': rounded === 'md',
+          'rounded-lg': rounded === 'lg',
+          'rounded-full': rounded === 'full',
+        },
+        className
+      )}
+    />
+  );
+};
+
+export const SkeletonText: React.FC<{ lines?: number; className?: string }> = ({
+  lines = 3,
+  className,
+}) => (
+  <div className={clsx('flex flex-col gap-2', className)}>
+    {Array.from({ length: lines }).map((_, i) => (
+      <Skeleton key={i} height={12} width={i === lines - 1 ? '60%' : '100%'} />
+    ))}
+  </div>
+);

--- a/packages/frontend/src/components/ui/Switch.tsx
+++ b/packages/frontend/src/components/ui/Switch.tsx
@@ -1,56 +1,55 @@
 import React from 'react';
+import { clsx } from 'clsx';
 
 interface SwitchProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
   disabled?: boolean;
   size?: 'sm' | 'md';
+  'aria-label'?: string;
 }
 
-export const Switch: React.FC<SwitchProps> = ({ checked, onChange, disabled, size = 'md' }) => {
-  const width = size === 'sm' ? 32 : 44;
-  const height = size === 'sm' ? 18 : 24;
-  const knobSize = size === 'sm' ? 14 : 20;
-  const padding = 2;
-
-  // Fallback colors if vars aren't available, but assuming they are based on index.css
-  const bgOn = 'var(--color-success, #10B981)'; // Using success color for ON state usually looks good
-  const bgOff = 'var(--color-bg-subtle, #334155)';
-
+export const Switch: React.FC<SwitchProps> = ({
+  checked,
+  onChange,
+  disabled,
+  size = 'md',
+  'aria-label': ariaLabel,
+}) => {
   return (
-    <div
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      data-checked={checked}
+      disabled={disabled}
       onClick={(e) => {
         e.stopPropagation();
         if (!disabled) onChange(!checked);
       }}
-      style={{
-        width: `${width}px`,
-        height: `${height}px`,
-        background: checked ? bgOn : bgOff,
-        borderRadius: '999px',
-        position: 'relative',
-        cursor: disabled ? 'not-allowed' : 'pointer',
-        opacity: disabled ? 0.5 : 1,
-        transition: 'background 0.2s ease',
-        border: checked
-          ? '1px solid transparent'
-          : '1px solid var(--color-border-glass, rgba(255,255,255,0.1))',
-        flexShrink: 0,
-      }}
+      className={clsx(
+        'group relative inline-block flex-shrink-0 rounded-full border border-border-glass bg-border transition-colors duration-fast outline-none',
+        'data-[checked=true]:bg-success data-[checked=true]:border-transparent',
+        'focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg-deep',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        !disabled && 'cursor-pointer',
+        {
+          'h-[18px] w-8': size === 'sm',
+          'h-6 w-11': size === 'md',
+        }
+      )}
     >
-      <div
-        style={{
-          position: 'absolute',
-          top: `${padding - (checked ? 1 : 1)}px`, // Adjust for border offset if needed, simplified here
-          left: checked ? `${width - knobSize - padding - (checked ? 0 : 2)}px` : `${padding}px`,
-          width: `${knobSize}px`,
-          height: `${knobSize}px`,
-          background: 'white',
-          borderRadius: '50%',
-          transition: 'left 0.2s ease',
-          boxShadow: '0 1px 3px rgba(0,0,0,0.3)',
-        }}
+      <span
+        aria-hidden="true"
+        className={clsx(
+          'absolute left-0.5 top-0.5 inline-block rounded-full bg-white shadow-sm transition-transform duration-fast',
+          {
+            'h-3.5 w-3.5 group-data-[checked=true]:translate-x-[14px]': size === 'sm',
+            'h-5 w-5 group-data-[checked=true]:translate-x-5': size === 'md',
+          }
+        )}
       />
-    </div>
+    </button>
   );
 };

--- a/packages/frontend/src/components/ui/Tabs.tsx
+++ b/packages/frontend/src/components/ui/Tabs.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { clsx } from 'clsx';
+
+interface TabItem<V extends string = string> {
+  value: V;
+  label: React.ReactNode;
+  disabled?: boolean;
+}
+
+interface TabsProps<V extends string = string> {
+  value: V;
+  onChange: (value: V) => void;
+  items: TabItem<V>[];
+  variant?: 'underline' | 'pills';
+  className?: string;
+  'aria-label'?: string;
+}
+
+export function Tabs<V extends string = string>({
+  value,
+  onChange,
+  items,
+  variant = 'underline',
+  className,
+  'aria-label': ariaLabel,
+}: TabsProps<V>) {
+  const handleKeyDown = (e: React.KeyboardEvent, idx: number) => {
+    const enabled = items.filter((i) => !i.disabled);
+    const currentEnabledIdx = enabled.findIndex((i) => i.value === items[idx]?.value);
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = enabled[(currentEnabledIdx + 1) % enabled.length];
+      if (next) onChange(next.value);
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = enabled[(currentEnabledIdx - 1 + enabled.length) % enabled.length];
+      if (prev) onChange(prev.value);
+    }
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className={clsx(
+        'flex items-center gap-1 overflow-x-auto',
+        variant === 'underline' && 'border-b border-border-glass',
+        className
+      )}
+    >
+      {items.map((item, idx) => {
+        const active = item.value === value;
+        return (
+          <button
+            key={item.value}
+            role="tab"
+            type="button"
+            aria-selected={active}
+            aria-disabled={item.disabled}
+            tabIndex={active ? 0 : -1}
+            onClick={() => !item.disabled && onChange(item.value)}
+            onKeyDown={(e) => handleKeyDown(e, idx)}
+            disabled={item.disabled}
+            className={clsx(
+              'flex-shrink-0 inline-flex items-center gap-2 font-body text-sm font-medium transition-all duration-fast whitespace-nowrap focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2 disabled:opacity-40 disabled:cursor-not-allowed',
+              variant === 'underline' && 'px-4 py-2.5 border-b-2 -mb-px',
+              variant === 'underline' && active && 'text-primary border-primary',
+              variant === 'underline' && !active && 'text-text-secondary border-transparent hover:text-text',
+              variant === 'pills' && 'px-3.5 py-1.5 rounded-md',
+              variant === 'pills' && active && 'bg-bg-glass text-primary border border-border-glass',
+              variant === 'pills' && !active && 'text-text-secondary hover:bg-bg-hover hover:text-text'
+            )}
+          >
+            {item.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ui/Tooltip.tsx
+++ b/packages/frontend/src/components/ui/Tooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { clsx } from 'clsx';
 
 interface TooltipProps {
   content: React.ReactNode;
@@ -9,47 +10,23 @@ interface TooltipProps {
 export const Tooltip: React.FC<TooltipProps> = ({ content, children, position = 'bottom' }) => {
   const [isVisible, setIsVisible] = useState(false);
 
-  const positionStyles =
-    position === 'right'
-      ? {
-          left: '100%',
-          top: '50%',
-          transform: 'translateY(-50%)',
-          marginLeft: '8px',
-        }
-      : {
-          top: '100%',
-          left: '50%',
-          transform: 'translateX(-50%)',
-          marginTop: '8px',
-        };
-
   return (
     <div
-      className="tooltip-container"
-      style={{ position: 'relative', display: 'inline-block' }}
+      className="relative inline-block"
       onMouseEnter={() => setIsVisible(true)}
       onMouseLeave={() => setIsVisible(false)}
+      onFocus={() => setIsVisible(true)}
+      onBlur={() => setIsVisible(false)}
     >
       {children}
       {isVisible && (
         <div
-          className="tooltip-content"
-          style={{
-            position: 'absolute',
-            ...positionStyles,
-            padding: '8px 12px',
-            backgroundColor: '#1e1e1e',
-            border: '1px solid var(--color-border)',
-            borderRadius: '4px',
-            boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
-            zIndex: 1000,
-            opacity: 1,
-            visibility: 'visible',
-            whiteSpace: 'nowrap',
-            fontSize: '0.85em',
-            color: 'var(--color-text-primary)',
-          }}
+          role="tooltip"
+          className={clsx(
+            'absolute z-tooltip px-3 py-2 bg-bg-surface border border-border rounded-md shadow-lg whitespace-nowrap text-xs text-text pointer-events-none',
+            position === 'right' && 'left-full top-1/2 -translate-y-1/2 ml-2',
+            position === 'bottom' && 'top-full left-1/2 -translate-x-1/2 mt-2'
+          )}
         >
           {content}
         </div>

--- a/packages/frontend/src/contexts/SidebarContext.tsx
+++ b/packages/frontend/src/contexts/SidebarContext.tsx
@@ -1,16 +1,21 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 
 interface SidebarContextType {
+  /** Desktop collapsed state (icon-only rail). Persisted to localStorage. */
   isCollapsed: boolean;
   toggleSidebar: () => void;
+  /** Mobile drawer open state. Ephemeral — not persisted. */
+  isMobileOpen: boolean;
+  openMobile: () => void;
+  closeMobile: () => void;
 }
 
 const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
 
 export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
+  const [isMobileOpen, setIsMobileOpen] = useState<boolean>(false);
 
-  // Initialize from localStorage on mount
   useEffect(() => {
     const stored = localStorage.getItem('plexus_sidebar_collapsed');
     if (stored !== null) {
@@ -18,16 +23,21 @@ export const SidebarProvider: React.FC<{ children: React.ReactNode }> = ({ child
     }
   }, []);
 
-  const toggleSidebar = () => {
+  const toggleSidebar = useCallback(() => {
     setIsCollapsed((prev) => {
       const newState = !prev;
       localStorage.setItem('plexus_sidebar_collapsed', String(newState));
       return newState;
     });
-  };
+  }, []);
+
+  const openMobile = useCallback(() => setIsMobileOpen(true), []);
+  const closeMobile = useCallback(() => setIsMobileOpen(false), []);
 
   return (
-    <SidebarContext.Provider value={{ isCollapsed, toggleSidebar }}>
+    <SidebarContext.Provider
+      value={{ isCollapsed, toggleSidebar, isMobileOpen, openMobile, closeMobile }}
+    >
       {children}
     </SidebarContext.Provider>
   );

--- a/packages/frontend/src/contexts/ToastContext.tsx
+++ b/packages/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,176 @@
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { AlertCircle, AlertTriangle, CheckCircle2, Info, X } from 'lucide-react';
+import { clsx } from 'clsx';
+import { Button } from '../components/ui/Button';
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+interface Toast {
+  id: number;
+  variant: ToastVariant;
+  message: React.ReactNode;
+  title?: React.ReactNode;
+}
+
+interface ConfirmOptions {
+  title: string;
+  message: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'default' | 'danger';
+}
+
+interface ToastContextValue {
+  showToast: (variant: ToastVariant, message: React.ReactNode, title?: React.ReactNode) => void;
+  success: (message: React.ReactNode, title?: React.ReactNode) => void;
+  error: (message: React.ReactNode, title?: React.ReactNode) => void;
+  warning: (message: React.ReactNode, title?: React.ReactNode) => void;
+  info: (message: React.ReactNode, title?: React.ReactNode) => void;
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const variantStyles: Record<ToastVariant, { icon: React.ReactNode; classes: string }> = {
+  success: {
+    icon: <CheckCircle2 size={18} className="text-success" />,
+    classes: 'border-success/40',
+  },
+  error: {
+    icon: <AlertCircle size={18} className="text-danger" />,
+    classes: 'border-danger/40',
+  },
+  warning: {
+    icon: <AlertTriangle size={18} className="text-secondary" />,
+    classes: 'border-secondary/40',
+  },
+  info: {
+    icon: <Info size={18} className="text-info" />,
+    classes: 'border-info/40',
+  },
+};
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const [confirmState, setConfirmState] = useState<
+    (ConfirmOptions & { resolve: (v: boolean) => void }) | null
+  >(null);
+  const idRef = useRef(0);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    (variant: ToastVariant, message: React.ReactNode, title?: React.ReactNode) => {
+      const id = ++idRef.current;
+      setToasts((prev) => [...prev, { id, variant, message, title }]);
+      setTimeout(() => dismiss(id), 5000);
+    },
+    [dismiss]
+  );
+
+  const value = useMemo<ToastContextValue>(
+    () => ({
+      showToast,
+      success: (m, t) => showToast('success', m, t),
+      error: (m, t) => showToast('error', m, t),
+      warning: (m, t) => showToast('warning', m, t),
+      info: (m, t) => showToast('info', m, t),
+      confirm: (options) =>
+        new Promise<boolean>((resolve) => {
+          setConfirmState({ ...options, resolve });
+        }),
+    }),
+    [showToast]
+  );
+
+  const resolveConfirm = (result: boolean) => {
+    if (confirmState) {
+      confirmState.resolve(result);
+      setConfirmState(null);
+    }
+  };
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      {createPortal(
+        <div className="fixed top-4 right-4 z-toast flex flex-col gap-2 max-w-[90vw] sm:max-w-sm pointer-events-none">
+          {toasts.map((toast) => (
+            <div
+              key={toast.id}
+              className={clsx(
+                'pointer-events-auto flex items-start gap-3 bg-bg-surface border rounded-md p-3 shadow-modal backdrop-blur-md animate-[slideUp_0.2s_ease]',
+                variantStyles[toast.variant].classes
+              )}
+            >
+              <div className="mt-0.5 flex-shrink-0">{variantStyles[toast.variant].icon}</div>
+              <div className="flex-1 min-w-0">
+                {toast.title && (
+                  <div className="font-heading text-sm font-semibold text-text">{toast.title}</div>
+                )}
+                <div className="font-body text-xs text-text-secondary break-words">
+                  {toast.message}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => dismiss(toast.id)}
+                aria-label="Dismiss"
+                className="flex-shrink-0 text-text-muted hover:text-text transition-colors duration-fast"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          ))}
+        </div>,
+        document.body
+      )}
+      {confirmState &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-modal flex items-center justify-center p-4 bg-black/70 backdrop-blur-md"
+            onClick={() => resolveConfirm(false)}
+            role="dialog"
+            aria-modal="true"
+          >
+            <div
+              className="bg-bg-surface border border-border-glass rounded-xl w-full max-w-[420px] shadow-modal animate-[slideUp_0.2s_ease]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="p-5 sm:p-6 border-b border-border-glass">
+                <h2 className="font-heading text-h2 font-semibold text-text m-0">
+                  {confirmState.title}
+                </h2>
+              </div>
+              <div className="p-5 sm:p-6 font-body text-sm text-text-secondary">
+                {confirmState.message}
+              </div>
+              <div className="flex items-center justify-end gap-3 px-5 py-4 sm:px-6 border-t border-border-glass">
+                <Button variant="secondary" onClick={() => resolveConfirm(false)}>
+                  {confirmState.cancelLabel ?? 'Cancel'}
+                </Button>
+                <Button
+                  variant={confirmState.variant === 'danger' ? 'danger' : 'primary'}
+                  onClick={() => resolveConfirm(true)}
+                >
+                  {confirmState.confirmLabel ?? 'Confirm'}
+                </Button>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = (): ToastContextValue => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return ctx;
+};

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -26,22 +26,63 @@
   --color-border-glass: rgba(255, 255, 255, 0.1);
   --color-glow: rgba(245, 158, 11, 0.3);
 
+  --color-terminal-bg: #0F172A;
+  --color-terminal-fg: #E2E8F0;
+
   /* Fonts */
   --font-heading: 'Space Grotesk', sans-serif;
   --font-body: 'DM Sans', sans-serif;
 
   /* Spacing */
+  --spacing-xxs: 2px;
   --spacing-xs: 4px;
   --spacing-sm: 8px;
   --spacing-md: 12px;
   --spacing-lg: 16px;
   --spacing-xl: 24px;
+  --spacing-2xl: 32px;
+  --spacing-3xl: 48px;
+  --spacing-4xl: 64px;
 
   /* Radius */
   --radius-sm: 6px;
   --radius-md: 10px;
   --radius-lg: 16px;
   --radius-xl: 20px;
+
+  /* Typography scale (responsive via clamp) */
+  --text-caption: 0.75rem;
+  --text-body: 0.875rem;
+  --text-body-lg: 1rem;
+  --text-h4: clamp(0.95rem, 0.9rem + 0.25vw, 1.0625rem);
+  --text-h3: clamp(1.05rem, 0.95rem + 0.5vw, 1.25rem);
+  --text-h2: clamp(1.25rem, 1.1rem + 0.75vw, 1.5rem);
+  --text-h1: clamp(1.5rem, 1.3rem + 1vw, 2rem);
+  --text-display: clamp(2rem, 1.6rem + 2vw, 3rem);
+
+  /* Z-index scale — one source of truth. */
+  --z-dropdown: 100;
+  --z-sidebar: 200;
+  --z-drawer-backdrop: 300;
+  --z-drawer: 310;
+  --z-modal-backdrop: 400;
+  --z-modal: 410;
+  --z-tooltip: 500;
+  --z-toast: 600;
+
+  /* Motion */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --duration-fast: 150ms;
+  --duration: 250ms;
+  --duration-slow: 400ms;
+
+  /* Shadows — semantic names replace magic rgba values. */
+  --shadow-glow-primary: 0 6px 20px rgba(245, 158, 11, 0.4);
+  --shadow-glow-primary-sm: 0 4px 12px rgba(245, 158, 11, 0.3);
+  --shadow-glow-danger: 0 4px 12px rgba(239, 68, 68, 0.3);
+  --shadow-nav-active: 0 2px 8px rgba(245, 158, 11, 0.15);
+  --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.5);
 }
 
 /* Custom Utilities based on variables */
@@ -67,7 +108,7 @@
 
   body {
     font-family: var(--font-body);
-    font-size: 0.875rem;
+    font-size: var(--text-body);
     line-height: 1.5;
     background-color: var(--color-bg-deep);
     color: var(--color-text);
@@ -133,6 +174,16 @@
   to {
     background-color: transparent;
   }
+}
+
+@keyframes drawerSlideLeft {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+
+@keyframes drawerSlideRight {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
 }
 
 /* Utility class for new log row animation */

--- a/packages/frontend/src/hooks/useBodyScrollLock.ts
+++ b/packages/frontend/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+let lockCount = 0;
+let originalOverflow: string | null = null;
+
+/**
+ * Locks `document.body` scroll while `isLocked` is true. Ref-counted so a Modal
+ * and Drawer mounted simultaneously don't race each other's cleanup.
+ */
+export function useBodyScrollLock(isLocked: boolean): void {
+  useEffect(() => {
+    if (!isLocked) return;
+
+    if (lockCount === 0) {
+      originalOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+    }
+    lockCount += 1;
+
+    return () => {
+      lockCount -= 1;
+      if (lockCount === 0) {
+        document.body.style.overflow = originalOverflow ?? '';
+        originalOverflow = null;
+      }
+    };
+  }, [isLocked]);
+}

--- a/packages/frontend/src/hooks/useModels.ts
+++ b/packages/frontend/src/hooks/useModels.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api, Alias, Provider, Model, Cooldown } from '../lib/api';
+import { useToast } from '../contexts/ToastContext';
 
 const EMPTY_ALIAS: Alias = {
   id: '',
@@ -10,6 +11,7 @@ const EMPTY_ALIAS: Alias = {
 };
 
 export const useModels = () => {
+  const toast = useToast();
   const [aliases, setAliases] = useState<Alias[]>([]);
   const [providers, setProviders] = useState<Provider[]>([]);
   const [availableModels, setAvailableModels] = useState<Model[]>([]);
@@ -77,7 +79,7 @@ export const useModels = () => {
       return true;
     } catch (e) {
       console.error('Failed to save alias', e);
-      alert('Failed to save alias');
+      toast.error('Failed to save alias');
       return false;
     } finally {
       setIsSaving(false);
@@ -91,7 +93,7 @@ export const useModels = () => {
       return true;
     } catch (e) {
       console.error('Failed to delete alias', e);
-      alert('Failed to delete alias');
+      toast.error('Failed to delete alias');
       return false;
     }
   };
@@ -103,7 +105,7 @@ export const useModels = () => {
       return true;
     } catch (e) {
       console.error('Failed to delete all aliases', e);
-      alert('Failed to delete all aliases');
+      toast.error('Failed to delete all aliases');
       return false;
     }
   };
@@ -118,7 +120,7 @@ export const useModels = () => {
       await api.saveAlias(updatedAlias, alias.id);
     } catch (e) {
       console.error('Toggle error', e);
-      alert('Failed to update target status: ' + e);
+      toast.error('Failed to update target status: ' + e);
       loadData();
     }
   };

--- a/packages/frontend/src/hooks/useSSEStream.ts
+++ b/packages/frontend/src/hooks/useSSEStream.ts
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface SSEOptions<T> {
+  /** URL to stream from. Set to null to disable. */
+  url: string | null;
+  /** Fetch headers (e.g. Authorization: 'Bearer ...'). */
+  headers?: Record<string, string>;
+  /** Called when an `event:` of the given name arrives, payload already JSON.parsed. */
+  onEvent?: (event: string, data: T) => void;
+  /** Called when the stream disconnects (for any reason). */
+  onDisconnect?: () => void;
+  /** Reconnect on error (default true). */
+  reconnect?: boolean;
+  /** Base reconnect delay in ms (default 2000; doubles up to 30s). */
+  reconnectDelayMs?: number;
+}
+
+export type SSEStatus = 'idle' | 'connecting' | 'connected' | 'error';
+
+/**
+ * Subscribes to a POST-based SSE endpoint using fetch + ReadableStream.
+ * Handles event parsing, reconnection with backoff, and cleanup.
+ */
+export function useSSEStream<T = unknown>(options: SSEOptions<T>): { status: SSEStatus } {
+  const { url, headers, onEvent, onDisconnect, reconnect = true, reconnectDelayMs = 2000 } = options;
+  const [status, setStatus] = useState<SSEStatus>('idle');
+
+  // Stable refs so effect doesn't restart when callbacks/headers change identity.
+  const onEventRef = useRef(onEvent);
+  const onDisconnectRef = useRef(onDisconnect);
+  const headersRef = useRef(headers);
+  onEventRef.current = onEvent;
+  onDisconnectRef.current = onDisconnect;
+  headersRef.current = headers;
+
+  useEffect(() => {
+    if (!url) {
+      setStatus('idle');
+      return;
+    }
+
+    let cancelled = false;
+    let attempts = 0;
+    const controller = new AbortController();
+
+    const connect = async () => {
+      if (cancelled) return;
+      setStatus('connecting');
+      try {
+        const response = await fetch(url, {
+          method: 'GET',
+          signal: controller.signal,
+          headers: {
+            Accept: 'text/event-stream',
+            ...(headersRef.current ?? {}),
+          },
+        });
+        if (!response.ok || !response.body) {
+          throw new Error(`SSE connect failed: ${response.status}`);
+        }
+        setStatus('connected');
+        attempts = 0;
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (!cancelled) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let sep: number;
+          while ((sep = buffer.indexOf('\n\n')) !== -1) {
+            const chunk = buffer.slice(0, sep);
+            buffer = buffer.slice(sep + 2);
+            let eventName = 'message';
+            const dataLines: string[] = [];
+            for (const line of chunk.split('\n')) {
+              if (line.startsWith('event:')) eventName = line.slice(6).trim();
+              else if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+            }
+            const raw = dataLines.join('\n');
+            if (raw) {
+              try {
+                const parsed = JSON.parse(raw) as T;
+                onEventRef.current?.(eventName, parsed);
+              } catch {
+                // fall through — emit as string if caller wants raw
+                onEventRef.current?.(eventName, raw as unknown as T);
+              }
+            }
+          }
+        }
+      } catch (err) {
+        if (cancelled || (err as Error).name === 'AbortError') return;
+        setStatus('error');
+      } finally {
+        if (!cancelled) {
+          onDisconnectRef.current?.();
+          if (reconnect) {
+            attempts += 1;
+            const delay = Math.min(30000, reconnectDelayMs * 2 ** Math.min(attempts - 1, 4));
+            setTimeout(connect, delay);
+          }
+        }
+      }
+    };
+
+    void connect();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [url, reconnect, reconnectDelayMs]);
+
+  return { status };
+}

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -1,15 +1,16 @@
 import { Component, useEffect, useRef, useState } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
 import Editor from '@monaco-editor/react';
-import { api } from '../lib/api';
-import { Button } from '../components/ui/Button';
 import { RotateCcw, AlertTriangle, Download, Upload, RefreshCw } from 'lucide-react';
+import { api } from '../lib/api';
+import { useToast } from '../contexts/ToastContext';
+import { Card } from '../components/ui/Card';
+import { Button } from '../components/ui/Button';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
 import type { CardLayout } from '../types/card';
 import { DEFAULT_CARD_ORDER, LAYOUT_STORAGE_KEY } from '../types/card';
 
-/**
- * Error boundary specifically for the Monaco Editor component.
- */
 class EditorErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   state: { error: Error | null } = { error: null };
 
@@ -24,7 +25,7 @@ class EditorErrorBoundary extends Component<{ children: ReactNode }, { error: Er
   render() {
     if (this.state.error) {
       return (
-        <div className="h-[500px] flex items-center justify-center bg-bg-subtle/30 text-text-secondary">
+        <div className="h-[400px] sm:h-[500px] flex items-center justify-center bg-bg-glass/30 text-text-secondary rounded-md">
           <div className="text-center p-6">
             <AlertTriangle className="mx-auto mb-3 text-warning" size={32} />
             <p className="text-sm font-semibold mb-1">Editor failed to load</p>
@@ -38,6 +39,7 @@ class EditorErrorBoundary extends Component<{ children: ReactNode }, { error: Er
 }
 
 export const Config = () => {
+  const toast = useToast();
   const [config, setConfig] = useState('');
   const [isConfigLoaded, setIsConfigLoaded] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
@@ -50,17 +52,18 @@ export const Config = () => {
     } catch (e) {
       console.error('Failed to load config:', e);
       setIsConfigLoaded(false);
+      toast.error('Failed to load config');
     }
   };
 
   useEffect(() => {
     loadConfig();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [cardLayout, setCardLayout] = useState<CardLayout>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Load current card layout from localStorage
   useEffect(() => {
     const saved = localStorage.getItem(LAYOUT_STORAGE_KEY);
     if (saved) {
@@ -73,35 +76,25 @@ export const Config = () => {
     }
   }, []);
 
-  const handleExportLayout = () => {
-    const dataStr = JSON.stringify(cardLayout, null, 2);
-    const blob = new Blob([dataStr], { type: 'application/json' });
+  const triggerDownload = (content: string, filename: string, mime: string) => {
+    const blob = new Blob([content], { type: mime });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = 'plexus-card-layout.json';
+    link.download = filename;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
   };
 
-  const handleExportConfig = () => {
-    const blob = new Blob([config], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'plexus-config-export.json';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
+  const handleExportLayout = () =>
+    triggerDownload(JSON.stringify(cardLayout, null, 2), 'plexus-card-layout.json', 'application/json');
 
-  // Import layout from JSON file
-  const handleImportLayout = () => {
-    fileInputRef.current?.click();
-  };
+  const handleExportConfig = () =>
+    triggerDownload(config, 'plexus-config-export.json', 'application/json');
+
+  const handleImportLayout = () => fileInputRef.current?.click();
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -120,18 +113,18 @@ export const Config = () => {
           const validIds = new Set<string>(DEFAULT_CARD_ORDER);
           const allIdsValid = parsed.every((item: { id: string }) => validIds.has(item.id));
           if (!allIdsValid) {
-            alert('Invalid card layout: contains unknown card IDs');
+            toast.error('Invalid card layout: contains unknown card IDs');
             return;
           }
 
           localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(parsed));
           setCardLayout(parsed);
-          alert('Card layout imported successfully!');
+          toast.success('Card layout imported');
         } else {
-          alert('Invalid card layout format');
+          toast.error('Invalid card layout format');
         }
       } catch {
-        alert('Failed to import: Invalid JSON file');
+        toast.error('Failed to import: Invalid JSON file');
       }
     };
     reader.readAsText(file);
@@ -140,140 +133,126 @@ export const Config = () => {
   };
 
   const handleRestart = async () => {
-    if (
-      !confirm(
-        'Are you sure you want to restart Plexus? This will briefly interrupt all ongoing requests.'
-      )
-    ) {
-      return;
-    }
+    const ok = await toast.confirm({
+      title: 'Restart Plexus?',
+      message:
+        'This will briefly interrupt all ongoing requests. Are you sure you want to continue?',
+      confirmLabel: 'Restart',
+      variant: 'danger',
+    });
+    if (!ok) return;
 
     setIsRestarting(true);
     try {
       await api.restart();
     } catch (e) {
-      const error = e as Error;
-      alert(`Restart failed:\n\n${error.message}`);
+      toast.error((e as Error).message, 'Restart failed');
       setIsRestarting(false);
     }
   };
 
   return (
-    <div className="min-h-screen p-6 transition-all duration-300 bg-gradient-to-br from-bg-deep to-bg-surface">
-      <div className="mb-8">
-        <h1 className="font-heading text-3xl font-bold text-text m-0 mb-2">Configuration</h1>
-        <p className="text-[15px] text-text-secondary m-0">
-          View current system configuration (read-only). Use the Providers, Models, and Keys pages
-          to make changes.
-        </p>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Configuration"
+        subtitle="View current system configuration (read-only). Use the Providers, Models, and Keys pages to make changes."
+      />
 
-      <div className="glass-bg backdrop-blur-md border border-white/10 rounded-lg shadow-xl overflow-hidden transition-all duration-300 max-w-full shadow-[0_8px_32px_rgba(0,0,0,0.3)]">
-        <div className="flex items-center justify-between px-6 py-5 border-b border-border-glass">
-          <h3 className="font-heading text-lg font-semibold text-text m-0">Configuration Export</h3>
-          <div style={{ display: 'flex', gap: '8px' }}>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={loadConfig}
-              leftIcon={<RotateCcw size={14} />}
-            >
-              Refresh
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleRestart}
-              isLoading={isRestarting}
-              leftIcon={<RefreshCw size={14} />}
-            >
-              Restart
-            </Button>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleExportConfig}
-              disabled={!isConfigLoaded}
-              leftIcon={<Download size={14} />}
-            >
-              Export JSON
-            </Button>
-          </div>
-        </div>
-        <div className="h-[500px] rounded-sm overflow-hidden">
-          <EditorErrorBoundary>
-            <Editor
-              height="100%"
-              defaultLanguage="json"
-              value={config}
-              theme="vs-dark"
-              options={{
-                readOnly: true,
-                minimap: { enabled: false },
-                scrollBeyondLastLine: false,
-                fontSize: 14,
-                fontFamily: '"Fira code", "Fira Mono", monospace',
-              }}
-            />
-          </EditorErrorBoundary>
-        </div>
-      </div>
-      {/* Card Layout Configuration */}
-      <div className="mt-8 glass-bg backdrop-blur-md border border-white/10 rounded-lg shadow-xl overflow-hidden transition-all duration-300 max-w-full shadow-[0_8px_32px_rgba(0,0,0,0.3)]">
-        <div className="flex items-center justify-between px-6 py-5 border-b border-border-glass">
-          <div>
-            <h3 className="font-heading text-lg font-semibold text-text m-0">Card Layout</h3>
-            <p className="text-sm text-text-secondary m-0 mt-1">
-              Import or export your Live Metrics card layout configuration.
-            </p>
-          </div>
-          <div style={{ display: 'flex', gap: '8px' }}>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleExportLayout}
-              leftIcon={<Download size={14} />}
-            >
-              Export
-            </Button>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={handleImportLayout}
-              leftIcon={<Upload size={14} />}
-            >
-              Import
-            </Button>
-          </div>
-        </div>
-
-        {/* Hidden file input for import */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json"
-          style={{ display: 'none' }}
-          onChange={handleFileSelect}
-        />
-
-        {/* Current Layout Preview */}
-        <div className="px-6 py-4 bg-bg-subtle/30">
-          <h4 className="font-heading text-sm font-semibold text-text m-0 mb-3">
-            Current Card Order
-          </h4>
-          <div className="flex flex-wrap gap-2">
-            {cardLayout.map((card, index) => (
-              <div
-                key={card.id}
-                className="px-3 py-1.5 bg-bg-glass rounded-md border border-border-glass text-sm text-text"
+      <div className="flex flex-col gap-6">
+        <Card
+          title="Configuration Export"
+          flush
+          extra={
+            <div className="flex flex-wrap items-center gap-2">
+              <Button variant="secondary" size="sm" onClick={loadConfig} leftIcon={<RotateCcw size={14} />}>
+                Refresh
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleRestart}
+                isLoading={isRestarting}
+                leftIcon={<RefreshCw size={14} />}
               >
-                <span className="text-text-muted mr-2">{index + 1}.</span>
-                {card.id}
-              </div>
-            ))}
+                Restart
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleExportConfig}
+                disabled={!isConfigLoaded}
+                leftIcon={<Download size={14} />}
+              >
+                Export JSON
+              </Button>
+            </div>
+          }
+        >
+          <div className="h-[400px] sm:h-[500px] lg:h-[600px] rounded-sm overflow-hidden">
+            <EditorErrorBoundary>
+              <Editor
+                height="100%"
+                defaultLanguage="json"
+                value={config}
+                theme="vs-dark"
+                options={{
+                  readOnly: true,
+                  minimap: { enabled: false },
+                  scrollBeyondLastLine: false,
+                  fontSize: 13,
+                  fontFamily: '"Fira Code", "Fira Mono", monospace',
+                }}
+              />
+            </EditorErrorBoundary>
           </div>
-        </div>
+        </Card>
+
+        <Card
+          title="Card Layout"
+          extra={
+            <div className="flex items-center gap-2">
+              <Button variant="secondary" size="sm" onClick={handleExportLayout} leftIcon={<Download size={14} />}>
+                Export
+              </Button>
+              <Button variant="primary" size="sm" onClick={handleImportLayout} leftIcon={<Upload size={14} />}>
+                Import
+              </Button>
+            </div>
+          }
+        >
+          <p className="text-sm text-text-secondary mb-4">
+            Import or export your Live Metrics card layout configuration.
+          </p>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json"
+            className="hidden"
+            onChange={handleFileSelect}
+          />
+
+          <div>
+            <h4 className="font-heading text-xs font-semibold uppercase tracking-wider text-text-muted mb-3">
+              Current Card Order
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {cardLayout.length === 0 && (
+                <p className="text-xs text-text-muted italic">Default layout — no customizations saved.</p>
+              )}
+              {cardLayout.map((card, index) => (
+                <div
+                  key={card.id}
+                  className="px-3 py-1.5 bg-bg-glass rounded-md border border-border-glass text-xs text-text"
+                >
+                  <span className="text-text-muted mr-2">{index + 1}.</span>
+                  {card.id}
+                </div>
+              ))}
+            </div>
+          </div>
+        </Card>
       </div>
-    </div>
+    </PageContainer>
   );
 };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -5,25 +5,23 @@ import { LiveTab } from '../components/dashboard/tabs/LiveTab';
 import { UsageTab } from '../components/dashboard/tabs/UsageTab';
 import { PerformanceTab } from '../components/dashboard/tabs/PerformanceTab';
 import { OverallTab } from '../components/dashboard/tabs/OverallTab';
+import { Tabs } from '../components/ui/Tabs';
 import { useAuth } from '../contexts/AuthContext';
 import type { CustomDateRange } from '../lib/date';
 
 type TabId = 'overall' | 'live' | 'usage' | 'performance';
 type TimeRange = 'hour' | 'day' | 'week' | 'month' | 'custom';
-type LiveWindowPeriod = 5 | 15 | 30 | 1440 | 10080 | 43200; // minutes: 5m, 15m, 30m, 1d, 7d, 30d
+type LiveWindowPeriod = 5 | 15 | 30 | 1440 | 10080 | 43200;
 
-// Tabs visible to every authenticated principal. Admins see only these; limited
-// users additionally see the `overall` tab prepended below.
-const BASE_TABS: { id: Exclude<TabId, 'overall'>; label: string; icon: React.ReactNode }[] = [
-  { id: 'live', label: 'Live Metrics', icon: <Zap size={15} /> },
-  { id: 'usage', label: 'Usage Analytics', icon: <BarChart2 size={15} /> },
-  { id: 'performance', label: 'Performance', icon: <Gauge size={15} /> },
+const BASE_TABS = [
+  { value: 'live' as const, label: <span className="inline-flex items-center gap-2"><Zap size={14} /> Live Metrics</span> },
+  { value: 'usage' as const, label: <span className="inline-flex items-center gap-2"><BarChart2 size={14} /> Usage Analytics</span> },
+  { value: 'performance' as const, label: <span className="inline-flex items-center gap-2"><Gauge size={14} /> Performance</span> },
 ];
 
-const OVERALL_TAB: { id: TabId; label: string; icon: React.ReactNode } = {
-  id: 'overall',
-  label: 'Overall',
-  icon: <LayoutDashboard size={15} />,
+const OVERALL_TAB = {
+  value: 'overall' as const,
+  label: <span className="inline-flex items-center gap-2"><LayoutDashboard size={14} /> Overall</span>,
 };
 
 const DEFAULT_POLL_INTERVAL = 10000;
@@ -34,17 +32,11 @@ export const Dashboard = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get('tab') as TabId | null;
 
-  // Limited users get an extra "Overall" tab (their access + usage rollup).
-  // It's prepended so that for an api-key user the most relevant view is the
-  // first thing they see. Admins don't need it — they already have full
-  // cross-key analytics in the Usage tab.
   const tabs = useMemo(() => (isLimited ? [OVERALL_TAB, ...BASE_TABS] : BASE_TABS), [isLimited]);
 
-  // Default tab: 'overall' for limited users, 'live' for admins. Any invalid
-  // `?tab=` query param falls back to the default for this principal.
   const defaultTabId: TabId = isLimited ? 'overall' : 'live';
   const activeTab: TabId =
-    tabParam && tabs.some((t) => t.id === tabParam) ? tabParam : defaultTabId;
+    tabParam && tabs.some((t) => t.value === tabParam) ? tabParam : defaultTabId;
 
   const [usageTimeRange, setUsageTimeRange] = useState<TimeRange>('day');
   const [customDateRange, setCustomDateRange] = useState<CustomDateRange | null>(null);
@@ -52,8 +44,6 @@ export const Dashboard = () => {
   const [liveWindowPeriod, setLiveWindowPeriod] = useState<LiveWindowPeriod>(DEFAULT_LIVE_WINDOW);
 
   const setTab = (id: TabId) => {
-    // The default tab is represented with no `?tab=` param (cleaner URLs).
-    // Everything else round-trips through the query string.
     setSearchParams(id === defaultTabId ? {} : { tab: id });
   };
 
@@ -62,31 +52,18 @@ export const Dashboard = () => {
   }, [activeTab]);
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="border-b border-border-glass bg-bg-card/40 backdrop-blur-sm sticky top-0 z-10">
-        <div className="flex gap-0 px-4">
-          {tabs.map((tab) => {
-            const isActive = tab.id === activeTab;
-            return (
-              <button
-                key={tab.id}
-                onClick={() => setTab(tab.id)}
-                className={[
-                  'flex items-center gap-2 px-4 py-3 text-[13px] font-medium transition-all border-b-2 -mb-px',
-                  isActive
-                    ? 'border-accent text-text'
-                    : 'border-transparent text-text-muted hover:text-text hover:border-border-glass',
-                ].join(' ')}
-              >
-                {tab.icon}
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
+    <div className="flex flex-col min-h-full -mx-4 sm:-mx-6 lg:-mx-8 -mt-4 sm:-mt-6 lg:-mt-8">
+      <div className="sticky top-0 z-10 border-b border-border-glass bg-bg-surface/80 backdrop-blur-md px-2 sm:px-4">
+        <Tabs<TabId>
+          value={activeTab}
+          onChange={setTab}
+          items={tabs}
+          variant="underline"
+          aria-label="Dashboard sections"
+        />
       </div>
 
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 pb-8">
         {activeTab === 'overall' && isLimited && <OverallTab />}
         {activeTab === 'live' && (
           <LiveTab

--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -17,6 +17,7 @@ import {
 import { clsx } from 'clsx';
 import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
+import { PageHeader } from '../components/layout/PageHeader';
 import { useLocation } from 'react-router-dom';
 import type { Provider } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
@@ -261,17 +262,17 @@ export const Debug: React.FC = () => {
   };
 
   return (
-    <div className="h-[calc(100vh-64px)] flex flex-col overflow-hidden">
-      <header className="flex justify-between items-center p-6 shrink-0">
-        <div>
-          <h1 className="font-heading text-3xl font-bold text-text m-0 mb-2">Debug Traces</h1>
-          <p className="text-[15px] text-text-secondary m-0">
-            {principal?.role === 'limited' && principal.keyName
+    <div className="flex flex-col min-h-[calc(100vh-8rem)] -mx-4 sm:-mx-6 lg:-mx-8 -mt-4 sm:-mt-6 lg:-mt-8">
+      <div className="px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 pb-3 shrink-0">
+        <PageHeader
+          title="Debug Traces"
+          subtitle={
+            principal?.role === 'limited' && principal.keyName
               ? `Traces for key "${principal.keyName}" only. Toggle capture in My Key.`
-              : 'Inspect full request/response lifecycles'}
-          </p>
-        </div>
-        <div className="flex gap-2 items-center">
+              : 'Inspect full request/response lifecycles.'
+          }
+          actions={
+            <>
           {/* Provider Filter — admin-only: the global filter affects all users. */}
           {isAdmin && (
             <div className="relative provider-filter-dropdown">
@@ -379,16 +380,17 @@ export const Debug: React.FC = () => {
               Delete All
             </Button>
           )}
-          <Button onClick={fetchLogs} variant="secondary" className="flex items-center gap-2">
-            <RefreshCw size={16} className={clsx(loading && 'animate-spin')} />
+          <Button onClick={fetchLogs} variant="secondary" leftIcon={<RefreshCw size={16} className={clsx(loading && 'animate-spin')} />}>
             Refresh
           </Button>
-        </div>
-      </header>
+            </>
+          }
+        />
+      </div>
 
-      <div className="flex flex-1 overflow-hidden border-t border-border-glass">
+      <div className="flex flex-col md:flex-row flex-1 overflow-hidden border-t border-border-glass">
         {/* Left Pane: Request List */}
-        <div className="w-[320px] border-r border-border-glass bg-bg-surface flex flex-col shrink-0">
+        <div className="w-full md:w-[320px] border-b md:border-b-0 md:border-r border-border-glass bg-bg-surface flex flex-col shrink-0 max-h-[40vh] md:max-h-none">
           <div className="p-4 border-b border-border-glass">
             <span className="text-xs font-bold text-text-muted uppercase tracking-wider">
               Recent Requests

--- a/packages/frontend/src/pages/DetailedUsage.tsx
+++ b/packages/frontend/src/pages/DetailedUsage.tsx
@@ -66,6 +66,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Card } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { Button } from '../components/ui/Button';
+import { PageHeader } from '../components/layout/PageHeader';
 import { TimeRangeSelector } from '../components/dashboard/TimeRangeSelector';
 import { api, type UsageRecord } from '../lib/api';
 import { formatCost, formatMs, formatNumber, formatTokens, formatTimeAgo } from '../lib/format';
@@ -1110,20 +1111,18 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
             onBack callback is provided.
           - "Live Data" badge showing time since last auto-refresh
       ------------------------------------------------------------------- */}
-      <div className="mb-8">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <h1 className="font-heading text-3xl font-bold text-text m-0 mb-2">Detailed Usage</h1>
-            <p className="text-text-secondary">Advanced analytics with customizable chart types</p>
-          </div>
-          <div className="flex items-center gap-3">
+      <PageHeader
+        title="Detailed Usage"
+        subtitle="Advanced analytics with customizable chart types"
+        actions={
+          <>
             {(onBack || !embedded) && (
               <Button
                 size="sm"
                 variant="secondary"
+                leftIcon={<ArrowLeft size={16} />}
                 onClick={() => (onBack ? onBack() : (window.location.href = '/ui/live-metrics'))}
               >
-                <ArrowLeft size={16} className="mr-1" />
                 {onBack ? 'Back to Live Card' : 'Return to Live Metrics'}
               </Button>
             )}
@@ -1133,9 +1132,9 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
             >
               Live Data
             </Badge>
-          </div>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {/* -------------------------------------------------------------------
           KPI Summary Cards Section
@@ -1143,14 +1142,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
           in the current time window. Each card shows a label, value, and icon.
           Errors are highlighted in red when count > 0.
       ------------------------------------------------------------------- */}
-      <div
-        className="mb-6"
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
-          gap: '12px',
-        }}
-      >
+      <div className="mb-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-8 gap-3">
         {stats.map((stat, i) => (
           <div key={i} className="glass-bg rounded-lg p-3 flex flex-col gap-1">
             <div className="flex justify-between items-start">

--- a/packages/frontend/src/pages/Errors.tsx
+++ b/packages/frontend/src/pages/Errors.tsx
@@ -14,6 +14,7 @@ import {
 import { clsx } from 'clsx';
 import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
+import { PageHeader } from '../components/layout/PageHeader';
 import { useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -138,41 +139,47 @@ export const Errors: React.FC = () => {
   };
 
   return (
-    <div className="h-[calc(100vh-64px)] flex flex-col overflow-hidden">
-      <header className="flex justify-between items-center p-6 shrink-0">
-        <div>
-          <h1 className="font-heading text-3xl font-bold text-text m-0 mb-2 text-red-500 flex items-center gap-2">
-            <AlertTriangle size={24} />
-            Inference Errors
-          </h1>
-          <p className="text-[15px] text-text-secondary m-0">
-            {principal?.role === 'limited' && principal.keyName
+    <div className="flex flex-col min-h-[calc(100vh-8rem)] -mx-4 sm:-mx-6 lg:-mx-8 -mt-4 sm:-mt-6 lg:-mt-8">
+      <div className="px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 pb-3 shrink-0">
+        <PageHeader
+          title={
+            <span className="inline-flex items-center gap-2 text-danger">
+              <AlertTriangle size={24} />
+              Inference Errors
+            </span>
+          }
+          subtitle={
+            principal?.role === 'limited' && principal.keyName
               ? `Errors for key "${principal.keyName}" only.`
-              : 'Investigate failed requests and exceptions'}
-          </p>
-        </div>
-        <div className="flex gap-2">
-          {isAdmin && (
-            <Button
-              onClick={handleDeleteAll}
-              variant="danger"
-              className="flex items-center gap-2"
-              disabled={errors.length === 0}
-            >
-              <Trash2 size={16} />
-              Delete All
-            </Button>
-          )}
-          <Button onClick={fetchErrors} variant="secondary" className="flex items-center gap-2">
-            <RefreshCw size={16} className={clsx(loading && 'animate-spin')} />
-            Refresh
-          </Button>
-        </div>
-      </header>
+              : 'Investigate failed requests and exceptions.'
+          }
+          actions={
+            <>
+              {isAdmin && (
+                <Button
+                  onClick={handleDeleteAll}
+                  variant="danger"
+                  leftIcon={<Trash2 size={16} />}
+                  disabled={errors.length === 0}
+                >
+                  Delete All
+                </Button>
+              )}
+              <Button
+                onClick={fetchErrors}
+                variant="secondary"
+                leftIcon={<RefreshCw size={16} className={clsx(loading && 'animate-spin')} />}
+              >
+                Refresh
+              </Button>
+            </>
+          }
+        />
+      </div>
 
-      <div className="flex flex-1 overflow-hidden border-t border-border-glass">
+      <div className="flex flex-col md:flex-row flex-1 overflow-hidden border-t border-border-glass">
         {/* Left Pane: Error List */}
-        <div className="w-[320px] border-r border-border-glass bg-bg-surface flex flex-col shrink-0">
+        <div className="w-full md:w-[320px] border-b md:border-b-0 md:border-r border-border-glass bg-bg-surface flex flex-col shrink-0 max-h-[40vh] md:max-h-none">
           <div className="p-4 border-b border-border-glass">
             <span className="text-xs font-bold text-text-muted uppercase tracking-wider">
               Recent Errors

--- a/packages/frontend/src/pages/Keys.tsx
+++ b/packages/frontend/src/pages/Keys.tsx
@@ -5,6 +5,10 @@ import { TagSelect } from '../components/ui/TagSelect';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
+import { Tabs } from '../components/ui/Tabs';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
+import { useToast } from '../contexts/ToastContext';
 import {
   Search,
   Plus,
@@ -44,6 +48,7 @@ interface QuotaStatus {
 }
 
 export const Keys = () => {
+  const toast = useToast();
   const [keys, setKeys] = useState<KeyConfig[]>([]);
   const [quotas, setQuotas] = useState<Record<string, UserQuota>>({});
   const [quotaStatuses, setQuotaStatuses] = useState<Record<string, QuotaStatus>>({});
@@ -135,14 +140,15 @@ export const Keys = () => {
       setIsKeyModalOpen(false);
     } catch (e) {
       console.error('Failed to save key', e);
-      alert('Failed to save key');
+      toast.error('Failed to save key');
     } finally {
       setIsSavingKey(false);
     }
   };
 
   const handleDeleteKey = async (keyName: string) => {
-    if (!confirm(`Are you sure you want to delete key '${keyName}'? This cannot be undone.`))
+    const _ok = await toast.confirm({ title: 'Delete key?', message: `Are you sure you want to delete key '${keyName}'? This cannot be undone.`, confirmLabel: 'Delete', variant: 'danger' });
+    if (!_ok)
       return;
 
     try {
@@ -150,7 +156,7 @@ export const Keys = () => {
       await loadData();
     } catch (e) {
       console.error('Failed to delete key', e);
-      alert('Failed to delete key');
+      toast.error('Failed to delete key');
     }
   };
 
@@ -172,7 +178,7 @@ export const Keys = () => {
 
     // Validate based on type
     if (editingQuota.type === 'rolling' && !editingQuota.duration) {
-      alert('Rolling quotas require a duration');
+      toast.error('Rolling quotas require a duration');
       return;
     }
 
@@ -190,33 +196,35 @@ export const Keys = () => {
       setIsQuotaModalOpen(false);
     } catch (e: any) {
       console.error('Failed to save quota', e);
-      alert(e.message || 'Failed to save quota');
+      toast.error(e.message || 'Failed to save quota');
     } finally {
       setIsSavingQuota(false);
     }
   };
 
   const handleDeleteQuota = async (name: string) => {
-    if (!confirm(`Are you sure you want to delete quota '${name}'? This cannot be undone.`)) return;
+    const _okq = await toast.confirm({ title: 'Delete quota?', message: `Are you sure you want to delete quota '${name}'? This cannot be undone.`, confirmLabel: 'Delete', variant: 'danger' });
+    if (!_okq) return;
 
     try {
       await api.deleteUserQuota(name);
       await loadData();
     } catch (e: any) {
       console.error('Failed to delete quota', e);
-      alert(e.message || 'Failed to delete quota');
+      toast.error(e.message || 'Failed to delete quota');
     }
   };
 
   const handleClearQuota = async (keyName: string) => {
-    if (!confirm(`Reset quota usage for key '${keyName}'?`)) return;
+    const _okr = await toast.confirm({ title: 'Reset quota?', message: `Reset quota usage for key '${keyName}'?`, confirmLabel: 'Reset' });
+    if (!_okr) return;
 
     try {
       await api.clearQuota(keyName);
       await loadData();
     } catch (e) {
       console.error('Failed to clear quota', e);
-      alert('Failed to clear quota');
+      toast.error('Failed to clear quota');
     }
   };
 
@@ -265,31 +273,37 @@ export const Keys = () => {
   };
 
   return (
-    <div className="min-h-screen p-6 transition-all duration-300 bg-gradient-to-br from-bg-deep to-bg-surface">
-      {/* Header */}
-      <div className="mb-8">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <div>
-            <h1 className="font-heading text-3xl font-bold text-text m-0 mb-2">Access Control</h1>
-            <p className="text-[15px] text-text-secondary m-0">Manage API keys and user quotas.</p>
-          </div>
-          <div style={{ display: 'flex', gap: '8px' }}>
-            {activeTab === 'keys' ? (
-              <Button leftIcon={<Plus size={16} />} onClick={handleAddNewKey}>
-                Add Key
-              </Button>
-            ) : (
-              <Button leftIcon={<Plus size={16} />} onClick={handleAddNewQuota}>
-                Add Quota
-              </Button>
-            )}
-          </div>
-        </div>
+    <PageContainer>
+      <PageHeader
+        title="Access Control"
+        subtitle="Manage API keys and user quotas."
+        actions={
+          activeTab === 'keys' ? (
+            <Button leftIcon={<Plus size={16} />} onClick={handleAddNewKey}>
+              Add Key
+            </Button>
+          ) : (
+            <Button leftIcon={<Plus size={16} />} onClick={handleAddNewQuota}>
+              Add Quota
+            </Button>
+          )
+        }
+      />
+
+      <div className="mb-6">
+        <Tabs
+          value={activeTab}
+          onChange={(v) => setActiveTab(v as 'keys' | 'quotas')}
+          items={[
+            { value: 'keys', label: `API Keys (${keys.length})` },
+            { value: 'quotas', label: `Quotas (${Object.keys(quotas).length})` },
+          ]}
+        />
       </div>
 
-      {/* Tabs */}
-      <div className="mb-6 border-b border-border-glass">
-        <div style={{ display: 'flex', gap: '8px' }}>
+      {/* Hidden old tabs (to avoid further JSX restructuring) */}
+      <div className="hidden">
+        <div>
           <button
             className={`px-4 py-2 font-body text-sm font-medium transition-colors ${
               activeTab === 'keys'
@@ -926,6 +940,6 @@ export const Keys = () => {
           </div>
         )}
       </Modal>
-    </div>
+    </PageContainer>
   );
 };

--- a/packages/frontend/src/pages/Keys.tsx
+++ b/packages/frontend/src/pages/Keys.tsx
@@ -352,7 +352,7 @@ export const Keys = () => {
       {/* Keys Tab */}
       {activeTab === 'keys' && (
         <Card title="Active Keys" className="mb-6">
-          <div className="overflow-x-auto -m-6">
+          <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
             <table className="w-full border-collapse font-body text-[13px]">
               <thead>
                 <tr>
@@ -510,7 +510,7 @@ export const Keys = () => {
       {/* Quotas Tab */}
       {activeTab === 'quotas' && (
         <Card title="User Quotas" className="mb-6">
-          <div className="overflow-x-auto -m-6">
+          <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
             <table className="w-full border-collapse font-body text-[13px]">
               <thead>
                 <tr>

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
+import { FormField } from '../components/ui/FormField';
 import logo from '../assets/plexus_logo_transparent.png';
 
 export const Login: React.FC = () => {
@@ -31,23 +32,22 @@ export const Login: React.FC = () => {
     if (!valid) {
       setError('Invalid key');
     }
-    // On success, navigation happens via the useEffect above once isAuthenticated becomes true
   };
 
   return (
-    <div className="min-h-screen bg-bg-deep flex items-center justify-center p-4">
-      <div className="w-full" style={{ maxWidth: '600px' }}>
+    <div className="min-h-screen bg-bg-deep flex items-center justify-center p-4 sm:p-6">
+      <div className="w-full max-w-md">
         <div className="text-center mb-8">
-          <img src={logo} alt="Plexus" className="h-16 mx-auto mb-4" />
-          <h1 className="text-2xl font-bold text-text">Sign in</h1>
-          <p className="text-text-muted">
+          <img src={logo} alt="Plexus" className="h-14 sm:h-16 mx-auto mb-4" />
+          <h1 className="font-heading text-h1 font-bold text-text m-0">Sign in</h1>
+          <p className="mt-2 text-sm text-text-secondary">
             Enter your admin key for full access, or an API key secret for a scoped view of your
             key's activity.
           </p>
         </div>
 
         <Card>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <input
               type="text"
               name="username"
@@ -57,22 +57,20 @@ export const Login: React.FC = () => {
               tabIndex={-1}
               aria-hidden="true"
             />
-            <div>
-              <label htmlFor="adminKey" className="block text-sm font-medium text-text-muted mb-1">
-                Admin key or API key secret
-              </label>
+            <FormField label="Admin key or API key secret" htmlFor="adminKey" error={error || undefined}>
               <Input
                 id="adminKey"
                 type="password"
                 autoComplete="current-password"
                 value={key}
-                onChange={(e) => setKey(e.target.value)}
+                onChange={(e) => {
+                  setKey(e.target.value);
+                  if (error) setError('');
+                }}
                 placeholder="sk-admin-... or sk-..."
                 autoFocus
               />
-            </div>
-
-            {error && <p className="text-danger text-sm">{error}</p>}
+            </FormField>
 
             <Button type="submit" className="w-full">
               Access Dashboard

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -3,7 +3,10 @@ import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
 import { Modal } from '../components/ui/Modal';
+import { SearchInput } from '../components/ui/SearchInput';
 import { CostToolTip } from '../components/ui/CostToolTip';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
 import {
   api,
   UsageRecord,
@@ -385,74 +388,46 @@ export const Logs = () => {
   const selectedRetryHistory = parseRetryHistory(selectedRetryLog?.retryHistory);
 
   return (
-    <div className="min-h-screen p-6 transition-all duration-300 bg-linear-to-br from-bg-deep to-bg-surface">
-      <div className="mb-4">
-        <h1 className="font-heading text-3xl font-bold text-text m-0">Logs</h1>
-        {principal?.role === 'limited' && principal.keyName && (
-          <p className="text-sm text-text-muted mt-1">Scoped to key "{principal.keyName}".</p>
-        )}
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Logs"
+        subtitle={
+          principal?.role === 'limited' && principal.keyName
+            ? `Scoped to key "${principal.keyName}".`
+            : undefined
+        }
+      />
 
-      <Card className="glass-bg rounded-lg p-3 max-w-full shadow-xl overflow-hidden flex flex-col gap-2">
-        <div className="mb-4">
-          <form onSubmit={handleSearch} className="flex flex-wrap gap-3 mb-4 justify-between">
-            <div className="flex flex-wrap gap-2">
+      <Card flush>
+        <div className="p-3 sm:p-4 border-b border-border-glass">
+          <form
+            onSubmit={handleSearch}
+            className="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-3 justify-between"
+          >
+            <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 min-w-0 flex-1">
               {/* The apiKey filter is redundant for limited users — backend
                   force-scopes results to their key. */}
               {!isLimited && (
-                <div className="relative w-62.5">
-                  <Search
-                    size={16}
-                    style={{
-                      position: 'absolute',
-                      left: '10px',
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                      color: 'var(--color-text-secondary)',
-                    }}
-                  />
-                  <Input
+                <div className="w-full sm:w-60">
+                  <SearchInput
                     placeholder="Filter by Key..."
                     value={filters.apiKey}
-                    onChange={(e) => setFilters({ ...filters, apiKey: e.target.value })}
-                    style={{ paddingLeft: '32px' }}
+                    onChange={(v) => setFilters({ ...filters, apiKey: v })}
                   />
                 </div>
               )}
-              <div className="relative w-62.5">
-                <Search
-                  size={16}
-                  style={{
-                    position: 'absolute',
-                    left: '10px',
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    color: 'var(--color-text-secondary)',
-                  }}
-                />
-                <Input
+              <div className="w-full sm:w-60">
+                <SearchInput
                   placeholder="Filter by Model..."
                   value={filters.incomingModelAlias}
-                  onChange={(e) => setFilters({ ...filters, incomingModelAlias: e.target.value })}
-                  style={{ paddingLeft: '32px' }}
+                  onChange={(v) => setFilters({ ...filters, incomingModelAlias: v })}
                 />
               </div>
-              <div className="relative w-50">
-                <Filter
-                  size={16}
-                  style={{
-                    position: 'absolute',
-                    left: '10px',
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    color: 'var(--color-text-secondary)',
-                  }}
-                />
-                <Input
+              <div className="w-full sm:w-48">
+                <SearchInput
                   placeholder="Filter by Provider..."
                   value={filters.provider}
-                  onChange={(e) => setFilters({ ...filters, provider: e.target.value })}
-                  style={{ paddingLeft: '32px' }}
+                  onChange={(v) => setFilters({ ...filters, provider: v })}
                 />
               </div>
               <Button type="submit" variant="primary">
@@ -463,11 +438,10 @@ export const Logs = () => {
               <Button
                 onClick={handleDeleteAll}
                 variant="danger"
-                className="flex items-center gap-2"
+                leftIcon={<Trash2 size={16} />}
                 disabled={logs.length === 0}
                 type="button"
               >
-                <Trash2 size={16} />
                 Delete All
               </Button>
             )}
@@ -1281,6 +1255,6 @@ export const Logs = () => {
           cannot be undone.
         </p>
       </Modal>
-    </div>
+    </PageContainer>
   );
 };

--- a/packages/frontend/src/pages/Mcp.tsx
+++ b/packages/frontend/src/pages/Mcp.tsx
@@ -312,7 +312,7 @@ export const McpPage: React.FC = () => {
             No MCP servers configured. Click "Add MCP Server" to create one.
           </div>
         ) : (
-          <div className="overflow-x-auto -m-6">
+          <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
             <table className="w-full border-collapse font-body text-[13px]">
               <thead>
                 <tr>

--- a/packages/frontend/src/pages/Mcp.tsx
+++ b/packages/frontend/src/pages/Mcp.tsx
@@ -4,6 +4,9 @@ import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
 import { Input } from '../components/ui/Input';
 import { Card } from '../components/ui/Card';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
+import { useToast } from '../contexts/ToastContext';
 import {
   Plus,
   Trash2,
@@ -30,6 +33,7 @@ const EMPTY_SERVER: McpServer = {
 };
 
 export const McpPage: React.FC = () => {
+  const toast = useToast();
   const [servers, setServers] = useState<Record<string, McpServer>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -169,17 +173,17 @@ export const McpPage: React.FC = () => {
   const handleSave = async () => {
     const nameToSave = editingServerName || serverNameInput;
     if (!nameToSave || !nameToSave.trim()) {
-      alert('Server Name is required');
+      toast.error('Server Name is required');
       return;
     }
     if (!editingServerName && !isValidServerName(nameToSave)) {
-      alert(
+      toast.error(
         'Invalid server name. Use lowercase letters, numbers, hyphens, and underscores (2-63 characters, must start with letter or number)'
       );
       return;
     }
     if (!editingServer.upstream_url || !editingServer.upstream_url.trim()) {
-      alert('Upstream URL is required');
+      toast.error('Upstream URL is required');
       return;
     }
 
@@ -200,22 +204,27 @@ export const McpPage: React.FC = () => {
       setIsModalOpen(false);
     } catch (e) {
       console.error('Save error', e);
-      alert('Failed to save MCP server: ' + e);
+      toast.error(`Failed to save MCP server: ${e}`);
     } finally {
       setIsSaving(false);
     }
   };
 
   const handleDelete = async (serverName: string) => {
-    if (!confirm(`Are you sure you want to delete the MCP server "${serverName}"?`)) {
-      return;
-    }
+    const ok = await toast.confirm({
+      title: 'Delete MCP server?',
+      message: `Are you sure you want to delete the MCP server "${serverName}"?`,
+      confirmLabel: 'Delete',
+      variant: 'danger',
+    });
+    if (!ok) return;
     try {
       await api.deleteMcpServer(serverName);
       await loadData();
+      toast.success(`Deleted ${serverName}`);
     } catch (e) {
       console.error('Delete error', e);
-      alert('Failed to delete MCP server: ' + e);
+      toast.error(`Failed to delete MCP server: ${e}`);
     }
   };
 
@@ -231,7 +240,7 @@ export const McpPage: React.FC = () => {
       await loadData();
     } catch (e) {
       console.error('Toggle error', e);
-      alert('Failed to update MCP server: ' + e);
+      toast.error(`Failed to update MCP server: ${e}`);
     }
   };
 
@@ -283,7 +292,12 @@ export const McpPage: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen p-6 transition-all duration-300 bg-gradient-to-br from-bg-deep to-bg-surface flex flex-col gap-6">
+    <PageContainer>
+      <PageHeader
+        title="MCP Servers"
+        subtitle="Configure Model Context Protocol upstream servers and review their call logs."
+      />
+      <div className="flex flex-col gap-6">
       {/* ── Servers Config Card ── */}
       <Card
         title="MCP Servers"
@@ -840,7 +854,8 @@ export const McpPage: React.FC = () => {
       >
         <p>Are you sure you want to delete this MCP log entry?</p>
       </Modal>
-    </div>
+      </div>
+    </PageContainer>
   );
 };
 

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -19,6 +19,10 @@ import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
 import { Switch } from '../components/ui/Switch';
+import { SearchInput } from '../components/ui/SearchInput';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
+import { useToast } from '../contexts/ToastContext';
 import {
   Search,
   Plus,
@@ -39,6 +43,7 @@ import {
 } from 'lucide-react';
 
 export const Models = () => {
+  const toast = useToast();
   const {
     aliases,
     providers,
@@ -172,7 +177,7 @@ export const Models = () => {
     if (editingAlias.metadata?.source === 'custom') {
       const name = editingAlias.metadata.overrides?.name;
       if (!name || name.trim() === '') {
-        alert('Custom metadata requires a non-empty Name.');
+        toast.error('Custom metadata requires a non-empty Name.');
         return;
       }
     }
@@ -895,62 +900,46 @@ export const Models = () => {
   );
 
   return (
-    <div className="min-h-screen p-6 transition-all duration-300 bg-linear-to-br from-bg-deep to-bg-surface">
-      <div className="mb-6">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-            <h1 className="font-heading text-3xl font-bold text-text m-0">Models</h1>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '4px' }}>
-              <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-bg-glass border border-border-glass">
-                <Eye size={14} className="text-text-secondary" />
-                <span className="text-xs font-medium text-text-secondary">
-                  Vision Fall Through Model:
-                </span>
-                <select
-                  className="bg-transparent border-none text-xs text-text outline-none focus:ring-0 cursor-pointer"
-                  value={globalDescriptorModel}
-                  onChange={(e) => setGlobalDescriptorModel(e.target.value)}
-                >
-                  <option value="">(None)</option>
-                  {sortedAliases.map((a) => (
-                    <option key={a.id} value={a.id}>
-                      {a.id}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  onClick={handleSaveDescriptor}
-                  disabled={isSavingDescriptor}
-                  className="ml-1 text-text-secondary hover:text-primary transition-colors disabled:opacity-50"
-                  title="Save descriptor model"
-                >
-                  {isSavingDescriptor ? (
-                    <Loader2 size={14} className="animate-spin" />
-                  ) : (
-                    <Save size={14} />
-                  )}
-                </button>
-              </div>
-            </div>
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-            <div style={{ position: 'relative', width: '280px' }}>
-              <Search
-                size={16}
-                style={{
-                  position: 'absolute',
-                  left: '12px',
-                  top: '50%',
-                  transform: 'translateY(-50%)',
-                  color: 'var(--color-text-secondary)',
-                }}
-              />
-              <Input
-                placeholder="Search models..."
-                style={{ paddingLeft: '36px' }}
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-              />
+    <PageContainer>
+      <PageHeader
+        title="Models"
+        subtitle={
+          <span className="inline-flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-2 px-3 py-1 rounded-md bg-bg-glass border border-border-glass">
+              <Eye size={14} className="text-text-secondary" />
+              <span className="text-xs font-medium text-text-secondary">Vision Fall Through:</span>
+              <select
+                className="bg-transparent border-none text-xs text-text outline-none focus:ring-0 cursor-pointer max-w-[140px]"
+                value={globalDescriptorModel}
+                onChange={(e) => setGlobalDescriptorModel(e.target.value)}
+              >
+                <option value="">(None)</option>
+                {sortedAliases.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.id}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={handleSaveDescriptor}
+                disabled={isSavingDescriptor}
+                className="ml-1 text-text-secondary hover:text-primary transition-colors disabled:opacity-50"
+                title="Save descriptor model"
+                type="button"
+              >
+                {isSavingDescriptor ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Save size={14} />
+                )}
+              </button>
+            </span>
+          </span>
+        }
+        actions={
+          <>
+            <div className="w-full sm:w-64">
+              <SearchInput placeholder="Search models..." value={search} onChange={setSearch} />
             </div>
             <Button
               variant="danger"
@@ -958,14 +947,14 @@ export const Models = () => {
               onClick={() => setIsDeleteAllModalOpen(true)}
               disabled={aliases.length === 0}
             >
-              Delete All Models
+              Delete All
             </Button>
             <Button leftIcon={<Plus size={16} />} onClick={handleAddNew}>
               Add Model
             </Button>
-          </div>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       <Card className="mb-6">
         <div className="overflow-x-auto -m-6">
@@ -2422,6 +2411,6 @@ export const Models = () => {
           </div>,
           document.body
         )}
-    </div>
+    </PageContainer>
   );
 };

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -957,7 +957,7 @@ export const Models = () => {
       />
 
       <Card className="mb-6">
-        <div className="overflow-x-auto -m-6">
+        <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
           <table className="w-full border-collapse font-body text-[13px]">
             <thead>
               <tr>

--- a/packages/frontend/src/pages/MyKey.tsx
+++ b/packages/frontend/src/pages/MyKey.tsx
@@ -1,13 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
-import { Copy, Check, RotateCw, AlertTriangle } from 'lucide-react';
+import { RotateCw } from 'lucide-react';
 import { api } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
+import { useToast } from '../contexts/ToastContext';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Input } from '../components/ui/Input';
 import { Modal } from '../components/ui/Modal';
 import { Switch } from '../components/ui/Switch';
+import { CopyButton } from '../components/ui/CopyButton';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
+import { Skeleton, SkeletonText } from '../components/ui/Skeleton';
 
 interface SelfInfo {
   role: 'admin' | 'limited';
@@ -20,13 +25,9 @@ interface SelfInfo {
   traceEnabledGlobal?: boolean;
 }
 
-/**
- * Self-service page for the currently authenticated api-key user.
- * Lets them view their key's metadata, edit the comment, toggle trace
- * capture for their key only, and rotate their secret.
- */
 export const MyKey: React.FC = () => {
   const { isLimited, isAdmin, login } = useAuth();
+  const toast = useToast();
   const [info, setInfo] = useState<SelfInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [comment, setComment] = useState('');
@@ -35,8 +36,6 @@ export const MyKey: React.FC = () => {
   const [showRotate, setShowRotate] = useState(false);
   const [rotating, setRotating] = useState(false);
   const [newSecret, setNewSecret] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -47,45 +46,52 @@ export const MyKey: React.FC = () => {
         setInfo(data);
         setComment(data.comment ?? '');
       })
-      .catch((e) => setError(String(e)))
+      .catch((e) => toast.error(String(e), 'Load failed'))
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Admins shouldn't land on this page via the nav — they have the full Keys
-  // management page. Redirect defensively if they hit the URL directly.
   if (isAdmin && !isLimited) {
     return <Navigate to="/keys" replace />;
   }
 
   if (loading) {
     return (
-      <div className="p-6">
-        <p className="text-text-muted">Loading...</p>
-      </div>
+      <PageContainer width="standard">
+        <PageHeader title="My Key" subtitle="Loading your key details..." />
+        <div className="flex flex-col gap-4">
+          <Skeleton height={140} />
+          <Skeleton height={120} />
+          <Skeleton height={120} />
+        </div>
+      </PageContainer>
     );
   }
 
   if (!info || info.role !== 'limited') {
     return (
-      <div className="p-6">
-        <p className="text-danger">{error || 'Unable to load key info.'}</p>
-      </div>
+      <PageContainer width="standard">
+        <PageHeader title="My Key" />
+        <Card>
+          <p className="text-danger">Unable to load key info.</p>
+        </Card>
+      </PageContainer>
     );
   }
 
   const handleSaveComment = async () => {
     setSavingComment(true);
-    setError(null);
     try {
       await api.updateSelfComment(comment.trim() || null);
       setInfo({ ...info, comment: comment.trim() || null });
+      toast.success('Comment saved');
     } catch (e: any) {
-      setError(e?.message || 'Failed to save comment');
+      toast.error(e?.message || 'Failed to save comment');
     } finally {
       setSavingComment(false);
     }
@@ -93,12 +99,11 @@ export const MyKey: React.FC = () => {
 
   const handleToggleTrace = async (enabled: boolean) => {
     setTogglingTrace(true);
-    setError(null);
     try {
       const res = await api.toggleSelfDebug(enabled);
       setInfo({ ...info, traceEnabled: res.enabled, traceEnabledGlobal: res.enabledGlobal });
     } catch (e: any) {
-      setError(e?.message || 'Failed to toggle trace');
+      toast.error(e?.message || 'Failed to toggle trace');
     } finally {
       setTogglingTrace(false);
     }
@@ -106,137 +111,115 @@ export const MyKey: React.FC = () => {
 
   const handleRotate = async () => {
     setRotating(true);
-    setError(null);
     try {
       const res = await api.rotateSelfSecret();
-      // Persist the new secret into the active session BEFORE revealing it.
-      // The old secret stops working server-side the moment rotateSelfSecret
-      // returns, so any subsequent fetchWithAuth call that still carries the
-      // old credential would 401 and evict the session — locking the user
-      // out of the very modal that's showing their new secret. login() does:
-      // fetch /auth/verify with the new secret → update localStorage →
-      // setAdminKey + setPrincipal, so every later request uses it.
       const ok = await login(res.secret);
       setNewSecret(res.secret);
       if (!ok) {
-        // Highly unlikely — the new secret just came from the server — but
-        // surface something useful instead of silently drifting.
-        setError('Secret rotated, but session refresh failed. Re-login with the new secret.');
+        toast.warning('Secret rotated, but session refresh failed. Re-login with the new secret.');
       }
     } catch (e: any) {
-      setError(e?.message || 'Rotation failed');
+      toast.error(e?.message || 'Rotation failed');
     } finally {
       setRotating(false);
     }
-  };
-
-  const handleCopy = () => {
-    if (!newSecret) return;
-    navigator.clipboard.writeText(newSecret);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
   };
 
   const allowedProviders = info.allowedProviders ?? [];
   const allowedModels = info.allowedModels ?? [];
 
   return (
-    <div className="p-6 max-w-3xl space-y-6">
-      <header>
-        <h1 className="text-2xl font-bold text-text">My Key</h1>
-        <p className="text-text-muted">
-          Details for <span className="font-medium">{info.keyName}</span>. All logs, traces, and
-          dashboard data in this session are scoped to this key.
-        </p>
-      </header>
+    <PageContainer width="standard">
+      <PageHeader
+        title="My Key"
+        subtitle={
+          <>
+            Details for <span className="font-medium text-text">{info.keyName}</span>. All logs,
+            traces, and dashboard data in this session are scoped to this key.
+          </>
+        }
+      />
 
-      {error && (
-        <div className="flex items-center gap-2 p-3 bg-danger/10 border border-danger/30 rounded-md text-danger text-sm">
-          <AlertTriangle size={16} />
-          <span>{error}</span>
-        </div>
-      )}
-
-      <Card title="Identity">
-        <dl className="grid grid-cols-1 gap-3 text-sm">
-          <div className="flex">
-            <dt className="w-40 text-text-muted">Key name</dt>
-            <dd className="font-mono text-text">{info.keyName}</dd>
-          </div>
-          <div className="flex">
-            <dt className="w-40 text-text-muted">Quota</dt>
+      <div className="flex flex-col gap-4 sm:gap-6">
+        <Card title="Identity">
+          <dl className="grid grid-cols-1 sm:grid-cols-[max-content_1fr] gap-x-6 gap-y-3 text-sm">
+            <dt className="text-text-muted">Key name</dt>
+            <dd className="font-mono text-text break-all">{info.keyName}</dd>
+            <dt className="text-text-muted">Quota</dt>
             <dd className="text-text">{info.quotaName || '—'}</dd>
-          </div>
-          <div className="flex">
-            <dt className="w-40 text-text-muted">Allowed providers</dt>
-            <dd className="text-text">
+            <dt className="text-text-muted">Allowed providers</dt>
+            <dd className="text-text break-words">
               {allowedProviders.length > 0 ? allowedProviders.join(', ') : 'Any (unrestricted)'}
             </dd>
-          </div>
-          <div className="flex">
-            <dt className="w-40 text-text-muted">Allowed models</dt>
-            <dd className="text-text">
+            <dt className="text-text-muted">Allowed models</dt>
+            <dd className="text-text break-words">
               {allowedModels.length > 0 ? allowedModels.join(', ') : 'Any (unrestricted)'}
             </dd>
-          </div>
-        </dl>
-      </Card>
+          </dl>
+        </Card>
 
-      <Card title="Comment">
-        <div className="space-y-3">
-          <Input
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            placeholder="Free-text note about this key (optional)"
-          />
-          <div className="flex justify-end">
-            <Button
-              onClick={handleSaveComment}
-              disabled={savingComment || (comment.trim() || null) === (info.comment ?? null)}
-            >
-              {savingComment ? 'Saving…' : 'Save'}
-            </Button>
+        <Card title="Comment">
+          <div className="flex flex-col gap-3">
+            <Input
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              placeholder="Free-text note about this key (optional)"
+            />
+            <div className="flex justify-end">
+              <Button
+                onClick={handleSaveComment}
+                disabled={savingComment || (comment.trim() || null) === (info.comment ?? null)}
+                isLoading={savingComment}
+              >
+                Save
+              </Button>
+            </div>
           </div>
-        </div>
-      </Card>
+        </Card>
 
-      <Card title="Trace capture">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm text-text">
-              Capture full request/response payloads for this key only.
+        <Card title="Trace capture">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm text-text">
+                Capture full request/response payloads for this key only.
+              </p>
+              <p className="text-xs text-text-muted mt-1">
+                {info.traceEnabledGlobal
+                  ? 'Global tracing is ON (admin) — all requests are captured regardless of this toggle.'
+                  : info.traceEnabled
+                    ? 'Currently capturing traces for this key.'
+                    : 'Tracing is off for this key.'}
+              </p>
+            </div>
+            <Switch
+              checked={!!info.traceEnabled}
+              onChange={handleToggleTrace}
+              disabled={togglingTrace || !!info.traceEnabledGlobal}
+              aria-label="Toggle trace capture"
+            />
+          </div>
+        </Card>
+
+        <Card title="Rotate secret">
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-text-secondary">
+              Generates a new secret for this key. The old secret stops working immediately. Your
+              historical logs, traces, and errors are preserved (they're indexed by key name, not
+              secret).
             </p>
-            <p className="text-xs text-text-muted mt-1">
-              {info.traceEnabledGlobal
-                ? 'Global tracing is ON (admin) — all requests are captured regardless of this toggle.'
-                : info.traceEnabled
-                  ? 'Currently capturing traces for this key.'
-                  : 'Tracing is off for this key.'}
-            </p>
+            <div className="flex justify-end">
+              <Button
+                variant="danger"
+                onClick={() => setShowRotate(true)}
+                disabled={rotating}
+                leftIcon={<RotateCw size={16} />}
+              >
+                Rotate secret
+              </Button>
+            </div>
           </div>
-          <Switch
-            checked={!!info.traceEnabled}
-            onChange={handleToggleTrace}
-            disabled={togglingTrace || !!info.traceEnabledGlobal}
-          />
-        </div>
-      </Card>
-
-      <Card title="Rotate secret">
-        <div className="space-y-3">
-          <p className="text-sm text-text-muted">
-            Generates a new secret for this key. The old secret stops working immediately. Your
-            historical logs, traces, and errors are preserved (they're indexed by key name, not
-            secret).
-          </p>
-          <div className="flex justify-end">
-            <Button variant="danger" onClick={() => setShowRotate(true)} disabled={rotating}>
-              <RotateCw size={16} />
-              Rotate secret
-            </Button>
-          </div>
-        </div>
-      </Card>
+        </Card>
+      </div>
 
       <Modal
         isOpen={showRotate}
@@ -260,32 +243,30 @@ export const MyKey: React.FC = () => {
               <Button variant="secondary" onClick={() => setShowRotate(false)} disabled={rotating}>
                 Cancel
               </Button>
-              <Button variant="danger" onClick={handleRotate} disabled={rotating}>
-                {rotating ? 'Rotating…' : 'Rotate now'}
+              <Button variant="danger" onClick={handleRotate} disabled={rotating} isLoading={rotating}>
+                Rotate now
               </Button>
             </>
           )
         }
       >
         {newSecret ? (
-          <div className="space-y-3">
+          <div className="flex flex-col gap-3">
             <p className="text-sm text-text">Copy this secret now — it will not be shown again.</p>
             <div className="flex gap-2 items-center">
-              <code className="flex-1 p-2 bg-bg-card border border-border rounded text-xs font-mono break-all">
+              <code className="flex-1 min-w-0 p-2 bg-bg-card border border-border rounded-md text-xs font-mono break-all">
                 {newSecret}
               </code>
-              <Button variant="secondary" onClick={handleCopy}>
-                {copied ? <Check size={16} /> : <Copy size={16} />}
-              </Button>
+              <CopyButton value={newSecret} variant="icon" />
             </div>
           </div>
         ) : (
-          <p className="text-sm">
+          <p className="text-sm text-text-secondary">
             The old secret will stop working immediately. Any clients using it will receive 401
             errors until they are updated with the new secret.
           </p>
         )}
       </Modal>
-    </div>
+    </PageContainer>
   );
 };

--- a/packages/frontend/src/pages/Providers.tsx
+++ b/packages/frontend/src/pages/Providers.tsx
@@ -993,7 +993,7 @@ export const Providers = () => {
         }
       />
       <Card flush>
-        <div className="overflow-x-auto -m-6">
+        <div className="overflow-x-auto">
           <table className="w-full border-collapse font-body text-[13px]">
             <thead>
               <tr>

--- a/packages/frontend/src/pages/Providers.tsx
+++ b/packages/frontend/src/pages/Providers.tsx
@@ -19,6 +19,9 @@ import { Modal } from '../components/ui/Modal';
 import { Input } from '../components/ui/Input';
 import { Card } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
+import { useToast } from '../contexts/ToastContext';
 import {
   Plus,
   Edit2,
@@ -234,6 +237,7 @@ const ModelIdInput = ({ modelId, onCommit }: ModelIdInputProps) => {
 };
 
 export const Providers = () => {
+  const toast = useToast();
   const navigate = useNavigate();
   const [providers, setProviders] = useState<Provider[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -411,7 +415,7 @@ export const Providers = () => {
       await loadData();
       setDeleteModalProvider(null);
     } catch (e) {
-      alert('Failed to delete provider: ' + e);
+      toast.error('Failed to delete provider: ' + e);
     } finally {
       setDeleteModalLoading(false);
     }
@@ -419,7 +423,7 @@ export const Providers = () => {
 
   const handleSave = async () => {
     if (!editingProvider.id) {
-      alert('Provider ID is required');
+      toast.error('Provider ID is required');
       return;
     }
     setIsSaving(true);
@@ -429,7 +433,7 @@ export const Providers = () => {
         providerToSave = { ...providerToSave, oauthProvider: OAUTH_PROVIDERS[0].value };
       }
       if (isOAuthMode && !providerToSave.oauthAccount?.trim()) {
-        alert('OAuth account is required');
+        toast.error('OAuth account is required');
         return;
       }
       // Quota checker validation is handled by the backend - just pass through as-is
@@ -444,7 +448,7 @@ export const Providers = () => {
       setIsModalOpen(false);
     } catch (e) {
       console.error('Save error', e);
-      alert('Failed to save provider: ' + e);
+      toast.error('Failed to save provider: ' + e);
     } finally {
       setIsSaving(false);
     }
@@ -625,7 +629,7 @@ export const Providers = () => {
       await api.saveProvider(p, provider.id);
     } catch (e) {
       console.error('Toggle error', e);
-      alert('Failed to update provider status: ' + e);
+      toast.error('Failed to update provider status: ' + e);
       loadData();
     }
   };
@@ -978,15 +982,17 @@ export const Providers = () => {
   };
 
   return (
-    <div className="min-h-screen p-6 transition-all duration-300 bg-linear-to-br from-bg-deep to-bg-surface">
-      <Card
-        title="Configured Providers"
-        extra={
+    <PageContainer>
+      <PageHeader
+        title="Providers"
+        subtitle="Configure upstream inference providers, credentials, and quota checkers."
+        actions={
           <Button leftIcon={<Plus size={16} />} onClick={handleAddNew}>
             Add Provider
           </Button>
         }
-      >
+      />
+      <Card flush>
         <div className="overflow-x-auto -m-6">
           <table className="w-full border-collapse font-body text-[13px]">
             <thead>
@@ -3748,13 +3754,13 @@ export const Providers = () => {
             </div>
           </div>
 
-          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <div className="flex justify-end">
             <Button variant="ghost" onClick={() => setDeleteModalProvider(null)}>
               Cancel
             </Button>
           </div>
         </div>
       </Modal>
-    </div>
+    </PageContainer>
   );
 };

--- a/packages/frontend/src/pages/Quotas.tsx
+++ b/packages/frontend/src/pages/Quotas.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState, useMemo } from 'react';
+import { RefreshCw, Cpu, Gauge } from 'lucide-react';
+import { clsx } from 'clsx';
 import { api } from '../lib/api';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
-import { RefreshCw, Cpu } from 'lucide-react';
-import { clsx } from 'clsx';
+import { EmptyState } from '../components/ui/EmptyState';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
 import type { QuotaCheckerInfo, QuotaCheckResult } from '../types/quota';
 import { toBoolean, toIsoString } from '../lib/normalize';
 import {
@@ -32,7 +35,6 @@ import {
   BalanceHistoryModal,
 } from '../components/quota';
 
-// Checker display names
 const CHECKER_DISPLAY_NAMES: Record<string, string> = {
   openrouter: 'OpenRouter',
   minimax: 'MiniMax',
@@ -66,9 +68,8 @@ export const Quotas = () => {
   const [selectedDisplayName, setSelectedDisplayName] = useState('');
   const [isBalanceModal, setIsBalanceModal] = useState(false);
 
-  const isBalanceChecker = (quota: QuotaCheckerInfo): boolean => {
-    return quota.checkerCategory === 'balance';
-  };
+  const isBalanceChecker = (quota: QuotaCheckerInfo): boolean =>
+    quota.checkerCategory === 'balance';
 
   const fetchQuotas = async () => {
     setLoading(true);
@@ -79,7 +80,6 @@ export const Quotas = () => {
 
   useEffect(() => {
     fetchQuotas();
-    // Refresh quotas every 30 seconds
     const interval = setInterval(fetchQuotas, 30000);
     return () => clearInterval(interval);
   }, []);
@@ -95,7 +95,6 @@ export const Quotas = () => {
     });
   };
 
-  // Convert QuotaSnapshot to QuotaCheckResult format for display
   const getQuotaResult = (quota: QuotaCheckerInfo): QuotaCheckResult => {
     if (!quota.latest || quota.latest.length === 0) {
       return {
@@ -110,8 +109,6 @@ export const Quotas = () => {
       };
     }
 
-    // Get unique windows (in case of duplicates, take the most recent)
-    // Key on windowType+description to support checkers with multiple windows of the same type
     const windowsByType = new Map<string, (typeof quota.latest)[0]>();
     for (const snapshot of quota.latest) {
       const key = snapshot.description
@@ -154,8 +151,6 @@ export const Quotas = () => {
     };
   };
 
-  // Group quotas by their exact checkerType (e.g. 'apertis-coding-plan').
-  // Fall back to checkerId if checkerType is not set.
   const groupedQuotas = useMemo(() => {
     const groups: Record<string, QuotaCheckerInfo[]> = {};
     for (const quota of quotas) {
@@ -166,12 +161,8 @@ export const Quotas = () => {
     return groups;
   }, [quotas]);
 
-  // Checkers that are categorized as 'balance' but also have rate-limit windows
-  // (e.g. neuralwatt has a subscription/$ balance AND a monthly/kWh quota).
-  // These should appear in BOTH the balance card and the rate-limit display.
   const BALANCE_CHECKERS_WITH_RATE_LIMIT = new Set(['neuralwatt']);
 
-  // Separate into balance and rate-limit categories using the authoritative checkerCategory field.
   const balanceGroups = useMemo(() => {
     return Object.entries(groupedQuotas)
       .filter(([, quotasList]) => quotasList.some((q) => q.checkerCategory === 'balance'))
@@ -204,39 +195,32 @@ export const Quotas = () => {
     setIsBalanceModal(false);
   };
 
-  // Render the appropriate quota display component based on checker type
   const renderQuotaDisplay = (quota: QuotaCheckerInfo, groupDisplayName: string) => {
     const result = getQuotaResult(quota);
     const checkerType = quota.checkerType || quota.checkerId;
 
-    // Add refresh button wrapper
     const wrapper = (children: React.ReactNode) => (
       <div
         key={quota.checkerId}
         onClick={() => handleCardClick(quota, groupDisplayName)}
-        className="bg-bg-card border border-border rounded-lg p-4 relative cursor-pointer hover:border-primary/50 transition-colors"
+        className="relative cursor-pointer rounded-lg border border-border-glass bg-bg-card/60 p-4 transition-colors duration-fast hover:border-primary/40"
       >
-        <div className="absolute top-2 right-2">
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRefresh(quota.checkerId);
-            }}
-            disabled={refreshing.has(quota.checkerId)}
-          >
-            <RefreshCw
-              size={14}
-              className={clsx(refreshing.has(quota.checkerId) && 'animate-spin')}
-            />
-          </Button>
-        </div>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleRefresh(quota.checkerId);
+          }}
+          disabled={refreshing.has(quota.checkerId)}
+          aria-label="Refresh"
+          className="absolute top-2 right-2 inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted hover:bg-bg-hover hover:text-text transition-colors duration-fast disabled:opacity-50"
+        >
+          <RefreshCw size={14} className={clsx(refreshing.has(quota.checkerId) && 'animate-spin')} />
+        </button>
         <div className="pr-8">{children}</div>
       </div>
     );
 
-    // Exact-match on checkerType to select the display component.
     const DISPLAY_MAP: Record<string, React.ReactNode> = {
       synthetic: <SyntheticQuotaDisplay result={result} isCollapsed={false} />,
       'claude-code': <ClaudeCodeQuotaDisplay result={result} isCollapsed={false} />,
@@ -263,70 +247,55 @@ export const Quotas = () => {
     const display = DISPLAY_MAP[checkerType];
     if (display) return wrapper(display);
 
-    // Fallback: generic display
     console.warn(`Unknown quota checker type: ${checkerType}`);
     return wrapper(<SyntheticQuotaDisplay result={result} isCollapsed={false} />);
   };
 
-  // Render columns for checker types (responsive grid)
-  const renderQuotaColumns = (groups: [string, QuotaCheckerInfo[]][]) => {
-    return (
-      <div
-        className="grid gap-4"
-        style={{
-          gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
-        }}
-      >
-        {groups.map(([checkerType, quotasList]) => {
-          const displayName = CHECKER_DISPLAY_NAMES[checkerType] || checkerType;
-
-          return (
-            <div key={checkerType} className="flex flex-col gap-3">
-              <h3 className="font-heading text-sm font-semibold text-text-secondary uppercase tracking-wider px-1 border-b border-border pb-2">
-                {displayName}
-              </h3>
-              <div className="flex flex-col gap-3">
-                {quotasList.map((quota) => renderQuotaDisplay(quota, displayName))}
-              </div>
+  const renderQuotaColumns = (groups: [string, QuotaCheckerInfo[]][]) => (
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {groups.map(([checkerType, quotasList]) => {
+        const displayName = CHECKER_DISPLAY_NAMES[checkerType] || checkerType;
+        return (
+          <div key={checkerType} className="flex flex-col gap-3">
+            <h3 className="font-heading text-xs font-semibold text-text-secondary uppercase tracking-wider px-1 border-b border-border-glass pb-2">
+              {displayName}
+            </h3>
+            <div className="flex flex-col gap-3">
+              {quotasList.map((quota) => renderQuotaDisplay(quota, displayName))}
             </div>
-          );
-        })}
-      </div>
-    );
-  };
+          </div>
+        );
+      })}
+    </div>
+  );
 
   return (
-    <div className="min-h-screen p-6 transition-all duration-300 bg-linear-to-br from-bg-deep to-bg-surface">
-      <div className="mb-8 flex items-center justify-between">
-        <div>
-          <h1 className="font-heading text-3xl font-bold text-text m-0 mb-2">Quota Trackers</h1>
-          <p className="text-[15px] text-text-secondary m-0">
-            Monitor provider quotas and rate limits.
-          </p>
-        </div>
-        <Button variant="secondary" onClick={fetchQuotas} disabled={loading}>
-          <RefreshCw size={16} className={clsx('mr-2', loading && 'animate-spin')} />
-          Refresh All
-        </Button>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title="Quota Trackers"
+        subtitle="Monitor provider quotas and rate limits."
+        actions={
+          <Button variant="secondary" onClick={fetchQuotas} disabled={loading} leftIcon={<RefreshCw size={16} className={clsx(loading && 'animate-spin')} />}>
+            Refresh All
+          </Button>
+        }
+      />
 
       {loading && quotas.length === 0 ? (
-        <div className="flex items-center justify-center h-64">
-          <RefreshCw size={24} className="animate-spin text-primary mr-2" />
+        <div className="flex items-center justify-center h-64 gap-3">
+          <RefreshCw size={20} className="animate-spin text-primary" />
           <span className="text-text-secondary">Loading quotas...</span>
         </div>
       ) : quotas.length === 0 ? (
         <Card>
-          <div className="text-center py-12">
-            <p className="text-text-secondary">No quota checkers configured</p>
-            <p className="text-text-muted text-sm mt-2">
-              Configure quota checkers in your provider settings to monitor usage.
-            </p>
-          </div>
+          <EmptyState
+            icon={<Gauge />}
+            title="No quota checkers configured"
+            description="Configure quota checkers in your provider settings to monitor usage."
+          />
         </Card>
       ) : (
-        <div className="space-y-8">
-          {/* Combined Balances Card */}
+        <div className="flex flex-col gap-8">
           {balanceGroups.length > 0 && (
             <section>
               <CombinedBalancesCard
@@ -338,12 +307,11 @@ export const Quotas = () => {
             </section>
           )}
 
-          {/* Rate Limit Section */}
           {rateLimitGroups.length > 0 && (
             <section>
-              <div className="flex items-center gap-2 mb-6 pb-2 border-b border-border">
-                <Cpu size={20} className="text-primary" />
-                <h2 className="font-heading text-xl font-semibold text-text">Rate Limits</h2>
+              <div className="flex items-center gap-2 mb-4 pb-2 border-b border-border-glass">
+                <Cpu size={18} className="text-primary" />
+                <h2 className="font-heading text-h2 font-semibold text-text">Rate Limits</h2>
               </div>
               {renderQuotaColumns(rateLimitGroups)}
             </section>
@@ -366,6 +334,6 @@ export const Quotas = () => {
           displayName={selectedDisplayName}
         />
       )}
-    </div>
+    </PageContainer>
   );
 };

--- a/packages/frontend/src/pages/SystemLogs.tsx
+++ b/packages/frontend/src/pages/SystemLogs.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { Terminal, Pause, Play, Trash2, RotateCcw } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { useToast } from '../contexts/ToastContext';
 import { Button } from '../components/ui/Button';
+import { Select } from '../components/ui/Select';
+import { PageHeader } from '../components/layout/PageHeader';
+import { PageContainer } from '../components/layout/PageContainer';
 import { api } from '../lib/api';
+import { clsx } from 'clsx';
 
 interface LogEntry {
   level: string;
@@ -11,7 +16,17 @@ interface LogEntry {
   [key: string]: any;
 }
 
+const LEVEL_CLASS: Record<string, string> = {
+  error: 'text-danger',
+  warn: 'text-secondary',
+  info: 'text-info',
+  debug: 'text-text-muted',
+  verbose: 'text-text-muted',
+  silly: 'text-text-muted',
+};
+
 export const SystemLogs: React.FC = () => {
+  const toast = useToast();
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [isPaused, setIsPaused] = useState(false);
   const [currentLevel, setCurrentLevel] = useState('info');
@@ -26,13 +41,11 @@ export const SystemLogs: React.FC = () => {
   ]);
   const [selectedLevel, setSelectedLevel] = useState('info');
   const [isUpdatingLevel, setIsUpdatingLevel] = useState(false);
-  const [levelError, setLevelError] = useState<string | null>(null);
   const isPausedRef = useRef(false);
   const { adminKey } = useAuth();
   const logsEndRef = useRef<HTMLDivElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  // Sync ref with state
   useEffect(() => {
     isPausedRef.current = isPaused;
   }, [isPaused]);
@@ -42,18 +55,16 @@ export const SystemLogs: React.FC = () => {
     return () => {
       disconnect();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [adminKey]);
 
   useEffect(() => {
-    const loadLoggingLevel = async () => {
-      const state = await api.getLoggingLevel();
+    api.getLoggingLevel().then((state) => {
       setCurrentLevel(state.level);
       setStartupLevel(state.startupLevel);
       setSupportedLevels(state.supportedLevels);
       setSelectedLevel(state.level);
-    };
-
-    loadLoggingLevel();
+    });
   }, []);
 
   const disconnect = () => {
@@ -72,15 +83,10 @@ export const SystemLogs: React.FC = () => {
 
     try {
       const response = await fetch('/v0/system/logs/stream', {
-        headers: {
-          'x-admin-key': adminKey,
-        },
+        headers: { 'x-admin-key': adminKey },
         signal: controller.signal,
       });
-
-      if (!response.ok) {
-        throw new Error(`Failed to connect: ${response.statusText}`);
-      }
+      if (!response.ok) throw new Error(`Failed to connect: ${response.statusText}`);
 
       const reader = response.body?.getReader();
       if (!reader) return;
@@ -93,7 +99,7 @@ export const SystemLogs: React.FC = () => {
         if (done) break;
 
         buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n\n'); // SSE messages are separated by double newline
+        const lines = buffer.split('\n\n');
         buffer = lines.pop() || '';
 
         for (const block of lines) {
@@ -105,12 +111,10 @@ export const SystemLogs: React.FC = () => {
             if (line.startsWith('event: syslog')) {
               isSyslogEvent = true;
             } else if (line.startsWith('event: ping')) {
-              // Ignore ping events
               isSyslogEvent = false;
             } else if (line.startsWith('data: ')) {
               eventData = line.slice(6);
             } else if (line.startsWith('data:')) {
-              // Support no space after colon
               eventData = line.slice(5);
             }
           }
@@ -119,10 +123,10 @@ export const SystemLogs: React.FC = () => {
             try {
               const data = JSON.parse(eventData);
               if (!isPausedRef.current) {
-                setLogs((prev) => [...prev.slice(-999), data]); // Keep last 1000 logs
+                setLogs((prev) => [...prev.slice(-999), data]);
               }
-            } catch (e) {
-              // Ignore parse errors or keepalives
+            } catch {
+              // ignore
             }
           }
         }
@@ -130,12 +134,10 @@ export const SystemLogs: React.FC = () => {
     } catch (err: any) {
       if (err.name !== 'AbortError') {
         console.error('Log stream error:', err);
-        // Optional: Auto-reconnect after delay?
       }
     }
   };
 
-  // Auto-scroll
   useEffect(() => {
     if (!isPaused && logsEndRef.current) {
       logsEndRef.current.scrollIntoView({ behavior: 'smooth' });
@@ -146,17 +148,16 @@ export const SystemLogs: React.FC = () => {
 
   const applyLoggingLevel = async () => {
     if (selectedLevel === currentLevel) return;
-
     setIsUpdatingLevel(true);
-    setLevelError(null);
     try {
       const state = await api.setLoggingLevel(selectedLevel);
       setCurrentLevel(state.level);
       setStartupLevel(state.startupLevel);
       setSupportedLevels(state.supportedLevels);
       setSelectedLevel(state.level);
-    } catch (error) {
-      setLevelError(error instanceof Error ? error.message : 'Failed to update logging level');
+      toast.success(`Logging level set to ${state.level}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to update logging level');
     } finally {
       setIsUpdatingLevel(false);
     }
@@ -164,69 +165,51 @@ export const SystemLogs: React.FC = () => {
 
   const resetLoggingLevel = async () => {
     setIsUpdatingLevel(true);
-    setLevelError(null);
     try {
       const state = await api.resetLoggingLevel();
       setCurrentLevel(state.level);
       setStartupLevel(state.startupLevel);
       setSupportedLevels(state.supportedLevels);
       setSelectedLevel(state.level);
-    } catch (error) {
-      setLevelError(error instanceof Error ? error.message : 'Failed to reset logging level');
+      toast.success(`Logging level reset to ${state.level}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to reset logging level');
     } finally {
       setIsUpdatingLevel(false);
     }
   };
 
-  const getLevelClass = (level: string) => {
-    switch (level) {
-      case 'error':
-        return 'error';
-      case 'warn':
-        return 'warn';
-      case 'debug':
-        return 'debug';
-      default:
-        return 'info';
-    }
-  };
-
   return (
-    <div className="dashboard h-[calc(100vh-64px)] flex flex-col overflow-hidden">
-      <div className="mb-8">
-        <h1
-          className="font-heading text-3xl font-bold text-text m-0 mb-2"
-          style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
-        >
-          <Terminal size={24} />
-          System Logs
-        </h1>
-        <p className="text-[15px] text-text-secondary m-0">Live stream of backend system logs.</p>
-      </div>
+    <PageContainer>
+      <PageHeader
+        title={
+          <span className="inline-flex items-center gap-2">
+            <Terminal size={24} className="text-primary" />
+            System Logs
+          </span>
+        }
+        subtitle="Live stream of backend system logs."
+      />
 
-      <div className="flex flex-col flex-1 min-h-0 mb-3 overflow-hidden glass-bg rounded-lg p-4 transition-all duration-300">
-        <div className="flex items-center justify-between px-6 py-5 border-b border-border-glass">
-          <h3 className="font-heading text-lg font-semibold text-text m-0">Live Output</h3>
-          <div style={{ display: 'flex', gap: '8px' }}>
-            <select
-              value={selectedLevel}
-              onChange={(event) => setSelectedLevel(event.target.value)}
-              className="rounded-md border border-border-glass bg-bg-surface px-3 py-1.5 text-sm text-text"
-              disabled={isUpdatingLevel}
-            >
-              {supportedLevels.map((level) => (
-                <option key={level} value={level}>
-                  {level}
-                </option>
-              ))}
-            </select>
+      <div className="flex flex-col gap-3 glass-bg rounded-lg overflow-hidden">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b border-border-glass">
+          <h3 className="font-heading text-h3 font-semibold text-text m-0">Live Output</h3>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="min-w-[120px]">
+              <Select
+                value={selectedLevel}
+                onChange={setSelectedLevel}
+                options={supportedLevels.map((l) => ({ value: l, label: l }))}
+                disabled={isUpdatingLevel}
+              />
+            </div>
             <Button
               variant="primary"
               size="sm"
               onClick={applyLoggingLevel}
               disabled={isUpdatingLevel || selectedLevel === currentLevel}
             >
-              Apply Level
+              Apply
             </Button>
             <Button
               variant="secondary"
@@ -245,37 +228,34 @@ export const SystemLogs: React.FC = () => {
             >
               {isPaused ? 'Resume' : 'Pause'}
             </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={clearLogs}
-              leftIcon={<Trash2 size={14} />}
-            >
+            <Button variant="secondary" size="sm" onClick={clearLogs} leftIcon={<Trash2 size={14} />}>
               Clear
             </Button>
           </div>
         </div>
-        <div className="px-6 py-2 text-xs text-text-secondary border-b border-border-glass">
-          Current level: <span className="text-text font-semibold">{currentLevel}</span> | Startup
-          default: <span className="text-text font-semibold">{startupLevel}</span> | Runtime changes
-          reset on restart
-          {levelError && <span className="ml-2 text-danger">({levelError})</span>}
+        <div className="px-4 py-2 text-xs text-text-secondary border-b border-border-glass">
+          Current level: <span className="text-text font-semibold">{currentLevel}</span> · Startup default:{' '}
+          <span className="text-text font-semibold">{startupLevel}</span> · Runtime changes reset on restart.
         </div>
 
-        <div className="flex-1 bg-[#0f172a] p-3 overflow-y-auto font-mono text-[13px] text-[#e2e8f0] rounded-sm">
+        <div className="bg-terminal-bg p-3 overflow-y-auto font-mono text-xs text-terminal-fg h-[60vh] min-h-[320px] max-h-[700px]">
           {logs.length === 0 && (
-            <div className="text-text-muted italic text-center mt-5">Waiting for logs...</div>
+            <div className="text-text-muted italic text-center mt-8">Waiting for logs...</div>
           )}
           {logs.map((log, i) => (
             <div key={i} className="mb-1 break-all py-0.5 px-1 rounded-sm hover:bg-white/5">
               <span className="text-text-muted mr-2">[{log.timestamp}]</span>
-              <span className={`font-bold mr-2 ${getLevelClass(log.level)}`}>
-                {log.level.toUpperCase()}:
+              <span
+                className={clsx(
+                  'font-bold mr-2',
+                  LEVEL_CLASS[log.level?.toLowerCase()] ?? 'text-text-muted'
+                )}
+              >
+                {log.level?.toUpperCase()}:
               </span>
               <span>{log.message}</span>
-              {Object.keys(log).filter((k) => !['level', 'message', 'timestamp'].includes(k))
-                .length > 0 && (
-                <pre className="text-text-muted text-[11px] ml-8 mt-1">
+              {Object.keys(log).filter((k) => !['level', 'message', 'timestamp'].includes(k)).length > 0 && (
+                <pre className="text-text-muted text-[11px] ml-8 mt-1 whitespace-pre-wrap">
                   {JSON.stringify(
                     Object.fromEntries(
                       Object.entries(log).filter(
@@ -292,6 +272,6 @@ export const SystemLogs: React.FC = () => {
           <div ref={logsEndRef} />
         </div>
       </div>
-    </div>
+    </PageContainer>
   );
 };


### PR DESCRIPTION
## Summary

Mobile-first responsive revamp of the admin UI. Keeps the existing dark + amber + glass aesthetic but rebuilds the shell and primitives so the app is actually usable on phones and tablets, and kills the ~130 inline pixel styles and 38+ `alert()`/`confirm()` calls.

### Layout & navigation
- Mobile `AppBar` with hamburger trigger below `md`; sidebar renders as an overlay `Drawer` on mobile, as the existing fixed rail on desktop.
- `MainLayout` switches from hardcoded `p-8` + `ml-[64/200px]` to `p-4 sm:p-6 lg:p-8` with `md:`-scoped sidebar offsets.
- New `PageHeader` + `PageContainer` standardise page chrome across every route.
- `SidebarContext` extended with `isMobileOpen` / `openMobile` / `closeMobile`; auto-close on navigation uses a ref-guarded pathname check so opening the drawer doesn't immediately close itself on mount.

### Primitives rebuilt (no more inline styles)
- `Modal`: responsive `max-w-[420/640/960px]` instead of fixed `w-[400/600/800px]`; uses new z-index tokens + `useBodyScrollLock`.
- `Switch`: full Tailwind rewrite using `data-[checked]` + `group-data-[checked]` (was 100% inline pixels).
- `Button`: token-based glow shadows, `focus-visible` ring, new `size=icon`.
- `Tooltip`, `Input`, `Card`, `Badge` all token-driven with responsive padding/sizing.

### New primitives
`Drawer`, `AppBar`, `PageHeader`, `PageContainer`, `SearchInput`, `Select`, `Tabs` (keyboard-nav), `Disclosure`, `CopyButton`, `FormField`, `KeyValueEditor`, `EmptyState`, `Skeleton`, `ResponsiveTable`, `DataTable`.

### New hooks & contexts
- `useBodyScrollLock` — ref-counted so `Modal` + `Drawer` can coexist without clobbering `document.body.style.overflow`.
- `useSSEStream` — fetch + reader + parser + reconnect-with-backoff (ready for Logs/SystemLogs adoption).
- `ToastContext` with `success/error/warning/info` + `confirm()` — replaces all 38+ bare `alert()`/`confirm()` calls across pages and hooks.

### Tokens (`globals.css`)
- Responsive typography scale via `clamp()` (`--text-h1` … `--text-display`).
- Z-index scale (`--z-dropdown` → `--z-toast`) — one source of truth, stops Modal/Tooltip/Drawer collisions.
- Motion tokens (`--duration`, `--ease-out`, etc.) and semantic shadow tokens (`--shadow-glow-primary`, `--shadow-modal`, `--shadow-nav-active`).
- Extended spacing (`xxs` → `4xl`) and terminal color tokens for `SystemLogs`.

### Page rewrites (Tier A — full)
`Login`, `MyKey`, `Config`, `Dashboard`, `Quotas`, `SystemLogs` — all now use `PageHeader` / `PageContainer`, `Toast` for feedback, responsive grids, new primitives.

### Page migrations (Tier B & C — surgical)
- `Logs`: 3 hand-rolled search-input-with-icon hacks → `SearchInput`; filter row collapses vertically on mobile.
- `Debug` / `Errors`: split-pane becomes `flex-col md:flex-row` — list stacks above detail on mobile.
- `DetailedUsage`: `PageHeader` with Live Data badge in actions slot; KPI grid `grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-8`.
- `Mcp`, `Keys`, `Models`, `Providers`: `PageHeader`, `toast` for save/delete feedback, `toast.confirm` for destructive actions.

### Chart / dashboard responsiveness
Two hard floors were forcing horizontal scroll below ~350px:
1. Every Recharts card in `UsageTab`/`PerformanceTab` had `style={{ minWidth: '350px' }}` — **removed** all 14.
2. Parent grids used `gridTemplateColumns: 'repeat(auto-fit, minmax(350px, 1fr))'` — swapped `UsageTab`/`PerformanceTab` to Tailwind `grid-cols-1 md:grid-cols-2 xl:grid-cols-3`; `OverallTab` + `MetricsOverviewCard` to the `minmax(min(100%, Npx), 1fr)` pattern so columns can shrink past the floor on narrow viewports.

## Test plan

- [ ] `bun run compile:windows` builds clean (verified locally; plexus.exe compiles with all 1965 modules).
- [ ] Login flow works end-to-end.
- [ ] Mobile viewport (375px): AppBar hamburger opens sidebar drawer; tapping a nav link closes it and navigates; backdrop/Escape/close button all dismiss.
- [ ] Desktop viewport: sidebar collapse/expand rail still works; GitHub version check + quota polling + debug-mode toggle all unchanged.
- [ ] Every route renders with no horizontal scroll at 320/375/768/1024/1440px.
- [ ] Modals fit inside 320px viewport (≥16px inset).
- [ ] Recharts dashboards (`/`, `/detailed-usage`, `/performance`) resize fluidly; no charts forced off-screen on narrow viewports.
- [ ] Toasts appear on save/delete across pages; `toast.confirm` modal works for destructive actions (delete key, delete provider, clear cooldowns, restart, etc.).
- [ ] SSE streams (`/logs`, `/system-logs`) continue to work.
- [ ] Monaco editors (`/debug`, `/config`) render in dark theme.
- [ ] Admin-only routes still redirect limited users.