### PR TITLE
fix(migrations): fix postgres integer to boolean cast in meter_snapshots

### DIFF
--- a/packages/backend/drizzle/migrations_pg/0040_fuzzy_metal_master.sql
+++ b/packages/backend/drizzle/migrations_pg/0040_fuzzy_metal_master.sql
@@ -1,2 +1,3 @@
-ALTER TABLE "meter_snapshots" ALTER COLUMN "success" SET DATA TYPE boolean;--> statement-breakpoint
+ALTER TABLE "meter_snapshots" ALTER COLUMN "success" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "meter_snapshots" ALTER COLUMN "success" SET DATA TYPE boolean USING (success::integer::boolean);--> statement-breakpoint
 ALTER TABLE "meter_snapshots" ALTER COLUMN "success" SET DEFAULT true;


### PR DESCRIPTION
## What happened

Migration `0040_fuzzy_metal_master` fails on PostgreSQL with:

```
column "success" cannot be cast automatically to type boolean
````

This breaks container startup entirely for anyone running PostgreSQL (tracked in #312).

## Root cause

Drizzle's migration generator emitted a bare:

```sql
ALTER COLUMN ... SET DATA TYPE boolean
````

for the integer → boolean conversion.

PostgreSQL has no implicit cast between these two types, so it rejects the statement. The migration was wrongly generated — this is a known gap in Drizzle's codegen for PostgreSQL type conversions that require an explicit `USING` clause.

SQLite is unaffected — it uses integer natively for booleans and has no equivalent `ALTER` in its migration chain.

## Fix

Three steps are required for PostgreSQL to accept the type change:

1. Drop the integer default first (Postgres blocks the type change while an incompatible default exists)
2. Alter the type with an explicit `USING (success::integer::boolean)` cast
3. Restore the default as `true`

```sql
ALTER TABLE meter_snapshots ALTER COLUMN success DROP DEFAULT;
ALTER TABLE meter_snapshots ALTER COLUMN success SET DATA TYPE boolean USING (success::int::boolean);
ALTER TABLE meter_snapshots ALTER COLUMN success SET DEFAULT true;
```

I applied and verified this fix against my production PostgreSQL database — migrations ran cleanly, the container came up, and no data was lost. All existing rows were converted in-place (1→true, 0→false).

Feel free to reject or adjust this if you prefer to handle it differently — no hard feelings either way! :)

