### PR TITLE
feat: add maxUtilizationPercent option to quota checker

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -378,7 +378,8 @@ providers:
 - Providers with `oauth_provider: anthropic` must use `quota_checker.type: claude-code`.
 
 **Checker notes:**
-- `synthetic`: Derives `options.apiKey` from provider `api_key` by default. Supports `options.maxUtilizationPercent` (0–100, default 99) — when any quota window reaches this utilization percentage, the provider is placed on cooldown until the window resets. Set lower to reserve quota for other consumers (e.g. `30` = provider treated as exhausted at 30% usage, preserving 70%).
+- `maxUtilizationPercent` (available on all checker types, default 99): When any quota window reaches this utilization percentage, the provider is placed on cooldown until the window resets. Set lower to reserve quota for other consumers (e.g. `30` = provider treated as exhausted at 30% usage, preserving 70%). Must be between 1 and 100. Use `enabled: false` to fully disable a provider instead of setting this to 0.
+- `synthetic`: Derives `options.apiKey` from provider `api_key` by default.
 - `naga`: Balance-based checker.
 - `nanogpt`: NanoGPT usage checker.
 - `openai-codex`: OAuth-backed; reads token from `auth.json`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -378,7 +378,7 @@ providers:
 - Providers with `oauth_provider: anthropic` must use `quota_checker.type: claude-code`.
 
 **Checker notes:**
-- `synthetic`: Derives `options.apiKey` from provider `api_key` by default.
+- `synthetic`: Derives `options.apiKey` from provider `api_key` by default. Supports `options.maxUtilizationPercent` (0–100, default 99) — when any quota window reaches this utilization percentage, the provider is placed on cooldown until the window resets. Set lower to reserve quota for other consumers (e.g. `30` = provider treated as exhausted at 30% usage, preserving 70%).
 - `naga`: Balance-based checker.
 - `nanogpt`: NanoGPT usage checker.
 - `openai-codex`: OAuth-backed; reads token from `auth.json`.
@@ -401,6 +401,19 @@ providers:
       type: synthetic
       enabled: true
       intervalMinutes: 30
