### PR TITLE
ci(pi-agent): fix silent failure via local in-place baseUrl override

### DIFF
--- a/.github/pi-extensions/plexus-override/index.js
+++ b/.github/pi-extensions/plexus-override/index.js
@@ -1,0 +1,46 @@
+// Plexus proxy baseUrl override for the Pi coding agent.
+//
+// Problem: pi-coding-agent-action's Agent constructor calls
+// modelRegistry.find() and caches the returned Model reference BEFORE any
+// extension factory runs. If we then call pi.registerProvider() in
+// override mode, the registry replaces its model objects via `.map(...)`
+// with new objects, leaving the Agent's captured reference stale. The
+// provider (openai-completions) reads baseUrl from the captured model at
+// request time and sends the request to the original openrouter.ai URL
+// with the Plexus API key, which fails silently.
+//
+// Fix: mutate the pi-ai source-of-truth model objects in place. getModels()
+// returns references to the singleton modelRegistry Map's values, which is
+// the same object the Agent cached. In-place mutation updates every
+// reference, including the Agent's.
+import { getModels } from "@mariozechner/pi-ai";
+
+const PROVIDER = "openrouter";
+
+export default function plexusOverride(pi) {
+  const baseUrl = process.env.PLEXUS_BASE_URL;
+  const apiKey = process.env.PLEXUS_API_KEY;
+
+  if (!baseUrl) {
+    console.error("[plexus-override] PLEXUS_BASE_URL not set; skipping");
+    return;
+  }
+
+  const models = getModels(PROVIDER);
+  if (!models.length) {
+    console.error(`[plexus-override] no built-in models found for ${PROVIDER}`);
+    return;
+  }
+
+  for (const m of models) {
+    m.baseUrl = baseUrl;
+  }
+
+  if (apiKey) {
+    pi.registerProvider(PROVIDER, {
+      baseUrl,
+      apiKey,
+      authHeader: true,
+    });
+  }
+}

--- a/.github/pi-extensions/plexus-override/package.json
+++ b/.github/pi-extensions/plexus-override/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "plexus-override",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "index.js",
+  "pi": {
+    "extensions": ["index.js"]
+  }
+}

--- a/.github/workflows/pi-agent.yml
+++ b/.github/workflows/pi-agent.yml
@@ -12,12 +12,14 @@ name: Pi Coding Agent
 #                          anthropic/claude-sonnet-4-5 or z-ai/glm-4.6
 #     PLEXUS_SMALL_MODEL — Fast/classification model (same constraint)
 #
-# The pi-env-var-provider extension is used in Mode 2 (override): it rewires
-# the built-in "openrouter" provider's baseUrl to PLEXUS_BASE_URL so requests
-# are routed through the Plexus proxy while keeping openrouter's built-in
-# model list.
-# Mode 1 (new provider) does not work here because pi-coding-agent-action
-# resolves the model in the Agent constructor BEFORE extensions are loaded.
+# The local plexus-override extension (.github/pi-extensions/plexus-override)
+# mutates the pi-ai built-in openrouter model objects in place so their baseUrl
+# points at PLEXUS_BASE_URL. This is required because pi-coding-agent-action's
+# Agent constructor caches the resolved Model reference BEFORE extensions load;
+# calling pi.registerProvider() in override mode replaces the registry's model
+# objects via .map() and leaves the cached reference stale. In-place mutation
+# of the source-of-truth objects updates every reference, including the
+# Agent's, so requests are routed to the Plexus proxy with the Plexus API key.
 #
 # Trigger with: @pi in comments, PR reviews, or issue bodies
 #
@@ -67,9 +69,8 @@ jobs:
         id: pi
         uses: shaftoe/pi-coding-agent-action@v2
         env:
-          PI_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
-          PI_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
-          PI_OVERRIDE_PROVIDER: openrouter
+          PLEXUS_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
+          PLEXUS_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           provider: openrouter
@@ -78,7 +79,7 @@ jobs:
           thinking_level: low
           trigger: '@pi'
           extensions: |
-            git:github.com/mcowger/pi-env-var-provider
+            .github/pi-extensions/plexus-override
           load_builtin_extensions: true
 
   # Automated PR code review (no trigger required)
@@ -109,9 +110,8 @@ jobs:
         id: pi-review
         uses: shaftoe/pi-coding-agent-action@v2
         env:
-          PI_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
-          PI_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
-          PI_OVERRIDE_PROVIDER: openrouter
+          PLEXUS_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
+          PLEXUS_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           provider: openrouter
@@ -120,5 +120,5 @@ jobs:
           thinking_level: high
           prompt: 'Review this pull request for code quality, security issues, potential bugs, and provide constructive feedback. Focus on the changes introduced in this PR.'
           extensions: |
-            git:github.com/mcowger/pi-env-var-provider
+            .github/pi-extensions/plexus-override
           load_builtin_extensions: true


### PR DESCRIPTION
## Summary

- Replaces the remote `pi-env-var-provider` extension with a local one that mutates the pi-ai built-in openrouter model objects **in place** instead of relying on `pi.registerProvider()`'s override mode.
- Fixes the silent failure where `@pi` ran successfully but never posted any comment.

## Root cause

`pi-coding-agent-action@v2.8.1`'s `Agent` constructor calls `modelRegistry.find(provider, model)` and caches the returned `Model` reference to `this.model` **before any extension runs**. When an extension later calls `pi.registerProvider("openrouter", { baseUrl })`, `applyProviderConfig` in override mode replaces each model via `this.models = this.models.map(m => ({ ...m, baseUrl: ... }))`. That produces brand-new objects, so `Agent.this.model` still points at the original object with `baseUrl = "https://openrouter.ai/api/v1"`. Requests go to openrouter.ai with the Plexus API key and are rejected — silently, since no output chunks arrive.

## Fix

The new `.github/pi-extensions/plexus-override` extension imports `getModels` from `@mariozechner/pi-ai`, which returns references into the singleton `modelRegistry` Map. Mutating `model.baseUrl` in place updates every reference — including the Agent's cached `this.model` — so the request hits the Plexus proxy with the Plexus key.

## Test plan

- [ ] Post a comment like `@pi say hi` on any PR/issue and verify the action replies.
- [ ] Confirm the Plexus proxy logs show the request (not openrouter.ai).

https://claude.ai/code/session_01684L3rjEZTNuceLL99odwU