### PR TITLE
ci(pi-agent): set trigger to '@pi' so the action actually runs the prompt

### DIFF
--- a/.github/workflows/pi-agent.yml
+++ b/.github/workflows/pi-agent.yml
@@ -76,6 +76,7 @@ jobs:
           model: ${{ vars.PLEXUS_MODEL }}
           token: ${{ secrets.PLEXUS_API_KEY }}
           thinking_level: low
+          trigger: '@pi'
           extensions: |
             git:github.com/mcowger/pi-env-var-provider
           load_builtin_extensions: true


### PR DESCRIPTION
## Summary

Follow-up to #212. After the openrouter override fix, `@pi please check` on #209 triggered the workflow (19s run) but posted no reply. Root cause: `pi-coding-agent-action`'s internal `trigger` input defaults to `/pi`, while the workflow's `if:` gate matches `@pi`. The job started, the action found no `/pi` in the comment body, and exited without producing a prompt.

Pass `trigger: '@pi'` to the main `pi` job to align both.

The `pi-review` job doesn't need this — it sets `prompt:` directly, which bypasses trigger parsing.

## Test plan

- [ ] Post `@pi ...` on an issue and confirm the bot replies
- [ ] Open a PR and confirm the `pi-review` job still runs unchanged

https://claude.ai/code/session_01684L3rjEZTNuceLL99odwU