### PR TITLE
fix(ci): add latest floating tag to Docker image on release

### DIFF
--- a/.github/workflows/release-build-docker.yml
+++ b/.github/workflows/release-build-docker.yml
@@ -44,6 +44,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=${{ inputs.tag }}
+            type=raw,value=latest
             type=ref,event=branch
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Problem
The release workflow was not tagging the Docker image with a `latest` floating tag. Only the version-specific tag (e.g. `2025.04.28.1`) and branch ref tag were being applied.

## Fix
Added `type=raw,value=latest` to the `docker/metadata-action` tags configuration in `.github/workflows/release-build-docker.yml`.

Now every release pushes three Docker tags:
1. The version tag (e.g. `2025.04.28.1`)
2. `latest`
3. The branch ref (e.g. `main`)

This ensures `latest` always points to the most recently published release image.