### PR TITLE
ci(claude-assistant): blanket-allow all MCP tools and all Bash commands

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -43,7 +43,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
-            --allowedTools Read,Write,Edit,Replace,Bash,Grep,Glob,TaskOutput,KillTask,mcp__github__*,mcp__github_comment__*,mcp__github_file_ops__*,mcp__github_inline_comment__*,mcp__github_ci__*
+            --allowedTools "Read,Write,Edit,Replace,Bash(*),Grep,Glob,TaskOutput,KillTask,mcp__*"
           path_to_bun_executable: /home/runner/.bun/bin/bun
           assignee_trigger: claude
           additional_permissions: |


### PR DESCRIPTION
PR #281 had narrower wildcards that still left some tools blocked at runtime:

```
Error: Claude requested permissions to use mcp__github_comment__update_claude_comment,
but you haven't granted it yet.
```

Python invocations were also being blocked because `Bash` on its own doesn't cover all subcommands.

## Change

In `.github/workflows/claude-assistant.yml`, replace the per-server MCP wildcards and bare `Bash` with:

```
--allowedTools "Read,Write,Edit,Replace,Bash(*),Grep,Glob,TaskOutput,KillTask,mcp__*"
```

- `mcp__*` — blanket allowlist for every built-in MCP server tool (`mcp__github__*`, `mcp__github_comment__*`, `mcp__github_file_ops__*`, `mcp__github_inline_comment__*`, `mcp__github_ci__*`, …).
- `Bash(*)` — any bash command, including `python …`.

## Test plan

- [ ] Trigger the workflow with `@claude` on an issue.
- [ ] Verify Claude can call MCP tools like `mcp__github_comment__update_claude_comment` without a permission error.
- [ ] Verify Claude can run `python …` via Bash without a permission error.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLvMmp6wUSUJtZRPpcRsrH)_