### PR TITLE
ci(pi-agent): route through openrouter override to fix Model not found

### DIFF
--- a/.github/workflows/pi-agent.yml
+++ b/.github/workflows/pi-agent.yml
@@ -8,12 +8,14 @@ name: Pi Coding Agent
 #
 #   Variables:
 #     PLEXUS_MODEL       — Main work model; must be a name known to the
-#                          overridden provider (openai), e.g. gpt-4o-mini
+#                          overridden provider (openrouter), e.g.
+#                          anthropic/claude-sonnet-4-5 or z-ai/glm-4.6
 #     PLEXUS_SMALL_MODEL — Fast/classification model (same constraint)
 #
 # The pi-env-var-provider extension is used in Mode 2 (override): it rewires
-# the built-in "openai" provider's baseUrl to PLEXUS_BASE_URL so requests are
-# routed through the Plexus proxy while keeping openai's built-in model list.
+# the built-in "openrouter" provider's baseUrl to PLEXUS_BASE_URL so requests
+# are routed through the Plexus proxy while keeping openrouter's built-in
+# model list.
 # Mode 1 (new provider) does not work here because pi-coding-agent-action
 # resolves the model in the Agent constructor BEFORE extensions are loaded.
 #
@@ -67,10 +69,10 @@ jobs:
         env:
           PI_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
           PI_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
-          PI_OVERRIDE_PROVIDER: openai
+          PI_OVERRIDE_PROVIDER: openrouter
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          provider: openai
+          provider: openrouter
           model: ${{ vars.PLEXUS_MODEL }}
           token: ${{ secrets.PLEXUS_API_KEY }}
           thinking_level: low
@@ -108,10 +110,10 @@ jobs:
         env:
           PI_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
           PI_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
-          PI_OVERRIDE_PROVIDER: openai
+          PI_OVERRIDE_PROVIDER: openrouter
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          provider: openai
+          provider: openrouter
           model: ${{ vars.PLEXUS_MODEL }}
           token: ${{ secrets.PLEXUS_API_KEY }}
           thinking_level: high

--- a/.github/workflows/pi-agent.yml
+++ b/.github/workflows/pi-agent.yml
@@ -7,8 +7,15 @@ name: Pi Coding Agent
 #     PLEXUS_BASE_URL  — Proxy URL (e.g. https://ai.home.cowger.us/v1)
 #
 #   Variables:
-#     PLEXUS_MODEL       — Main work model (e.g. glm-5.1)
-#     PLEXUS_SMALL_MODEL — Fast/classification model (e.g. claude-haiku-4-5)
+#     PLEXUS_MODEL       — Main work model; must be a name known to the
+#                          overridden provider (openai), e.g. gpt-4o-mini
+#     PLEXUS_SMALL_MODEL — Fast/classification model (same constraint)
+#
+# The pi-env-var-provider extension is used in Mode 2 (override): it rewires
+# the built-in "openai" provider's baseUrl to PLEXUS_BASE_URL so requests are
+# routed through the Plexus proxy while keeping openai's built-in model list.
+# Mode 1 (new provider) does not work here because pi-coding-agent-action
+# resolves the model in the Agent constructor BEFORE extensions are loaded.
 #
 # Trigger with: @pi in comments, PR reviews, or issue bodies
 #
@@ -58,20 +65,15 @@ jobs:
         id: pi
         uses: shaftoe/pi-coding-agent-action@v2
         env:
-          # Secrets referenced as env vars for the custom provider extension
           PI_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
           PI_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
-          PI_PROVIDER_NAME: plexus-custom
-          PI_MODEL_ID: ${{ vars.PLEXUS_MODEL }}
-          PI_MODEL_NAME: ${{ vars.PLEXUS_MODEL }}
+          PI_OVERRIDE_PROVIDER: openai
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # The custom provider extension handles env-var-based model resolution
-          provider: plexus-custom
+          provider: openai
           model: ${{ vars.PLEXUS_MODEL }}
           token: ${{ secrets.PLEXUS_API_KEY }}
           thinking_level: low
-          # Load the custom env-var provider extension
           extensions: |
             git:github.com/mcowger/pi-env-var-provider
           load_builtin_extensions: true
@@ -106,12 +108,10 @@ jobs:
         env:
           PI_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
           PI_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
-          PI_PROVIDER_NAME: plexus-custom
-          PI_MODEL_ID: ${{ vars.PLEXUS_MODEL }}
-          PI_MODEL_NAME: ${{ vars.PLEXUS_MODEL }}
+          PI_OVERRIDE_PROVIDER: openai
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          provider: plexus-custom
+          provider: openai
           model: ${{ vars.PLEXUS_MODEL }}
           token: ${{ secrets.PLEXUS_API_KEY }}
           thinking_level: high


### PR DESCRIPTION
## Summary

- Fix `Model not found: plexus-custom/...` failure in the Pi Coding Agent workflow by switching `pi-env-var-provider` from Mode 1 (new provider) to Mode 2 (override).
- `pi-coding-agent-action` resolves `provider`/`model` in the `Agent` constructor (`src/pi/agent.ts`) before extensions are loaded in `ready()`, so a custom provider registered via `git:github.com/mcowger/pi-env-var-provider` never got a chance to register `plexus-custom` in time.
- Use the built-in `openrouter` provider (confirmed in `@mariozechner/pi-ai@0.67.68` at `models.generated.js:6894` — `api: openai-completions`, `baseUrl: https://openrouter.ai/api/v1`), override its `baseUrl` to `PLEXUS_BASE_URL`, and let the openrouter model catalog resolve the model name.

## Repo variable required

`PLEXUS_MODEL` / `PLEXUS_SMALL_MODEL` must now be openrouter-style ids that the Plexus proxy accepts (e.g. `anthropic/claude-sonnet-4-5`, `z-ai/glm-4.6`).

## Test plan

- [ ] Trigger via `@pi` comment on an issue — verify the action resolves the model and completes without `Model not found`
- [ ] Open a PR — verify the `pi-review` job runs and posts a review
- [ ] Confirm requests hit the Plexus proxy URL (`PLEXUS_BASE_URL`) and not `openrouter.ai` directly

https://claude.ai/code/session_01684L3rjEZTNuceLL99odwU