### PR TITLE
ci(claude): re-add github_token and id-token: write to fix OIDC failure

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -11,7 +11,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
   actions: read
 
 jobs:

--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -11,6 +11,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
   actions: read
 
 jobs:
@@ -40,6 +41,7 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
             --allowedTools "Read,Write,Edit,Replace,Bash(*),Grep,Glob,TaskOutput,KillTask,mcp__*"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6
@@ -27,6 +28,7 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
             --allowedTools Read,Write,Edit,Replace,Bash,Grep,Glob,TaskOutput,KillTask


### PR DESCRIPTION
## Problem

Both `claude-assistant.yml` and `claude-pr-review.yml` are failing with:

```
Auto-detected mode: tag for event: issue_comment
Requesting OIDC token...
error: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Attempt 1 failed: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

This regressed in #284, which was squash-merged from a stale branch tip that had inadvertently removed both `id-token: write` and the `github_token` input. The net effect on `main` is that the action attempts OIDC (because `OVERRIDE_GITHUB_TOKEN` is unset) but cannot fetch a token (because `id-token: write` is missing).

## Fix

Per `anthropics/claude-code-action@v1`'s `src/github/token.ts`:

```typescript
export async function setupGitHubToken(): Promise<string> {
  const providedToken = process.env.OVERRIDE_GITHUB_TOKEN;
  if (providedToken) {
    console.log("Using provided GITHUB_TOKEN for authentication");
    return providedToken;
  }
  // ... only here does it request OIDC and exchange for an app token
```

The `github_token` input is mapped to the `OVERRIDE_GITHUB_TOKEN` env var via `action.yml`. When set, `setupGitHubToken()` returns immediately, fully bypassing the OIDC fetch and the Anthropic app-token exchange (which 401s against a custom `ANTHROPIC_BASE_URL` anyway).

This PR adds back to both workflows:

1. `id-token: write` permission — defensive only; harmless once `github_token` is set.
2. `github_token: ${{ secrets.GITHUB_TOKEN }}` — the actual fix; populates `OVERRIDE_GITHUB_TOKEN` and short-circuits the OIDC path.

## Verification

The latest failing run dumps the action's environment:
```
OVERRIDE_GITHUB_TOKEN:
"github_token": "",
```
Both empty, confirming the action takes the OIDC branch only because the override is unset. After this PR, `OVERRIDE_GITHUB_TOKEN` will be the runner's `GITHUB_TOKEN` (non-empty), and the action's first `if (providedToken) return` branch will execute.

## Test plan

- [ ] Open a new PR after merge → `claude-pr-review.yml` runs without OIDC errors.
- [ ] Comment `@claude` on an issue/PR after merge → `claude-assistant.yml` runs without OIDC errors.

https://claude.ai/code/session_01MxM4S5nzChuPH14QQmBQWv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxM4S5nzChuPH14QQmBQWv)_