### PR TITLE
fix(quota): use boolean type for meter_snapshots.success on Postgres

### DIFF
--- a/packages/backend/drizzle/schema/postgres/meter-snapshots.ts
+++ b/packages/backend/drizzle/schema/postgres/meter-snapshots.ts
@@ -1,4 +1,13 @@
-import { pgTable, serial, text, real, integer, bigint, index } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  serial,
+  text,
+  real,
+  integer,
+  bigint,
+  boolean,
+  index,
+} from 'drizzle-orm/pg-core';
 
 export const meterSnapshots = pgTable(
   'meter_snapshots',
@@ -23,7 +32,7 @@ export const meterSnapshots = pgTable(
     periodUnit: text('period_unit'),
     periodCycle: text('period_cycle'),
     resetsAt: bigint('resets_at', { mode: 'number' }),
-    success: integer('success').notNull().default(1),
+    success: boolean('success').notNull().default(true),
     errorMessage: text('error_message'),
     checkedAt: bigint('checked_at', { mode: 'number' }).notNull(),
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),


### PR DESCRIPTION
The Postgres schema typed `success` as integer while the quota scheduler inserts a JS boolean, so every meter snapshot INSERT failed on Postgres with `column "success" is of type integer but expression is of type boolean`. SQLite hid this because its column is declared with `integer({ mode: 'boolean' })`, which auto-casts.

Switch the Postgres column to `boolean` (default `true`) so both dialects present a boolean to the application — no callsite changes needed and the existing `!r.success` read paths work for both.