### PR TITLE
docs: quota &amp; balance tracking redesign plan

### DIFF
--- a/docs/QUOTA_BALANCE_REDESIGN.md
+++ b/docs/QUOTA_BALANCE_REDESIGN.md
@@ -174,8 +174,19 @@ interface Meter {
   key: string;
   /** Human-readable, e.g. "5-hour quota", "Account balance", "Search". */
   label: string;
-  /** Optional refinement, e.g. "Pro models", "Flash models". */
-  subject?: string;
+
+  /** Optional UI grouping. Meters that share a `group` are rendered
+   *  together under one heading (e.g. all "Pro models" rows from
+   *  Antigravity, or both "5-hour" and "weekly" rows of a single
+   *  Claude plan). Pure cosmetic — nothing keys off it. */
+  group?: string;
+
+  /** Optional resource scope — the specific thing this meter is
+   *  measuring within its checker (e.g. "gemini-2.5-pro", "cash",
+   *  "voucher", "search", "input_tokens"). Used to disambiguate
+   *  meters that share a label and to label a row in the UI when the
+   *  group rolls multiple scopes together. */
+  scope?: string;
 
   // ── Classification ────────────────────────────────────────────────────
   kind: 'balance' | 'allowance';
@@ -215,8 +226,8 @@ Notes:
 
 - `key` is a checker-local identifier. The frontend never branches on
   its value; it identifies the meter for history graphing.
-- `label`/`subject` is what the UI shows; the checker translates
-  provider-speak.
+- `label` is what the UI shows; the checker translates
+  provider-speak. `group` and `scope` add structure when needed.
 - `kind` is what divides the UI: balances on one card, allowances on
   another. Hybrid checkers emit meters of both kinds.
 - Period fields are flat. A balance meter omits all of them.
@@ -247,7 +258,8 @@ Notes:
 
 - `meters` is the only payload. There are no `windows`, no `groups`,
   no checker-level `category`. If a provider exposes per-model rows,
-  each row is a meter with the model name in `subject`.
+  each row is a separate meter (with the model name in `scope` and an
+  optional `group` to roll related models together).
 - There is **no `rawResponse` field.** It exists today as a debugging
   aid and gets used as a feature crutch (frontend code reaching into
   raw provider JSON because the modelled fields are insufficient).
@@ -310,7 +322,7 @@ meters: [
     limit: 200, used: 37, remaining: 163,
     periodValue: 5, periodUnit: 'hour', periodCycle: 'rolling',
     utilizationPercent: 18.5, status: 'ok' },
-  { key: 'search_hourly', label: 'Search requests', subject: 'hourly',
+  { key: 'search_hourly', label: 'Search', scope: 'search',
     kind: 'allowance', unit: 'requests',
     periodValue: 1, periodUnit: 'hour', periodCycle: 'fixed',
     resetsAt: '2026-04-25T18:00:00Z', ... },
@@ -375,6 +387,37 @@ meters: [{
 }]
 ```
 
+**Antigravity** (per-model rows, grouped by family):
+```js
+meters: [
+  { key: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro',
+    group: 'Pro', scope: 'gemini-2.5-pro',
+    kind: 'allowance', unit: 'percentage',
+    used: 12, remaining: 88,
+    periodValue: 5, periodUnit: 'hour', periodCycle: 'rolling',
+    utilizationPercent: 12, status: 'ok' },
+  { key: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash',
+    group: 'Flash', scope: 'gemini-2.5-flash',
+    kind: 'allowance', unit: 'percentage',
+    used: 3, remaining: 97,
+    periodValue: 5, periodUnit: 'hour', periodCycle: 'rolling',
+    utilizationPercent: 3, status: 'ok' },
+  // ... one meter per model, sorted by group in the UI
+]
+```
+
+**Moonshot** (cash and voucher balances surfaced separately):
+```js
+meters: [
+  { key: 'cash', label: 'Cash balance', scope: 'cash',
+    kind: 'balance', unit: 'usd',
+    remaining: 4.20, utilizationPercent: 'not_applicable', status: 'ok' },
+  { key: 'voucher', label: 'Voucher balance', scope: 'voucher',
+    kind: 'balance', unit: 'usd',
+    remaining: 25.00, utilizationPercent: 'not_applicable', status: 'ok' },
+]
+```
+
 ## 4. Database Schema
 
 A new table — `meter_snapshots` — is created from scratch. The existing
@@ -396,7 +439,8 @@ One row per (checker invocation, meter). Columns:
 | `kind`                  | text           | `'balance'` or `'allowance'`                             |
 | `unit`                  | text           | open string; canonical names recommended (§ 3.3)         |
 | `label`                 | text           | human-readable, set by the checker                       |
-| `subject`               | text NULL      | optional sub-scope (e.g. model name)                     |
+| `group`                 | text NULL      | optional UI grouping (e.g. "Pro models")                 |
+| `scope`                 | text NULL      | optional resource scope (e.g. model name, "cash")        |
 | `limit`                 | real NULL      |                                                          |
 | `used`                  | real NULL      |                                                          |
 | `remaining`             | real NULL      |                                                          |
@@ -476,10 +520,10 @@ Each checker's `check(ctx)` returns a `Meter[]`. Helpers on the context
 build meters with derived fields filled in:
 
 ```ts
-ctx.balance({ key, label, unit, remaining, limit?, subject? })
+ctx.balance({ key, label, unit, remaining, limit?, group?, scope? })
 ctx.allowance({ key, label, unit, used, limit?, remaining?,
                 periodValue, periodUnit, periodCycle, resetsAt?,
-                subject? })
+                group?, scope? })
 ```
 
 `utilizationPercent` and `status` are derived inside the helper — the
@@ -505,13 +549,21 @@ sentinels (`'unknown'`, `'not_applicable'`) skip cooldown evaluation
 for that meter.
 
 **Balance meters.** `exhaustionThreshold` is a **floor on `remaining`**
-in the meter's `unit` (e.g. `0.50` for USD, `100` for points). When
-`remaining <= threshold`, the provider is cooled down. The cooldown
-lasts until the next checker poll — a balance can be topped up
-out-of-band at any moment, so the only way to learn the new value is
-to keep checking. Default floor is `0` (cool down only when the
-balance is fully drained); operators can raise it per-checker to
-"reserve" a tail.
+in the meter's `unit`. When `remaining <= threshold`, the provider is
+cooled down. The cooldown lasts until the **next normally-scheduled
+checker poll** — a balance can be topped up out-of-band at any moment,
+so we just keep checking at the configured cadence; we do not
+accelerate polling when exhausted, and we do not extend the cooldown
+beyond it.
+
+Defaults:
+
+- For `unit === 'usd'`, the default floor is **`0.50`** (i.e. cool
+  down once the balance falls to fifty cents or below). USD balances
+  are the common case and "near zero" is meaningful here.
+- For all other units, the default floor is `0`. There is no
+  one-size-fits-all "near zero" for points, tokens, or kWh — the
+  operator sets the floor per-checker if they want a buffer.
 
 Every meter contributes to the cooldown decision; the most-constrained
 one wins. The "strictest threshold" calculation iterates all meters
@@ -551,14 +603,16 @@ components:
 
 - `BalanceMeterRow` — wallet icon, label, formatted `remaining` value,
   optional progress bar when `limit` is known.
-- `AllowanceMeterRow` — progress bar with `utilizationPercent`, a label,
-  `used / limit` formatted by unit, and a countdown to `period.resetsAt`
-  if present.
+- `AllowanceMeterRow` — progress bar with `utilizationPercent`, a
+  label, `used / limit` formatted by unit, and a countdown to
+  `resetsAt` if present.
 
-`MeterValue.tsx` formats a number based on `unit`:
+`MeterValue.tsx` formats a number based on `unit`. For canonical units
+it uses a known formatter; for **anything else, the unit string is
+shown verbatim** as the suffix:
 
 ```ts