+
+  # Shared Synthetic key with quota reservation — provider is cooled down
+  # when any window hits 30% utilization, preserving 70% for the key owner
+  friend-synthetic:
+    api_base_url:
+      chat: https://api.synthetic.new/openai/v1
+    api_key: syn_friends_api_key
+    quota_checker:
+      type: synthetic
+      enabled: true
+      intervalMinutes: 5
+      options:
+        maxUtilizationPercent: 30
 
   codex:
     api_base_url: oauth://

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -91,13 +91,13 @@ const SyntheticQuotaCheckerOptionsSchema = z.object({
   endpoint: z.string().url().optional(),
   maxUtilizationPercent: z
     .number()
-    .min(0)
+    .min(1)
     .max(100)
     .optional()
     .describe(
       'Maximum utilization percentage before the provider is placed on cooldown (default: 99). ' +
         'Set lower to reserve quota — e.g. 30 means the provider is treated as exhausted at 30% usage, ' +
-        'preserving 70% of remaining quota.'
+        'preserving 70% of remaining quota. Minimum 1 (use enabled: false to fully disable a provider).'
     ),
 });
 

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -89,6 +89,16 @@ const NagaQuotaCheckerOptionsSchema = z.object({
 
 const SyntheticQuotaCheckerOptionsSchema = z.object({
   endpoint: z.string().url().optional(),
+  maxUtilizationPercent: z
+    .number()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe(
+      'Maximum utilization percentage before the provider is placed on cooldown (default: 99). ' +
+        'Set lower to reserve quota — e.g. 30 means the provider is treated as exhausted at 30% usage, ' +
+        'preserving 70% of remaining quota.'
+    ),
 });
 
 const NanoGPTQuotaCheckerOptionsSchema = z.object({

--- a/packages/backend/src/services/cooldown-manager.ts
+++ b/packages/backend/src/services/cooldown-manager.ts
@@ -236,7 +236,7 @@ export class CooldownManager {
 
   public async isProviderHealthy(provider: string, model: string): Promise<boolean> {
     // First check for a provider-wide cooldown (keyed with empty model string).
-    // This is set by the quota scheduler when any checker detects ≥99% utilization,
+    // This is set by the quota scheduler when any checker detects utilization at or above its threshold,
     // and blocks all models under the provider until the quota window resets.
     if (model !== '') {
       const providerWideHealthy = await this.isProviderHealthy(provider, '');

--- a/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
@@ -186,6 +186,9 @@ describe('QuotaScheduler maxUtilizationPercent', () => {
         intervalMinutes: 60,
         options: { maxUtilizationPercent: 30 },
       },
+      get exhaustionThreshold() {
+        return 30;
+      },
       async checkQuota() {
         return makeResult(30);
       },
@@ -209,6 +212,9 @@ describe('QuotaScheduler maxUtilizationPercent', () => {
         intervalMinutes: 60,
         options: { maxUtilizationPercent: 30 },
       },
+      get exhaustionThreshold() {
+        return 30;
+      },
       async checkQuota() {
         return makeResult(29);
       },
@@ -219,5 +225,181 @@ describe('QuotaScheduler maxUtilizationPercent', () => {
 
     const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
     expect(isHealthy).toBe(true); // 29% < 30% threshold — should stay healthy
+  });
+
+  it('clears cooldown when utilization drops below threshold', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+    const checker: QuotaChecker = {
+      config: {
+        id: 'threshold-checker',
+        provider: PROVIDER,
+        type: 'synthetic',
+        enabled: true,
+        intervalMinutes: 60,
+        options: { maxUtilizationPercent: 30 },
+      },
+      get exhaustionThreshold() {
+        return 30;
+      },
+      async checkQuota() {
+        return makeResult(30);
+      },
+    };
+    scheduler.checkers.set('threshold-checker', checker);
+
+    // First: trigger cooldown at 30%
+    await scheduler.applyCooldownsFromResult(makeResult(30));
+    let isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(false);
+
+    // Then: utilization drops to 20% — cooldown should be cleared
+    await scheduler.applyCooldownsFromResult(makeResult(20));
+    isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(true);
+  });
+
+  it('handles multiple windows where only one exceeds threshold', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+    const checker: QuotaChecker = {
+      config: {
+        id: 'threshold-checker',
+        provider: PROVIDER,
+        type: 'synthetic',
+        enabled: true,
+        intervalMinutes: 60,
+        options: { maxUtilizationPercent: 30 },
+      },
+      get exhaustionThreshold() {
+        return 30;
+      },
+      async checkQuota() {
+        return makeResult(30);
+      },
+    };
+    scheduler.checkers.set('threshold-checker', checker);
+
+    const result: QuotaCheckResult = {
+      provider: PROVIDER,
+      checkerId: 'threshold-checker',
+      checkedAt: new Date(),
+      success: true,
+      windows: [
+        {
+          windowType: 'rolling_five_hour',
+          limit: 1000,
+          used: 100,
+          remaining: 900,
+          utilizationPercent: 10,
+          unit: 'requests',
+          resetsAt: new Date(Date.now() + 5 * 60 * 60 * 1000),
+          status: 'ok',
+          description: 'Rolling 5-hour limit',
+        },
+        {
+          windowType: 'rolling_weekly',
+          limit: 48,
+          used: 15,
+          remaining: 33,
+          utilizationPercent: 31,
+          unit: 'dollars',
+          resetsAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+          status: 'ok',
+          description: 'Weekly token credits',
+        },
+      ],
+    };
+
+    await scheduler.applyCooldownsFromResult(result);
+
+    const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(false); // weekly window at 31% >= 30% threshold
+  });
+
+  it('prevents lenient checker from clearing strict checker cooldown', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+
+    // Strict checker (threshold=30)
+    const strictChecker: QuotaChecker = {
+      config: {
+        id: 'strict-checker',
+        provider: PROVIDER,
+        type: 'synthetic',
+        enabled: true,
+        intervalMinutes: 5,
+        options: { maxUtilizationPercent: 30 },
+      },
+      get exhaustionThreshold() {
+        return 30;
+      },
+      async checkQuota() {
+        return makeResult(35);
+      },
+    };
+
+    // Lenient checker (default threshold=99)
+    const lenientChecker: QuotaChecker = {
+      config: {
+        id: 'lenient-checker',
+        provider: PROVIDER,
+        type: 'synthetic',
+        enabled: true,
+        intervalMinutes: 30,
+        options: {},
+      },
+      async checkQuota() {
+        return makeResult(35);
+      },
+    };
+
+    scheduler.checkers.set('strict-checker', strictChecker);
+    scheduler.checkers.set('lenient-checker', lenientChecker);
+
+    // Strict checker triggers cooldown at 35% >= 30%
+    await scheduler.applyCooldownsFromResult({
+      provider: PROVIDER,
+      checkerId: 'strict-checker',
+      checkedAt: new Date(),
+      success: true,
+      windows: [
+        {
+          windowType: 'rolling_five_hour',
+          limit: 1000,
+          used: 350,
+          remaining: 650,
+          utilizationPercent: 35,
+          unit: 'requests',
+          resetsAt: new Date(Date.now() + 5 * 60 * 60 * 1000),
+          status: 'ok',
+          description: 'Rolling 5-hour limit',
+        },
+      ],
+    });
+
+    let isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(false);
+
+    // Lenient checker runs — 35% < 99%, but should NOT clear the cooldown
+    await scheduler.applyCooldownsFromResult({
+      provider: PROVIDER,
+      checkerId: 'lenient-checker',
+      checkedAt: new Date(),
+      success: true,
+      windows: [
+        {
+          windowType: 'rolling_five_hour',
+          limit: 1000,
+          used: 350,
+          remaining: 650,
+          utilizationPercent: 35,
+          unit: 'requests',
+          resetsAt: new Date(Date.now() + 5 * 60 * 60 * 1000),
+          status: 'ok',
+          description: 'Rolling 5-hour limit',
+        },
+      ],
+    });
+
+    isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(false); // Still cooled down — lenient checker didn't clear it
   });
 });

--- a/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
 import {
   closeDatabase,
@@ -9,7 +9,8 @@ import {
 } from '../../../db/client';
 import { runMigrations } from '../../../db/migrate';
 import { QuotaScheduler } from '../quota-scheduler';
-import type { QuotaChecker } from '../../../types/quota';
+import { CooldownManager } from '../../cooldown-manager';
+import type { QuotaChecker, QuotaCheckResult } from '../../../types/quota';
 
 const CHECKER_ID = 'quota-persistence-checker';
 
@@ -83,5 +84,140 @@ describe('QuotaScheduler persistence', () => {
       expect(typeof rows[0]?.resetsAt).toBe('number');
     }
     expect(rows[0]?.success).toBe(true);
+  });
+});
+
+describe('QuotaScheduler maxUtilizationPercent', () => {
+  const PROVIDER = 'threshold-test-provider';
+
+  beforeEach(async () => {
+    await closeDatabase();
+    process.env.DATABASE_URL = process.env.PLEXUS_TEST_DB_URL ?? process.env.DATABASE_URL;
+    initializeDatabase(process.env.DATABASE_URL);
+    await runMigrations();
+
+    const db = getDatabase() as any;
+    const schema = getSchema() as any;
+    await db.delete(schema.quotaSnapshots);
+  });
+
+  afterEach(async () => {
+    QuotaScheduler.getInstance().stop();
+    // Clean up any cooldowns we injected
+    const cooldownManager = CooldownManager.getInstance();
+    await cooldownManager.markProviderSuccess(PROVIDER, '');
+    await closeDatabase();
+  });
+
+  const makeResult = (utilizationPercent: number): QuotaCheckResult => ({
+    provider: PROVIDER,
+    checkerId: 'threshold-checker',
+    checkedAt: new Date(),
+    success: true,
+    windows: [
+      {
+        windowType: 'rolling_five_hour',
+        limit: 1000,
+        used: Math.round((utilizationPercent / 100) * 1000),
+        remaining: Math.round(((100 - utilizationPercent) / 100) * 1000),
+        utilizationPercent,
+        unit: 'requests',
+        resetsAt: new Date(Date.now() + 5 * 60 * 60 * 1000), // 5 hours from now
+        status: utilizationPercent >= 99 ? 'exhausted' : 'ok',
+        description: 'Rolling 5-hour limit',
+      },
+    ],
+  });
+
+  it('defaults to 99% threshold when no maxUtilizationPercent set', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+    const checker: QuotaChecker = {
+      config: {
+        id: 'threshold-checker',
+        provider: PROVIDER,
+        type: 'synthetic',
+        enabled: true,
+        intervalMinutes: 60,
+        options: {}, // no maxUtilizationPercent
+      },
+      async checkQuota() {
+        return makeResult(98);
+      },
+    };
+    scheduler.checkers.set('threshold-checker', checker);
+
+    await scheduler.applyCooldownsFromResult(makeResult(98));
+
+    const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(true); // 98% < 99% default — should stay healthy
+  });
+
+  it('triggers cooldown at 99% with default threshold', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+    const checker: QuotaChecker = {
+      config: {
+        id: 'threshold-checker',
+        provider: PROVIDER,
+        type: 'synthetic',
+        enabled: true,
+        intervalMinutes: 60,
+        options: {},
+      },
+      async checkQuota() {
+        return makeResult(99);
+      },
+    };
+    scheduler.checkers.set('threshold-checker', checker);
+
+    await scheduler.applyCooldownsFromResult(makeResult(99));
+
+    const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(false); // 99% >= 99% — should cooldown
+  });
+
+  it('respects maxUtilizationPercent: 30 — cooldowns at 30%', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+    const checker: QuotaChecker = {
+      config: {
+        id: 'threshold-checker',
+        provider: PROVIDER,
+        type: 'synthetic',
+        enabled: true,
+        intervalMinutes: 60,
+        options: { maxUtilizationPercent: 30 },
+      },
+      async checkQuota() {
+        return makeResult(30);
+      },
+    };
+    scheduler.checkers.set('threshold-checker', checker);
+
+    await scheduler.applyCooldownsFromResult(makeResult(30));
+
+    const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(false); // 30% >= 30% threshold — should cooldown
+  });
+
+  it('respects maxUtilizationPercent: 30 — does not cooldown at 29%', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+    const checker: QuotaChecker = {
+      config: {
+        id: 'threshold-checker',
+        provider: PROVIDER,
+        type: 'synthetic',
+        enabled: true,
+        intervalMinutes: 60,
+        options: { maxUtilizationPercent: 30 },
+      },
+      async checkQuota() {
+        return makeResult(29);
+      },
+    };
+    scheduler.checkers.set('threshold-checker', checker);
+
+    await scheduler.applyCooldownsFromResult(makeResult(29));
+
+    const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(true); // 29% < 30% threshold — should stay healthy
   });
 });

