### PR TITLE
Collect kwh data from neuralwatt response

### DIFF
--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -147,6 +147,30 @@ export class DebugLoggingInspector extends BaseInspector {
     return lastCost;
   }
 
+  /**
+   * Extract provider-reported energy from SSE comment lines (e.g., neuralwatt).
+   * Providers emit `: energy {"energy_kwh": ...}` as SSE comments
+   * alongside the standard `data:` events. These contain actual energy usage.
+   */
+  private extractProviderEnergyFromSSEComments(fullBody: string): any | null {
+    const lines = fullBody.split(/\r?\n/);
+    let lastEnergy: any = null;
+
+    for (const line of lines) {
+      // Match `: energy {json}` pattern (SSE comment with energy data)
+      const energyMatch = line.match(/^:\s*energy\s+(\{.+\})\s*$/);
+      if (energyMatch) {
+        try {
+          lastEnergy = JSON.parse(energyMatch[1]!);
+        } catch (e) {
+          // Skip malformed energy lines
+        }
+      }
+    }
+
+    return lastEnergy;
+  }
+
   private reconstructChatCompletions(fullBody: string): any {
     const trimmed = fullBody.trim();
     if (!trimmed) return null;
@@ -169,8 +193,9 @@ export class DebugLoggingInspector extends BaseInspector {
     const lines = fullBody.split(/\r?\n/);
     let snapshot: any = null;
 
-    // Extract provider-reported cost from SSE comment lines
+    // Extract provider-reported cost and energy from SSE comment lines
     const providerCost = this.extractProviderCostFromSSEComments(fullBody);
+    const providerEnergy = this.extractProviderEnergyFromSSEComments(fullBody);
 
     for (const line of lines) {
       if (!line.startsWith('data:')) continue;
@@ -190,6 +215,11 @@ export class DebugLoggingInspector extends BaseInspector {
       snapshot.providerReportedCost = providerCost;
     }
 
+    // Attach provider-reported energy if found in SSE comments
+    if (providerEnergy && snapshot) {
+      snapshot.providerReportedEnergy = providerEnergy;
+    }
+
     return snapshot;
   }
 
@@ -202,8 +232,12 @@ export class DebugLoggingInspector extends BaseInspector {
       try {
         const parsed = JSON.parse(trimmed);
         const providerCost = this.extractProviderCostFromSSEComments(fullBody);
+        const providerEnergy = this.extractProviderEnergyFromSSEComments(fullBody);
         if (providerCost) {
           parsed.providerReportedCost = providerCost;
+        }
+        if (providerEnergy) {
+          parsed.providerReportedEnergy = providerEnergy;
         }
         return parsed;
       } catch (e) {
@@ -214,8 +248,9 @@ export class DebugLoggingInspector extends BaseInspector {
     const lines = fullBody.split(/\r?\n/);
     let snapshot: any = null;
 
-    // Extract provider-reported cost from SSE comment lines
+    // Extract provider-reported cost and energy from SSE comment lines
     const providerCost = this.extractProviderCostFromSSEComments(fullBody);
+    const providerEnergy = this.extractProviderEnergyFromSSEComments(fullBody);
 
     for (const line of lines) {
       if (!line.startsWith('data:')) continue;
@@ -234,6 +269,10 @@ export class DebugLoggingInspector extends BaseInspector {
       snapshot.providerReportedCost = providerCost;
     }
 
+    if (providerEnergy && snapshot) {
+      snapshot.providerReportedEnergy = providerEnergy;
+    }
+
     return snapshot;
   }
 
@@ -246,8 +285,12 @@ export class DebugLoggingInspector extends BaseInspector {
       try {
         const parsed = JSON.parse(trimmed);
         const providerCost = this.extractProviderCostFromSSEComments(fullBody);
+        const providerEnergy = this.extractProviderEnergyFromSSEComments(fullBody);
         if (providerCost) {
           parsed.providerReportedCost = providerCost;
+        }
+        if (providerEnergy) {
+          parsed.providerReportedEnergy = providerEnergy;
         }
         return parsed;
       } catch (e) {
@@ -258,8 +301,9 @@ export class DebugLoggingInspector extends BaseInspector {
     const lines = fullBody.split(/\r?\n/);
     let snapshot: any = null;
 
-    // Extract provider-reported cost from SSE comment lines
+    // Extract provider-reported cost and energy from SSE comment lines
     const providerCost = this.extractProviderCostFromSSEComments(fullBody);
+    const providerEnergy = this.extractProviderEnergyFromSSEComments(fullBody);
 
     for (const line of lines) {
       if (!line.startsWith('data:')) continue;
@@ -278,6 +322,10 @@ export class DebugLoggingInspector extends BaseInspector {
       snapshot.providerReportedCost = providerCost;
     }
 
+    if (providerEnergy && snapshot) {
+      snapshot.providerReportedEnergy = providerEnergy;
+    }
+
     return snapshot;
   }
 
@@ -290,8 +338,12 @@ export class DebugLoggingInspector extends BaseInspector {
       try {
         const parsed = JSON.parse(trimmed);
         const providerCost = this.extractProviderCostFromSSEComments(fullBody);
+        const providerEnergy = this.extractProviderEnergyFromSSEComments(fullBody);
         if (providerCost) {
           parsed.providerReportedCost = providerCost;
+        }
+        if (providerEnergy) {
+          parsed.providerReportedEnergy = providerEnergy;
         }
         return parsed;
       } catch (e) {
@@ -315,10 +367,14 @@ export class DebugLoggingInspector extends BaseInspector {
       }
     }
 
-    // Attach provider-reported cost if found in SSE comments
+    // Attach provider-reported cost and energy if found in SSE comments
     const providerCost = this.extractProviderCostFromSSEComments(fullBody);
+    const providerEnergy = this.extractProviderEnergyFromSSEComments(fullBody);
     if (providerCost && snapshot) {
       snapshot.providerReportedCost = providerCost;
+    }
+    if (providerEnergy && snapshot) {
+      snapshot.providerReportedEnergy = providerEnergy;
     }
 
     return snapshot;
@@ -402,10 +458,14 @@ export class DebugLoggingInspector extends BaseInspector {
       }
     }
 
-    // Extract provider-reported cost from SSE comment lines
+    // Extract provider-reported cost and energy from SSE comment lines
     const providerCost = this.extractProviderCostFromSSEComments(fullBody);
+    const providerEnergy = this.extractProviderEnergyFromSSEComments(fullBody);
     if (providerCost) {
       snapshot.providerReportedCost = providerCost;
+    }
+    if (providerEnergy) {
+      snapshot.providerReportedEnergy = providerEnergy;
     }
 
     return snapshot;

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -150,13 +150,22 @@ export class UsageInspector extends PassThrough {
         applyProviderReportedCost(this.usageRecord, reconstructed.providerReportedCost);
       }
 
-      // Estimate energy consumption using resolved GPU and model params
-      this.usageRecord.kwhUsed = estimateKwhUsed(
-        stats.inputTokens,
-        stats.outputTokens,
-        this.modelParams,
-        this.gpuParams
-      );
+      // Use provider-reported energy if available, otherwise estimate
+      // Some providers emit `: energy {"energy_kwh": ...}` as SSE comments
+      if (reconstructed?.providerReportedEnergy?.energy_kwh != null) {
+        const energyKwh = Number(reconstructed.providerReportedEnergy.energy_kwh);
+        if (!isNaN(energyKwh) && energyKwh >= 0) {
+          this.usageRecord.kwhUsed = Number(energyKwh.toFixed(10));
+        }
+      } else {
+        // Estimate energy consumption using resolved GPU and model params
+        this.usageRecord.kwhUsed = estimateKwhUsed(
+          stats.inputTokens,
+          stats.outputTokens,
+          this.modelParams,
+          this.gpuParams
+        );
+      }
 
       // Fire-and-forget: saveRequest is async but _flush is synchronous
       // Attach error handler to prevent unhandled promise rejections

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -282,15 +282,24 @@ async function finalizeUsage(
     usageRecord.tokensPerSec = (outputTokens / usageRecord.durationMs) * 1000;
   }
 
-  // Estimate energy consumption using resolved GPU and model params from dispatcher
-  const plexusGpuParams = unifiedResponse.plexus?.gpuParams ?? DEFAULT_GPU_PARAMS;
-  const plexusModelParams = unifiedResponse.plexus?.modelParams ?? DEFAULT_MODEL;
-  usageRecord.kwhUsed = estimateKwhUsed(
-    usageRecord.tokensInput ?? 0,
-    usageRecord.tokensOutput ?? 0,
-    plexusModelParams,
-    plexusGpuParams
-  );
+  // Use provider-reported energy if available, otherwise estimate
+  // Some providers emit `: energy {"energy_kwh": ...}` as SSE comments
+  if (reconstructed?.providerReportedEnergy?.energy_kwh != null) {
+    const energyKwh = Number(reconstructed.providerReportedEnergy.energy_kwh);
+    if (!isNaN(energyKwh) && energyKwh >= 0) {
+      usageRecord.kwhUsed = Number(energyKwh.toFixed(10));
+    }
+  } else {
+    // Estimate energy consumption using resolved GPU and model params from dispatcher
+    const plexusGpuParams = unifiedResponse.plexus?.gpuParams ?? DEFAULT_GPU_PARAMS;
+    const plexusModelParams = unifiedResponse.plexus?.modelParams ?? DEFAULT_MODEL;
+    usageRecord.kwhUsed = estimateKwhUsed(
+      usageRecord.tokensInput ?? 0,
+      usageRecord.tokensOutput ?? 0,
+      plexusModelParams,
+      plexusGpuParams
+    );
+  }
 
   // Persist usage record to database
   await usageStorage.saveRequest(usageRecord as UsageRecord);

--- a/packages/backend/src/utils/__tests__/provider-cost.test.ts
+++ b/packages/backend/src/utils/__tests__/provider-cost.test.ts
@@ -208,3 +208,108 @@ describe('extractProviderCostFromSSEComments (via DebugLoggingInspector)', () =>
     expect(lastCost.request_cost_usd).toBe(0.001);
   });
 });
+
+describe('extractProviderEnergyFromSSEComments (via DebugLoggingInspector)', () => {
+  test('parses : energy SSE comment lines from raw SSE body', () => {
+    const rawBody = [
+      'data: {"id":"chatcmpl-123","choices":[{"delta":{"content":"Hello"}}]}',
+      '',
+      ': energy {"energy_joules": 190.46, "energy_kwh": 5.2904e-05, "avg_power_watts": 3109.0, "duration_seconds": 0.613}',
+      '',
+      'data: {"id":"chatcmpl-123","choices":[{"delta":{"content":" world"}}]}',
+      '',
+      'data: [DONE]',
+    ].join('\n');
+
+    // Use the same regex logic that DebugLoggingInspector uses
+    const lines = rawBody.split(/\r?\n/);
+    let lastEnergy: any = null;
+
+    for (const line of lines) {
+      const energyMatch = line.match(/^:\s*energy\s+(\{.+\})\s*$/);
+      if (energyMatch) {
+        lastEnergy = JSON.parse(energyMatch[1]!);
+      }
+    }
+
+    expect(lastEnergy).not.toBeNull();
+    expect(lastEnergy.energy_joules).toBe(190.46);
+    expect(lastEnergy.energy_kwh).toBe(5.2904e-05);
+    expect(lastEnergy.avg_power_watts).toBe(3109.0);
+    expect(lastEnergy.duration_seconds).toBe(0.613);
+  });
+
+  test('uses last energy line when multiple are present', () => {
+    const rawBody = [
+      ': energy {"energy_kwh": 0.0001}',
+      ': energy {"energy_kwh": 0.00052904}',
+    ].join('\n');
+
+    const lines = rawBody.split(/\r?\n/);
+    let lastEnergy: any = null;
+
+    for (const line of lines) {
+      const energyMatch = line.match(/^:\s*energy\s+(\{.+\})\s*$/);
+      if (energyMatch) {
+        lastEnergy = JSON.parse(energyMatch[1]!);
+      }
+    }
+
+    expect(lastEnergy.energy_kwh).toBe(0.00052904);
+  });
+
+  test('returns null when no energy lines present', () => {
+    const rawBody = [
+      'data: {"id":"chatcmpl-123","choices":[{"delta":{"content":"Hello"}}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    const lines = rawBody.split(/\r?\n/);
+    let lastEnergy: any = null;
+
+    for (const line of lines) {
+      const energyMatch = line.match(/^:\s*energy\s+(\{.+\})\s*$/);
+      if (energyMatch) {
+        lastEnergy = JSON.parse(energyMatch[1]!);
+      }
+    }
+
+    expect(lastEnergy).toBeNull();
+  });
+
+  test('skips malformed energy lines', () => {
+    const rawBody = [': energy not-json', ': energy {"energy_kwh": 0.0001}'].join('\n');
+
+    const lines = rawBody.split(/\r?\n/);
+    let lastEnergy: any = null;
+
+    for (const line of lines) {
+      const energyMatch = line.match(/^:\s*energy\s+(\{.+\})\s*$/);
+      if (energyMatch) {
+        try {
+          lastEnergy = JSON.parse(energyMatch[1]!);
+        } catch (e) {
+          // Skip
+        }
+      }
+    }
+
+    expect(lastEnergy.energy_kwh).toBe(0.0001);
+  });
+
+  test('handles scientific notation for energy_kwh', () => {
+    const rawBody = [': energy {"energy_kwh": 5.2904e-05}'].join('\n');
+
+    const lines = rawBody.split(/\r?\n/);
+    let lastEnergy: any = null;
+
+    for (const line of lines) {
+      const energyMatch = line.match(/^:\s*energy\s+(\{.+\})\s*$/);
+      if (energyMatch) {
+        lastEnergy = JSON.parse(energyMatch[1]!);
+      }
+    }
+
+    expect(lastEnergy.energy_kwh).toBe(5.2904e-05);
+  });
+});


### PR DESCRIPTION
Extract energy_kwh from SSE energy comments and store as the energy usage where available instead of the estimate we currently store.

Closes #204

🤖 Generated with [Claude Code](https://claude.ai/code)