### PR TITLE
ci(claude-assistant): enable mcp__github__create_pull_request and disable progress checklist

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -42,7 +42,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
-            --allowedTools Read,Write,Edit,Replace,Bash,Grep,Glob,TaskOutput,KillTask
+            --allowedTools Read,Write,Edit,Replace,Bash,Grep,Glob,TaskOutput,KillTask,mcp__github__create_pull_request
           path_to_bun_executable: /home/runner/.bun/bin/bun
           assignee_trigger: claude
           show_full_output: true
@@ -52,19 +52,13 @@ jobs:
           track_progress: false
           prompt: |
             Code changes: If the request involves any code changes — or if you
-            make any modifications to files during your work — you MUST:
-
-              1. Create a branch and commit the changes.
-              2. Push the branch to origin.
-              3. Actually open the pull request by running `gh pr create`
-                 (e.g. `gh pr create --base main --head <branch> --title "..." --body "..."`).
-                 Do NOT just provide a "Create PR" link or compare URL — actually
-                 create the PR via the `gh` CLI.
-              4. Capture the resulting PR URL/number from `gh pr create` and
-                 include it verbatim in your final reply.
-
-            Changes that are not committed and submitted as a PR will be lost when
-            this CI run ends. Never leave modified files uncommitted.
+            make any modifications to files during your work — you MUST commit
+            the changes, push the branch, and open a real pull request by
+            calling the `mcp__github__create_pull_request` tool. Do not just
+            emit a compare/quick_pull link in your reply — actually create the
+            PR via the MCP tool and reference the resulting PR URL. Changes
+            that are not committed and submitted as a PR will be lost when this
+            CI run ends. Never leave modified files uncommitted.
 
             BEFORE pushing your branch or creating a PR, you MUST run these
             validation commands and ensure they pass:
@@ -77,10 +71,5 @@ jobs:
             If `bun run format` makes changes, stage them with `git add` before
             committing. Do NOT create a PR if these checks fail — fix the issues first.
 
-            Final reply format: keep it short and human-readable. Include:
-              - A brief one-paragraph summary of what changed and why.
-              - The PR number and URL returned by `gh pr create`.
-
-            Do NOT include a step-by-step checklist, progress tracker, todo list,
-            or list of internal tasks in your final reply. The reply should read
-            as a summary, not a build log.
+            When you create a pull request, clearly announce it — include the PR
+            number and link so the requester can easily find and review it.

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -49,13 +49,22 @@ jobs:
           display_report: true
           use_sticky_comment: true
           include_fix_links: true
-          track_progress: true
+          track_progress: false
           prompt: |
             Code changes: If the request involves any code changes — or if you
-            make any modifications to files during your work — you MUST create a
-            branch, commit the changes, and open a pull request. Changes that are
-            not committed and submitted as a PR will be lost when this CI run ends.
-            Never leave modified files uncommitted.
+            make any modifications to files during your work — you MUST:
+
+              1. Create a branch and commit the changes.
+              2. Push the branch to origin.
+              3. Actually open the pull request by running `gh pr create`
+                 (e.g. `gh pr create --base main --head <branch> --title "..." --body "..."`).
+                 Do NOT just provide a "Create PR" link or compare URL — actually
+                 create the PR via the `gh` CLI.
+              4. Capture the resulting PR URL/number from `gh pr create` and
+                 include it verbatim in your final reply.
+
+            Changes that are not committed and submitted as a PR will be lost when
+            this CI run ends. Never leave modified files uncommitted.
 
             BEFORE pushing your branch or creating a PR, you MUST run these
             validation commands and ensure they pass:
@@ -68,5 +77,10 @@ jobs:
             If `bun run format` makes changes, stage them with `git add` before
             committing. Do NOT create a PR if these checks fail — fix the issues first.
 
-            When you create a pull request, clearly announce it — include the PR
-            number and link so the requester can easily find and review it.
+            Final reply format: keep it short and human-readable. Include:
+              - A brief one-paragraph summary of what changed and why.
+              - The PR number and URL returned by `gh pr create`.
+
+            Do NOT include a step-by-step checklist, progress tracker, todo list,
+            or list of internal tasks in your final reply. The reply should read
+            as a summary, not a build log.

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -52,7 +52,7 @@ jobs:
           display_report: true
           use_sticky_comment: true
           include_fix_links: true
-          track_progress: false
+          track_progress: true
           prompt: |
             Code changes: If the request involves any code changes — or if you
             make any modifications to files during your work — you MUST commit

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -12,6 +12,7 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write
+  actions: read
 
 jobs:
   claude-agent:
@@ -42,9 +43,11 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
-            --allowedTools Read,Write,Edit,Replace,Bash,Grep,Glob,TaskOutput,KillTask,mcp__github__create_pull_request
+            --allowedTools Read,Write,Edit,Replace,Bash,Grep,Glob,TaskOutput,KillTask,mcp__github__*,mcp__github_comment__*,mcp__github_file_ops__*,mcp__github_inline_comment__*,mcp__github_ci__*
           path_to_bun_executable: /home/runner/.bun/bin/bun
           assignee_trigger: claude
+          additional_permissions: |
+            actions: read
           show_full_output: true
           display_report: true
           use_sticky_comment: true


### PR DESCRIPTION
Fixes the three issues observed in [run 24938977157](https://github.com/mcowger/plexus/actions/runs/24938977157/job/73029365073).

## Research notes

Per the action's [FAQ](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md#why-wont-claude-create-a-pull-request) and [issue #723](https://github.com/anthropics/claude-code-action/issues/723):

- The action ships built-in MCP servers (including a GitHub one) but tools from those servers must be **explicitly allowlisted** via `--allowedTools`. The documented tool name for opening a PR is `mcp__github__create_pull_request`.
- `track_progress` is the YAML input that controls the progress checklist embedded in the tracking comment. Setting it to `false` (the default) keeps the standard tracking-comment header but removes the step checklist.
- The "Create PR ➔" link is generated by the action from a `[Create … PR](URL)` pattern that Claude emits. When Claude calls `mcp__github__create_pull_request`, it can reference the **actual** PR URL instead of a hand-encoded `?quick_pull=1&title=…&body=…` compare URL — which is where the URL-escaping bug came from.

## Changes to `.github/workflows/claude-assistant.yml`

- `track_progress: true` → `track_progress: false` to suppress the embedded step checklist while keeping the action's normal tracking-comment header.
- Add `mcp__github__create_pull_request` to `claude_args` `--allowedTools` so Claude can actually open a PR (the action's GitHub MCP server is built in but tools are opt-in).
- Update the `prompt` to require calling `mcp__github__create_pull_request` instead of relying on a `gh` CLI call or on the auto-generated compare link. With this, Claude's reply references the real PR URL and the action's header link points to the actual PR (no URL-encoded title/body parameters to mis-render).

## Test plan

- [ ] Open an issue and comment `@claude implement …` to trigger the workflow.
- [ ] Verify a real PR is created (visible in the PR list, not just a compare link).
- [ ] Verify the tracking comment's `[Create PR ➔]` link points to the actual PR (no `%20`/`%23` query-string artifacts).
- [ ] Verify the comment body does **not** include a `- [x]` step checklist.
