### PR TITLE
fix(quota): update WisdomGate checker for flat API response format

### DIFF
--- a/packages/backend/src/services/quota/checkers/__tests__/wisdomgate-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/wisdomgate-checker.test.ts
@@ -27,7 +27,7 @@ describe('WisdomGateQuotaChecker', () => {
     expect(QuotaCheckerFactory.isRegistered('wisdomgate')).toBe(true);
   });
 
-  it('queries balance with session cookie and returns monthly subscription quota with dollars', async () => {
+  it('queries balance with session cookie and returns subscription quota with dollars', async () => {
     let capturedUrl: string | undefined;
     let capturedCookie: string | undefined;
 
@@ -38,22 +38,10 @@ describe('WisdomGateQuotaChecker', () => {
 
       return new Response(
         JSON.stringify({
-          object: 'billing_details',
-          total_usage: 76.147972,
-          total_available: 23.852028,
-          regular_amount: 100,
-          package_details: [
-            {
-              package_id: 'pkg_123',
-              title: 'Test Package',
-              amount: 23.852028,
-              total_amount: 100,
-              expiry_time: 1735689600,
-              expiry_date: '2025-01-01',
-              begin_time: 1704067200,
-              begin_date: '2024-01-01',
-            },
-          ],
+          object: 'usage_details',
+          total_usage: 148.49091,
+          total_available: 0.067706,
+          regular_amount: 0.067706,
         }),
         {
           status: 200,
@@ -73,13 +61,13 @@ describe('WisdomGateQuotaChecker', () => {
     expect(result.windows).toHaveLength(1);
 
     const window = result.windows?.[0];
-    expect(window?.windowType).toBe('monthly');
+    expect(window?.windowType).toBe('subscription');
     expect(window?.unit).toBe('dollars');
-    expect(window?.limit).toBe(100);
-    expect(window?.used).toBeCloseTo(76.147972, 6);
-    expect(window?.remaining).toBeCloseTo(23.852028, 6);
-    expect(window?.description).toBe('Wisdom Gate monthly subscription');
-    expect(window?.resetsAt).toBeInstanceOf(Date);
+    expect(window?.used).toBeCloseTo(148.49091, 6);
+    expect(window?.remaining).toBeCloseTo(0.067706, 6);
+    expect(window?.limit).toBeCloseTo(148.558616, 6);
+    expect(window?.description).toBe('Wisdom Gate subscription');
+    expect(window?.resetsAt).toBeUndefined();
   });
 
   it('returns error for non-200 response', async () => {
@@ -101,22 +89,10 @@ describe('WisdomGateQuotaChecker', () => {
       capturedUrl = String(input);
       return new Response(
         JSON.stringify({
-          object: 'billing_details',
-          total_usage: 0,
+          object: 'usage_details',
+          total_usage: 10,
           total_available: 10,
           regular_amount: 10,
-          package_details: [
-            {
-              package_id: 'pkg_123',
-              title: 'Test Package',
-              amount: 10,
-              total_amount: 10,
-              expiry_time: 1735689600,
-              expiry_date: '2025-01-01',
-              begin_time: 1704067200,
-              begin_date: '2024-01-01',
-            },
-          ],
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } }
       );

--- a/packages/backend/src/services/quota/checkers/__tests__/wisdomgate-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/wisdomgate-checker.test.ts
@@ -41,7 +41,6 @@ describe('WisdomGateQuotaChecker', () => {
           object: 'usage_details',
           total_usage: 148.49091,
           total_available: 0.067706,
-          regular_amount: 0.067706,
         }),
         {
           status: 200,
@@ -92,7 +91,6 @@ describe('WisdomGateQuotaChecker', () => {
           object: 'usage_details',
           total_usage: 10,
           total_available: 10,
-          regular_amount: 10,
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } }
       );
@@ -114,6 +112,11 @@ describe('WisdomGateQuotaChecker', () => {
     expect(capturedUrl).toBe(
       'https://custom.endpoint.example.com/api/dashboard/billing/usage/details'
     );
+  });
+
+  it('has category balance', () => {
+    const checker = new WisdomGateQuotaChecker(makeConfig());
+    expect(checker.category).toBe('balance');
   });
 
   it('throws error when session option is missing', async () => {

--- a/packages/backend/src/services/quota/checkers/wisdomgate-checker.ts
+++ b/packages/backend/src/services/quota/checkers/wisdomgate-checker.ts
@@ -1,4 +1,4 @@
-import type { QuotaCheckResult, QuotaWindow, QuotaCheckerConfig } from '../../../types/quota';
+import type { QuotaCheckResult, QuotaWindow } from '../../../types/quota';
 import { QuotaChecker } from '../quota-checker';
 import { logger } from '../../../utils/logger';
 
@@ -7,16 +7,6 @@ interface WisdomGateUsageResponse {
   total_usage: number;
   total_available: number;
   regular_amount: number;
-  package_details: Array<{
-    package_id: string;
-    title: string;
-    amount: number;
-    total_amount: number;
-    expiry_time: number;
-    expiry_date: string;
-    begin_time: number;
-    begin_date: string;
-  }>;
 }
 
 export class WisdomGateQuotaChecker extends QuotaChecker {
@@ -49,24 +39,18 @@ export class WisdomGateQuotaChecker extends QuotaChecker {
 
       logger.silly(`[wisdomgate] Response: ${JSON.stringify(data)}`);
 
-      const packageDetail = data.package_details?.[0];
-      if (!packageDetail) {
-        return this.errorResult(new Error('No package details found in response'));
-      }
-
-      const limit = packageDetail.total_amount;
-      const remaining = packageDetail.amount;
-      const used = packageDetail.total_amount - packageDetail.amount;
-      const resetsAt = new Date(packageDetail.expiry_time * 1000);
+      const used = data.total_usage;
+      const remaining = data.total_available;
+      const limit = used + remaining;
 
       const window: QuotaWindow = this.createWindow(
-        'monthly',
+        'subscription',
         limit,
         used,
         remaining,
         'dollars',
-        resetsAt,
-        'Wisdom Gate monthly subscription'
+        undefined,
+        'Wisdom Gate subscription'
       );
 
       return this.successResult([window]);

--- a/packages/backend/src/services/quota/checkers/wisdomgate-checker.ts
+++ b/packages/backend/src/services/quota/checkers/wisdomgate-checker.ts
@@ -6,11 +6,10 @@ interface WisdomGateUsageResponse {
   object: string;
   total_usage: number;
   total_available: number;
-  regular_amount: number;
 }
 
 export class WisdomGateQuotaChecker extends QuotaChecker {
-  readonly category = 'rate-limit' as const;
+  readonly category = 'balance' as const;
 
   async checkQuota(): Promise<QuotaCheckResult> {
     const session = this.requireOption<string>('session');

--- a/packages/frontend/src/components/quota/CombinedBalancesCard.tsx
+++ b/packages/frontend/src/components/quota/CombinedBalancesCard.tsx
@@ -24,6 +24,7 @@ const CHECKER_DISPLAY_NAMES: Record<string, string> = {
   poe: 'POE',
   apertis: 'Apertis',
   neuralwatt: 'Neuralwatt',
+  wisdomgate: 'Wisdom Gate',
 };
 
 export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({

--- a/packages/frontend/src/components/quota/CompactQuotasCard.tsx
+++ b/packages/frontend/src/components/quota/CompactQuotasCard.tsx
@@ -187,7 +187,7 @@ export const getTrackedWindowsForChecker = (category: string, windows: any[]): s
         .filter((t) => t !== 'subscription')
         .sort((a, b) => (WINDOW_PRIORITY[a] || 99) - (WINDOW_PRIORITY[b] || 99));
     case 'wisdomgate':
-      return ['monthly'].filter((t) => availableTypes.has(t));
+      return ['subscription'].filter((t) => availableTypes.has(t));
     case 'minimax-coding':
       return ['custom'].filter((t) => availableTypes.has(t));
     case 'apertis-coding-plan':

--- a/packages/frontend/src/components/quota/WisdomGateQuotaDisplay.tsx
+++ b/packages/frontend/src/components/quota/WisdomGateQuotaDisplay.tsx
@@ -26,7 +26,7 @@ export const WisdomGateQuotaDisplay: React.FC<WisdomGateQuotaDisplayProps> = ({
   }
 
   const windows = result.windows || [];
-  const window = windows.find((w) => w.windowType === 'monthly');
+  const window = windows.find((w) => w.windowType === 'subscription');
   const remaining = window?.remaining ?? 0;
   const limit = window?.limit ?? 0;
   const used = window?.used ?? 0;
@@ -51,7 +51,7 @@ export const WisdomGateQuotaDisplay: React.FC<WisdomGateQuotaDisplayProps> = ({
         <span className="text-xs font-semibold text-text whitespace-nowrap">Wisdom Gate</span>
       </div>
       <div className="flex items-baseline gap-2">
-        <span className="text-xs font-semibold text-text-secondary">Monthly Credits</span>
+        <span className="text-xs font-semibold text-text-secondary">Subscription</span>
       </div>
       <div className="flex items-baseline gap-2">
         <span className="text-xs text-text-secondary">


### PR DESCRIPTION
The wisgate.ai API no longer populates `package_details` — it returns an empty array. All billing data now lives at the top level (`total_usage`, `total_available`).

**What changed:**
- Read `used`/`remaining` from top-level `total_usage`/`total_available` fields
- Compute `limit` as `used + remaining` (no reset timestamp in new format)
- Change window type from `monthly` to `subscription`
- Remove unused `package_details` interface type

**Verified:** The `session` cookie name has **not** changed — confirmed via live curl against the endpoint (only `session` is needed; SSID/SID/SIDCC are Google SSO cookies unrelated to API auth).