### PR TITLE
Add Postgres test coverage with pglite

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.4.4",
         "@types/bun": "latest",
         "@types/node": "^25.6.0",
         "@types/winston": "^2.4.4",
@@ -183,6 +184,8 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.4", "", {}, "sha512-g/6CWAJ4XOkObWCWAQ2IReZD8VvsDy3poRHSKvpRR2F96F8WJ3HVbjpso3gN7l0q6QPPgvxSSpl/qo5k8a7mkQ=="],
+
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
     "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
@@ -283,9 +286,9 @@
 
     "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.67.5", "", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-TgxI2seq+gIRy6oRQA/ogyj8c9vESMQEeICPKYe29hJCLkN/i7tgKnU9jIM+rcAJmtGaO4Iy0IL7wYV4g0qjsw=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.67.68", "", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-DWWQmcb3IV3mbGXmzYBScfKA6kA52n/stY029eiBikrIxVT7DGLG6n7KSvTA2R4qBSgi1iFL3nGHtwxmtIn6Lg=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.0", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-JQUGIXjFWnw/J9LpTSf/ZXwVW3Sh8FBAcfTo5QvAHqkl4CfSiIwnjRJhMoAFcP6ncCe84YPU1ncDGX+p3OXnfg=="],
 
     "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
 
@@ -1186,10 +1189,6 @@
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
-
-    "@mariozechner/pi-ai/@google/genai": ["@google/genai@1.44.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A=="],
-
-    "@mistralai/mistralai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -34,6 +34,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.4.4",
     "@types/bun": "latest",
     "@types/node": "^25.6.0",
     "@types/winston": "^2.4.4",

