### PR TITLE
ci(claude): pass github_token to skip OIDC->Anthropic-app exchange

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -11,7 +11,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
   actions: read
 
 jobs:
@@ -41,7 +40,6 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
             --allowedTools "Read,Write,Edit,Replace,Bash(*),Grep,Glob,TaskOutput,KillTask,mcp__*"

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -41,6 +41,7 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
             --allowedTools "Read,Write,Edit,Replace,Bash(*),Grep,Glob,TaskOutput,KillTask,mcp__*"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,6 +28,7 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
             --allowedTools Read,Write,Edit,Replace,Bash,Grep,Glob,TaskOutput,KillTask

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@v6
@@ -28,7 +27,6 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
             --allowedTools Read,Write,Edit,Replace,Bash,Grep,Glob,TaskOutput,KillTask


### PR DESCRIPTION
The action attempts to exchange the GitHub OIDC token for an Anthropic
GitHub App token unconditionally. With a custom ANTHROPIC_BASE_URL (not
Anthropic's first-party app), that exchange returns 401 Unauthorized.
Providing github_token directly causes the action to skip the OIDC
exchange and use the standard GITHUB_TOKEN.

https://claude.ai/code/session_01MxM4S5nzChuPH14QQmBQWv