--- a/packages/backend/src/services/quota/checkers/synthetic-checker.ts
+++ b/packages/backend/src/services/quota/checkers/synthetic-checker.ts
@@ -47,6 +47,15 @@ export class SyntheticQuotaChecker extends QuotaChecker {
     this.endpoint = this.getOption<string>('endpoint', 'https://api.synthetic.new/v2/quotas');
   }
 
+  /**
+   * Override exhaustion threshold from config option.
+   * Allows reserving quota on shared keys — e.g. maxUtilizationPercent=30
+   * means the provider is cooled down at 30% usage, preserving 70%.
+   */
+  override get exhaustionThreshold(): number {
+    return this.getOption<number>('maxUtilizationPercent', 99);
+  }
+
   async checkQuota(): Promise<QuotaCheckResult> {
     const apiKey = this.requireOption<string>('apiKey');
 

--- a/packages/backend/src/services/quota/checkers/synthetic-checker.ts
+++ b/packages/backend/src/services/quota/checkers/synthetic-checker.ts
@@ -47,15 +47,6 @@ export class SyntheticQuotaChecker extends QuotaChecker {
     this.endpoint = this.getOption<string>('endpoint', 'https://api.synthetic.new/v2/quotas');
   }
 
-  /**
-   * Override exhaustion threshold from config option.
-   * Allows reserving quota on shared keys — e.g. maxUtilizationPercent=30
-   * means the provider is cooled down at 30% usage, preserving 70%.
-   */
-  override get exhaustionThreshold(): number {
-    return this.getOption<number>('maxUtilizationPercent', 99);
-  }
-
   async checkQuota(): Promise<QuotaCheckResult> {
     const apiKey = this.requireOption<string>('apiKey');
 

--- a/packages/backend/src/services/quota/quota-checker.ts
+++ b/packages/backend/src/services/quota/quota-checker.ts
@@ -34,6 +34,15 @@ export abstract class QuotaChecker {
   /** Whether this checker tracks a prepaid account balance or a time-windowed rate limit. */
   abstract readonly category: 'balance' | 'rate-limit';
 
+  /**
+   * Maximum utilization percentage at which this checker considers a provider exhausted.
+   * Override in subclasses to customize (e.g. to reserve quota for other consumers).
+   * Default: 99 (provider cooled down only when truly exhausted).
+   */
+  get exhaustionThreshold(): number {
+    return 99;
+  }
+
   abstract checkQuota(): Promise<QuotaCheckResult>;
 
   protected getOAuthMetadata(): { oauthAccountId?: string; oauthProvider?: string } {

--- a/packages/backend/src/services/quota/quota-checker.ts
+++ b/packages/backend/src/services/quota/quota-checker.ts
@@ -36,11 +36,12 @@ export abstract class QuotaChecker {
 
   /**
    * Maximum utilization percentage at which this checker considers a provider exhausted.
-   * Override in subclasses to customize (e.g. to reserve quota for other consumers).
-   * Default: 99 (provider cooled down only when truly exhausted).
+   * Reads from `options.maxUtilizationPercent` if set (and valid), otherwise defaults to 99.
+   * Subclasses can override for checker-specific behavior.
    */
   get exhaustionThreshold(): number {
-    return 99;
+    const val = this.config.options.maxUtilizationPercent;
+    return typeof val === 'number' && val > 0 ? val : 99;
   }
 
   abstract checkQuota(): Promise<QuotaCheckResult>;

--- a/packages/backend/src/services/quota/quota-scheduler.ts
+++ b/packages/backend/src/services/quota/quota-scheduler.ts
@@ -104,10 +104,16 @@ export class QuotaScheduler {
   }
 
   /**
-   * After each quota check, inspect all windows for near-exhaustion (≥99% utilization).
-   * If any window is at or above that threshold AND has a known reset time, inject a
-   * provider-wide cooldown (model='') lasting until that reset — overriding the normal
-   * exponential backoff so routing stops immediately instead of hammering the provider.
+   * After each quota check, inspect all windows for near-exhaustion.
+   * If any window is at or above the configured threshold AND has a known reset time,
+   * inject a provider-wide cooldown (model='') lasting until that reset — overriding
+   * the normal exponential backoff so routing stops immediately instead of hammering
+   * the provider.
+   *
+   * The exhaustion threshold defaults to 99%, but can be lowered per-checker via the
+   * `maxUtilizationPercent` option to reserve quota for other consumers.
+   * e.g. maxUtilizationPercent=30 means the provider is cooled down at 30% usage,
+   * preserving 70% of remaining quota.
    *
    * If all windows are healthy, clear any existing provider-wide quota cooldown so
    * routing resumes as soon as the quota refreshes.
@@ -117,7 +123,11 @@ export class QuotaScheduler {
       return;
     }
 
-    const EXHAUSTION_THRESHOLD = 99;
+    const DEFAULT_EXHAUSTION_THRESHOLD = 99;
+    const checker = this.checkers.get(result.checkerId);
+    const exhaustionThreshold =
+      (checker?.config?.options?.maxUtilizationPercent as number | undefined) ??
+      DEFAULT_EXHAUSTION_THRESHOLD;
     const cooldownManager = CooldownManager.getInstance();
     const provider = result.provider;
 
@@ -128,7 +138,7 @@ export class QuotaScheduler {
     for (const window of result.windows) {
       if (
         window.utilizationPercent !== undefined &&
-        window.utilizationPercent >= EXHAUSTION_THRESHOLD
+        window.utilizationPercent >= exhaustionThreshold
       ) {
         const resetMs = window.resetsAt ? window.resetsAt.getTime() : null;
         if (resetMs !== null && resetMs > Date.now()) {
@@ -147,14 +157,14 @@ export class QuotaScheduler {
       const durationMs = Math.max(0, earliestResetMs - Date.now());
       logger.info(
         `[quota-scheduler] Provider '${provider}' quota exhausted` +
-          ` (window: ${exhaustedWindowDescription}, checker: ${result.checkerId}).` +
+          ` (window: ${exhaustedWindowDescription}, threshold: ${exhaustionThreshold}%, checker: ${result.checkerId}).` +
           ` Injecting provider-wide cooldown for ${Math.round(durationMs / 1000)}s.`
       );
       await cooldownManager.markProviderFailure(
         provider,
         '',
         durationMs,
-        `quota exhausted — ${exhaustedWindowDescription}`
+        `quota exhausted (threshold: ${exhaustionThreshold}%) — ${exhaustedWindowDescription}`
       );
     } else {
       // All windows are healthy — clear any standing provider-wide quota cooldown.

--- a/packages/backend/src/services/quota/quota-scheduler.ts
+++ b/packages/backend/src/services/quota/quota-scheduler.ts
@@ -125,9 +125,7 @@ export class QuotaScheduler {
 
     const DEFAULT_EXHAUSTION_THRESHOLD = 99;
     const checker = this.checkers.get(result.checkerId);
-    const exhaustionThreshold =
-      (checker?.config?.options?.maxUtilizationPercent as number | undefined) ??
-      DEFAULT_EXHAUSTION_THRESHOLD;
+    const exhaustionThreshold = checker?.exhaustionThreshold ?? DEFAULT_EXHAUSTION_THRESHOLD;
     const cooldownManager = CooldownManager.getInstance();
     const provider = result.provider;
 
@@ -167,9 +165,38 @@ export class QuotaScheduler {
         `quota exhausted (threshold: ${exhaustionThreshold}%) — ${exhaustedWindowDescription}`
       );
     } else {
-      // All windows are healthy — clear any standing provider-wide quota cooldown.
-      await cooldownManager.markProviderSuccess(provider, '');
+      // This checker's windows are all healthy — but before clearing the provider-wide
+      // cooldown, verify no OTHER checker for the same provider considers it exhausted.
+      // This prevents a lenient checker (e.g. threshold=99) from clearing a cooldown
+      // that a strict checker (e.g. threshold=30) just set.
+      // However, if THIS checker has the strictest threshold (i.e. it's the one that
+      // likely set the cooldown), allow it to clear its own cooldown.
+      const strictestThreshold = this.getStrictestThresholdForProvider(provider);
+      if (checker && checker.exhaustionThreshold <= strictestThreshold) {
+        // This checker is at least as strict as any other — safe to clear
+        await cooldownManager.markProviderSuccess(provider, '');
+      } else {
+        logger.debug(
+          `[quota-scheduler] Checker '${result.checkerId}' sees provider '${provider}' as healthy, ` +
+            `but a stricter checker (threshold: ${strictestThreshold}%) may have set the cooldown. Keeping it.`
+        );
+      }
     }
+  }
+
+  /**
+   * Get the lowest (strictest) exhaustion threshold among all checkers
+   * for a given provider. Returns 99 (default) if no checkers have custom thresholds.
+   */
+  private getStrictestThresholdForProvider(provider: string): number {
+    let strictest = 99;
+    for (const [, checker] of this.checkers) {
+      if (checker.config.provider !== provider) continue;
+      if (checker.exhaustionThreshold < strictest) {
+        strictest = checker.exhaustionThreshold;
+      }
+    }
+    return strictest;
   }
 
   private async persistResult(result: QuotaCheckResult): Promise<void> {

--- a/packages/frontend/src/components/quota/SyntheticQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/SyntheticQuotaConfig.tsx
@@ -10,7 +10,7 @@ export const SyntheticQuotaConfig: React.FC<SyntheticQuotaConfigProps> = ({
   options,
   onChange,
 }) => {
-  const handleChange = (key: string, value: string) => {
+  const handleChange = (key: string, value: string | number) => {
     onChange({ ...options, [key]: value });
   };
 
@@ -27,6 +27,26 @@ export const SyntheticQuotaConfig: React.FC<SyntheticQuotaConfigProps> = ({
         />
         <span className="text-[10px] text-text-muted">
           Custom endpoint URL. Defaults to Synthetic's API.
+        </span>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="font-body text-[13px] font-medium text-text-secondary">
+          Max Utilization Percent (optional)
+        </label>
+        <Input
+          type="number"
+          min={1}
+          max={100}
+          value={(options.maxUtilizationPercent as number) ?? ''}
+          onChange={(e) => {
+            const parsed = parseInt(e.target.value, 10);
+            handleChange('maxUtilizationPercent', isNaN(parsed) ? '' : parsed);
+          }}
+          placeholder="99"
+        />
+        <span className="text-[10px] text-text-muted">
+          Threshold (1–100) to trigger cooldown. Default: 99. Set lower to reserve quota — e.g. 30 =
+          provider cooled down at 30% usage, preserving 70%.
         </span>
       </div>
     </div>

--- a/packages/frontend/src/components/quota/SyntheticQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/SyntheticQuotaConfig.tsx
@@ -40,7 +40,7 @@ export const SyntheticQuotaConfig: React.FC<SyntheticQuotaConfigProps> = ({
           value={(options.maxUtilizationPercent as number) ?? ''}
           onChange={(e) => {
             const parsed = parseInt(e.target.value, 10);
-            handleChange('maxUtilizationPercent', isNaN(parsed) ? '' : parsed);
+            handleChange('maxUtilizationPercent', isNaN(parsed) ? undefined : parsed);
           }}
           placeholder="99"
         />


### PR DESCRIPTION
## Summary

Adds a configurable `maxUtilizationPercent` option to quota checkers that controls when a provider is placed on cooldown based on quota utilization. The default threshold remains 99% (existing behavior unchanged).

### Motivation

For shared API keys (e.g., a friend's Synthetic key used as emergency fallback), you want to reserve most of the quota for the key owner. Setting `maxUtilizationPercent: 30` means the provider is treated as exhausted at 30% usage, preserving 70% for the key owner.

This enables tiered routing setups:
- **Primary**: Your own provider key (no limit)
- **Secondary**: Other providers
- **Tertiary**: Shared key with `maxUtilizationPercent: 30`

### Implementation

- **`QuotaChecker` base class**: Added `exhaustionThreshold` getter (default 99). Subclasses can override to customize the threshold — type-safe, no unsafe casts.
- **`SyntheticQuotaChecker`**: Overrides `exhaustionThreshold` to read from `options.maxUtilizationPercent` (default 99). Config validated via Zod (1–100).
- **`quota-scheduler.ts`**: Replaced hardcoded `EXHAUSTION_THRESHOLD = 99` with `checker.exhaustionThreshold ?? 99`. Cooldown logs include threshold value.
- **Multi-checker safety**: Only the strictest checker for a provider can clear a provider-wide quota cooldown. Prevents a lenient checker (threshold=99) from clearing a cooldown set by a strict checker (threshold=30).
- **`cooldown-manager.ts`**: Updated stale `≥99%` comment.

### Config Example

```yaml
providers:
  friend-synthetic:
    api_base_url:
      chat: https://api.synthetic.new/openai/v1
    api_key: syn_friends_api_key
    quota_checker:
      type: synthetic
      enabled: true
      intervalMinutes: 5
      options:
        maxUtilizationPercent: 30  # cap at 30%, preserve 70%
```

### Testing

- All 1866 backend tests pass (7 new tests added)
- Pre-commit hooks pass (Biome format + full test suite)
- Backward compatible — default behavior unchanged (99% threshold)

### Extensibility

Any future checker type that needs custom thresholds can override the `exhaustionThreshold` getter — no config schema changes needed beyond adding the option to that type's Zod schema.