### PR TITLE
ci: align pr-tests and release workflows with plexus-override extension

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -82,19 +82,16 @@ jobs:
         id: pi
         uses: shaftoe/pi-coding-agent-action@v2
         env:
-          PI_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
-          PI_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
-          PI_PROVIDER_NAME: plexus-custom
-          PI_MODEL_ID: ${{ vars.PLEXUS_MODEL }}
-          PI_MODEL_NAME: ${{ vars.PLEXUS_MODEL }}
+          PLEXUS_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
+          PLEXUS_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
         with:
           github_token: ${{ github.token }}
-          provider: plexus-custom
+          provider: openrouter
           model: ${{ vars.PLEXUS_MODEL }}
           token: ${{ secrets.PLEXUS_API_KEY }}
           thinking_level: high
           extensions: |
-            git:github.com/mcowger/pi-env-var-provider
+            .github/pi-extensions/plexus-override
           load_builtin_extensions: true
           prompt: |
             Review the pull request ${{ github.repository }}/pull/${{ github.event.pull_request.number }}.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,19 +258,16 @@ jobs:
         timeout-minutes: 5
         uses: shaftoe/pi-coding-agent-action@v2
         env:
-          PI_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
-          PI_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
-          PI_PROVIDER_NAME: plexus-custom
-          PI_MODEL_ID: ${{ vars.PLEXUS_MODEL }}
-          PI_MODEL_NAME: ${{ vars.PLEXUS_MODEL }}
+          PLEXUS_BASE_URL: ${{ secrets.PLEXUS_BASE_URL }}
+          PLEXUS_API_KEY: ${{ secrets.PLEXUS_API_KEY }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          provider: plexus-custom
+          provider: openrouter
           model: ${{ vars.PLEXUS_MODEL }}
           token: ${{ secrets.PLEXUS_API_KEY }}
           thinking_level: medium
           extensions: |
-            git:github.com/mcowger/pi-env-var-provider
+            .github/pi-extensions/plexus-override
           prompt: |
             You are a technical writer creating release notes for a software project called Plexus, an LLM API gateway.
 


### PR DESCRIPTION
## Summary

- `pr-tests.yml` (Pi Code Review job) and `release.yml` (release notes job) still used the broken `plexus-custom` Mode 1 approach, failing with `Model not found: plexus-custom/...`.
- Switch both to the same `provider: openrouter` + local `plexus-override` extension pattern that now works in `pi-agent.yml` (see #214).

## Test plan

- [ ] PR CI run on this PR triggers the updated Pi Code Review with `provider: openrouter` and completes without `Model not found`.
- [ ] Next release tag generates release notes successfully.

https://claude.ai/code/session_01684L3rjEZTNuceLL99odwU