-function formatMeterValue(v: number, unit: MeterUnit) {
+function formatMeterValue(v: number, unit: string): string {
   switch (unit) {
     case 'usd':        return formatCost(v);
     case 'tokens':     return formatTokens(v);
@@ -566,9 +620,21 @@ function formatMeterValue(v: number, unit: MeterUnit) {
     case 'kwh':        return `${v.toFixed(3)} kWh`;
     case 'points':     return `${formatPointsFull(v)} pts`;
     case 'percentage': return `${Math.round(v)}%`;
+    default:           return `${formatNumber(v)} ${unit}`;
   }
 }
 ```
+
+A meter with `unit: 'flows'` therefore renders as `82 flows`, matching
+what the provider's docs call them. The provider-config UI shows the
+unit string the same way — verbatim, not coerced to a friendly label.
+
+Display also respects the `utilizationPercent` sentinels: `'unknown'`
+and `'not_applicable'` suppress the progress bar and colour scale,
+showing only the raw `remaining` value.
+
+Meters that share a `group` are rendered under a sub-heading inside
+the same checker card; otherwise each meter gets its own row.
 
 ### 6.2 Sidebar / dashboard sections
 
@@ -660,7 +726,7 @@ Tying it back to the issues from § 1:
 | Problem                                       | Resolution                                              |
 |-----------------------------------------------|---------------------------------------------------------|
 | `category` on the wrong object                | Moved to `kind` on each meter.                          |
-| `windowType` conflates four axes              | Split into `kind`, `period.duration`, `period.cycle`, `subject`. |
+| `windowType` conflates four axes              | Split into `kind`, flat `period*` fields, and `group`/`scope`. |
 | `unit: 'points'` overloaded for kWh           | New `kwh` unit. `points` reserved for opaque provider currencies. |
 | Hybrid checkers need manual override sets     | Mixed checkers naturally emit meters of both kinds.     |
 | 21 near-duplicate display components          | Two generic row components + a presentation registry.   |
@@ -669,46 +735,18 @@ Tying it back to the issues from § 1:
 | `getTrackedWindowsForChecker` 23-arm switch   | Deleted — every meter is rendered the same way.         |
 | OAuth fields duplicated on every snapshot     | Removed from the wire shape; resolved from checker config only when needed. |
 
-## 9. Open questions
+## 9. Resolved decisions
 
-These need answers before implementation; they affect the data model:
+For posterity, the points that were called out during review and
+folded into the design above:
 
-1. **Balance-cooldown threshold semantics.** I've defined
-   `exhaustionThreshold` as a percentage for allowance meters and a
-   floor on `remaining` (in `unit`) for balance meters. Two follow-on
-   questions:
-   - Default for balance meters is `0` (cool down only when fully
-     drained). Is that right, or should the default be a small
-     non-zero value (e.g. 1% of `limit` when known) to leave a buffer?
-   - Should we allow operators to express the floor as a percentage
-     of `limit` for balances that have a known total (Wisdom Gate,
-     Neuralwatt PAYG cap)?
-2. **Cooldown duration when balance is exhausted.** A balance with no
-   `resetsAt` cools down "until the next checker poll." That means
-   exactly the polling cadence of the checker — typically 30 minutes.
-   Is that the right cadence, or should an exhausted balance accelerate
-   polling (e.g. every minute) so that an out-of-band top-up resumes
-   routing quickly?
-3. **Open `unit` strings in the management UI.** The provider config
-   modal shows the unit somewhere; if a checker emits `'flows'` rather
-   than the canonical `'requests'`, do we surface "flows" verbatim in
-   the UI or coerce to a friendly label? Suggest verbatim — it matches
-   what the provider's docs say. Confirm.
-4. **Per-model meters in the schema.** Antigravity and Gemini-CLI emit
-   one row per model (using `subject` for the model name). Some have
-   dozens of models; the history table grows by `models * checks`.
-   Should we cap or aggregate (e.g. keep only the worst-utilized model
-   per check), or store every row and let retention sweep handle it?
-5. **`subject` semantics.** Used for "cash vs. voucher" balances,
-   "Pro vs. Flash" model-grouped quotas, "search" within a multi-meter
-   provider, and per-model rows. Are those all the same field, or
-   should we split (e.g. `groupKey` for model-rollup, `qualifier` for
-   "input tokens" vs "output tokens")? Right now the design uses one
-   field. Confirm that's enough.
-6. **Rolling-window `resetsAt`.** Rolling windows recover
-   continuously; the API sometimes returns a "next-tick" timestamp.
-   The design keeps `resetsAt` as "earliest moment capacity will
-   visibly improve" for rolling cycles. Acceptable? Or should rolling
-   meters omit `resetsAt` entirely and the UI render "rolling" with no
-   countdown?
+| Decision                               | Choice                                                      | Where it lives          |
+|----------------------------------------|-------------------------------------------------------------|-------------------------|
+| Default balance-cooldown floor (USD)   | `$0.50`                                                     | § 5.3                   |
+| Default balance-cooldown floor (other) | `0`                                                         | § 5.3                   |
+| Polling cadence when exhausted         | Keep the configured cadence; don't accelerate or extend     | § 5.3                   |
+| Per-model meter retention              | Store every row; let retention sweeps handle it             | § 4.1                   |
+| `subject` overloading                  | Split into `group` (UI rollup) and `scope` (resource id)    | § 3.5, § 3.7, § 4.1     |
+| Rolling-window `resetsAt`              | Keep populated; means "earliest visible improvement"        | § 3.4                   |
+| Open `unit` strings in the UI          | Render verbatim, don't coerce to friendly labels            | § 3.3, § 6.1            |
 

--- a/docs/QUOTA_BALANCE_REDESIGN.md
+++ b/docs/QUOTA_BALANCE_REDESIGN.md
@@ -3,214 +3,55 @@
 > Status: **Proposal** — no code changes have been made. This document is the
 > design that the implementation should be measured against.
 
-## 1. Problem Statement
+## 1. Problem
 
-Plexus currently tracks two related-but-distinct things under one umbrella:
+Plexus tracks two distinct things under one model: **prepaid balances**
+that drain with use and refill out-of-band, and **periodic allowances**
+that reset on a schedule. The current `QuotaWindow[]` + checker-level
+`category: 'balance' | 'rate-limit'` collapses them poorly:
 
-1. **Account balances** — prepaid amounts that get drawn down as the user
-   makes requests, do not refill on a schedule, and are topped up out-of-band
-   (e.g. OpenRouter credits, Naga balance, Moonshot cash, Apertis PAYG).
-2. **Subscription quotas / rate limits** — recurring entitlements bound to a
-   billing cycle or rolling window (e.g. Claude Code 5-hour + weekly limits,
-   Codex primary/secondary, Copilot monthly premium interactions).
+- **Hybrid providers don't fit.** Neuralwatt has both a dollar balance
+  *and* a monthly kWh quota; Apertis has a PAYG balance *and* a coding
+  plan cycle quota. Workaround: a `BALANCE_CHECKERS_WITH_RATE_LIMIT`
+  set duplicated across `Sidebar.tsx` and `Quotas.tsx`, and Apertis
+  registered twice as two separate checkers hitting the same endpoint.
+- **`windowType` flattens four orthogonal axes.** It conflates "this
+  is a balance, not a quota" (`subscription`), period length (`hourly`,
+  `five_hour`, `daily`, ...), cycle kind (`weekly` vs `rolling_weekly`),
+  and what's measured (`toolcalls`, `search`). 11 strings that should
+  be 3-4 independent fields.
+- **`unit` is overloaded.** `'points'` is used for Poe points (currency),
+  Zenmux flows (a per-cycle count), and Neuralwatt kWh (an energy
+  quantity). `'kwh'` exists in the enum but nothing emits it.
+  `'percentage'` is encoded as `limit=100, used=N, remaining=100-N`.
+- **Same checker, different units across snapshots.** Copilot emits
+  `requests` or `percentage` depending on whether the API returned
+  entitlement counts; history graphs get broken.
+- **Frontend lives off magic strings.** 21 near-duplicate
+  `XxxQuotaDisplay.tsx` components and a 23-arm switch in
+  `CompactQuotasCard.getTrackedWindowsForChecker` mapping checker name
+  → which `windowType` strings to render.
+- **Four parallel checker-type registrations.**
+  `VALID_QUOTA_CHECKER_TYPES` (config.ts), `quotaCheckerTypeEnum`
+  (postgres), `FALLBACK_QUOTA_CHECKER_TYPES` (api.ts),
+  `QUOTA_CHECKER_TYPES_FALLBACK` (Providers.tsx) — and three copies of
+  `CHECKER_DISPLAY_NAMES`.
 
-The current model collapses these into a single `QuotaWindow[]` shape with a
-fixed `category: 'balance' | 'rate-limit'` per checker. That works for the
-simple cases but breaks down quickly:
+The 23 existing checkers fall into four shapes:
 
-- Some providers expose **both at once** (Neuralwatt: dollar credit balance
-  *and* a monthly kWh subscription quota; Apertis: a PAYG balance *and* a
-  coding-plan cycle quota — solved today by registering two separate
-  checkers).
-- Some "balances" are actually **bounded** with a known total (Wisdom Gate
-  reports `total_usage` and `total_available` — i.e. it's really a cycle
-  quota that the code labels as `subscription`/`balance`).
-- Some "subscriptions" are denominated in **dollars** (Synthetic weekly
-  credits in `$`), some in **points** (Zenmux flows, Poe points), some in
-  **percentage only** (Claude Code, Codex, Antigravity, Gemini-CLI), some in
-  **tokens** (NanoGPT), and some in **requests** (Copilot, Apertis-coding,
-  MiniMax-coding, Kimi-code).
-- Some providers have **multiple independent meters** with different units
-  (NanoGPT: weekly tokens + daily tokens + daily images; ZAI: 5h tokens +
-  monthly MCP requests; Synthetic: rolling-5h requests + hourly search
-  requests + rolling-weekly dollars).
-- The `unit: 'points'` value is overloaded — Neuralwatt uses it for kWh and
-  the frontend has a special-case branch (`if (unit === 'kwh') ...`) that
-  never matches the actual data.
+| Shape                             | Examples                                                                                       |
+|-----------------------------------|------------------------------------------------------------------------------------------------|
+| Pure prepaid balance              | `naga`, `kilo`, `moonshot`, `novita`, `minimax`, `apertis` (PAYG), `openrouter`, `poe`          |
+| Single periodic allowance         | `copilot`, `apertis-coding-plan`, `wisdomgate`, `minimax-coding`, `gemini-cli`, `antigravity`   |
+| Multiple independent allowances   | `claude-code`, `openai-codex`, `zenmux`, `ollama`, `kimi-code`, `zai`, `nanogpt`, `synthetic`   |
+| Hybrid (balance + allowance)      | `neuralwatt`                                                                                   |
 
-The implementation has accumulated workarounds:
+The goal: one self-describing model where any of these shapes is just
+*N* independent meters with their own kind, unit, and optional period —
+no checker-level category, no window-type enum, no per-checker UI
+switches.
 
-- A `BALANCE_CHECKERS_WITH_RATE_LIMIT = new Set(['neuralwatt'])` literal
-  duplicated in `Sidebar.tsx` and `Quotas.tsx` to coerce one "balance"
-  checker into also appearing in the rate-limit section.
-- A `windowType` enum with overlapping/aliased members
-  (`five_hour`/`rolling_five_hour`, `weekly`/`rolling_weekly`,
-  `subscription`/`monthly`, `custom`) where `subscription` is overloaded to
-  mean "this is a balance row, not a periodic quota."
-- Per-checker hardcoded display lists in `CompactQuotasCard.getTrackedWindowsForChecker`
-  picking which windows to render for each provider.
-- 21+ display components, one per checker, most of which differ only in
-  which icon and which `windowType` strings they reach for.
-
-The goal of this document is to design a **single, flexible data model** that
-can describe every existing provider and any reasonable future one without
-needing per-checker conditionals in either the schema or the UI.
-
-## 2. Survey of the 23 Existing Checkers
-
-The matrix below normalises what each checker actually returns. Rows are
-grouped by structural shape, not by current `category` label.
-
-### 2.1 Pure prepaid balances (one number, no reset)
-
-| Checker      | Unit    | API exposes                  | Notes                                  |
-|--------------|---------|------------------------------|----------------------------------------|
-| `naga`       | dollars | `balance`                    |                                        |
-| `kilo`       | dollars | `balance`                    |                                        |
-| `moonshot`   | dollars | `available_balance`          | Also has cash/voucher subtotals        |
-| `novita`     | dollars | `availableBalance`           | Stored in 1/10000 USD, divided in code |
-| `minimax`    | dollars | `available_amount`           | Cookie auth                            |
-| `apertis`    | dollars | `payg.account_credits`       | Same endpoint as `apertis-coding-plan` |
-| `openrouter` | dollars | `total_credits - total_usage`| Computes remaining locally             |
-| `poe`        | points  | `current_point_balance`      | Points, not dollars                    |
-
-Today these all emit `windowType: 'subscription'`, `category: 'balance'`,
-`limit: undefined`, `used: undefined`, `remaining: <value>`, no `resetsAt`.
-
-### 2.2 Subscription quotas with a single periodic window
-
-| Checker               | Window      | Unit                       | Notes                                                  |
-|-----------------------|-------------|----------------------------|--------------------------------------------------------|
-| `copilot`             | monthly     | requests **or** percentage | Falls back to % when entitlement missing               |
-| `apertis-coding-plan` | monthly     | requests                   | `cycle_*` fields                                       |
-| `wisdomgate`          | monthly     | dollars                    | Returns `total_usage`/`total_available`; cycle-bound   |
-| `minimax-coding`      | "custom"    | requests                   | API field is misnamed; remaining lives in `usage_count`|
-| `gemini-cli`          | "five_hour" | percentage                 | Aggregated per-model bucket                            |
-| `antigravity`         | "five_hour" | percentage                 | Per-model rows                                         |
-
-### 2.3 Subscription quotas with multiple independent windows
-
-| Checker        | Windows                                                       | Units                                |
-|----------------|---------------------------------------------------------------|--------------------------------------|
-| `claude-code`  | 5-hour + 7-day                                                | percentage, percentage               |
-| `openai-codex` | primary (5-hour) + secondary (7-day)                          | percentage, percentage               |
-| `zenmux`       | rolling-5h flows + rolling-7-day flows                        | points, points                       |
-| `ollama`       | session (5-hour) + weekly                                     | percentage, percentage               |
-| `kimi-code`    | "usage" + N variable rate-limit windows                       | requests                             |
-| `zai`          | 5-hour tokens + monthly MCP requests                          | percentage, requests                 |
-| `nanogpt`      | weekly input tokens + daily input tokens + daily images       | tokens, tokens, requests             |
-| `synthetic`    | rolling-5h requests + hourly search + rolling-weekly credits  | requests, requests, dollars          |
-
-### 2.4 Hybrid: balance **and** subscription quota together
-
-| Checker      | Balance side                       | Subscription side                                       |
-|--------------|------------------------------------|---------------------------------------------------------|
-| `neuralwatt` | dollar credits remaining (PAYG)    | monthly kWh quota (`unit:'points'` today, mislabelled)  |
-
-This is the case the current model fails most clearly: the checker's single
-`category` field is `'balance'`, and the frontend has to special-case
-`neuralwatt` in two different `BALANCE_CHECKERS_WITH_RATE_LIMIT` sets to also
-render its monthly window in the rate-limit section.
-
-`apertis` and `apertis-coding-plan` sidestep this by being registered as two
-*separate* checkers hitting the same endpoint — paying twice for the API
-call and producing twice the snapshots.
-
-## 3. Concrete Inconsistencies in the Current Model
-
-Pulled from `packages/backend/src/types/quota.ts`, the checker
-implementations, the schema, and the frontend.
-
-### 3.1 `category` is on the wrong object
-
-`QuotaChecker.category: 'balance' | 'rate-limit'` is a *checker-level*
-attribute. But "balance vs. rate-limit" is a property of an individual
-**meter**, not the API endpoint that returns them. Neuralwatt has both;
-Wisdom Gate is recorded as `balance` even though its bounded shape is
-indistinguishable from a quota. Apertis only escapes this by being split
-into two checkers.
-
-### 3.2 `windowType` conflates four different axes
-
-`QuotaWindowType =
-  'subscription' | 'hourly' | 'five_hour' | 'rolling_five_hour' |
-  'toolcalls' | 'search' | 'daily' | 'weekly' | 'rolling_weekly' |
-  'monthly' | 'custom'`
-
-This single enum tries to express all of:
-
-1. **Kind of meter** — `subscription` is used as "this is a balance, not a
-   periodic quota."
-2. **Period length** — `hourly`, `five_hour`, `daily`, `weekly`, `monthly`.
-3. **Whether the period is fixed-cycle or rolling/sliding** —
-   `weekly` vs `rolling_weekly`, `five_hour` vs `rolling_five_hour`.
-4. **What the meter is measuring** — `toolcalls`, `search`.
-
-These are independent dimensions and should be modelled as such. Today the
-frontend has to do `windows.find(w => w.windowType === 'subscription')` to
-locate the balance, and `getTrackedWindowsForChecker` has 16 hard-coded
-cases mapping checker name → window-type strings to render.
-
-### 3.3 `unit` carries a misleading value (`points`)
-
-`QuotaUnit = 'dollars' | 'requests' | 'tokens' | 'percentage' | 'points' | 'kwh'`
-
-- `kwh` exists in the type but no checker emits it. Neuralwatt emits
-  `'points'` for kilowatt-hours and the frontend has both
-  `if (unit === 'kwh')` *and* `if (unit === 'points') ... kWh remaining`
-  branches that work around it.
-- `points` is used for both **Poe points** (a real currency-like balance)
-  and **Zenmux flows** (a per-cycle quota count) and **kWh** (an energy
-  quantity). Three completely different things, all stored under the
-  same name.
-- `percentage` is encoded as `limit=100, used=<percent>, remaining=<percent>`
-  rather than just storing the percentage in `used` and letting the
-  consumer treat the unit as the unit. Mostly cosmetic, but it leaks
-  into every history graph.
-
-### 3.4 Window output is not uniform within a checker
-
-In several checkers the same window field is conditionally either `requests`
-or `percentage` depending on what the upstream API returned (e.g.
-`copilot-checker` lines 82-112 chooses unit at runtime). This makes
-historical comparison meaningless — a snapshot from yesterday in `requests`
-is not graphable on the same axis as today's snapshot in `percentage`.
-
-### 3.5 Frontend has 21 near-duplicate display components
-
-Each checker has its own `XxxQuotaDisplay.tsx`. They all do the same thing:
-
-1. Find a window by hardcoded `windowType` string.
-2. Render either a `Wallet` icon + formatted number, or a
-   `QuotaProgressBar`.
-3. Show a reset countdown if there is one.
-
-`CompactQuotasCard.getTrackedWindowsForChecker` further duplicates this
-selection logic with a 23-arm switch statement that maps each checker name
-to the window types it expects.
-
-### 3.6 Cross-cutting overrides
-
-- `BALANCE_CHECKERS_WITH_RATE_LIMIT = new Set(['neuralwatt'])` — defined
-  twice (`Sidebar.tsx:265`, `Quotas.tsx:166`). Both literals must stay in
-  sync. They exist purely because `category` cannot be split per-meter.
-- `CHECKER_DISPLAY_NAMES` defined three times
-  (`Quotas.tsx:39`, `CombinedBalancesCard.tsx:17`, plus implicit
-  via `CompactQuotasCard.getTypeDisplayName`).
-- `FALLBACK_QUOTA_CHECKER_TYPES` (`api.ts`) and
-  `QUOTA_CHECKER_TYPES_FALLBACK` (`Providers.tsx`) duplicate
-  `VALID_QUOTA_CHECKER_TYPES` from the backend and the
-  `quotaCheckerTypeEnum` postgres enum — four copies of the same list.
-
-### 3.7 Adding a checker requires touching ~10 files
-
-Per `AGENTS.md` § "Adding a Quota Checker": backend Zod schema, checker
-class, factory registry, postgres enum, frontend display, frontend config,
-frontend index, sidebar arrays, providers page fallback, api.ts fallback,
-combined-balances display name, compact-quotas tracked-windows switch.
-Most of that is rote.
-
-## 4. Design Goals
+## 2. Design Goals
 
 1. **One concept, atomically.** A checker emits zero or more independent
    *meters*. A meter is the single unit of "thing that has a value, a unit,
@@ -237,9 +78,9 @@ Most of that is rote.
 This is a rethink, not a refactor. There is no requirement to preserve
 the current data model, the current wire format, or any stored history.
 
-## 5. Proposed Data Model
+## 3. Proposed Data Model
 
-### 5.1 Vocabulary
+### 3.1 Vocabulary
 
 - **Checker** — the thing that talks to a provider's billing/usage
   endpoint. Identified by `checkerType` (e.g. `claude-code`) and a
@@ -251,7 +92,7 @@ the current data model, the current wire format, or any stored history.
 
 A checker invocation produces *N* meter snapshots (commonly 1–4).
 
-### 5.2 Meter kinds
+### 3.2 Meter kinds
 
 ```ts
 type MeterKind =
@@ -265,118 +106,129 @@ N per cycle." The kind alone tells the UI which icon family to use and
 which section of the dashboard the meter lives in. There is no third kind
 and there is no checker-level kind.
 
-### 5.3 Units
+### 3.3 Units
+
+`unit` is an **open string**, not a closed enum. The checker emits the
+provider's own terminology — `'flows'`, `'interactions'`, `'images'`,
+`'tokens'`, `'kwh'`, `'points'`, `'usd'`, `'percentage'`, `'credits'`,
+whatever the upstream calls them.
+
+A small set of canonical strings is documented (and recommended where
+they fit), with a default formatter for each:
+
+| Canonical    | Renders as                  | Use for upstream terms like        |
+|--------------|-----------------------------|------------------------------------|
+| `usd`        | currency formatter (`$1.23`)| dollars, credits-in-USD, balance, available_amount |
+| `tokens`     | token formatter             | tokens, input_tokens, output_tokens |
+| `requests`   | `N` (or `N reqs`)           | requests, interactions, flows, calls, usages, count |
+| `kwh`        | `N kWh`                     | kwh, energy                        |
+| `points`     | `N pts`                     | points (Poe-style opaque currency) |
+| `images`     | `N images`                  | images, image_generations          |
+| `percentage` | `N%`                        | percent, percentage, fraction (normalize fractions to 0..100) |
+
+**Conventions:**
+
+- A checker **should** prefer the canonical string when the meaning is
+  the same (Copilot's "premium_interactions" → `'requests'`, Zenmux's
+  "flows" → `'requests'`). The display shouldn't have to know that
+  "flows" means "interactions" means "requests".
+- A checker **may** emit a non-canonical string when the provider's
+  meaning is genuinely distinct, or when the upstream label is part of
+  the user's mental model and shouldn't be flattened. The display
+  formats unknown units as `${value} ${unit}` and moves on. Adding a
+  new unit costs nothing — no schema change, no enum migration.
+- Because `unit` is plain text, `points`-as-kWh is no longer possible;
+  the checker either says `'kwh'` or it says `'kwh'`.
+- A meter's unit must not change between snapshots (it's how history
+  graphs join). If a checker has a fallback path that yields a
+  different unit (today's Copilot `requests`-vs-`percentage` flip), it
+  should emit two distinct meters with different `key`s instead.
+
+### 3.4 Period (flat fields on Meter)
+
+Period information lives directly on the Meter, not in a nested object.
+The fields:
+
+| Field           | Type                                         | When                                     |
+|-----------------|----------------------------------------------|------------------------------------------|
+| `periodValue`   | number                                       | only when `kind === 'allowance'`         |
+| `periodUnit`    | `'minute'` \| `'hour'` \| `'day'` \| `'week'` \| `'month'` | "                              |
+| `periodCycle`   | `'fixed'` \| `'rolling'`                     | "                                        |
+| `resetsAt`      | ISO-8601 string                              | optional; "earliest moment capacity will visibly improve" |
+
+A balance meter omits all four. An allowance meter sets the first three
+and may set `resetsAt`. Examples:
+
+- Claude's 5-hour rolling: `periodValue: 5, periodUnit: 'hour', periodCycle: 'rolling'`
+- Copilot's monthly fixed cycle: `periodValue: 1, periodUnit: 'month', periodCycle: 'fixed', resetsAt: '...'`
+
+### 3.5 The Meter shape
 
 ```ts
-type MeterUnit =
-  | 'usd'         // dollars / credits expressed in dollars
-  | 'tokens'      // LLM tokens
-  | 'requests'    // API calls / interactions / "flows" / coding-plan calls
-  | 'kwh'         // kilowatt-hours
-  | 'points'      // opaque provider-specific units — used only when the
-                  // provider's docs literally call them "points" and there
-                  // is no better mapping (Poe is the canonical case)
-  | 'percentage'  // when the provider only tells us a fraction and there
-                  // is no underlying count we can recover
-```
+type Utilization = number | 'unknown' | 'not_applicable';
 
-Notes:
-
-- The unit names what is being counted, not the measurement. `kwh` is a
-  unit; "energy" is the measurement, and we don't need to encode the
-  measurement separately — the label and subject already say "Energy
-  quota."
-- `percentage` is a real unit, not a degenerate one. Several providers
-  (Claude Code, Codex, Antigravity, Gemini-CLI) only expose a fraction,
-  and inventing a fake "limit=100, used=N" requests count would lie
-  about what we know. When `unit: 'percentage'`, `used`/`remaining` are
-  on the 0..100 scale and the formatter prints `N%`.
-- `points` is reserved for opaque provider currencies. Energy quotas
-  use `kwh`. Per-cycle "flows" and "interactions" are `requests`. There
-  is no `'points'`-as-anything-else.
-
-### 5.4 Periods
-
-```ts
-interface Period {
-  // Length of the cycle.
-  duration: { value: number; unit: 'minute' | 'hour' | 'day' | 'week' | 'month' };
-  // Fixed-window (resets on a calendar boundary; everyone resets together)
-  // vs. rolling/sliding (resets N units after the request that spent it).
-  cycle: 'fixed' | 'rolling';
-  // When the *current* cycle ends / when the meter next regains capacity.
-  // Required for fixed cycles when the API returns it; optional for
-  // rolling (rolling windows often don't have a single reset moment).
-  resetsAt?: string; // ISO-8601
-}
-```
-
-`Period` is only present on `MeterKind === 'allowance'` meters. Balance
-meters have no period.
-
-### 5.5 The Meter shape
-
-```ts
 interface Meter {
   // ── Identity ───────────────────────────────────────────────────────────
   /** Stable id within a checker invocation. Two snapshots with the same
    *  (checkerId, key) describe the same meter at two points in time. */
   key: string;
-  /** Provider-readable label, e.g. "5-hour quota", "Account balance",
-   *  "Search requests". Already localised for the UI. */
+  /** Human-readable, e.g. "5-hour quota", "Account balance", "Search". */
   label: string;
-  /** Optional refinement, e.g. "Pro models", "Flash models", "Input tokens".
-   *  When two meters share a label this disambiguates them. */
+  /** Optional refinement, e.g. "Pro models", "Flash models". */
   subject?: string;
 
   // ── Classification ────────────────────────────────────────────────────
-  kind: MeterKind;
-  unit: MeterUnit;
+  kind: 'balance' | 'allowance';
+  unit: string;     // see § 3.3 — open string, canonical names recommended
 
   // ── Values ────────────────────────────────────────────────────────────
-  /** Total cycle entitlement (allowance) or initial deposit (balance, if
-   *  knowable — most providers don't expose this for prepaid balances). */
   limit?: number;
   used?: number;
   remaining?: number;
-  /** Always 0..100. Derived if any two of (limit, used, remaining) known. */
-  utilizationPercent: number;
+  /** 0..100, OR one of the sentinels:
+   *    'unknown'        — checker tried but the provider didn't expose enough
+   *                       (e.g. balance with no total deposit known);
+   *                       the meter is still useful but no progress bar.
+   *    'not_applicable' — % utilization is meaningless for this meter
+   *                       (e.g. an unbounded counter). */
+  utilizationPercent: Utilization;
 
-  // ── Time ──────────────────────────────────────────────────────────────
-  /** Required when kind === 'allowance', omitted when kind === 'balance'. */
-  period?: Period;
+  // ── Period (only for allowance) ───────────────────────────────────────
+  periodValue?: number;
+  periodUnit?: 'minute' | 'hour' | 'day' | 'week' | 'month';
+  periodCycle?: 'fixed' | 'rolling';
+  resetsAt?: string;       // ISO-8601
 
   // ── Status ────────────────────────────────────────────────────────────
   status: 'ok' | 'warning' | 'critical' | 'exhausted';
 
   // ── Cooldown gating ───────────────────────────────────────────────────
-  /** Per-meter override; falls back to checker default, falls back to 99. */
+  /** For allowance meters: % utilization that triggers cooldown.
+   *  For balance meters:    floor on `remaining` (in `unit`) below which
+   *                         the provider is cooled down.
+   *  Falls back to checker default, then to a global default. */
   exhaustionThreshold?: number;
 }
 ```
 
 Notes:
 
-- `key` is a checker-local identifier (`'five_hour'`, `'weekly'`,
-  `'balance'`, `'energy'`, `'search'`). It is **not** a global enum and
-  the frontend never branches on its value. It's what `(checkerId, key)`
-  uniquely identifies a meter for history graphing.
-- `label`/`subject` is what the UI shows. The checker is responsible for
-  translating provider-speak into something a human reads. The frontend
-  never has to look up "what does `'five_hour'` mean for Claude vs.
-  Gemini" — the meter already says "5-hour quota".
-- `kind` (not `windowType`) is what divides the UI: balances on one card,
-  allowances on another. No `BALANCE_CHECKERS_WITH_RATE_LIMIT` set is
-  needed because mixed checkers simply emit meters of both kinds.
-- `period` collapses today's `windowType` enum into orthogonal fields.
-  Claude's 5-hour limit becomes
-  `{ duration: { value: 5, unit: 'hour' }, cycle: 'rolling' }`.
-  Synthetic's hourly search becomes
-  `{ duration: { value: 1, unit: 'hour' }, cycle: 'fixed' }`.
-- The estimation/projection block from the current `QuotaWindow` is kept
-  unchanged on `Meter` (omitted above for brevity).
+- `key` is a checker-local identifier. The frontend never branches on
+  its value; it identifies the meter for history graphing.
+- `label`/`subject` is what the UI shows; the checker translates
+  provider-speak.
+- `kind` is what divides the UI: balances on one card, allowances on
+  another. Hybrid checkers emit meters of both kinds.
+- Period fields are flat. A balance meter omits all of them.
+- `utilizationPercent` is required (no `?`); when it's not knowable,
+  the checker emits `'unknown'` or `'not_applicable'` explicitly. The
+  UI uses these sentinels to suppress the progress bar / colour scale
+  and just print the raw `remaining` value instead.
+- `exhaustionThreshold`'s meaning depends on `kind` — see § 5.3.
+- The estimation/projection block from the current `QuotaWindow` is
+  kept unchanged on `Meter` (omitted above for brevity).
 
-### 5.6 The CheckResult shape
+### 3.6 The CheckResult shape
 
 ```ts
 interface QuotaCheckResult {
@@ -388,30 +240,35 @@ interface QuotaCheckResult {
   error?: string;
 
   meters: Meter[];       // 0..N independent meters
-  rawResponse?: unknown; // for debugging only
 }
 ```
 
 Notes:
 
 - `meters` is the only payload. There are no `windows`, no `groups`,
-  no checker-level `category`. If a provider exposes per-model rows
-  (Antigravity, Gemini-CLI), each row becomes a meter with the model
-  name in `subject`.
+  no checker-level `category`. If a provider exposes per-model rows,
+  each row is a meter with the model name in `subject`.
+- There is **no `rawResponse` field.** It exists today as a debugging
+  aid and gets used as a feature crutch (frontend code reaching into
+  raw provider JSON because the modelled fields are insufficient).
+  Anything the rest of the system needs goes into a meter; nothing
+  else gets a sneak path. Raw provider responses, when needed for
+  debugging a checker, are written to the debug log by the checker
+  itself.
 - `oauthProvider`/`oauthAccountId` are **not** on the result. They're
-  duplicative: a checker is configured against a single OAuth account,
-  so `(checkerType, checkerId)` already identifies the account.
-  Anything that needs to display the OAuth account name resolves it
-  from the checker's config, not from each snapshot.
+  duplicative with checker config; the API resolves them on demand
+  when the UI needs to label an account.
 
-### 5.7 Worked examples (existing providers in the new model)
+### 3.7 Worked examples (existing providers in the new model)
 
-**Naga** (pure dollar balance, one meter):
+**Naga** (pure dollar balance, no known total):
 ```js
 meters: [{
   key: 'balance', label: 'Account balance',
   kind: 'balance', unit: 'usd',
-  remaining: 12.34, utilizationPercent: 0, status: 'ok',
+  remaining: 12.34,
+  utilizationPercent: 'not_applicable',     // unbounded prepaid
+  status: 'ok',
 }]
 ```
 
@@ -421,8 +278,8 @@ meters: [{
   key: 'monthly_credits', label: 'Wisdom Gate subscription',
   kind: 'allowance', unit: 'usd',
   limit: 50, used: 18.20, remaining: 31.80,
-  period: { duration: {value: 1, unit: 'month'}, cycle: 'fixed',
-            resetsAt: '2026-05-01T00:00:00Z' },
+  periodValue: 1, periodUnit: 'month', periodCycle: 'fixed',
+  resetsAt: '2026-05-01T00:00:00Z',
   utilizationPercent: 36.4, status: 'ok',
 }]
 ```
@@ -433,14 +290,14 @@ meters: [
   { key: 'five_hour', label: '5-hour quota',
     kind: 'allowance', unit: 'percentage',
     used: 27, remaining: 73,
-    period: { duration: {value: 5, unit: 'hour'}, cycle: 'rolling',
-              resetsAt: '2026-04-25T18:00:00Z' },
+    periodValue: 5, periodUnit: 'hour', periodCycle: 'rolling',
+    resetsAt: '2026-04-25T18:00:00Z',
     utilizationPercent: 27, status: 'ok' },
   { key: 'weekly', label: 'Weekly quota',
     kind: 'allowance', unit: 'percentage',
     used: 41, remaining: 59,
-    period: { duration: {value: 7, unit: 'day'}, cycle: 'rolling',
-              resetsAt: '2026-04-30T00:00:00Z' },
+    periodValue: 7, periodUnit: 'day', periodCycle: 'rolling',
+    resetsAt: '2026-04-30T00:00:00Z',
     utilizationPercent: 41, status: 'ok' },
 ]
 ```
@@ -451,13 +308,15 @@ meters: [
   { key: 'rolling_5h', label: 'Rolling 5-hour limit',
     kind: 'allowance', unit: 'requests',
     limit: 200, used: 37, remaining: 163,
-    period: { duration: {value: 5, unit: 'hour'}, cycle: 'rolling' }, ...},
+    periodValue: 5, periodUnit: 'hour', periodCycle: 'rolling',
+    utilizationPercent: 18.5, status: 'ok' },
   { key: 'search_hourly', label: 'Search requests', subject: 'hourly',
     kind: 'allowance', unit: 'requests',
-    period: { duration: {value: 1, unit: 'hour'}, cycle: 'fixed', resetsAt: ...}, ...},
+    periodValue: 1, periodUnit: 'hour', periodCycle: 'fixed',
+    resetsAt: '2026-04-25T18:00:00Z', ... },
   { key: 'weekly_credits', label: 'Weekly token credits',
     kind: 'allowance', unit: 'usd',
-    period: { duration: {value: 7, unit: 'day'}, cycle: 'rolling', resetsAt: ...}, ...},
+    periodValue: 7, periodUnit: 'day', periodCycle: 'rolling', ... },
 ]
 ```
 
@@ -466,72 +325,97 @@ meters: [
 meters: [
   { key: 'credits', label: 'Credit balance',
     kind: 'balance', unit: 'usd',
-    limit: 100, used: 23.50, remaining: 76.50, ...},
+    limit: 100, used: 23.50, remaining: 76.50,
+    utilizationPercent: 23.5, status: 'ok' },
   { key: 'energy', label: 'Energy quota',
     kind: 'allowance', unit: 'kwh',
     limit: 50, used: 12.4, remaining: 37.6,
-    period: { duration: {value: 1, unit: 'month'}, cycle: 'fixed',
-              resetsAt: '2026-05-01T00:00:00Z' }, ...},
+    periodValue: 1, periodUnit: 'month', periodCycle: 'fixed',
+    resetsAt: '2026-05-01T00:00:00Z',
+    utilizationPercent: 24.8, status: 'ok' },
 ]
 ```
 