--- a/packages/backend/src/db/__tests__/encrypt-migration.test.ts
+++ b/packages/backend/src/db/__tests__/encrypt-migration.test.ts
@@ -1,9 +1,16 @@
 import { beforeEach, afterEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
-import { closeDatabase, getDatabase, getSchema, initializeDatabase } from '../client';
+import {
+  closeDatabase,
+  getCurrentDialect,
+  getDatabase,
+  getSchema,
+  initializeDatabase,
+} from '../client';
 import { runMigrations } from '../migrate';
 import { runEncryptionMigration } from '../encrypt-migration';
 import { decrypt, hashSecret, isEncrypted, resetEncryptionKeyCache } from '../../utils/encryption';
+import { toDbBoolean } from '../../utils/normalize';
 
 const TEST_KEY = 'b'.repeat(64);
 
@@ -22,11 +29,15 @@ describe('encryption migration', () => {
 
   beforeEach(async () => {
     await closeDatabase();
-    process.env.DATABASE_URL = 'sqlite://:memory:';
+    process.env.DATABASE_URL = process.env.PLEXUS_TEST_DB_URL ?? process.env.DATABASE_URL;
     initializeDatabase(process.env.DATABASE_URL);
     await runMigrations();
     db = getDatabase();
     schema = getSchema();
+    await db.delete(schema.providers);
+    await db.delete(schema.apiKeys);
+    await db.delete(schema.oauthCredentials);
+    await db.delete(schema.mcpServers);
   });
 
   afterEach(async () => {
@@ -100,11 +111,11 @@ describe('encryption migration', () => {
       slug: 'test-provider',
       apiBaseUrl: '"https://api.example.com"',
       apiKey: 'provider-api-key-123',
-      enabled: 1,
-      disableCooldown: 0,
-      estimateTokens: 0,
-      useClaudeMasking: 0,
-      quotaCheckerEnabled: 1,
+      enabled: toDbBoolean(true, getCurrentDialect()),
+      disableCooldown: toDbBoolean(false, getCurrentDialect()),
+      estimateTokens: toDbBoolean(false, getCurrentDialect()),
+      useClaudeMasking: toDbBoolean(false, getCurrentDialect()),
+      quotaCheckerEnabled: toDbBoolean(true, getCurrentDialect()),
       quotaCheckerInterval: 30,
       createdAt: ts,
       updatedAt: ts,
@@ -130,11 +141,11 @@ describe('encryption migration', () => {
       headers,
       extraBody,
       quotaCheckerOptions: quotaOpts,
-      enabled: 1,
-      disableCooldown: 0,
-      estimateTokens: 0,
-      useClaudeMasking: 0,
-      quotaCheckerEnabled: 1,
+      enabled: toDbBoolean(true, getCurrentDialect()),
+      disableCooldown: toDbBoolean(false, getCurrentDialect()),
+      estimateTokens: toDbBoolean(false, getCurrentDialect()),
+      useClaudeMasking: toDbBoolean(false, getCurrentDialect()),
+      quotaCheckerEnabled: toDbBoolean(true, getCurrentDialect()),
       quotaCheckerInterval: 30,
       createdAt: ts,
       updatedAt: ts,
@@ -164,7 +175,7 @@ describe('encryption migration', () => {
     await db.insert(schema.mcpServers).values({
       name: 'test-mcp',
       upstreamUrl: 'https://mcp.example.com/mcp',
-      enabled: 1,
+      enabled: toDbBoolean(true, getCurrentDialect()),
       headers,
       createdAt: ts,
       updatedAt: ts,

--- a/packages/backend/src/db/client.ts
+++ b/packages/backend/src/db/client.ts
@@ -2,15 +2,20 @@ import { Database } from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { drizzle as drizzlePg } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
-import { getDatabaseConfig } from '../config';
 import { getCurrentLogLevel, logger } from '../utils/logger';
 import path from 'node:path';
 import fs from 'node:fs';
 
 type SupportedDialect = 'sqlite' | 'postgres';
+type PostgresDriver = 'postgres-js' | 'pglite';
 
-let dbInstance: ReturnType<typeof drizzle> | ReturnType<typeof drizzlePg> | null = null;
+type SqliteDb = ReturnType<typeof drizzle>;
+type PostgresJsDb = ReturnType<typeof drizzlePg>;
+type PgliteDb = any;
+
+let dbInstance: SqliteDb | PostgresJsDb | PgliteDb | null = null;
 let sqlClient: postgres.Sql | null = null;
+let pgliteClient: any = null;
 let currentDialect: SupportedDialect | null = null;
 let currentSchema: any = null;
 
@@ -43,6 +48,10 @@ function resolvePath(relPath: string): string {
   }
   const projectRoot = path.resolve(process.cwd(), '../../');
   return path.join(projectRoot, relPath);
+}
+
+function getPostgresDriver(): PostgresDriver {
+  return process.env.PLEXUS_POSTGRES_DRIVER === 'pglite' ? 'pglite' : 'postgres-js';
 }
 
 export function initializeDatabase(connectionString?: string) {
@@ -124,19 +133,7 @@ export function initializeDatabase(connectionString?: string) {
       logger: createDrizzleLogger(),
     });
   } else {
-    sqlClient = postgres(connStr, {
-      ssl: false,
-      max: 10,
-      idle_timeout: 20,
-      connect_timeout: 10,
-      onnotice: () => {},
-    });
-
-    // Set statement timeout to prevent long-running queries from blocking
-    sqlClient`SET statement_timeout = '30s'`.catch((err) => {
-      logger.silly(`Failed to set statement_timeout: ${err}`);
-    });
-
+    const postgresDriver = getPostgresDriver();
     const pgSchema = require('../../drizzle/schema/postgres/index');
     const {
       requestUsage,
@@ -157,26 +154,53 @@ export function initializeDatabase(connectionString?: string) {
     } = pgSchema;
 
     currentSchema = pgSchema;
-    dbInstance = drizzlePg(sqlClient, {
-      schema: {
-        requestUsage,
-        providerCooldowns,
-        debugLogs,
-        inferenceErrors,
-        providerPerformance,
-        quotaState,
-        providers: providersTable,
-        providerModels,
-        modelAliases,
-        modelAliasTargets,
-        apiKeys,
-        userQuotaDefinitions,
-        mcpServers,
-        systemSettings,
-        oauthCredentials,
-      },
-      logger: createDrizzleLogger(),
-    });
+
+    const schema = {
+      requestUsage,
+      providerCooldowns,
+      debugLogs,
+      inferenceErrors,
+      providerPerformance,
+      quotaState,
+      providers: providersTable,
+      providerModels,
+      modelAliases,
+      modelAliasTargets,
+      apiKeys,
+      userQuotaDefinitions,
+      mcpServers,
+      systemSettings,
+      oauthCredentials,
+    };
+
+    if (postgresDriver === 'pglite') {
+      const { PGlite } = require('@electric-sql/pglite');
+      const { drizzle: drizzlePglite } = require('drizzle-orm/pglite');
+      const dataDir = process.env.PLEXUS_PGLITE_DATA_DIR;
+      pgliteClient = dataDir ? new PGlite(dataDir) : new PGlite();
+      dbInstance = drizzlePglite(pgliteClient, {
+        schema,
+        logger: createDrizzleLogger(),
+      });
+    } else {
+      sqlClient = postgres(connStr, {
+        ssl: false,
+        max: 10,
+        idle_timeout: 20,
+        connect_timeout: 10,
+        onnotice: () => {},
+      });
+
+      // Set statement timeout to prevent long-running queries from blocking
+      sqlClient`SET statement_timeout = '30s'`.catch((err) => {
+        logger.silly(`Failed to set statement_timeout: ${err}`);
+      });
+
+      dbInstance = drizzlePg(sqlClient, {
+        schema,
+        logger: createDrizzleLogger(),
+      });
+    }
   }
 
   return dbInstance;
@@ -186,7 +210,7 @@ export function getDatabase() {
   if (!dbInstance) {
     initializeDatabase();
   }
-  return dbInstance as ReturnType<typeof drizzle>;
+  return dbInstance as SqliteDb | PostgresJsDb | PgliteDb;
 }
 
 export function getSchema() {
@@ -207,6 +231,10 @@ export async function closeDatabase() {
   if (sqlClient) {
     await sqlClient.end();
     sqlClient = null;
+  }
+  if (pgliteClient) {
+    await pgliteClient.close();
+    pgliteClient = null;
   }
   dbInstance = null;
 }

--- a/packages/backend/src/routes/management/__tests__/usage-summary.test.ts
+++ b/packages/backend/src/routes/management/__tests__/usage-summary.test.ts
@@ -12,7 +12,7 @@ describe('Usage summary route', () => {
 
   beforeEach(async () => {
     await closeDatabase();
-    process.env.DATABASE_URL = 'sqlite://:memory:';
+    process.env.DATABASE_URL = process.env.PLEXUS_TEST_DB_URL ?? process.env.DATABASE_URL;
     initializeDatabase(process.env.DATABASE_URL);
     await runMigrations();
 

--- a/packages/backend/src/services/__tests__/usage-storage-performance.test.ts
+++ b/packages/backend/src/services/__tests__/usage-storage-performance.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { sql, eq, and } from 'drizzle-orm';
 import { registerSpy } from '../../../test/test-utils';
 import { UsageStorageService } from '../usage-storage';
 import { closeDatabase, getDatabase, getSchema, initializeDatabase } from '../../db/client';
@@ -49,10 +50,15 @@ const createUsageRecord = (
 describe('UsageStorageService performance metrics', () => {
   beforeEach(async () => {
     await closeDatabase();
-    process.env.DATABASE_URL = 'sqlite://:memory:';
+    process.env.DATABASE_URL = process.env.PLEXUS_TEST_DB_URL ?? process.env.DATABASE_URL;
     delete process.env.PLEXUS_PROVIDER_PERFORMANCE_RETENTION_LIMIT;
     initializeDatabase(process.env.DATABASE_URL);
     await runMigrations();
+
+    const db = getDatabase() as any;
+    const schema = getSchema() as any;
+    await db.delete(schema.providerPerformance);
+    await db.delete(schema.requestUsage);
   });
 
   afterEach(async () => {
@@ -86,12 +92,16 @@ describe('UsageStorageService performance metrics', () => {
       );
     }
 
-    const rows = storage
+    const schema = getSchema() as any;
+    const rows = await storage
       .getDb()
-      .$client.query(
-        'SELECT provider, model, COUNT(*) as count FROM provider_performance GROUP BY provider, model'
-      )
-      .all() as Array<{ provider: string; model: string; count: number }>;
+      .select({
+        provider: schema.providerPerformance.provider,
+        model: schema.providerPerformance.model,
+        count: sql<number>`COUNT(*)`,
+      })
+      .from(schema.providerPerformance)
+      .groupBy(schema.providerPerformance.provider, schema.providerPerformance.model);
 
     const a = rows.find((r) => r.provider === 'provider-a' && r.model === 'model-1');
     const b = rows.find((r) => r.provider === 'provider-b' && r.model === 'model-2');
@@ -230,12 +240,22 @@ describe('UsageStorageService performance metrics', () => {
       );
     }
 
-    const rows = storage
+    const schema = getSchema() as any;
+    const rows = await storage
       .getDb()
-      .$client.query(
-        'SELECT provider, model, COUNT(*) as count FROM provider_performance WHERE provider = ? AND model = ? GROUP BY provider, model'
+      .select({
+        provider: schema.providerPerformance.provider,
+        model: schema.providerPerformance.model,
+        count: sql<number>`COUNT(*)`,
+      })
+      .from(schema.providerPerformance)
+      .where(
+        and(
+          eq(schema.providerPerformance.provider, 'provider-c'),
+          eq(schema.providerPerformance.model, 'model-3')
+        )
       )
-      .all('provider-c', 'model-3') as Array<{ provider: string; model: string; count: number }>;
+      .groupBy(schema.providerPerformance.provider, schema.providerPerformance.model);
 
     expect(rows[0]?.count).toBe(5);
   });

--- a/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
-import { closeDatabase, getDatabase, getSchema, initializeDatabase } from '../../../db/client';
+import {
+  closeDatabase,
+  getCurrentDialect,
+  getDatabase,
+  getSchema,
+  initializeDatabase,
+} from '../../../db/client';
 import { runMigrations } from '../../../db/migrate';
 import { QuotaScheduler } from '../quota-scheduler';
 import type { QuotaChecker } from '../../../types/quota';
 
-const CHECKER_ID = 'sqlite-persistence-checker';
+const CHECKER_ID = 'quota-persistence-checker';
 
 const makeChecker = (): QuotaChecker => ({
   config: {
@@ -39,12 +45,16 @@ const makeChecker = (): QuotaChecker => ({
   },
 });
 
-describe('QuotaScheduler SQLite persistence', () => {
+describe('QuotaScheduler persistence', () => {
   beforeEach(async () => {
     await closeDatabase();
-    process.env.DATABASE_URL = 'sqlite://:memory:';
+    process.env.DATABASE_URL = process.env.PLEXUS_TEST_DB_URL ?? process.env.DATABASE_URL;
     initializeDatabase(process.env.DATABASE_URL);
     await runMigrations();
+
+    const db = getDatabase() as any;
+    const schema = getSchema() as any;
+    await db.delete(schema.quotaSnapshots);
   });
 
   afterEach(async () => {
@@ -52,7 +62,7 @@ describe('QuotaScheduler SQLite persistence', () => {
     await closeDatabase();
   });
 
-  it('persists quota windows with resetsAt in SQLite without timestamp conversion errors', async () => {
+  it('persists quota windows with resetsAt without timestamp conversion errors', async () => {
     const scheduler = QuotaScheduler.getInstance() as any;
     scheduler.checkers.set(CHECKER_ID, makeChecker());
 
@@ -67,7 +77,11 @@ describe('QuotaScheduler SQLite persistence', () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]?.windowType).toBe('subscription');
-    expect(rows[0]?.resetsAt).toBeInstanceOf(Date);
+    if (getCurrentDialect() === 'sqlite') {
+      expect(rows[0]?.resetsAt).toBeInstanceOf(Date);
+    } else {
+      expect(typeof rows[0]?.resetsAt).toBe('number');
+    }
     expect(rows[0]?.success).toBe(true);
   });
 });

--- a/packages/backend/test/vitest.global-setup.ts
+++ b/packages/backend/test/vitest.global-setup.ts
@@ -4,16 +4,47 @@ import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 
+function copyDirectory(sourceDir: string, targetDir: string) {
+  fs.mkdirSync(targetDir, { recursive: true });
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectory(sourcePath, targetPath);
+    } else {
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
+
 export default async function globalSetup() {
   const moduleDir = path.dirname(fileURLToPath(import.meta.url));
   const backendRoot = path.resolve(moduleDir, '..');
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'plexus-vitest-'));
-  const defaultDbPath = path.join(tmpRoot, 'vitest-template.sqlite');
-  const testDbUrl = process.env.PLEXUS_TEST_DB_URL || `sqlite://${defaultDbPath}`;
-  process.env.PLEXUS_TEST_DB_TEMPLATE_URL = testDbUrl;
+  const testDialect = process.env.PLEXUS_TEST_DIALECT === 'postgres' ? 'postgres' : 'sqlite';
+
+  const sqliteTemplatePath = path.join(tmpRoot, 'vitest-template.sqlite');
+  const postgresTemplateDir = path.join(tmpRoot, 'vitest-template.pglite');
+  const defaultDbUrl =
+    testDialect === 'postgres'
+      ? 'postgres://postgres:postgres@localhost:5432/plexus_test'
+      : `sqlite://${sqliteTemplatePath}`;
+  const testDbUrl = process.env.PLEXUS_TEST_DB_URL || defaultDbUrl;
+
   process.env.PLEXUS_TEST_DB_URL = testDbUrl;
   process.env.PLEXUS_TEST_DB_TMP_ROOT = tmpRoot;
-  process.env.DATABASE_URL = process.env.DATABASE_URL || testDbUrl;
+  process.env.PLEXUS_TEST_DIALECT = testDialect;
+  process.env.DATABASE_URL = testDbUrl;
+
+  if (testDialect === 'sqlite') {
+    process.env.PLEXUS_TEST_DB_TEMPLATE_URL = testDbUrl;
+    delete process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR;
+    delete process.env.PLEXUS_PGLITE_DATA_DIR;
+  } else {
+    process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR = postgresTemplateDir;
+    process.env.PLEXUS_PGLITE_DATA_DIR = postgresTemplateDir;
+    delete process.env.PLEXUS_TEST_DB_TEMPLATE_URL;
+  }
 
   const originalLogLevel = process.env.LOG_LEVEL;
   process.env.LOG_LEVEL = 'error';
@@ -52,6 +83,18 @@ keys: {}
   await runMigrations();
   await closeDatabase();
 
+  if (testDialect === 'postgres') {
+    const finalTemplateDir = process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR!;
+    if (!fs.existsSync(finalTemplateDir)) {
+      fs.mkdirSync(finalTemplateDir, { recursive: true });
+    }
+    // Ensure the template directory exists even if pglite created it lazily.
+    const currentDir = process.env.PLEXUS_PGLITE_DATA_DIR;
+    if (currentDir && currentDir !== finalTemplateDir && fs.existsSync(currentDir)) {
+      copyDirectory(currentDir, finalTemplateDir);
+    }
+  }
+
   if (originalLogLevel === undefined) {
     delete process.env.LOG_LEVEL;
   } else {
@@ -65,7 +108,9 @@ keys: {}
       // ignore temp cleanup errors
     }
     delete process.env.PLEXUS_TEST_DB_TEMPLATE_URL;
+    delete process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR;
     delete process.env.PLEXUS_TEST_DB_URL;
     delete process.env.PLEXUS_TEST_DB_TMP_ROOT;
+    delete process.env.PLEXUS_PGLITE_DATA_DIR;
   };
 }

--- a/packages/backend/test/vitest.setup.ts
+++ b/packages/backend/test/vitest.setup.ts
@@ -5,7 +5,21 @@ import { vi } from 'vitest';
 const sqliteUrlToPath = (url: string) =>
   url.startsWith('sqlite://') ? url.slice('sqlite://'.length) : null;
 
+function copyDirectory(sourceDir: string, targetDir: string) {
+  fs.mkdirSync(targetDir, { recursive: true });
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectory(sourcePath, targetPath);
+    } else {
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
+
 const templateDbUrl = process.env.PLEXUS_TEST_DB_TEMPLATE_URL;
+const pgliteTemplateDir = process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR;
 const tmpRoot = process.env.PLEXUS_TEST_DB_TMP_ROOT;
 const workerId = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? '0';
 
@@ -18,6 +32,19 @@ if (templateDbUrl && tmpRoot) {
   }
 
   const workerDbUrl = `sqlite://${workerDbPath}`;
+  process.env.PLEXUS_TEST_DB_URL = workerDbUrl;
+  process.env.DATABASE_URL = workerDbUrl;
+} else if (pgliteTemplateDir && tmpRoot) {
+  const workerDataDir = path.join(tmpRoot, `vitest-worker-${workerId}.pglite`);
+
+  if (!fs.existsSync(workerDataDir)) {
+    copyDirectory(pgliteTemplateDir, workerDataDir);
+  }
+
+  const workerDbUrl =
+    process.env.PLEXUS_TEST_DB_URL || 'postgres://postgres:postgres@localhost:5432/plexus_test';
+  process.env.PLEXUS_POSTGRES_DRIVER = 'pglite';
+  process.env.PLEXUS_PGLITE_DATA_DIR = workerDataDir;
   process.env.PLEXUS_TEST_DB_URL = workerDbUrl;
   process.env.DATABASE_URL = workerDbUrl;
 } else {

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -4,6 +4,7 @@ const isStructuredLoggerLine = (log: string) => /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:
 
 export default defineConfig({
   test: {
+    projects: ['./vitest.sqlite.config.ts', './vitest.postgres.config.ts'],
     include: ['src/**/*.{test,spec}.ts', 'test/**/*.{test,spec}.ts'],
     exclude: [
       '../frontend/**',
@@ -31,6 +32,7 @@ export default defineConfig({
         (type === 'stdout' || type === 'stderr') &&
         (isStructuredLoggerLine(log) ||
           log.includes('Running sqlite migrations...') ||
+          log.includes('Running postgres migrations...') ||
           log.includes('Loaded ') ||
           log.includes('Migrations completed successfully'))
       ) {

--- a/packages/backend/vitest.postgres.config.ts
+++ b/packages/backend/vitest.postgres.config.ts
@@ -1,0 +1,15 @@
+import { defineProject } from 'vitest/config';
+import baseConfig from './vitest.config';
+
+export default defineProject({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    name: 'postgres',
+    env: {
+      ...baseConfig.test?.env,
+      PLEXUS_TEST_DIALECT: 'postgres',
+      PLEXUS_POSTGRES_DRIVER: 'pglite',
+    },
+  },
+});

--- a/packages/backend/vitest.sqlite.config.ts
+++ b/packages/backend/vitest.sqlite.config.ts
@@ -1,0 +1,14 @@
+import { defineProject } from 'vitest/config';
+import baseConfig from './vitest.config';
+
+export default defineProject({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    name: 'sqlite',
+    env: {
+      ...baseConfig.test?.env,
+      PLEXUS_TEST_DIALECT: 'sqlite',
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- run the backend test suite in separate sqlite and postgres Vitest projects
- back the postgres project with pglite while exercising the normal Postgres schema and migration paths
- remove sqlite-only test assumptions so the same tests pass under both dialects

## Testing
- bun run test
