### PR TITLE
feat: auto-create release tag if it doesn't exist

### DIFF
--- a/.github/workflows/release-setup.yml
+++ b/.github/workflows/release-setup.yml
@@ -15,6 +15,8 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       tag: ${{ steps.release_tag.outputs.tag }}
     steps:
@@ -23,8 +25,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get tag from ref
+      - name: Get tag from ref and create if missing
         id: release_tag
         run: |
           TAG="${{ inputs.tag || github.ref_name }}"
+
+          # If the tag doesn't exist, create it on HEAD of main
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG does not exist, creating it on main"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       tag:
         required: true
         type: string
-        description: "The release tag to publish (must already exist)"
+        description: "The release tag to publish (will be created on main if it doesn't exist)"
 
 jobs:
   setup:


### PR DESCRIPTION
## Summary

- When triggering `release.yml` via `workflow_dispatch`, the tag no longer needs to exist beforehand
- `release-setup.yml` now checks if the tag exists and, if missing, creates it on the current HEAD (main) and pushes it to origin
- Updated the `workflow_dispatch` input description to reflect the new behavior
- Added `contents: write` permission to the setup job so it can push the new tag

Closes #295

---

Generated with [Claude Code](https://claude.ai/code)