-**Apertis** (one checker, both PAYG balance and the cycle quota when
-the account is also a subscriber — both come from the same response):
+**Apertis** (single checker, both PAYG balance and cycle quota from
+one response):
 ```js
 meters: [
   { key: 'payg', label: 'PAYG balance',
-    kind: 'balance', unit: 'usd', remaining: 8.42, ...},
+    kind: 'balance', unit: 'usd', remaining: 8.42,
+    utilizationPercent: 'not_applicable', status: 'ok' },
   { key: 'cycle_quota', label: 'Apertis pro plan',
     kind: 'allowance', unit: 'requests',
     limit: 5000, used: 1200, remaining: 3800,
-    period: { duration: {value:1, unit:'month'}, cycle: 'fixed', resetsAt: ...}, ...},
+    periodValue: 1, periodUnit: 'month', periodCycle: 'fixed',
+    resetsAt: '2026-05-01T00:00:00Z',
+    utilizationPercent: 24, status: 'ok' },
 ]
 ```
 
-**Poe** (points balance):
+**Poe** (opaque points balance, no known total):
 ```js
 meters: [{
   key: 'balance', label: 'POE point balance',
   kind: 'balance', unit: 'points',
-  remaining: 1_350_000, utilizationPercent: 0, status: 'ok',
+  remaining: 1_350_000,
+  utilizationPercent: 'not_applicable',
+  status: 'ok',
 }]
 ```
 
-## 6. Database Schema
+**Zenmux** (rolling flows in provider's own terminology):
+```js
+meters: [{
+  key: 'flows_5h', label: '5-hour rolling',
+  kind: 'allowance', unit: 'flows',     // non-canonical, kept verbatim
+  limit: 100, used: 18, remaining: 82,
+  periodValue: 5, periodUnit: 'hour', periodCycle: 'rolling',
+  resetsAt: '2026-04-25T18:00:00Z',
+  utilizationPercent: 18, status: 'ok',
+}]
+```
+
+## 4. Database Schema
 
 A new table — `meter_snapshots` — is created from scratch. The existing
 `quota_snapshots` table is left alone and ignored by the new code. There
 is no data migration. Anything historical that someone wants from the old
 table can be addressed separately, later.
 
-### 6.1 `meter_snapshots`
+### 4.1 `meter_snapshots`
 
 One row per (checker invocation, meter). Columns:
 
-| Column                  | Type        | Notes                                            |
-|-------------------------|-------------|--------------------------------------------------|
-| `id`                    | int PK      |                                                  |
-| `checker_id`            | text        | operator-chosen instance id                      |
-| `checker_type`          | text        | e.g. `'claude-code'`                             |
-| `provider`              | text        | routing provider this checker is attached to     |
-| `meter_key`             | text        | checker-local id, e.g. `'five_hour'`, `'balance'`|
-| `kind`                  | text        | `'balance'` or `'allowance'`                     |
-| `unit`                  | text        | `'usd'`, `'tokens'`, `'requests'`, `'kwh'`, `'points'`, `'percentage'` |
-| `label`                 | text        | human-readable, set by the checker               |
-| `subject`               | text NULL   | optional sub-scope (e.g. model name)             |
-| `limit`                 | real NULL   |                                                  |
-| `used`                  | real NULL   |                                                  |
-| `remaining`             | real NULL   |                                                  |
-| `utilization_percent`   | real        | 0..100                                           |
-| `status`                | text        | `'ok'` / `'warning'` / `'critical'` / `'exhausted'` |
-| `period_duration_value` | int NULL    | only for allowances                              |
-| `period_duration_unit`  | text NULL   | `'minute'` / `'hour'` / `'day'` / `'week'` / `'month'` |
-| `period_cycle`          | text NULL   | `'fixed'` / `'rolling'`                          |
-| `resets_at`             | timestamp NULL | when the meter next regains capacity          |
-| `success`               | bool        | did the checker call succeed                     |
-| `error_message`         | text NULL   |                                                  |
-| `checked_at`            | timestamp   |                                                  |
-| `created_at`            | timestamp   |                                                  |
+| Column                  | Type           | Notes                                                    |
+|-------------------------|----------------|----------------------------------------------------------|
+| `id`                    | int PK         |                                                          |
+| `checker_id`            | text           | operator-chosen instance id                              |
+| `checker_type`          | text           | e.g. `'claude-code'`                                     |
+| `provider`              | text           | routing provider this checker is attached to             |
+| `meter_key`             | text           | checker-local id, e.g. `'five_hour'`, `'balance'`        |
+| `kind`                  | text           | `'balance'` or `'allowance'`                             |
+| `unit`                  | text           | open string; canonical names recommended (§ 3.3)         |
+| `label`                 | text           | human-readable, set by the checker                       |
+| `subject`               | text NULL      | optional sub-scope (e.g. model name)                     |
+| `limit`                 | real NULL      |                                                          |
+| `used`                  | real NULL      |                                                          |
+| `remaining`             | real NULL      |                                                          |
+| `utilization_state`     | text           | `'reported'` / `'unknown'` / `'not_applicable'`          |
+| `utilization_percent`   | real NULL      | the 0..100 number when `utilization_state = 'reported'`  |
+| `status`                | text           | `'ok'` / `'warning'` / `'critical'` / `'exhausted'`      |
+| `period_value`          | int NULL       | only for allowances                                      |
+| `period_unit`           | text NULL      | `'minute'` / `'hour'` / `'day'` / `'week'` / `'month'`   |
+| `period_cycle`          | text NULL      | `'fixed'` / `'rolling'`                                  |
+| `resets_at`             | timestamp NULL | when the meter next regains capacity                     |
+| `success`               | bool           | did the checker call succeed                             |
+| `error_message`         | text NULL      |                                                          |
+| `checked_at`            | timestamp      |                                                          |
+| `created_at`            | timestamp      |                                                          |
+
+`utilization_state` is a small derived column rather than overloading
+`utilization_percent` with NULL/sentinels. Keeping the number column
+purely numeric makes history graphs trivial: `WHERE utilization_state =
+'reported'` filters out the rows that don't plot.
 
 Indexes:
 
@@ -540,21 +424,19 @@ Indexes:
 - `(provider, checked_at)` — for any cross-provider scans.
 - `(checked_at)` — for retention sweeps.
 
-### 6.2 No SQL enums
+### 4.2 No SQL enums
 
-All categorical columns (`kind`, `unit`, `period_cycle`,
-`period_duration_unit`, `status`, `checker_type`) are plain `text`.
-Validation lives in code: the checker base class only emits valid
-values, and the API layer rejects anything malformed. Adding a new
-checker type or a new unit therefore costs zero database migrations.
+All categorical columns (`kind`, `unit`, `period_cycle`, `period_unit`,
+`status`, `utilization_state`, `checker_type`) are plain `text`.
+Validation lives in code; the checker layer is the only thing that
+writes to this table.
 
-The trade-off is well understood: a typo on the write path becomes a
-runtime bug instead of a database error. We accept that — typos are
-caught by the checker's tests and the type system.
+`unit` in particular is intentionally open (see § 3.3) — adding a new
+unit (or a new checker type) costs zero database migrations.
 
-## 7. Backend
+## 5. Backend
 
-### 7.1 Checker registration
+### 5.1 Checker registration
 
 A checker is a class plus an options-schema. They live together in the
 checker's own module and self-register:
@@ -588,7 +470,7 @@ The frontend calls `/v0/management/quota-checker-types` and uses what it
 gets back. There is no fallback list duplicated in the frontend — if the
 API is unreachable, the dropdown shows a loading state.
 
-### 7.2 Base behaviour
+### 5.2 Base behaviour
 
 Each checker's `check(ctx)` returns a `Meter[]`. Helpers on the context
 build meters with derived fields filled in:
@@ -596,7 +478,7 @@ build meters with derived fields filled in:
 ```ts
 ctx.balance({ key, label, unit, remaining, limit?, subject? })
 ctx.allowance({ key, label, unit, used, limit?, remaining?,
-                period: { duration, cycle, resetsAt? },
+                periodValue, periodUnit, periodCycle, resetsAt?,
                 subject? })
 ```
 
@@ -609,15 +491,34 @@ options schema. If a checker wants to expose per-meter overrides, it
 does so via its own option shape; the base class doesn't pretend to
 solve it generically.
 
-### 7.3 Cooldown / scheduler
+### 5.3 Cooldown / scheduler
 
-Cooldown injection iterates over the latest meters for each checker.
-Only allowance meters with a known `resetsAt` participate — a balance
-meter at zero is a billing failure, not a rate-limit, and there is
-nothing to wait for. The "strictest threshold" calculation looks at all
-allowance meters across all checkers attached to a provider.
+Cooldown injection iterates over the latest meters for each checker
+attached to a provider. Both kinds of meter participate, but they use
+the threshold differently:
 
-### 7.4 API response shape
+**Allowance meters.** `exhaustionThreshold` is a percentage. When
+`utilizationPercent >= threshold` (default 99), the provider is cooled
+down until the meter's `resetsAt` (if known). If `resetsAt` is unknown
+the cooldown lasts until the next checker poll. `utilizationPercent`
+sentinels (`'unknown'`, `'not_applicable'`) skip cooldown evaluation
+for that meter.
+
+**Balance meters.** `exhaustionThreshold` is a **floor on `remaining`**
+in the meter's `unit` (e.g. `0.50` for USD, `100` for points). When
+`remaining <= threshold`, the provider is cooled down. The cooldown
+lasts until the next checker poll — a balance can be topped up
+out-of-band at any moment, so the only way to learn the new value is
+to keep checking. Default floor is `0` (cool down only when the
+balance is fully drained); operators can raise it per-checker to
+"reserve" a tail.
+
+Every meter contributes to the cooldown decision; the most-constrained
+one wins. The "strictest threshold" calculation iterates all meters
+across all checkers attached to the provider, so a lenient checker
+can't lift a cooldown that a strict one set.
+
+### 5.4 API response shape
 
 `GET /v0/management/quotas` returns:
 
@@ -641,9 +542,9 @@ the most recent row for each `(checker_id, meter_key)`. There is no
 response — the frontend asks the provider-config endpoint when it wants
 to label an OAuth account.
 
-## 8. Frontend changes
+## 6. Frontend
 
-### 8.1 Two generic display components, not 21
+### 6.1 Two generic display components, not 21
 
 Replace the per-checker `XxxQuotaDisplay.tsx` family with two generic
 components:
@@ -669,7 +570,7 @@ function formatMeterValue(v: number, unit: MeterUnit) {
 }
 ```
 
-### 8.2 Sidebar / dashboard sections
+### 6.2 Sidebar / dashboard sections
 
 A checker no longer has a category. Sections are derived by walking the
 meters:
@@ -685,7 +586,7 @@ The `BALANCE_CHECKERS_WITH_RATE_LIMIT` constants disappear. A hybrid
 checker like Neuralwatt naturally appears in both lists because it emits
 both kinds of meter.
 
-### 8.3 Per-checker icons (the only thing that stays per-checker)
+### 6.3 Per-checker icons (the only thing that stays per-checker)
 
 A small registry that maps `checkerType` to an icon and a display name.
 This is purely cosmetic and lives in **one** file:
@@ -704,7 +605,7 @@ single object. `CompactQuotasCard.getTrackedWindowsForChecker`,
 `getCheckerCategory`, `getTypeDisplayName`, and `getCheckerIcon` all
 delete: there is nothing left to switch on.
 
-### 8.4 Per-checker config components
+### 6.4 Per-checker config components
 
 Config components stay, because each checker has different config inputs
 (API key URL, organisation id, cookie name, …). But:
@@ -716,13 +617,13 @@ Config components stay, because each checker has different config inputs
   registry entry exists, so adding a checker with no extra options
   needs zero frontend changes.
 
-### 8.5 Frontend types
+### 6.5 Frontend types
 
 `packages/frontend/src/types/quota.ts` is rewritten to mirror the
 backend shape — `Meter`, `MeterKind`, `MeterUnit`, `Period`, etc. The
 old `QuotaWindow`/`QuotaWindowType` types are removed.
 
-## 9. Implementation Order
+## 7. Implementation Order
 
 This is a greenfield build alongside the existing one, then a cutover.
 There is no historical-data migration to worry about. Suggested order:
@@ -752,9 +653,9 @@ Each step except the cutover is independently shippable behind code
 that nothing else calls, so a half-finished step doesn't break anything
 in production.
 
-## 10. What this fixes, concretely
+## 8. What this fixes, concretely
 
-Tying it back to the issues from § 3:
+Tying it back to the issues from § 1:
 
 | Problem                                       | Resolution                                              |
 |-----------------------------------------------|---------------------------------------------------------|
@@ -768,24 +669,46 @@ Tying it back to the issues from § 3:
 | `getTrackedWindowsForChecker` 23-arm switch   | Deleted — every meter is rendered the same way.         |
 | OAuth fields duplicated on every snapshot     | Removed from the wire shape; resolved from checker config only when needed. |
 
-## 11. Open questions
+## 9. Open questions
 
-- **Per-meter exhaustion thresholds.** Today `maxUtilizationPercent` is
-  a checker-level option. For checkers with multiple meters the
-  operator may want to cool down on the 5-hour window at 95% but
-  tolerate 99% on the weekly. Suggest allowing the option as either a
-  number (applies to all meters) or a `Record<meterKey, number>`. Each
-  checker can opt in via its own options schema; the base class doesn't
-  need to know.
-- **Rolling-window reset semantics.** Truly rolling windows don't have
-  a single "reset moment" — they recover continuously. Today the code
-  pretends they do (using `nextTickAt`/`resetTime` from the API). The
-  new model keeps `resetsAt` populated when the API supplies one and
-  documents that for `cycle: 'rolling'` it means "earliest moment
-  capacity will visibly improve," not "everything resets."
-- **Multiple balance currencies on one provider.** Moonshot exposes
-  `cash_balance` and `voucher_balance` separately. Today only
-  `available_balance` is recorded. The new model has no obstacle to
-  emitting both as separate meters with `subject: 'cash'` /
-  `subject: 'voucher'`; whether to do so is a UX call per provider.
+These need answers before implementation; they affect the data model:
+
+1. **Balance-cooldown threshold semantics.** I've defined
+   `exhaustionThreshold` as a percentage for allowance meters and a
+   floor on `remaining` (in `unit`) for balance meters. Two follow-on
+   questions:
+   - Default for balance meters is `0` (cool down only when fully
+     drained). Is that right, or should the default be a small
+     non-zero value (e.g. 1% of `limit` when known) to leave a buffer?
+   - Should we allow operators to express the floor as a percentage
+     of `limit` for balances that have a known total (Wisdom Gate,
+     Neuralwatt PAYG cap)?
+2. **Cooldown duration when balance is exhausted.** A balance with no
+   `resetsAt` cools down "until the next checker poll." That means
+   exactly the polling cadence of the checker — typically 30 minutes.
+   Is that the right cadence, or should an exhausted balance accelerate
+   polling (e.g. every minute) so that an out-of-band top-up resumes
+   routing quickly?
+3. **Open `unit` strings in the management UI.** The provider config
+   modal shows the unit somewhere; if a checker emits `'flows'` rather
+   than the canonical `'requests'`, do we surface "flows" verbatim in
+   the UI or coerce to a friendly label? Suggest verbatim — it matches
+   what the provider's docs say. Confirm.
+4. **Per-model meters in the schema.** Antigravity and Gemini-CLI emit
+   one row per model (using `subject` for the model name). Some have
+   dozens of models; the history table grows by `models * checks`.
+   Should we cap or aggregate (e.g. keep only the worst-utilized model
+   per check), or store every row and let retention sweep handle it?
+5. **`subject` semantics.** Used for "cash vs. voucher" balances,
+   "Pro vs. Flash" model-grouped quotas, "search" within a multi-meter
+   provider, and per-model rows. Are those all the same field, or
+   should we split (e.g. `groupKey` for model-rollup, `qualifier` for
+   "input tokens" vs "output tokens")? Right now the design uses one
+   field. Confirm that's enough.
+6. **Rolling-window `resetsAt`.** Rolling windows recover
+   continuously; the API sometimes returns a "next-tick" timestamp.
+   The design keeps `resetsAt` as "earliest moment capacity will
+   visibly improve" for rolling cycles. Acceptable? Or should rolling
+   meters omit `resetsAt` entirely and the UI render "rolling" with no
+   countdown?
 

--- a/docs/QUOTA_BALANCE_REDESIGN.md
+++ b/docs/QUOTA_BALANCE_REDESIGN.md
@@ -77,26 +77,18 @@ grouped by structural shape, not by current `category` label.
 Today these all emit `windowType: 'subscription'`, `category: 'balance'`,
 `limit: undefined`, `used: undefined`, `remaining: <value>`, no `resetsAt`.
 
-### 2.2 Bounded balances with a known total (still no time reset)
-
-| Checker      | Unit    | Exposes                                                            |
-|--------------|---------|--------------------------------------------------------------------|
-| `wisdomgate` | dollars | `total_usage`, `total_available` → code derives `limit = used + remaining` |
-
-Currently emitted as `windowType: 'subscription'` with a `limit`.
-Semantically it's still a balance — it just has a known historical total.
-
-### 2.3 Subscription quotas with a single periodic window
+### 2.2 Subscription quotas with a single periodic window
 
 | Checker               | Window      | Unit                       | Notes                                                  |
 |-----------------------|-------------|----------------------------|--------------------------------------------------------|
 | `copilot`             | monthly     | requests **or** percentage | Falls back to % when entitlement missing               |
 | `apertis-coding-plan` | monthly     | requests                   | `cycle_*` fields                                       |
+| `wisdomgate`          | monthly     | dollars                    | Returns `total_usage`/`total_available`; cycle-bound   |
 | `minimax-coding`      | "custom"    | requests                   | API field is misnamed; remaining lives in `usage_count`|
 | `gemini-cli`          | "five_hour" | percentage                 | Aggregated per-model bucket                            |
 | `antigravity`         | "five_hour" | percentage                 | Per-model rows                                         |
 
-### 2.4 Subscription quotas with multiple independent windows
+### 2.3 Subscription quotas with multiple independent windows
 
 | Checker        | Windows                                                       | Units                                |
 |----------------|---------------------------------------------------------------|--------------------------------------|
@@ -109,7 +101,7 @@ Semantically it's still a balance — it just has a known historical total.
 | `nanogpt`      | weekly input tokens + daily input tokens + daily images       | tokens, tokens, requests             |
 | `synthetic`    | rolling-5h requests + hourly search + rolling-weekly credits  | requests, requests, dollars          |
 
-### 2.5 Hybrid: balance **and** subscription quota together
+### 2.4 Hybrid: balance **and** subscription quota together
 
 | Checker      | Balance side                       | Subscription side                                       |
 |--------------|------------------------------------|---------------------------------------------------------|
@@ -169,11 +161,12 @@ cases mapping checker name → window-type strings to render.
   branches that work around it.
 - `points` is used for both **Poe points** (a real currency-like balance)
   and **Zenmux flows** (a per-cycle quota count) and **kWh** (an energy
-  quantity). Three completely different things.
-- `percentage` is a degenerate unit — it means "we don't know the underlying
-  count, only the fraction." Everywhere `unit='percentage'` is used,
-  `limit=100`, `used=<percent>`, `remaining=<percent>`, which is a clumsy
-  encoding of "no count, just utilization."
+  quantity). Three completely different things, all stored under the
+  same name.
+- `percentage` is encoded as `limit=100, used=<percent>, remaining=<percent>`
+  rather than just storing the percentage in `used` and letting the
+  consumer treat the unit as the unit. Mostly cosmetic, but it leaks
+  into every history graph.
 
 ### 3.4 Window output is not uniform within a checker
 
@@ -226,19 +219,23 @@ Most of that is rote.
 2. **Orthogonal axes.** Period duration, period kind (rolling vs. fixed),
    unit of measure, and what the meter counts are independent fields. No
    compound enums.
-3. **No degenerate units.** `percentage` stops being a unit; it's a
-   *display preference* derived from `used/limit`. Units name what is being
-   counted (USD, tokens, requests, kWh, opaque-points).
+3. **One unit per number, never overloaded.** kWh is `kwh`, points are
+   `points`, percentages are `percentage`. We never pretend a kWh
+   reading is a "point" so that the schema enum is shorter.
 4. **No magic strings to wire up the UI.** The model carries enough
    self-describing metadata that a generic balance row and a generic quota
    row can render any checker. Per-checker custom UI is only needed when a
    provider has genuinely unusual semantics — and even then it is opt-in,
    not the default.
-5. **One source of truth for checker registration.** Type list, postgres
-   enum, frontend dropdown, factory map should derive from a single
-   declaration.
-6. **The migration must be backwards-compatible** for stored snapshots —
-   we don't want to lose history.
+5. **One source of truth for checker registration.** Type list,
+   frontend dropdown, factory map should derive from a single
+   declaration. Don't repeat the same list in three places.
+6. **No SQL enums on values that change with every new checker.**
+   Plain text columns; validation lives in code, not in a migration
+   that has to ship every time we add a provider.
+
+This is a rethink, not a refactor. There is no requirement to preserve
+the current data model, the current wire format, or any stored history.
 
 ## 5. Proposed Data Model
 
@@ -273,26 +270,30 @@ and there is no checker-level kind.
 ```ts
 type MeterUnit =
   | 'usd'         // dollars / credits expressed in dollars
-  | 'tokens'      // LLM tokens (input + output unless qualified by `subject`)
+  | 'tokens'      // LLM tokens
   | 'requests'    // API calls / interactions / "flows" / coding-plan calls
-  | 'energy_kwh'  // kilowatt-hours
-  | 'points'      // opaque provider-specific units (Poe points, etc.) —
-                  // used only when the provider's docs literally call them
-                  // "points" and there is no better mapping
+  | 'kwh'         // kilowatt-hours
+  | 'points'      // opaque provider-specific units — used only when the
+                  // provider's docs literally call them "points" and there
+                  // is no better mapping (Poe is the canonical case)
+  | 'percentage'  // when the provider only tells us a fraction and there
+                  // is no underlying count we can recover
 ```
 
-`percentage` is removed as a unit. When a provider only exposes a
-percentage (Claude Code, Codex, Antigravity, Gemini-CLI), the meter is
-emitted with `unit: 'requests'`, `limit: 100`, `used: <percent>`,
-`remaining: 100 - <percent>`, and a flag `valuesArePercent: true` that
-tells the UI not to print "37 requests" but "37%". This keeps the wire
-format honest about what we know (only a fraction) without inventing a
-fake count.
+Notes:
 
-Alternative considered: keep `percentage` as a unit. Rejected because it
-forces every consumer to branch on it ("if percentage, render differently;
-if anything else, render normally"), which is exactly the situation we
-have today.
+- The unit names what is being counted, not the measurement. `kwh` is a
+  unit; "energy" is the measurement, and we don't need to encode the
+  measurement separately — the label and subject already say "Energy
+  quota."
+- `percentage` is a real unit, not a degenerate one. Several providers
+  (Claude Code, Codex, Antigravity, Gemini-CLI) only expose a fraction,
+  and inventing a fake "limit=100, used=N" requests count would lie
+  about what we know. When `unit: 'percentage'`, `used`/`remaining` are
+  on the 0..100 scale and the formatter prints `N%`.
+- `points` is reserved for opaque provider currencies. Energy quotas
+  use `kwh`. Per-cycle "flows" and "interactions" are `requests`. There
+  is no `'points'`-as-anything-else.
 
 ### 5.4 Periods
 
@@ -331,9 +332,6 @@ interface Meter {
   // ── Classification ────────────────────────────────────────────────────
   kind: MeterKind;
   unit: MeterUnit;
-  /** When true, `used`/`remaining`/`limit` are 0..100 percentages, not
-   *  counts of `unit`. Set when the upstream API only reports a fraction. */
-  valuesArePercent?: boolean;
 
   // ── Values ────────────────────────────────────────────────────────────
   /** Total cycle entitlement (allowance) or initial deposit (balance, if
@@ -382,27 +380,29 @@ Notes:
 
 ```ts
 interface QuotaCheckResult {
-  checkerId: string;
-  checkerType: string;            // 'claude-code', 'neuralwatt', etc.
-  provider: string;
-  checkedAt: string;              // ISO-8601
+  checkerId: string;     // unique instance id chosen by the operator
+  checkerType: string;   // 'claude-code', 'neuralwatt', etc.
+  provider: string;      // routing provider this checker is attached to
+  checkedAt: string;     // ISO-8601
   success: boolean;
   error?: string;
 
-  meters: Meter[];                // 0..N. Replaces `windows` and `groups`.
-
-  oauthAccountId?: string;
-  oauthProvider?: string;
-  rawResponse?: unknown;
+  meters: Meter[];       // 0..N independent meters
+  rawResponse?: unknown; // for debugging only
 }
 ```
 
 Notes:
 
-- `meters` replaces both `windows` and `groups`. If a checker wants to
-  group meters (e.g. per-model rows), each group member is its own meter
-  with `subject` set to the model name.
-- No checker-level `category` field.
+- `meters` is the only payload. There are no `windows`, no `groups`,
+  no checker-level `category`. If a provider exposes per-model rows
+  (Antigravity, Gemini-CLI), each row becomes a meter with the model
+  name in `subject`.
+- `oauthProvider`/`oauthAccountId` are **not** on the result. They're
+  duplicative: a checker is configured against a single OAuth account,
+  so `(checkerType, checkerId)` already identifies the account.
+  Anything that needs to display the OAuth account name resolves it
+  from the checker's config, not from each snapshot.
 
 ### 5.7 Worked examples (existing providers in the new model)
 
@@ -415,12 +415,14 @@ meters: [{
 }]
 ```
 
-**Wisdom Gate** (bounded balance — note: still a balance, has no period):
+**Wisdom Gate** (monthly subscription credit allowance):
 ```js
 meters: [{
-  key: 'balance', label: 'Wisdom Gate balance',
-  kind: 'balance', unit: 'usd',
+  key: 'monthly_credits', label: 'Wisdom Gate subscription',
+  kind: 'allowance', unit: 'usd',
   limit: 50, used: 18.20, remaining: 31.80,
+  period: { duration: {value: 1, unit: 'month'}, cycle: 'fixed',
+            resetsAt: '2026-05-01T00:00:00Z' },
   utilizationPercent: 36.4, status: 'ok',
 }]
 ```
@@ -429,14 +431,14 @@ meters: [{
 ```js
 meters: [
   { key: 'five_hour', label: '5-hour quota',
-    kind: 'allowance', unit: 'requests', valuesArePercent: true,
-    limit: 100, used: 27, remaining: 73,
+    kind: 'allowance', unit: 'percentage',
+    used: 27, remaining: 73,
     period: { duration: {value: 5, unit: 'hour'}, cycle: 'rolling',
               resetsAt: '2026-04-25T18:00:00Z' },
     utilizationPercent: 27, status: 'ok' },
   { key: 'weekly', label: 'Weekly quota',
-    kind: 'allowance', unit: 'requests', valuesArePercent: true,
-    limit: 100, used: 41, remaining: 59,
+    kind: 'allowance', unit: 'percentage',
+    used: 41, remaining: 59,
     period: { duration: {value: 7, unit: 'day'}, cycle: 'rolling',
               resetsAt: '2026-04-30T00:00:00Z' },
     utilizationPercent: 41, status: 'ok' },
@@ -459,26 +461,26 @@ meters: [
 ]
 ```
 
-**Neuralwatt** (the hybrid case — no special-casing needed):
+**Neuralwatt** (hybrid: balance + monthly energy allowance):
 ```js
 meters: [
   { key: 'credits', label: 'Credit balance',
     kind: 'balance', unit: 'usd',
     limit: 100, used: 23.50, remaining: 76.50, ...},
   { key: 'energy', label: 'Energy quota',
-    kind: 'allowance', unit: 'energy_kwh',
+    kind: 'allowance', unit: 'kwh',
     limit: 50, used: 12.4, remaining: 37.6,
     period: { duration: {value: 1, unit: 'month'}, cycle: 'fixed',
               resetsAt: '2026-05-01T00:00:00Z' }, ...},
 ]
 ```
 
-**Apertis** (combined into a single checker — no more two-checker split):
+**Apertis** (one checker, both PAYG balance and the cycle quota when
+the account is also a subscriber — both come from the same response):
 ```js
 meters: [
   { key: 'payg', label: 'PAYG balance',
     kind: 'balance', unit: 'usd', remaining: 8.42, ...},
-  // emitted only if the account is a subscriber:
   { key: 'cycle_quota', label: 'Apertis pro plan',
     kind: 'allowance', unit: 'requests',
     limit: 5000, used: 1200, remaining: 3800,
@@ -497,148 +499,123 @@ meters: [{
 
 ## 6. Database Schema
 
-The current `quota_snapshots` table stores one row per (checker, window,
-checkedAt). That granularity is right and should be preserved; only the
-column set changes.
+A new table — `meter_snapshots` — is created from scratch. The existing
+`quota_snapshots` table is left alone and ignored by the new code. There
+is no data migration. Anything historical that someone wants from the old
+table can be addressed separately, later.
 
-### 6.1 New columns (proposed)
+### 6.1 `meter_snapshots`
 
-| Column                | Type      | Replaces / new                                          |
-|-----------------------|-----------|---------------------------------------------------------|
-| `id`                  | int PK    | unchanged                                               |
-| `provider`            | text      | unchanged                                               |
-| `checker_id`          | text      | unchanged                                               |
-| `meter_key`           | text      | replaces `window_type`                                  |
-| `kind`                | text      | new: `'balance' \| 'allowance'`                         |
-| `label`               | text      | replaces `description` for the human-readable name      |
-| `subject`             | text NULL | new: optional sub-scope                                 |
-| `unit`                | text      | new enum: `'usd'\|'tokens'\|'requests'\|'energy_kwh'\|'points'` |
-| `values_are_percent`  | bool      | new                                                     |
-| `limit`               | real      | unchanged                                               |
-| `used`                | real      | unchanged                                               |
-| `remaining`           | real      | unchanged                                               |
-| `utilization_percent` | real      | unchanged                                               |
-| `period_duration_value`| int NULL | new                                                     |
-| `period_duration_unit`| text NULL | new: `'minute'\|'hour'\|'day'\|'week'\|'month'`         |
-| `period_cycle`        | text NULL | new: `'fixed'\|'rolling'`                               |
-| `resets_at`           | timestamp | unchanged (now nullable for balances, was always so)    |
-| `status`              | text      | unchanged                                               |
-| `success`             | bool      | unchanged                                               |
-| `error_message`       | text      | unchanged                                               |
-| `checked_at`          | timestamp | unchanged                                               |
-| `created_at`          | timestamp | unchanged                                               |
+One row per (checker invocation, meter). Columns:
 
-The compound primary index becomes `(checker_id, meter_key, checked_at)`,
-which lines up with how the history modal queries data.
+| Column                  | Type        | Notes                                            |
+|-------------------------|-------------|--------------------------------------------------|
+| `id`                    | int PK      |                                                  |
+| `checker_id`            | text        | operator-chosen instance id                      |
+| `checker_type`          | text        | e.g. `'claude-code'`                             |
+| `provider`              | text        | routing provider this checker is attached to     |
+| `meter_key`             | text        | checker-local id, e.g. `'five_hour'`, `'balance'`|
+| `kind`                  | text        | `'balance'` or `'allowance'`                     |
+| `unit`                  | text        | `'usd'`, `'tokens'`, `'requests'`, `'kwh'`, `'points'`, `'percentage'` |
+| `label`                 | text        | human-readable, set by the checker               |
+| `subject`               | text NULL   | optional sub-scope (e.g. model name)             |
+| `limit`                 | real NULL   |                                                  |
+| `used`                  | real NULL   |                                                  |
+| `remaining`             | real NULL   |                                                  |
+| `utilization_percent`   | real        | 0..100                                           |
+| `status`                | text        | `'ok'` / `'warning'` / `'critical'` / `'exhausted'` |
+| `period_duration_value` | int NULL    | only for allowances                              |
+| `period_duration_unit`  | text NULL   | `'minute'` / `'hour'` / `'day'` / `'week'` / `'month'` |
+| `period_cycle`          | text NULL   | `'fixed'` / `'rolling'`                          |
+| `resets_at`             | timestamp NULL | when the meter next regains capacity          |
+| `success`               | bool        | did the checker call succeed                     |
+| `error_message`         | text NULL   |                                                  |
+| `checked_at`            | timestamp   |                                                  |
+| `created_at`            | timestamp   |                                                  |
 
-`group_id` is dropped — `subject` covers the per-model case in a way the
-UI can render generically.
+Indexes:
 
-### 6.2 Postgres enums
+- `(checker_id, meter_key, checked_at)` — primary access path for the
+  history modal and the "latest meter" lookup.
+- `(provider, checked_at)` — for any cross-provider scans.
+- `(checked_at)` — for retention sweeps.
 
-- `quota_meter_kind_enum` = `('balance', 'allowance')`
-- `quota_meter_unit_enum` = `('usd', 'tokens', 'requests', 'energy_kwh', 'points')`
-- `quota_period_duration_unit_enum` = `('minute','hour','day','week','month')`
-- `quota_period_cycle_enum` = `('fixed', 'rolling')`
-- `quota_checker_type_enum` — kept, but its source-of-truth list is moved
-  (see § 7.1).
+### 6.2 No SQL enums
 
-### 6.3 Migration plan for stored history
+All categorical columns (`kind`, `unit`, `period_cycle`,
+`period_duration_unit`, `status`, `checker_type`) are plain `text`.
+Validation lives in code: the checker base class only emits valid
+values, and the API layer rejects anything malformed. Adding a new
+checker type or a new unit therefore costs zero database migrations.
 
-A backfill migration maps old rows to new ones with a deterministic
-translation table. Critical mappings:
+The trade-off is well understood: a typo on the write path becomes a
+runtime bug instead of a database error. We accept that — typos are
+caught by the checker's tests and the type system.
 
-| Old `windowType`      | New `kind`  | New `period`                                            |
-|-----------------------|-------------|---------------------------------------------------------|
-| `subscription`        | `balance`   | (none)                                                  |
-| `hourly`              | `allowance` | `{1, 'hour', 'fixed'}`                                  |
-| `five_hour`           | `allowance` | `{5, 'hour', 'rolling'}` (Claude/Codex use rolling)     |
-| `rolling_five_hour`   | `allowance` | `{5, 'hour', 'rolling'}`                                |
-| `daily`               | `allowance` | `{1, 'day', 'fixed'}`                                   |
-| `weekly`              | `allowance` | `{1, 'week', 'fixed'}`                                  |
-| `rolling_weekly`      | `allowance` | `{1, 'week', 'rolling'}`                                |
-| `monthly`             | `allowance` | `{1, 'month', 'fixed'}`                                 |
-| `toolcalls`           | `allowance` | (per-checker; `subject='tool calls'`)                   |
-| `search`              | `allowance` | (per-checker; `subject='search'`)                       |
-| `custom`              | `allowance` | (per-checker; encoded from API metadata where possible) |
+## 7. Backend
 
-Old `unit='percentage'` rows become `unit='requests'` with
-`values_are_percent=true`. Old `unit='points'` rows for Neuralwatt become
-`unit='energy_kwh'` (special-case in the migration based on `checker_id`).
-Old `unit='kwh'` is renamed to `energy_kwh` for consistency. Other
-`unit='points'` rows (Poe, Zenmux) stay as `points`.
+### 7.1 Checker registration
 
-For safety, keep the old columns for one release and write to both. The
-quota scheduler reads from new columns only; the history modal
-double-reads during the transition window.
-
-## 7. Backend changes
-
-### 7.1 Single source of truth for checker registration
-
-Replace the four parallel lists with one declaration per checker:
+A checker is a class plus an options-schema. They live together in the
+checker's own module and self-register:
 
 ```ts
-// packages/backend/src/services/quota/checkers/registry.ts
-export const CHECKER_DEFS = [
-  { type: 'naga',         class: NagaQuotaChecker,         optionsSchema: NagaQuotaCheckerOptionsSchema },
-  { type: 'claude-code',  class: ClaudeCodeQuotaChecker,   optionsSchema: ClaudeCodeQuotaCheckerOptionsSchema },
-  ...
-] as const;
+// packages/backend/src/services/quota/checkers/claude-code.ts
+import { defineChecker } from '../checker-registry';
+
+export default defineChecker({
+  type: 'claude-code',
+  optionsSchema: z.object({
+    endpoint: z.string().url().optional(),
+    oauthAccountId: z.string().optional(),
+    maxUtilizationPercent: z.number().min(1).max(100).optional(),
+  }),
+  async check(ctx): Promise<Meter[]> {
+    // hits the API, returns meters
+  },
+});
 ```
 
-Derived from this single array:
+`defineChecker` adds the entry to a module-private registry. Importing
+the checker file is enough; there is no separate factory map, no enum
+list, no parallel array of types in `config.ts`. The registry exposes:
 
-- `VALID_QUOTA_CHECKER_TYPES` (config.ts)
-- `ProviderQuotaCheckerSchema` (the discriminated union, generated by
-  mapping over `CHECKER_DEFS`)
-- `CHECKER_REGISTRY` (factory)
-- `quotaCheckerTypeEnum` values (postgres)
-- The response of `/v0/management/quota-checker-types`
+- `getCheckerTypes(): string[]` — for the management API.
+- `validateProviderConfig(cfg)` — uses the per-type `optionsSchema`.
+- `instantiate(type, options)` — replaces the old `createChecker`.
 
-The frontend fetches `/v0/management/quota-checker-types` and the
-fallback constants in `api.ts` and `Providers.tsx` are removed (a stale
-fallback is worse than a brief loading state).
+The frontend calls `/v0/management/quota-checker-types` and uses what it
+gets back. There is no fallback list duplicated in the frontend — if the
+API is unreachable, the dropdown shows a loading state.
 
-### 7.2 Base class shape
+### 7.2 Base behaviour
+
+Each checker's `check(ctx)` returns a `Meter[]`. Helpers on the context
+build meters with derived fields filled in:
 
 ```ts
-abstract class QuotaChecker {
-  abstract readonly type: string;          // e.g. 'claude-code'
-  abstract checkQuota(): Promise<QuotaCheckResult>;
-
-  /** Default exhaustion threshold for the whole checker; overridable
-   *  per-meter inside checkQuota(). */
-  get exhaustionThreshold(): number {
-    return this.config.options.maxUtilizationPercent ?? 99;
-  }
-
-  // Helpers — emit a meter, derive utilization, compute status, etc.
-  protected balanceMeter(...): Meter;
-  protected allowanceMeter(...): Meter;
-}
+ctx.balance({ key, label, unit, remaining, limit?, subject? })
+ctx.allowance({ key, label, unit, used, limit?, remaining?,
+                period: { duration, cycle, resetsAt? },
+                subject? })
 ```
 
-Note: no more `category` getter on the checker. The
-`getCheckerCategory(checkerId)` function in
-`packages/backend/src/routes/management/quotas.ts` is deleted; the API
-returns meters with their own `kind` already.
+`utilizationPercent` and `status` are derived inside the helper — the
+checker does not compute them. There is no checker-level `category`,
+`window`, or `category` getter.
+
+Configuration like `maxUtilizationPercent` lives in the checker's own
+options schema. If a checker wants to expose per-meter overrides, it
+does so via its own option shape; the base class doesn't pretend to
+solve it generically.
 
 ### 7.3 Cooldown / scheduler
 
-`QuotaScheduler.applyCooldownsFromResult` already iterates windows and
-picks the most-constrained one. The same logic applies to meters. Two
-small adjustments:
-
-1. **Skip balance meters** for cooldown injection. A balance going to
-   zero is a billing problem, not a rate-limit problem; the request will
-   fail upstream with a clear error. The scheduler should *not* keep
-   slamming the cooldown awake/asleep on every poll just because a
-   balance was 0 — and it cannot reset itself, so there's nothing to
-   wait for. (Today this is implicit because balances have no
-   `resetsAt`; making it explicit makes the intent obvious.)
-2. The "strictest threshold" calculation iterates `meters`, not
-   `windows`.
+Cooldown injection iterates over the latest meters for each checker.
+Only allowance meters with a known `resetsAt` participate — a balance
+meter at zero is a billing failure, not a rate-limit, and there is
+nothing to wait for. The "strictest threshold" calculation looks at all
+allowance meters across all checkers attached to a provider.
 
 ### 7.4 API response shape
 
@@ -647,22 +624,22 @@ small adjustments:
 ```ts
 {
   checkerId: string;
-  checkerType: string;          // moves up — was always there but now
-                                // is the only "what kind of checker is this"
-  oauthAccountId?: string;
-  oauthProvider?: string;
+  checkerType: string;
+  provider: string;
   latest: {
     checkedAt: string;
     success: boolean;
     error?: string;
-    meters: Meter[];            // the most recent snapshot reconstructed
-                                // by grouping rows on `meter_key`
+    meters: Meter[];
   };
 }[]
 ```
 
-`checkerCategory` is removed from the API. Consumers determine kind
-per-meter.
+The "latest" meters are reconstructed from `meter_snapshots` by taking
+the most recent row for each `(checker_id, meter_key)`. There is no
+`checkerCategory`, no `oauthAccountId`, no `oauthProvider` on the
+response — the frontend asks the provider-config endpoint when it wants
+to label an OAuth account.
 
 ## 8. Frontend changes
 
@@ -674,21 +651,20 @@ components:
 - `BalanceMeterRow` — wallet icon, label, formatted `remaining` value,
   optional progress bar when `limit` is known.
 - `AllowanceMeterRow` — progress bar with `utilizationPercent`, a label,
-  `used / limit` formatted via `unit` and `valuesArePercent`, and a
-  countdown to `period.resetsAt` if present.
+  `used / limit` formatted by unit, and a countdown to `period.resetsAt`
+  if present.
 
-`MeterValue.tsx` formats a number based on `unit` (and
-`valuesArePercent`):
+`MeterValue.tsx` formats a number based on `unit`:
 
 ```ts
-function formatMeterValue(v: number, unit: MeterUnit, asPercent?: boolean) {
-  if (asPercent) return `${Math.round(v)}%`;
+function formatMeterValue(v: number, unit: MeterUnit) {
   switch (unit) {
-    case 'usd':         return formatCost(v);
-    case 'tokens':      return formatTokens(v);
-    case 'requests':    return `${formatNumber(v)} reqs`;
-    case 'energy_kwh':  return `${v.toFixed(3)} kWh`;
-    case 'points':      return `${formatPointsFull(v)} pts`;
+    case 'usd':        return formatCost(v);
+    case 'tokens':     return formatTokens(v);
+    case 'requests':   return `${formatNumber(v)} reqs`;
+    case 'kwh':        return `${v.toFixed(3)} kWh`;
+    case 'points':     return `${formatPointsFull(v)} pts`;
+    case 'percentage': return `${Math.round(v)}%`;
   }
 }
 ```
@@ -746,34 +722,35 @@ Config components stay, because each checker has different config inputs
 backend shape — `Meter`, `MeterKind`, `MeterUnit`, `Period`, etc. The
 old `QuotaWindow`/`QuotaWindowType` types are removed.
 
-## 9. Migration / Rollout Plan
+## 9. Implementation Order
 
-The change is large but cleanly stageable:
+This is a greenfield build alongside the existing one, then a cutover.
+There is no historical-data migration to worry about. Suggested order:
 
-1. **Land the new types** alongside the old ones (`Meter` next to
-   `QuotaWindow`). Add a `meters: Meter[]` field to the wire shape; keep
-   `windows: QuotaWindow[]` populated from `meters` for one release so
-   nothing breaks during deploy.
-2. **Migrate one checker** end-to-end (suggest `naga` — simplest balance
-   case) to prove the new base class. Snapshot it with both old and new
-   columns.
-3. **Generate the schema migration** (new columns nullable, old columns
-   nullable). Backfill with a one-shot script using the mapping table
-   from § 6.3.
-4. **Migrate the remaining checkers**. The hybrid case (Neuralwatt) and
-   the multi-meter cases (Synthetic, NanoGPT, Codex, Claude) prove the
-   model. Apertis collapses from two checkers into one — provider
-   configs that reference `apertis-coding-plan` are mapped to
-   `apertis` on read for one release.
-5. **Frontend cutover**: ship the generic `BalanceMeterRow` /
-   `AllowanceMeterRow`. Delete the 21 per-checker display components in
-   the same PR. The two `BALANCE_CHECKERS_WITH_RATE_LIMIT` literals,
-   the three `CHECKER_DISPLAY_NAMES` copies, and
-   `getTrackedWindowsForChecker` all delete.
-6. **Drop the old columns and types** one release later, after the
-   double-write window has expired.
+1. **New types and base class.** Land `Meter`, `MeterKind`, `MeterUnit`,
+   `Period`, the `defineChecker` helper, and the `meter_snapshots`
+   schema. No checkers yet.
+2. **Build new checkers from scratch.** One per existing provider, in
+   the new base class. The hybrid (Neuralwatt) and multi-meter cases
+   (Synthetic, NanoGPT, Codex, Claude) are the most informative to do
+   early — they prove the model. Apertis is a single checker emitting
+   both meters from one response; `apertis-coding-plan` does not exist
+   in the new world.
+3. **New API endpoints.** `/v0/management/quotas` returns the new
+   shape. The old endpoint is left in place but unused, and is removed
+   at the end.
+4. **New frontend components.** `BalanceMeterRow`, `AllowanceMeterRow`,
+   the presentation registry, the config-component lookup. The Quotas
+   page and the sidebar render from `meters` directly.
+5. **Cutover.** The new scheduler reads from `meter_snapshots`; the new
+   provider-config UI writes the new options; the old code is deleted
+   in the same PR. There is no double-write, no compatibility shim.
+   The old `quota_snapshots` table is left untouched in the database
+   and ignored by the application.
 
-Each step is independently shippable; the system stays green throughout.
+Each step except the cutover is independently shippable behind code
+that nothing else calls, so a half-finished step doesn't break anything
+in production.
 
 ## 10. What this fixes, concretely
 
@@ -783,35 +760,32 @@ Tying it back to the issues from § 3:
 |-----------------------------------------------|---------------------------------------------------------|
 | `category` on the wrong object                | Moved to `kind` on each meter.                          |
 | `windowType` conflates four axes              | Split into `kind`, `period.duration`, `period.cycle`, `subject`. |
-| `unit: 'percentage'` is degenerate            | Replaced by `valuesArePercent` flag on the underlying real unit. |
-| `unit: 'points'` overloaded for kWh           | New `energy_kwh` unit; `points` reserved for opaque provider currencies. |
+| `unit: 'points'` overloaded for kWh           | New `kwh` unit. `points` reserved for opaque provider currencies. |
 | Hybrid checkers need manual override sets     | Mixed checkers naturally emit meters of both kinds.     |
 | 21 near-duplicate display components          | Two generic row components + a presentation registry.   |
-| 4 parallel checker-type registrations         | One `CHECKER_DEFS` array generates all of them.         |
+| 4 parallel checker-type registrations         | `defineChecker` self-registers; a single in-process registry serves API, factory, and validation. |
 | Apertis pays for two API calls                | Single checker emits both meters from one response.     |
-| History rows mix `requests` and `percentage`  | Stored unit is stable; `valuesArePercent` decides display only. |
 | `getTrackedWindowsForChecker` 23-arm switch   | Deleted — every meter is rendered the same way.         |
+| OAuth fields duplicated on every snapshot     | Removed from the wire shape; resolved from checker config only when needed. |
 
 ## 11. Open questions
 
-- **Per-meter exhaustion thresholds.** Today `maxUtilizationPercent` is a
-  checker-level config. For checkers with multiple meters the operator
-  may want to cool down on the 5-hour window at 95% but tolerate 99% on
-  the weekly. Suggest allowing the option as either a number (applies
-  to all meters) or a `Record<meterKey, number>`. Out of scope for the
-  initial migration; can land later without further schema changes.
+- **Per-meter exhaustion thresholds.** Today `maxUtilizationPercent` is
+  a checker-level option. For checkers with multiple meters the
+  operator may want to cool down on the 5-hour window at 95% but
+  tolerate 99% on the weekly. Suggest allowing the option as either a
+  number (applies to all meters) or a `Record<meterKey, number>`. Each
+  checker can opt in via its own options schema; the base class doesn't
+  need to know.
 - **Rolling-window reset semantics.** Truly rolling windows don't have
   a single "reset moment" — they recover continuously. Today the code
-  pretends they do (using `nextTickAt`/`resetTime` from the API).
-  Acceptable for now: keep `resetsAt` populated when the API gives us
-  one, document that for `cycle: 'rolling'` it means "earliest moment
-  capacity will visibly improve."
+  pretends they do (using `nextTickAt`/`resetTime` from the API). The
+  new model keeps `resetsAt` populated when the API supplies one and
+  documents that for `cycle: 'rolling'` it means "earliest moment
+  capacity will visibly improve," not "everything resets."
 - **Multiple balance currencies on one provider.** Moonshot exposes
   `cash_balance` and `voucher_balance` separately. Today only
-  `available_balance` is recorded. The new model can emit both as
-  separate meters if we want to surface them; deferring that decision.
-- **Energy units beyond kWh.** Neuralwatt is the only energy meter
-  today. If others appear with different units (joules, CO₂eq), promote
-  `energy_kwh` to a more general `{ unit: 'energy', subUnit: 'kwh' }`.
-  Premature now.
+  `available_balance` is recorded. The new model has no obstacle to
+  emitting both as separate meters with `subject: 'cash'` /
+  `subject: 'voucher'`; whether to do so is a UX call per provider.
 

--- a/docs/QUOTA_BALANCE_REDESIGN.md
+++ b/docs/QUOTA_BALANCE_REDESIGN.md
@@ -1,0 +1,817 @@
+# Quota & Balance Tracking Redesign
+
+> Status: **Proposal** — no code changes have been made. This document is the
+> design that the implementation should be measured against.
+
+## 1. Problem Statement
+
+Plexus currently tracks two related-but-distinct things under one umbrella:
+
+1. **Account balances** — prepaid amounts that get drawn down as the user
+   makes requests, do not refill on a schedule, and are topped up out-of-band
+   (e.g. OpenRouter credits, Naga balance, Moonshot cash, Apertis PAYG).
+2. **Subscription quotas / rate limits** — recurring entitlements bound to a
+   billing cycle or rolling window (e.g. Claude Code 5-hour + weekly limits,
+   Codex primary/secondary, Copilot monthly premium interactions).
+
+The current model collapses these into a single `QuotaWindow[]` shape with a
+fixed `category: 'balance' | 'rate-limit'` per checker. That works for the
+simple cases but breaks down quickly:
+
+- Some providers expose **both at once** (Neuralwatt: dollar credit balance
+  *and* a monthly kWh subscription quota; Apertis: a PAYG balance *and* a
+  coding-plan cycle quota — solved today by registering two separate
+  checkers).
+- Some "balances" are actually **bounded** with a known total (Wisdom Gate
+  reports `total_usage` and `total_available` — i.e. it's really a cycle
+  quota that the code labels as `subscription`/`balance`).
+- Some "subscriptions" are denominated in **dollars** (Synthetic weekly
+  credits in `$`), some in **points** (Zenmux flows, Poe points), some in
+  **percentage only** (Claude Code, Codex, Antigravity, Gemini-CLI), some in
+  **tokens** (NanoGPT), and some in **requests** (Copilot, Apertis-coding,
+  MiniMax-coding, Kimi-code).
+- Some providers have **multiple independent meters** with different units
+  (NanoGPT: weekly tokens + daily tokens + daily images; ZAI: 5h tokens +
+  monthly MCP requests; Synthetic: rolling-5h requests + hourly search
+  requests + rolling-weekly dollars).
+- The `unit: 'points'` value is overloaded — Neuralwatt uses it for kWh and
+  the frontend has a special-case branch (`if (unit === 'kwh') ...`) that
+  never matches the actual data.
+
+The implementation has accumulated workarounds:
+
+- A `BALANCE_CHECKERS_WITH_RATE_LIMIT = new Set(['neuralwatt'])` literal
+  duplicated in `Sidebar.tsx` and `Quotas.tsx` to coerce one "balance"
+  checker into also appearing in the rate-limit section.
+- A `windowType` enum with overlapping/aliased members
+  (`five_hour`/`rolling_five_hour`, `weekly`/`rolling_weekly`,
+  `subscription`/`monthly`, `custom`) where `subscription` is overloaded to
+  mean "this is a balance row, not a periodic quota."
+- Per-checker hardcoded display lists in `CompactQuotasCard.getTrackedWindowsForChecker`
+  picking which windows to render for each provider.
+- 21+ display components, one per checker, most of which differ only in
+  which icon and which `windowType` strings they reach for.
+
+The goal of this document is to design a **single, flexible data model** that
+can describe every existing provider and any reasonable future one without
+needing per-checker conditionals in either the schema or the UI.
+
+## 2. Survey of the 23 Existing Checkers
+
+The matrix below normalises what each checker actually returns. Rows are
+grouped by structural shape, not by current `category` label.
+
+### 2.1 Pure prepaid balances (one number, no reset)
+
+| Checker      | Unit    | API exposes                  | Notes                                  |
+|--------------|---------|------------------------------|----------------------------------------|
+| `naga`       | dollars | `balance`                    |                                        |
+| `kilo`       | dollars | `balance`                    |                                        |
+| `moonshot`   | dollars | `available_balance`          | Also has cash/voucher subtotals        |
+| `novita`     | dollars | `availableBalance`           | Stored in 1/10000 USD, divided in code |
+| `minimax`    | dollars | `available_amount`           | Cookie auth                            |
+| `apertis`    | dollars | `payg.account_credits`       | Same endpoint as `apertis-coding-plan` |
+| `openrouter` | dollars | `total_credits - total_usage`| Computes remaining locally             |
+| `poe`        | points  | `current_point_balance`      | Points, not dollars                    |
+
+Today these all emit `windowType: 'subscription'`, `category: 'balance'`,
+`limit: undefined`, `used: undefined`, `remaining: <value>`, no `resetsAt`.
+
+### 2.2 Bounded balances with a known total (still no time reset)
+
+| Checker      | Unit    | Exposes                                                            |
+|--------------|---------|--------------------------------------------------------------------|
+| `wisdomgate` | dollars | `total_usage`, `total_available` → code derives `limit = used + remaining` |
+
+Currently emitted as `windowType: 'subscription'` with a `limit`.
+Semantically it's still a balance — it just has a known historical total.
+
+### 2.3 Subscription quotas with a single periodic window
+
+| Checker               | Window      | Unit                       | Notes                                                  |
+|-----------------------|-------------|----------------------------|--------------------------------------------------------|
+| `copilot`             | monthly     | requests **or** percentage | Falls back to % when entitlement missing               |
+| `apertis-coding-plan` | monthly     | requests                   | `cycle_*` fields                                       |
+| `minimax-coding`      | "custom"    | requests                   | API field is misnamed; remaining lives in `usage_count`|
+| `gemini-cli`          | "five_hour" | percentage                 | Aggregated per-model bucket                            |
+| `antigravity`         | "five_hour" | percentage                 | Per-model rows                                         |
+
+### 2.4 Subscription quotas with multiple independent windows
+
+| Checker        | Windows                                                       | Units                                |
+|----------------|---------------------------------------------------------------|--------------------------------------|
+| `claude-code`  | 5-hour + 7-day                                                | percentage, percentage               |
+| `openai-codex` | primary (5-hour) + secondary (7-day)                          | percentage, percentage               |
+| `zenmux`       | rolling-5h flows + rolling-7-day flows                        | points, points                       |
+| `ollama`       | session (5-hour) + weekly                                     | percentage, percentage               |
+| `kimi-code`    | "usage" + N variable rate-limit windows                       | requests                             |
+| `zai`          | 5-hour tokens + monthly MCP requests                          | percentage, requests                 |
+| `nanogpt`      | weekly input tokens + daily input tokens + daily images       | tokens, tokens, requests             |
+| `synthetic`    | rolling-5h requests + hourly search + rolling-weekly credits  | requests, requests, dollars          |
+
+### 2.5 Hybrid: balance **and** subscription quota together
+
+| Checker      | Balance side                       | Subscription side                                       |
+|--------------|------------------------------------|---------------------------------------------------------|
+| `neuralwatt` | dollar credits remaining (PAYG)    | monthly kWh quota (`unit:'points'` today, mislabelled)  |
+
+This is the case the current model fails most clearly: the checker's single
+`category` field is `'balance'`, and the frontend has to special-case
+`neuralwatt` in two different `BALANCE_CHECKERS_WITH_RATE_LIMIT` sets to also
+render its monthly window in the rate-limit section.
+
+`apertis` and `apertis-coding-plan` sidestep this by being registered as two
+*separate* checkers hitting the same endpoint — paying twice for the API
+call and producing twice the snapshots.
+
+## 3. Concrete Inconsistencies in the Current Model
+
+Pulled from `packages/backend/src/types/quota.ts`, the checker
+implementations, the schema, and the frontend.
+
+### 3.1 `category` is on the wrong object
+
+`QuotaChecker.category: 'balance' | 'rate-limit'` is a *checker-level*
+attribute. But "balance vs. rate-limit" is a property of an individual
+**meter**, not the API endpoint that returns them. Neuralwatt has both;
+Wisdom Gate is recorded as `balance` even though its bounded shape is
+indistinguishable from a quota. Apertis only escapes this by being split
+into two checkers.
+
+### 3.2 `windowType` conflates four different axes
+
+`QuotaWindowType =
+  'subscription' | 'hourly' | 'five_hour' | 'rolling_five_hour' |
+  'toolcalls' | 'search' | 'daily' | 'weekly' | 'rolling_weekly' |
+  'monthly' | 'custom'`
+
+This single enum tries to express all of:
+
+1. **Kind of meter** — `subscription` is used as "this is a balance, not a
+   periodic quota."
+2. **Period length** — `hourly`, `five_hour`, `daily`, `weekly`, `monthly`.
+3. **Whether the period is fixed-cycle or rolling/sliding** —
+   `weekly` vs `rolling_weekly`, `five_hour` vs `rolling_five_hour`.
+4. **What the meter is measuring** — `toolcalls`, `search`.
+
+These are independent dimensions and should be modelled as such. Today the
+frontend has to do `windows.find(w => w.windowType === 'subscription')` to
+locate the balance, and `getTrackedWindowsForChecker` has 16 hard-coded
+cases mapping checker name → window-type strings to render.
+
+### 3.3 `unit` carries a misleading value (`points`)
+
+`QuotaUnit = 'dollars' | 'requests' | 'tokens' | 'percentage' | 'points' | 'kwh'`
+
+- `kwh` exists in the type but no checker emits it. Neuralwatt emits
+  `'points'` for kilowatt-hours and the frontend has both
+  `if (unit === 'kwh')` *and* `if (unit === 'points') ... kWh remaining`
+  branches that work around it.
+- `points` is used for both **Poe points** (a real currency-like balance)
+  and **Zenmux flows** (a per-cycle quota count) and **kWh** (an energy
+  quantity). Three completely different things.
+- `percentage` is a degenerate unit — it means "we don't know the underlying
+  count, only the fraction." Everywhere `unit='percentage'` is used,
+  `limit=100`, `used=<percent>`, `remaining=<percent>`, which is a clumsy
+  encoding of "no count, just utilization."
+
+### 3.4 Window output is not uniform within a checker
+
+In several checkers the same window field is conditionally either `requests`
+or `percentage` depending on what the upstream API returned (e.g.
+`copilot-checker` lines 82-112 chooses unit at runtime). This makes
+historical comparison meaningless — a snapshot from yesterday in `requests`
+is not graphable on the same axis as today's snapshot in `percentage`.
+
+### 3.5 Frontend has 21 near-duplicate display components
+
+Each checker has its own `XxxQuotaDisplay.tsx`. They all do the same thing:
+
+1. Find a window by hardcoded `windowType` string.
+2. Render either a `Wallet` icon + formatted number, or a
+   `QuotaProgressBar`.
+3. Show a reset countdown if there is one.
+
+`CompactQuotasCard.getTrackedWindowsForChecker` further duplicates this
+selection logic with a 23-arm switch statement that maps each checker name
+to the window types it expects.
+
+### 3.6 Cross-cutting overrides
+
+- `BALANCE_CHECKERS_WITH_RATE_LIMIT = new Set(['neuralwatt'])` — defined
+  twice (`Sidebar.tsx:265`, `Quotas.tsx:166`). Both literals must stay in
+  sync. They exist purely because `category` cannot be split per-meter.
+- `CHECKER_DISPLAY_NAMES` defined three times
+  (`Quotas.tsx:39`, `CombinedBalancesCard.tsx:17`, plus implicit
+  via `CompactQuotasCard.getTypeDisplayName`).
+- `FALLBACK_QUOTA_CHECKER_TYPES` (`api.ts`) and
+  `QUOTA_CHECKER_TYPES_FALLBACK` (`Providers.tsx`) duplicate
+  `VALID_QUOTA_CHECKER_TYPES` from the backend and the
+  `quotaCheckerTypeEnum` postgres enum — four copies of the same list.
+
+### 3.7 Adding a checker requires touching ~10 files
+
+Per `AGENTS.md` § "Adding a Quota Checker": backend Zod schema, checker
+class, factory registry, postgres enum, frontend display, frontend config,
+frontend index, sidebar arrays, providers page fallback, api.ts fallback,
+combined-balances display name, compact-quotas tracked-windows switch.
+Most of that is rote.
+
+## 4. Design Goals
+
+1. **One concept, atomically.** A checker emits zero or more independent
+   *meters*. A meter is the single unit of "thing that has a value, a unit,
+   maybe a limit, maybe a reset, and a status." Balance vs. quota is a
+   property of the meter, not the checker.
+2. **Orthogonal axes.** Period duration, period kind (rolling vs. fixed),
+   unit of measure, and what the meter counts are independent fields. No
+   compound enums.
+3. **No degenerate units.** `percentage` stops being a unit; it's a
+   *display preference* derived from `used/limit`. Units name what is being
+   counted (USD, tokens, requests, kWh, opaque-points).
+4. **No magic strings to wire up the UI.** The model carries enough
+   self-describing metadata that a generic balance row and a generic quota
+   row can render any checker. Per-checker custom UI is only needed when a
+   provider has genuinely unusual semantics — and even then it is opt-in,
+   not the default.
+5. **One source of truth for checker registration.** Type list, postgres
+   enum, frontend dropdown, factory map should derive from a single
+   declaration.
+6. **The migration must be backwards-compatible** for stored snapshots —
+   we don't want to lose history.
+
+## 5. Proposed Data Model
+
+### 5.1 Vocabulary
+
+- **Checker** — the thing that talks to a provider's billing/usage
+  endpoint. Identified by `checkerType` (e.g. `claude-code`) and a
+  user-chosen `checkerId`. Configured per-provider.
+- **Meter** — a single measurable. The atomic record. Has a kind, a unit,
+  a value, optionally a limit, optionally a renewal period.
+- **Snapshot** — one observation of one meter at one point in time. The
+  database row.
+
+A checker invocation produces *N* meter snapshots (commonly 1–4).
+
+### 5.2 Meter kinds
+
+```ts
+type MeterKind =
+  | 'balance'    // a stored value drawn down by use; topped up out-of-band
+  | 'allowance'  // a per-period entitlement that resets on a schedule
+```
+
+Two values, deliberately. "Allowance" replaces today's
+`'rate-limit'`/`'subscription'` muddle: it's the right word for "you get
+N per cycle." The kind alone tells the UI which icon family to use and
+which section of the dashboard the meter lives in. There is no third kind
+and there is no checker-level kind.
+
+### 5.3 Units
+
+```ts
+type MeterUnit =
+  | 'usd'         // dollars / credits expressed in dollars
+  | 'tokens'      // LLM tokens (input + output unless qualified by `subject`)
+  | 'requests'    // API calls / interactions / "flows" / coding-plan calls
+  | 'energy_kwh'  // kilowatt-hours
+  | 'points'      // opaque provider-specific units (Poe points, etc.) —
+                  // used only when the provider's docs literally call them
+                  // "points" and there is no better mapping
+```
+
+`percentage` is removed as a unit. When a provider only exposes a
+percentage (Claude Code, Codex, Antigravity, Gemini-CLI), the meter is
+emitted with `unit: 'requests'`, `limit: 100`, `used: <percent>`,
+`remaining: 100 - <percent>`, and a flag `valuesArePercent: true` that
+tells the UI not to print "37 requests" but "37%". This keeps the wire
+format honest about what we know (only a fraction) without inventing a
+fake count.
+
+Alternative considered: keep `percentage` as a unit. Rejected because it
+forces every consumer to branch on it ("if percentage, render differently;
+if anything else, render normally"), which is exactly the situation we
+have today.
+
+### 5.4 Periods
+
+```ts
+interface Period {
+  // Length of the cycle.
+  duration: { value: number; unit: 'minute' | 'hour' | 'day' | 'week' | 'month' };
+  // Fixed-window (resets on a calendar boundary; everyone resets together)
+  // vs. rolling/sliding (resets N units after the request that spent it).
+  cycle: 'fixed' | 'rolling';
+  // When the *current* cycle ends / when the meter next regains capacity.
+  // Required for fixed cycles when the API returns it; optional for
+  // rolling (rolling windows often don't have a single reset moment).
+  resetsAt?: string; // ISO-8601
+}
+```
+
+`Period` is only present on `MeterKind === 'allowance'` meters. Balance
+meters have no period.
+
+### 5.5 The Meter shape
+
+```ts
+interface Meter {
+  // ── Identity ───────────────────────────────────────────────────────────
+  /** Stable id within a checker invocation. Two snapshots with the same
+   *  (checkerId, key) describe the same meter at two points in time. */
+  key: string;
+  /** Provider-readable label, e.g. "5-hour quota", "Account balance",
+   *  "Search requests". Already localised for the UI. */
+  label: string;
+  /** Optional refinement, e.g. "Pro models", "Flash models", "Input tokens".
+   *  When two meters share a label this disambiguates them. */
+  subject?: string;
+
+  // ── Classification ────────────────────────────────────────────────────
+  kind: MeterKind;
+  unit: MeterUnit;
+  /** When true, `used`/`remaining`/`limit` are 0..100 percentages, not
+   *  counts of `unit`. Set when the upstream API only reports a fraction. */
+  valuesArePercent?: boolean;
+
+  // ── Values ────────────────────────────────────────────────────────────
+  /** Total cycle entitlement (allowance) or initial deposit (balance, if
+   *  knowable — most providers don't expose this for prepaid balances). */
+  limit?: number;
+  used?: number;
+  remaining?: number;
+  /** Always 0..100. Derived if any two of (limit, used, remaining) known. */
+  utilizationPercent: number;
+
+  // ── Time ──────────────────────────────────────────────────────────────
+  /** Required when kind === 'allowance', omitted when kind === 'balance'. */
+  period?: Period;
+
+  // ── Status ────────────────────────────────────────────────────────────
+  status: 'ok' | 'warning' | 'critical' | 'exhausted';
+
+  // ── Cooldown gating ───────────────────────────────────────────────────
+  /** Per-meter override; falls back to checker default, falls back to 99. */
+  exhaustionThreshold?: number;
+}
+```
+
+Notes:
+
+- `key` is a checker-local identifier (`'five_hour'`, `'weekly'`,
+  `'balance'`, `'energy'`, `'search'`). It is **not** a global enum and
+  the frontend never branches on its value. It's what `(checkerId, key)`
+  uniquely identifies a meter for history graphing.
+- `label`/`subject` is what the UI shows. The checker is responsible for
+  translating provider-speak into something a human reads. The frontend
+  never has to look up "what does `'five_hour'` mean for Claude vs.
+  Gemini" — the meter already says "5-hour quota".
+- `kind` (not `windowType`) is what divides the UI: balances on one card,
+  allowances on another. No `BALANCE_CHECKERS_WITH_RATE_LIMIT` set is
+  needed because mixed checkers simply emit meters of both kinds.
+- `period` collapses today's `windowType` enum into orthogonal fields.
+  Claude's 5-hour limit becomes
+  `{ duration: { value: 5, unit: 'hour' }, cycle: 'rolling' }`.
+  Synthetic's hourly search becomes
+  `{ duration: { value: 1, unit: 'hour' }, cycle: 'fixed' }`.
+- The estimation/projection block from the current `QuotaWindow` is kept
+  unchanged on `Meter` (omitted above for brevity).
+
+### 5.6 The CheckResult shape
+
+```ts
+interface QuotaCheckResult {
+  checkerId: string;
+  checkerType: string;            // 'claude-code', 'neuralwatt', etc.
+  provider: string;
+  checkedAt: string;              // ISO-8601
+  success: boolean;
+  error?: string;
+
+  meters: Meter[];                // 0..N. Replaces `windows` and `groups`.
+
+  oauthAccountId?: string;
+  oauthProvider?: string;
+  rawResponse?: unknown;
+}
+```
+
+Notes:
+
+- `meters` replaces both `windows` and `groups`. If a checker wants to
+  group meters (e.g. per-model rows), each group member is its own meter
+  with `subject` set to the model name.
+- No checker-level `category` field.
+
+### 5.7 Worked examples (existing providers in the new model)
+
+**Naga** (pure dollar balance, one meter):
+```js
+meters: [{
+  key: 'balance', label: 'Account balance',
+  kind: 'balance', unit: 'usd',
+  remaining: 12.34, utilizationPercent: 0, status: 'ok',
+}]
+```
+
+**Wisdom Gate** (bounded balance — note: still a balance, has no period):
+```js
+meters: [{
+  key: 'balance', label: 'Wisdom Gate balance',
+  kind: 'balance', unit: 'usd',
+  limit: 50, used: 18.20, remaining: 31.80,
+  utilizationPercent: 36.4, status: 'ok',
+}]
+```
+
+**Claude Code** (two allowances, percentage-only):
+```js
+meters: [
+  { key: 'five_hour', label: '5-hour quota',
+    kind: 'allowance', unit: 'requests', valuesArePercent: true,
+    limit: 100, used: 27, remaining: 73,
+    period: { duration: {value: 5, unit: 'hour'}, cycle: 'rolling',
+              resetsAt: '2026-04-25T18:00:00Z' },
+    utilizationPercent: 27, status: 'ok' },
+  { key: 'weekly', label: 'Weekly quota',
+    kind: 'allowance', unit: 'requests', valuesArePercent: true,
+    limit: 100, used: 41, remaining: 59,
+    period: { duration: {value: 7, unit: 'day'}, cycle: 'rolling',
+              resetsAt: '2026-04-30T00:00:00Z' },
+    utilizationPercent: 41, status: 'ok' },
+]
+```
+
+**Synthetic** (mixed: rolling-5h requests, hourly fixed search, rolling-week dollars):
+```js
+meters: [
+  { key: 'rolling_5h', label: 'Rolling 5-hour limit',
+    kind: 'allowance', unit: 'requests',
+    limit: 200, used: 37, remaining: 163,
+    period: { duration: {value: 5, unit: 'hour'}, cycle: 'rolling' }, ...},
+  { key: 'search_hourly', label: 'Search requests', subject: 'hourly',
+    kind: 'allowance', unit: 'requests',
+    period: { duration: {value: 1, unit: 'hour'}, cycle: 'fixed', resetsAt: ...}, ...},
+  { key: 'weekly_credits', label: 'Weekly token credits',
+    kind: 'allowance', unit: 'usd',
+    period: { duration: {value: 7, unit: 'day'}, cycle: 'rolling', resetsAt: ...}, ...},
+]
+```
+
+**Neuralwatt** (the hybrid case — no special-casing needed):
+```js
+meters: [
+  { key: 'credits', label: 'Credit balance',
+    kind: 'balance', unit: 'usd',
+    limit: 100, used: 23.50, remaining: 76.50, ...},
+  { key: 'energy', label: 'Energy quota',
+    kind: 'allowance', unit: 'energy_kwh',
+    limit: 50, used: 12.4, remaining: 37.6,
+    period: { duration: {value: 1, unit: 'month'}, cycle: 'fixed',
+              resetsAt: '2026-05-01T00:00:00Z' }, ...},
+]
+```
+
+**Apertis** (combined into a single checker — no more two-checker split):
+```js
+meters: [
+  { key: 'payg', label: 'PAYG balance',
+    kind: 'balance', unit: 'usd', remaining: 8.42, ...},
+  // emitted only if the account is a subscriber:
+  { key: 'cycle_quota', label: 'Apertis pro plan',
+    kind: 'allowance', unit: 'requests',
+    limit: 5000, used: 1200, remaining: 3800,
+    period: { duration: {value:1, unit:'month'}, cycle: 'fixed', resetsAt: ...}, ...},
+]
+```
+
+**Poe** (points balance):
+```js
+meters: [{
+  key: 'balance', label: 'POE point balance',
+  kind: 'balance', unit: 'points',
+  remaining: 1_350_000, utilizationPercent: 0, status: 'ok',
+}]
+```
+
+## 6. Database Schema
+
+The current `quota_snapshots` table stores one row per (checker, window,
+checkedAt). That granularity is right and should be preserved; only the
+column set changes.
+
+### 6.1 New columns (proposed)
+
+| Column                | Type      | Replaces / new                                          |
+|-----------------------|-----------|---------------------------------------------------------|
+| `id`                  | int PK    | unchanged                                               |
+| `provider`            | text      | unchanged                                               |
+| `checker_id`          | text      | unchanged                                               |
+| `meter_key`           | text      | replaces `window_type`                                  |
+| `kind`                | text      | new: `'balance' \| 'allowance'`                         |
+| `label`               | text      | replaces `description` for the human-readable name      |
+| `subject`             | text NULL | new: optional sub-scope                                 |
+| `unit`                | text      | new enum: `'usd'\|'tokens'\|'requests'\|'energy_kwh'\|'points'` |
+| `values_are_percent`  | bool      | new                                                     |
+| `limit`               | real      | unchanged                                               |
+| `used`                | real      | unchanged                                               |
+| `remaining`           | real      | unchanged                                               |
+| `utilization_percent` | real      | unchanged                                               |
+| `period_duration_value`| int NULL | new                                                     |
+| `period_duration_unit`| text NULL | new: `'minute'\|'hour'\|'day'\|'week'\|'month'`         |
+| `period_cycle`        | text NULL | new: `'fixed'\|'rolling'`                               |
+| `resets_at`           | timestamp | unchanged (now nullable for balances, was always so)    |
+| `status`              | text      | unchanged                                               |
+| `success`             | bool      | unchanged                                               |
+| `error_message`       | text      | unchanged                                               |
+| `checked_at`          | timestamp | unchanged                                               |
+| `created_at`          | timestamp | unchanged                                               |
+
+The compound primary index becomes `(checker_id, meter_key, checked_at)`,
+which lines up with how the history modal queries data.
+
+`group_id` is dropped — `subject` covers the per-model case in a way the
+UI can render generically.
+
+### 6.2 Postgres enums
+
+- `quota_meter_kind_enum` = `('balance', 'allowance')`
+- `quota_meter_unit_enum` = `('usd', 'tokens', 'requests', 'energy_kwh', 'points')`
+- `quota_period_duration_unit_enum` = `('minute','hour','day','week','month')`
+- `quota_period_cycle_enum` = `('fixed', 'rolling')`
+- `quota_checker_type_enum` — kept, but its source-of-truth list is moved
+  (see § 7.1).
+
+### 6.3 Migration plan for stored history
+
+A backfill migration maps old rows to new ones with a deterministic
+translation table. Critical mappings:
+
+| Old `windowType`      | New `kind`  | New `period`                                            |
+|-----------------------|-------------|---------------------------------------------------------|
+| `subscription`        | `balance`   | (none)                                                  |
+| `hourly`              | `allowance` | `{1, 'hour', 'fixed'}`                                  |
+| `five_hour`           | `allowance` | `{5, 'hour', 'rolling'}` (Claude/Codex use rolling)     |
+| `rolling_five_hour`   | `allowance` | `{5, 'hour', 'rolling'}`                                |
+| `daily`               | `allowance` | `{1, 'day', 'fixed'}`                                   |
+| `weekly`              | `allowance` | `{1, 'week', 'fixed'}`                                  |
+| `rolling_weekly`      | `allowance` | `{1, 'week', 'rolling'}`                                |
+| `monthly`             | `allowance` | `{1, 'month', 'fixed'}`                                 |
+| `toolcalls`           | `allowance` | (per-checker; `subject='tool calls'`)                   |
+| `search`              | `allowance` | (per-checker; `subject='search'`)                       |
+| `custom`              | `allowance` | (per-checker; encoded from API metadata where possible) |
+
+Old `unit='percentage'` rows become `unit='requests'` with
+`values_are_percent=true`. Old `unit='points'` rows for Neuralwatt become
+`unit='energy_kwh'` (special-case in the migration based on `checker_id`).
+Old `unit='kwh'` is renamed to `energy_kwh` for consistency. Other
+`unit='points'` rows (Poe, Zenmux) stay as `points`.
+
+For safety, keep the old columns for one release and write to both. The
+quota scheduler reads from new columns only; the history modal
+double-reads during the transition window.
+
+## 7. Backend changes
+
+### 7.1 Single source of truth for checker registration
+
+Replace the four parallel lists with one declaration per checker:
+
+```ts
+// packages/backend/src/services/quota/checkers/registry.ts
+export const CHECKER_DEFS = [
+  { type: 'naga',         class: NagaQuotaChecker,         optionsSchema: NagaQuotaCheckerOptionsSchema },
+  { type: 'claude-code',  class: ClaudeCodeQuotaChecker,   optionsSchema: ClaudeCodeQuotaCheckerOptionsSchema },
+  ...
+] as const;
+```
+
+Derived from this single array:
+
+- `VALID_QUOTA_CHECKER_TYPES` (config.ts)
+- `ProviderQuotaCheckerSchema` (the discriminated union, generated by
+  mapping over `CHECKER_DEFS`)
+- `CHECKER_REGISTRY` (factory)
+- `quotaCheckerTypeEnum` values (postgres)
+- The response of `/v0/management/quota-checker-types`
+
+The frontend fetches `/v0/management/quota-checker-types` and the
+fallback constants in `api.ts` and `Providers.tsx` are removed (a stale
+fallback is worse than a brief loading state).
+
+### 7.2 Base class shape
+
+```ts
+abstract class QuotaChecker {
+  abstract readonly type: string;          // e.g. 'claude-code'
+  abstract checkQuota(): Promise<QuotaCheckResult>;
+
+  /** Default exhaustion threshold for the whole checker; overridable
+   *  per-meter inside checkQuota(). */
+  get exhaustionThreshold(): number {
+    return this.config.options.maxUtilizationPercent ?? 99;
+  }
+
+  // Helpers — emit a meter, derive utilization, compute status, etc.
+  protected balanceMeter(...): Meter;
+  protected allowanceMeter(...): Meter;
+}
+```
+
+Note: no more `category` getter on the checker. The
+`getCheckerCategory(checkerId)` function in
+`packages/backend/src/routes/management/quotas.ts` is deleted; the API
+returns meters with their own `kind` already.
+
+### 7.3 Cooldown / scheduler
+
+`QuotaScheduler.applyCooldownsFromResult` already iterates windows and
+picks the most-constrained one. The same logic applies to meters. Two
+small adjustments:
+
+1. **Skip balance meters** for cooldown injection. A balance going to
+   zero is a billing problem, not a rate-limit problem; the request will
+   fail upstream with a clear error. The scheduler should *not* keep
+   slamming the cooldown awake/asleep on every poll just because a
+   balance was 0 — and it cannot reset itself, so there's nothing to
+   wait for. (Today this is implicit because balances have no
+   `resetsAt`; making it explicit makes the intent obvious.)
+2. The "strictest threshold" calculation iterates `meters`, not
+   `windows`.
+
+### 7.4 API response shape
+
+`GET /v0/management/quotas` returns:
+
+```ts
+{
+  checkerId: string;
+  checkerType: string;          // moves up — was always there but now
+                                // is the only "what kind of checker is this"
+  oauthAccountId?: string;
+  oauthProvider?: string;
+  latest: {
+    checkedAt: string;
+    success: boolean;
+    error?: string;
+    meters: Meter[];            // the most recent snapshot reconstructed
+                                // by grouping rows on `meter_key`
+  };
+}[]
+```
+
+`checkerCategory` is removed from the API. Consumers determine kind
+per-meter.
+
+## 8. Frontend changes
+
+### 8.1 Two generic display components, not 21
+
+Replace the per-checker `XxxQuotaDisplay.tsx` family with two generic
+components:
+
+- `BalanceMeterRow` — wallet icon, label, formatted `remaining` value,
+  optional progress bar when `limit` is known.
+- `AllowanceMeterRow` — progress bar with `utilizationPercent`, a label,
+  `used / limit` formatted via `unit` and `valuesArePercent`, and a
+  countdown to `period.resetsAt` if present.
+
+`MeterValue.tsx` formats a number based on `unit` (and
+`valuesArePercent`):
+
+```ts
+function formatMeterValue(v: number, unit: MeterUnit, asPercent?: boolean) {
+  if (asPercent) return `${Math.round(v)}%`;
+  switch (unit) {
+    case 'usd':         return formatCost(v);
+    case 'tokens':      return formatTokens(v);
+    case 'requests':    return `${formatNumber(v)} reqs`;
+    case 'energy_kwh':  return `${v.toFixed(3)} kWh`;
+    case 'points':      return `${formatPointsFull(v)} pts`;
+  }
+}
+```
+
+### 8.2 Sidebar / dashboard sections
+
+A checker no longer has a category. Sections are derived by walking the
+meters:
+
+```ts
+const balanceMeters  = quotas.flatMap(q => q.meters.filter(m => m.kind === 'balance')
+                                                  .map(m => ({ quota: q, meter: m })));
+const allowanceMeters = quotas.flatMap(q => q.meters.filter(m => m.kind === 'allowance')
+                                                   .map(m => ({ quota: q, meter: m })));
+```
+
+The `BALANCE_CHECKERS_WITH_RATE_LIMIT` constants disappear. A hybrid
+checker like Neuralwatt naturally appears in both lists because it emits
+both kinds of meter.
+
+### 8.3 Per-checker icons (the only thing that stays per-checker)
+
+A small registry that maps `checkerType` to an icon and a display name.
+This is purely cosmetic and lives in **one** file:
+
+```ts
+// packages/frontend/src/components/quota/checker-presentation.ts
+export const CHECKER_PRESENTATION: Record<string, { icon: LucideIcon; name: string }> = {
+  'claude-code':  { icon: MessageSquare, name: 'Claude Code' },
+  'openai-codex': { icon: Bot,            name: 'OpenAI Codex' },
+  // ...
+};
+```
+
+The three current copies of `CHECKER_DISPLAY_NAMES` collapse into this
+single object. `CompactQuotasCard.getTrackedWindowsForChecker`,
+`getCheckerCategory`, `getTypeDisplayName`, and `getCheckerIcon` all
+delete: there is nothing left to switch on.
+
+### 8.4 Per-checker config components
+
+Config components stay, because each checker has different config inputs
+(API key URL, organisation id, cookie name, …). But:
+
+- They're discovered by `checkerType`, not imported one-by-one in
+  `Providers.tsx`. A registry like `CONFIG_COMPONENTS[checkerType]`
+  replaces the long `if/else` ladder.
+- The default config component (no extra fields) is used when no
+  registry entry exists, so adding a checker with no extra options
+  needs zero frontend changes.
+
+### 8.5 Frontend types
+
+`packages/frontend/src/types/quota.ts` is rewritten to mirror the
+backend shape — `Meter`, `MeterKind`, `MeterUnit`, `Period`, etc. The
+old `QuotaWindow`/`QuotaWindowType` types are removed.
+
+## 9. Migration / Rollout Plan
+
+The change is large but cleanly stageable:
+
+1. **Land the new types** alongside the old ones (`Meter` next to
+   `QuotaWindow`). Add a `meters: Meter[]` field to the wire shape; keep
+   `windows: QuotaWindow[]` populated from `meters` for one release so
+   nothing breaks during deploy.
+2. **Migrate one checker** end-to-end (suggest `naga` — simplest balance
+   case) to prove the new base class. Snapshot it with both old and new
+   columns.
+3. **Generate the schema migration** (new columns nullable, old columns
+   nullable). Backfill with a one-shot script using the mapping table
+   from § 6.3.
+4. **Migrate the remaining checkers**. The hybrid case (Neuralwatt) and
+   the multi-meter cases (Synthetic, NanoGPT, Codex, Claude) prove the
+   model. Apertis collapses from two checkers into one — provider
+   configs that reference `apertis-coding-plan` are mapped to
+   `apertis` on read for one release.
+5. **Frontend cutover**: ship the generic `BalanceMeterRow` /
+   `AllowanceMeterRow`. Delete the 21 per-checker display components in
+   the same PR. The two `BALANCE_CHECKERS_WITH_RATE_LIMIT` literals,
+   the three `CHECKER_DISPLAY_NAMES` copies, and
+   `getTrackedWindowsForChecker` all delete.
+6. **Drop the old columns and types** one release later, after the
+   double-write window has expired.
+
+Each step is independently shippable; the system stays green throughout.
+
+## 10. What this fixes, concretely
+
+Tying it back to the issues from § 3:
+
+| Problem                                       | Resolution                                              |
+|-----------------------------------------------|---------------------------------------------------------|
+| `category` on the wrong object                | Moved to `kind` on each meter.                          |
+| `windowType` conflates four axes              | Split into `kind`, `period.duration`, `period.cycle`, `subject`. |
+| `unit: 'percentage'` is degenerate            | Replaced by `valuesArePercent` flag on the underlying real unit. |
+| `unit: 'points'` overloaded for kWh           | New `energy_kwh` unit; `points` reserved for opaque provider currencies. |
+| Hybrid checkers need manual override sets     | Mixed checkers naturally emit meters of both kinds.     |
+| 21 near-duplicate display components          | Two generic row components + a presentation registry.   |
+| 4 parallel checker-type registrations         | One `CHECKER_DEFS` array generates all of them.         |
+| Apertis pays for two API calls                | Single checker emits both meters from one response.     |
+| History rows mix `requests` and `percentage`  | Stored unit is stable; `valuesArePercent` decides display only. |
+| `getTrackedWindowsForChecker` 23-arm switch   | Deleted — every meter is rendered the same way.         |
+
+## 11. Open questions
+
+- **Per-meter exhaustion thresholds.** Today `maxUtilizationPercent` is a
+  checker-level config. For checkers with multiple meters the operator
+  may want to cool down on the 5-hour window at 95% but tolerate 99% on
+  the weekly. Suggest allowing the option as either a number (applies
+  to all meters) or a `Record<meterKey, number>`. Out of scope for the
+  initial migration; can land later without further schema changes.
+- **Rolling-window reset semantics.** Truly rolling windows don't have
+  a single "reset moment" — they recover continuously. Today the code
+  pretends they do (using `nextTickAt`/`resetTime` from the API).
+  Acceptable for now: keep `resetsAt` populated when the API gives us
+  one, document that for `cycle: 'rolling'` it means "earliest moment
+  capacity will visibly improve."
+- **Multiple balance currencies on one provider.** Moonshot exposes
+  `cash_balance` and `voucher_balance` separately. Today only
+  `available_balance` is recorded. The new model can emit both as
+  separate meters if we want to surface them; deferring that decision.
+- **Energy units beyond kWh.** Neuralwatt is the only energy meter
+  today. If others appear with different units (joules, CO₂eq), promote
+  `energy_kwh` to a more general `{ unit: 'energy', subUnit: 'kwh' }`.
+  Premature now.
+


### PR DESCRIPTION
## Summary

Adds `docs/QUOTA_BALANCE_REDESIGN.md` — a design proposal for unifying the
quota / balance tracking model. **No code changes.**

The current model collapses two distinct concepts (prepaid balances and
recurring subscription quotas) under one shape with a checker-level
`category`, an overloaded `windowType` enum, and a `unit` field that
includes the degenerate `'percentage'` and an overloaded `'points'` (used
for kWh, Poe points, and Zenmux flows interchangeably). This breaks down
for hybrid providers like Neuralwatt and is patched up with manual
override sets duplicated across the codebase.

The plan proposes a **meter** as the atomic unit. A checker emits zero or
more independent meters, each with its own `kind` (`balance` |
`allowance`), `unit`, optional `period`, and a `valuesArePercent` flag for
the percentage-only providers. This collapses:

- the `BALANCE_CHECKERS_WITH_RATE_LIMIT` overrides duplicated in
  `Sidebar.tsx` and `Quotas.tsx`
- the four parallel checker-type lists (`VALID_QUOTA_CHECKER_TYPES`,
  `quotaCheckerTypeEnum`, `FALLBACK_QUOTA_CHECKER_TYPES`,
  `QUOTA_CHECKER_TYPES_FALLBACK`)
- the 21 near-duplicate per-checker display components
- the 23-arm switch in `CompactQuotasCard.getTrackedWindowsForChecker`
- the Apertis double-checker workaround

The document covers: the survey of all 23 checkers grouped by structural
shape, every concrete inconsistency in the current model, the new data
model with worked examples for every existing provider, a `quota_snapshots`
schema migration with an old-window-type → new-meter mapping table, the
backend changes (single source of truth for checker registration; cooldown
scheduler tweak to skip balance meters), the frontend changes (two generic
meter components instead of 21 per-checker ones), a staged rollout plan,
and open questions.

## Test plan

- [ ] Review the design and confirm the meter model covers every existing
      provider correctly.
- [ ] Sanity-check the schema migration mapping table (§ 6.3) against the
      current `quota_snapshots` rows in production.
- [ ] Decide on the open questions in § 11 before implementation starts.

https://claude.ai/code/session_01CS5aHqY9VahB4DtFP5hGfB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CS5aHqY9VahB4DtFP5hGfB)_