### PR TITLE
feat(frontend): redesign console — glass shell, denser tables, responsive everywhere

### DIFF
--- a/packages/frontend/build.ts
+++ b/packages/frontend/build.ts
@@ -86,8 +86,12 @@ const runBuild = async () => {
   html = html.replace('src="/src/main.tsx"', 'src="main.js"'); // Handle both absolute/relative
   html = html.replace('type="module"', '');
 
-  // Inject Favicons and Manifest
+  // Inject Favicons and Manifest. SVG comes first so modern browsers prefer
+  // the new Plexus geometric mark; older browsers fall back to the PNGs.
+  // (SVG is named plexus-icon.svg rather than favicon.svg to avoid an
+  // output-collision with favicon.ico / favicon-*.png in --compile bundling.)
   const faviconHtml = `
+    <link rel="icon" type="image/svg+xml" href="plexus-icon.svg">
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">

--- a/packages/frontend/src/assets/plexus-icon.svg
+++ b/packages/frontend/src/assets/plexus-icon.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44 44" fill="none">
+  <defs>
+    <linearGradient id="lg" x1="0" y1="0" x2="44" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#FBBF24"/>
+      <stop offset="100%" stop-color="#D97706"/>
+    </linearGradient>
+  </defs>
+  <g stroke="url(#lg)" stroke-width="2.4" fill="none" stroke-linecap="round">
+    <line x1="22" y1="6" x2="6" y2="16"/>
+    <line x1="22" y1="6" x2="38" y2="16"/>
+    <line x1="6" y1="16" x2="22" y2="38"/>
+    <line x1="38" y1="16" x2="22" y2="38"/>
+    <line x1="6" y1="16" x2="38" y2="16"/>
+    <line x1="22" y1="6" x2="22" y2="38"/>
+  </g>
+  <circle cx="22" cy="6" r="4" fill="url(#lg)"/>
+  <circle cx="6" cy="16" r="4" fill="url(#lg)"/>
+  <circle cx="38" cy="16" r="4" fill="url(#lg)"/>
+  <circle cx="22" cy="38" r="4" fill="url(#lg)"/>
+</svg>

--- a/packages/frontend/src/components/analytics/AnalyzeButton.tsx
+++ b/packages/frontend/src/components/analytics/AnalyzeButton.tsx
@@ -197,19 +197,21 @@ export const buildQueryString = (cardType: CardType, context?: AnalyzeContext): 
 
 /**
  * Get human-readable label for the analysis action based on card type.
- * Provides contextual messaging so users understand what they're navigating to.
+ * Returns [shortLabel, fullLabel] — the short label is shown on small screens
+ * so the button doesn't blow out the card on mobile, and the full descriptive
+ * label appears on `sm:` breakpoint and up.
  */
-const getAnalyzeLabel = (cardType: CardType): string => {
-  const labels: Record<CardType, string> = {
-    velocity: 'Analyze Velocity Trends',
-    provider: 'Analyze Provider Performance',
-    model: 'Analyze Model Usage',
-    modelstack: 'Analyze Model Stack',
-    timeline: 'Analyze Timeline',
-    requests: 'View Detailed Logs',
-    concurrency: 'Analyze Concurrency',
+const getAnalyzeLabel = (cardType: CardType): { short: string; full: string } => {
+  const labels: Record<CardType, { short: string; full: string }> = {
+    velocity: { short: 'Analyze', full: 'Analyze Velocity Trends' },
+    provider: { short: 'Analyze', full: 'Analyze Provider Performance' },
+    model: { short: 'Analyze', full: 'Analyze Model Usage' },
+    modelstack: { short: 'Analyze', full: 'Analyze Model Stack' },
+    timeline: { short: 'Analyze', full: 'Analyze Timeline' },
+    requests: { short: 'Logs', full: 'View Detailed Logs' },
+    concurrency: { short: 'Analyze', full: 'Analyze Concurrency' },
   };
-  return labels[cardType] || 'Analyze in Detail';
+  return labels[cardType] || { short: 'Analyze', full: 'Analyze in Detail' };
 };
 
 /**
@@ -251,16 +253,18 @@ export const AnalyzeButton: React.FC<AnalyzeButtonProps> = ({
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
+  const { short, full } = getAnalyzeLabel(cardType);
   return (
     <Button
       size={size}
       variant="primary"
       onClick={handleAnalyze}
-      className={`flex items-center gap-2 ${className}`}
+      className={`shrink-0 ${className}`}
     >
       <BarChart3 size={size === 'sm' ? 14 : 16} />
-      {getAnalyzeLabel(cardType)}
-      <ExternalLink size={size === 'sm' ? 12 : 14} className="ml-1 opacity-70" />
+      <span className="xl:hidden">{short}</span>
+      <span className="hidden xl:inline">{full}</span>
+      <ExternalLink size={size === 'sm' ? 12 : 14} className="hidden sm:block opacity-70" />
     </Button>
   );
 };

--- a/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
@@ -536,7 +536,7 @@ const CooldownRow: React.FC<CooldownRowProps> = ({
               <div
                 ref={popoverRef}
                 onClick={(e) => e.stopPropagation()}
-                className="fixed z-100 w-72 rounded-md border border-border shadow-lg p-3 text-xs space-y-2"
+                className="fixed z-[500] w-72 rounded-md border border-border shadow-lg p-3 text-xs space-y-2"
                 style={{
                   backgroundColor: 'rgb(15, 23, 42)',
                   top: popoverStyle.top,
@@ -2114,16 +2114,18 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               id: cardId,
               title: 'Metrics',
               extra: (
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center justify-end gap-2">
                   <Signal size={15} className="text-info" />
-                  <span className="text-[11px] text-text-muted">Overview & Live Stats</span>
+                  <span className="hidden text-[11px] text-text-muted sm:inline">
+                    Overview & Live Stats
+                  </span>
                 </div>
               ),
               onClick: () => openModal('stats'),
               style: { cursor: 'pointer' },
               className: 'hover:shadow-lg hover:border-primary/30 transition-all',
               content: (
-                <div className="h-56 grid grid-cols-2 divide-x divide-border overflow-hidden">
+                <div className="h-48 sm:h-56 grid grid-cols-2 divide-x divide-border overflow-hidden">
                   {/* Overview column */}
                   <div className="divide-y divide-border">
                     <div className="px-3 py-1.5 bg-bg-subtle/50">
@@ -2204,7 +2206,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               id: cardId,
               title: 'Alerts & Providers',
               extra: (
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center justify-end gap-2">
                   <AlertTriangle
                     size={15}
                     className={cooldowns.length > 0 ? 'text-warning' : 'text-text-muted'}
@@ -2226,7 +2228,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               style: { cursor: 'pointer' },
               className: 'hover:shadow-lg hover:border-primary/30 transition-all',
               content: (
-                <div className="h-56 flex flex-col overflow-hidden">
+                <div className="h-48 sm:h-56 flex flex-col overflow-hidden">
                   {cooldowns.length > 0 && (
                     <div className="divide-y divide-border border-b border-warning/30 bg-warning/5 max-h-30 overflow-y-auto">
                       {Object.entries(groupedCooldowns).map(([key, modelCooldowns]) => {
@@ -2291,8 +2293,10 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               id: cardId,
               title: 'Request Velocity (Last 5 Minutes)',
               extra: (
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-text-secondary">Minute-over-minute delta</span>
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <span className="hidden text-xs text-text-secondary sm:inline">
+                    Minute-over-minute delta
+                  </span>
                   <AnalyzeButton
                     cardType="velocity"
                     size="sm"
@@ -2305,11 +2309,11 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               className: 'hover:shadow-lg hover:border-primary/30 transition-all',
               content:
                 velocitySeries.length === 0 ? (
-                  <div className="h-56 flex items-center justify-center text-text-secondary">
+                  <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary">
                     No velocity data available
                   </div>
                 ) : (
-                  <div className="h-56">
+                  <div className="h-48 sm:h-56">
                     <ResponsiveContainer width="100%" height="100%">
                       <LineChart
                         data={velocitySeries}
@@ -2359,7 +2363,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               id: cardId,
               title: 'Provider Pulse (5m)',
               extra: (
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center justify-end gap-2">
                   <span className="text-xs text-text-secondary">Top 8 providers</span>
                   <AnalyzeButton
                     cardType="provider"
@@ -2373,11 +2377,11 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               className: 'hover:shadow-lg hover:border-primary/30 transition-all',
               content:
                 providerPulseRows.length === 0 ? (
-                  <div className="h-56 flex items-center justify-center text-text-secondary">
+                  <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary">
                     No provider traffic in the selected live window.
                   </div>
                 ) : (
-                  <div className="h-56">
+                  <div className="h-48 sm:h-56">
                     <ResponsiveContainer width="100%" height="100%">
                       <BarChart
                         data={providerPulseRows.slice(0, 6)}
@@ -2425,7 +2429,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               id: cardId,
               title: 'Model Pulse (5m)',
               extra: (
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center justify-end gap-2">
                   <span className="text-xs text-text-secondary">Top 8 models</span>
                   <AnalyzeButton
                     cardType="model"
@@ -2439,11 +2443,11 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               className: 'hover:shadow-lg hover:border-primary/30 transition-all',
               content:
                 modelPulseRows.length === 0 ? (
-                  <div className="h-56 flex items-center justify-center text-text-secondary">
+                  <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary">
                     No model traffic in the selected live window.
                   </div>
                 ) : (
-                  <div className="h-56">
+                  <div className="h-48 sm:h-56">
                     <ResponsiveContainer width="100%" height="100%">
                       <BarChart
                         data={modelPulseRows.slice(0, 6)}
@@ -2492,7 +2496,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               id: cardId,
               title: 'Live Timeline',
               extra: (
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center justify-end gap-2">
                   <Clock size={16} className="text-primary" />
                   <AnalyzeButton
                     cardType="timeline"
@@ -2505,15 +2509,15 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               style: { cursor: 'pointer' },
               className: 'min-w-0 hover:shadow-lg hover:border-primary/30 transition-all',
               content: loading ? (
-                <div className="h-56 flex items-center justify-center text-text-secondary">
+                <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary">
                   Loading...
                 </div>
               ) : minuteSeries.length === 0 ? (
-                <div className="h-56 flex items-center justify-center text-text-secondary">
+                <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary">
                   No requests in the last {liveWindowMinutes} minutes
                 </div>
               ) : (
-                <div className="h-56">
+                <div className="h-48 sm:h-56">
                   <ResponsiveContainer width="100%" height="100%">
                     <AreaChart
                       data={minuteSeries}
@@ -2623,15 +2627,15 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               style: { cursor: 'pointer' },
               className: 'min-w-0 hover:shadow-lg hover:border-primary/30 transition-all',
               content: loading ? (
-                <div className="h-56 flex items-center justify-center text-text-secondary">
+                <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary">
                   Loading...
                 </div>
               ) : modelTimeline.series.length === 0 ? (
-                <div className="h-56 flex items-center justify-center text-text-secondary">
+                <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary">
                   No model stack data in the last {liveWindowMinutes} minutes
                 </div>
               ) : (
-                <div className="h-56">
+                <div className="h-48 sm:h-56">
                   <ResponsiveContainer width="100%" height="100%">
                     <ComposedChart
                       data={modelTimeline.data}
@@ -2734,8 +2738,10 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               style: { cursor: 'pointer' },
               className: 'hover:shadow-lg hover:border-primary/30 transition-all',
               extra: (
-                <div className="flex items-center gap-1">
-                  <span className="text-xs text-text-secondary mr-1">Latest 20</span>
+                <div className="flex flex-wrap items-center justify-end gap-1">
+                  <span className="hidden text-xs text-text-secondary mr-1 sm:inline">
+                    Latest 20
+                  </span>
                   <Button
                     size="sm"
                     variant={streamFilter === 'all' ? 'primary' : 'secondary'}
@@ -2775,13 +2781,13 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               ),
               content:
                 filteredLiveRequests.length === 0 ? (
-                  <div className="h-56 flex items-center justify-center text-text-secondary">
+                  <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary">
                     {liveRequests.length === 0
                       ? 'No requests observed yet.'
                       : 'No requests match the current filter.'}
                   </div>
                 ) : (
-                  <div className="h-56 space-y-2 overflow-y-auto pr-1">
+                  <div className="h-48 sm:h-56 space-y-2 overflow-y-auto pr-1">
                     {filteredLiveRequests.slice(0, 20).map((request) => {
                       const requestTimeSeconds = Math.max(
                         0,
@@ -2851,8 +2857,11 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               id: cardId,
               title: 'Concurrency',
               extra: (
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-text-muted">Auto-refresh: 10s</span>
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <span className="text-xs text-text-muted">
+                    <span className="sm:hidden">10s</span>
+                    <span className="hidden sm:inline">Auto-refresh: 10s</span>
+                  </span>
                   <AnalyzeButton
                     cardType="concurrency"
                     size="sm"
@@ -2865,15 +2874,15 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               className: 'hover:shadow-lg hover:border-primary/30 transition-all',
               content:
                 concurrencyLoading && concurrencyHistory.length === 0 ? (
-                  <div className="h-56 flex items-center justify-center text-text-secondary text-sm">
+                  <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary text-sm">
                     Loading concurrency data...
                   </div>
                 ) : concurrencyHistory.length === 0 ? (
-                  <div className="h-56 flex items-center justify-center text-text-secondary text-sm">
+                  <div className="h-48 sm:h-56 flex items-center justify-center text-text-secondary text-sm">
                     Collecting concurrency data...
                   </div>
                 ) : (
-                  <div className="h-56">
+                  <div className="h-48 sm:h-56">
                     <div className="flex items-center justify-between mb-2">
                       <span className="text-xs text-text-muted">In-Flight by Provider</span>
                       <span className="text-sm font-semibold text-text tabular-nums">
@@ -2933,7 +2942,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
               style: { cursor: 'pointer' },
               className: 'hover:shadow-lg hover:border-primary/30 transition-all',
               content: (
-                <div className="h-56 grid grid-cols-1 lg:grid-cols-2 gap-4 overflow-y-auto">
+                <div className="h-48 sm:h-56 grid grid-cols-1 lg:grid-cols-2 gap-4 overflow-y-auto">
                   <div className="space-y-2">
                     <h4 className="text-sm font-semibold text-text flex items-center gap-2">
                       <Server size={16} className="text-primary" />
@@ -3004,17 +3013,19 @@ export const LiveTab: React.FC<LiveTabProps> = ({
    *    or an embedded DetailedUsage page.
    */
   return (
-    <div className="p-6 transition-all duration-300">
+    <div className="overflow-x-clip px-3 py-4 transition-all duration-300 sm:p-6">
       {/* ------- Page Header ------- */}
-      <div className="mb-8 flex flex-wrap items-start justify-between gap-3">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-3 sm:mb-8">
         <div className="header-left">
-          <h1 className="font-heading text-3xl font-bold text-text m-0 mb-2">Live Metrics</h1>
+          <h1 className="font-heading text-xl sm:text-3xl font-bold text-text m-0 mb-2">
+            Live Metrics
+          </h1>
         </div>
 
         <Badge
           status={isConnected && !isStale ? 'connected' : 'warning'}
           secondaryText={'Window: last ' + liveWindowMinutes + 'm'}
-          style={{ minWidth: '210px' }}
+          className="w-full sm:w-auto sm:min-w-[210px]"
         >
           {isConnected
             ? isStale
@@ -3053,7 +3064,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
         </div>
       )}
 
-      <div className="mb-4 flex flex-wrap items-center gap-2">
+      <div className="-mx-3 mb-4 flex flex-nowrap items-center gap-1.5 overflow-x-auto px-3 pb-1 [scrollbar-width:none] [-ms-overflow-style:none] sm:mx-0 sm:flex-wrap sm:gap-2 sm:overflow-visible sm:px-0 sm:pb-0 [&::-webkit-scrollbar]:hidden">
         <Button
           size="sm"
           variant="secondary"
@@ -3079,7 +3090,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
             </Button>
           );
         })}
-        <span className="text-xs text-text-secondary">|</span>
+        <span className="hidden text-xs text-text-secondary sm:inline">|</span>
         {LIVE_WINDOW_OPTIONS.map((option) => (
           <Button
             key={option.value}
@@ -3093,7 +3104,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
             {option.label}
           </Button>
         ))}
-        <span className="text-xs text-text-muted">
+        <span className="hidden text-xs text-text-muted sm:inline">
           {isVisible ? 'Tab active' : 'Tab hidden'} - data refresh resumes on focus.
         </span>
       </div>
@@ -3115,9 +3126,11 @@ export const LiveTab: React.FC<LiveTabProps> = ({
         onDragCancel={handleDragCancel}
       >
         <SortableContext items={orderedCardIds}>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+          <div className="grid min-w-0 grid-cols-1 gap-4 mb-4 lg:grid-cols-2">
             {orderedCardIds.map((cardId, index) => (
-              <div key={cardId}>{renderDraggableCard(cardId, index)}</div>
+              <div key={cardId} className="min-w-0">
+                {renderDraggableCard(cardId, index)}
+              </div>
             ))}
           </div>
         </SortableContext>

--- a/packages/frontend/src/components/layout/AppBar.tsx
+++ b/packages/frontend/src/components/layout/AppBar.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import { Menu } from 'lucide-react';
 import { useSidebar } from '../../contexts/SidebarContext';
-import logo from '../../assets/plexus_logo_transparent.png';
+import { useAuth } from '../../contexts/AuthContext';
+import { PlexusMark } from './PlexusMark';
 
 export const AppBar: React.FC = () => {
   const { openMobile } = useSidebar();
+  const { principal } = useAuth();
+
+  const initials = principal?.role === 'admin'
+    ? 'AD'
+    : (principal?.keyName || 'KU').slice(0, 2).toUpperCase();
 
   return (
-    <header className="md:hidden sticky top-0 z-sidebar h-14 flex items-center gap-3 px-4 bg-bg-surface/90 backdrop-blur-md border-b border-border">
+    <header className="md:hidden sticky top-0 z-sidebar h-14 flex items-center gap-3 px-4 glass-bg border-b border-white/5">
       <button
         type="button"
         onClick={openMobile}
@@ -17,10 +23,13 @@ export const AppBar: React.FC = () => {
         <Menu size={22} />
       </button>
       <div className="flex items-center gap-2">
-        <img src={logo} alt="" className="w-6 h-6" />
-        <span className="font-heading text-lg font-bold bg-clip-text text-transparent bg-gradient-to-br from-primary to-secondary">
-          Plexus
-        </span>
+        <PlexusMark size={22} />
+        <span className="font-heading text-base font-semibold amber-grad-text">Plexus</span>
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <div className="w-7 h-7 rounded-full amber-grad-bg grid place-items-center text-[10px] font-semibold text-amber-950">
+          {initials}
+        </div>
       </div>
     </header>
   );

--- a/packages/frontend/src/components/layout/AppBar.tsx
+++ b/packages/frontend/src/components/layout/AppBar.tsx
@@ -1,35 +1,24 @@
 import React from 'react';
 import { Menu } from 'lucide-react';
 import { useSidebar } from '../../contexts/SidebarContext';
-import { useAuth } from '../../contexts/AuthContext';
 import { PlexusMark } from './PlexusMark';
 
 export const AppBar: React.FC = () => {
   const { openMobile } = useSidebar();
-  const { principal } = useAuth();
-
-  const initials = principal?.role === 'admin'
-    ? 'AD'
-    : (principal?.keyName || 'KU').slice(0, 2).toUpperCase();
 
   return (
-    <header className="md:hidden sticky top-0 z-sidebar h-14 flex items-center gap-3 px-4 glass-bg border-b border-white/5">
+    <header className="md:hidden sticky top-0 z-[200] h-12 flex items-center gap-3 px-3 bg-bg-card border-b border-border">
       <button
         type="button"
         onClick={openMobile}
         aria-label="Open navigation"
         className="p-2 -ml-2 rounded-md text-text-secondary hover:bg-bg-hover hover:text-text transition-colors duration-fast focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
       >
-        <Menu size={22} />
+        <Menu size={20} />
       </button>
       <div className="flex items-center gap-2">
-        <PlexusMark size={22} />
-        <span className="font-heading text-base font-semibold amber-grad-text">Plexus</span>
-      </div>
-      <div className="ml-auto flex items-center gap-2">
-        <div className="w-7 h-7 rounded-full amber-grad-bg grid place-items-center text-[10px] font-semibold text-amber-950">
-          {initials}
-        </div>
+        <PlexusMark size={20} />
+        <span className="font-heading text-sm font-semibold amber-grad-text">Plexus</span>
       </div>
     </header>
   );

--- a/packages/frontend/src/components/layout/MainLayout.tsx
+++ b/packages/frontend/src/components/layout/MainLayout.tsx
@@ -9,6 +9,9 @@ export const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }
   const { isCollapsed, isMobileOpen, closeMobile } = useSidebar();
 
   return (
+    // No overflow-x-clip here — the AppBar lives in this wrapper as a sticky
+    // child, and clip-on-the-parent can break sticky positioning in some
+    // browsers. Horizontal overflow is contained one level down on <main>.
     <div className="min-h-screen bg-bg-deep">
       <AppBar />
 
@@ -22,7 +25,11 @@ export const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }
 
       <main
         className={clsx(
-          'min-h-screen transition-[margin] duration-300',
+          // overflow-x: clip (NOT hidden) keeps wide children from blowing out
+          // the viewport on mobile WITHOUT turning <main> into a scroll
+          // container — overflow-x:hidden would have done that and broken
+          // every `position: sticky` page header inside.
+          'min-h-screen min-w-0 overflow-x-clip transition-[margin] duration-300',
           isCollapsed ? 'md:ml-[64px]' : 'md:ml-[220px]'
         )}
       >

--- a/packages/frontend/src/components/layout/MainLayout.tsx
+++ b/packages/frontend/src/components/layout/MainLayout.tsx
@@ -22,8 +22,8 @@ export const MainLayout: React.FC<{ children: React.ReactNode }> = ({ children }
 
       <main
         className={clsx(
-          'min-h-screen p-4 sm:p-6 lg:p-8 transition-[margin] duration-300',
-          isCollapsed ? 'md:ml-[64px]' : 'md:ml-[200px]'
+          'min-h-screen transition-[margin] duration-300',
+          isCollapsed ? 'md:ml-[64px]' : 'md:ml-[220px]'
         )}
       >
         {children}

--- a/packages/frontend/src/components/layout/PageContainer.tsx
+++ b/packages/frontend/src/components/layout/PageContainer.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 
 interface PageContainerProps {
   children: React.ReactNode;
-  /** Constrain content width. Defaults to wide. */
+  /** Constrain content width. Defaults to full. */
   width?: 'narrow' | 'standard' | 'wide' | 'full';
   className?: string;
 }
@@ -17,8 +17,12 @@ const widthClasses: Record<NonNullable<PageContainerProps['width']>, string> = {
 
 export const PageContainer: React.FC<PageContainerProps> = ({
   children,
-  width = 'wide',
+  width = 'full',
   className,
 }) => {
-  return <div className={clsx('mx-auto w-full', widthClasses[width], className)}>{children}</div>;
+  return (
+    <div className={clsx('p-4 sm:p-6 lg:p-8 mx-auto w-full', widthClasses[width], className)}>
+      {children}
+    </div>
+  );
 };

--- a/packages/frontend/src/components/layout/PageContainer.tsx
+++ b/packages/frontend/src/components/layout/PageContainer.tsx
@@ -21,7 +21,9 @@ export const PageContainer: React.FC<PageContainerProps> = ({
   className,
 }) => {
   return (
-    <div className={clsx('p-4 sm:p-6 lg:p-8 mx-auto w-full', widthClasses[width], className)}>
+    <div
+      className={clsx('mx-auto w-full min-w-0 p-3 sm:p-6 lg:p-8', widthClasses[width], className)}
+    >
       {children}
     </div>
   );

--- a/packages/frontend/src/components/layout/PageHeader.tsx
+++ b/packages/frontend/src/components/layout/PageHeader.tsx
@@ -5,24 +5,43 @@ interface PageHeaderProps {
   title: React.ReactNode;
   subtitle?: React.ReactNode;
   actions?: React.ReactNode;
+  /** Render below the title/actions row (filters, tabs, etc.). */
+  children?: React.ReactNode;
   className?: string;
+  /** Sticky to top of scroll container with glass background. Defaults to true. */
+  sticky?: boolean;
 }
 
-export const PageHeader: React.FC<PageHeaderProps> = ({ title, subtitle, actions, className }) => {
+export const PageHeader: React.FC<PageHeaderProps> = ({
+  title,
+  subtitle,
+  actions,
+  children,
+  className,
+  sticky = true,
+}) => {
   return (
     <div
       className={clsx(
-        'mb-6 sm:mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between',
+        'px-4 sm:px-6 lg:px-8 py-4',
+        sticky && 'sticky top-0 z-20 glass-bg border-b border-white/5',
         className
       )}
     >
-      <div className="min-w-0 flex-1">
-        <h1 className="font-heading text-h1 font-bold text-text m-0 leading-tight">{title}</h1>
-        {subtitle && <p className="mt-1 font-body text-sm text-text-secondary">{subtitle}</p>}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="min-w-0">
+          <h1 className="font-heading text-xl sm:text-2xl font-semibold tracking-tight text-text m-0 leading-tight">
+            {title}
+          </h1>
+          {subtitle && (
+            <p className="text-xs text-text-secondary mt-0.5">{subtitle}</p>
+          )}
+        </div>
+        {actions && (
+          <div className="flex flex-wrap items-center gap-2 sm:flex-shrink-0">{actions}</div>
+        )}
       </div>
-      {actions && (
-        <div className="flex flex-wrap items-center gap-2 sm:gap-3 sm:flex-shrink-0">{actions}</div>
-      )}
+      {children && <div className="mt-3">{children}</div>}
     </div>
   );
 };

--- a/packages/frontend/src/components/layout/PageHeader.tsx
+++ b/packages/frontend/src/components/layout/PageHeader.tsx
@@ -23,18 +23,20 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
   return (
     <div
       className={clsx(
-        'px-4 sm:px-6 lg:px-8 py-4',
-        sticky && 'sticky top-0 z-20 glass-bg border-b border-white/5',
+        'px-3 py-3 sm:px-6 sm:py-4 lg:px-8',
+        // On mobile the AppBar (h-12, top-0, sticky) sits above the page content,
+        // so the page header has to start below it. On md+ the AppBar is hidden.
+        sticky && 'sticky top-12 md:top-0 z-20 bg-bg-card border-b border-border',
         className
       )}
     >
       <div className="flex items-center justify-between gap-3 flex-wrap">
         <div className="min-w-0">
-          <h1 className="font-heading text-xl sm:text-2xl font-semibold tracking-tight text-text m-0 leading-tight">
+          <h1 className="font-heading text-lg sm:text-2xl font-semibold tracking-tight text-text m-0 leading-tight">
             {title}
           </h1>
           {subtitle && (
-            <p className="text-xs text-text-secondary mt-0.5">{subtitle}</p>
+            <p className="text-[11px] sm:text-xs text-text-secondary mt-0.5">{subtitle}</p>
           )}
         </div>
         {actions && (

--- a/packages/frontend/src/components/layout/PlexusMark.tsx
+++ b/packages/frontend/src/components/layout/PlexusMark.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface PlexusMarkProps {
+  size?: number;
+  className?: string;
+}
+
+let counter = 0;
+
+export const PlexusMark: React.FC<PlexusMarkProps> = ({ size = 28, className }) => {
+  const id = React.useMemo(() => `plexus-mark-${++counter}`, []);
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 44 44"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <defs>
+        <linearGradient id={id} x1="0" y1="0" x2="44" y2="44">
+          <stop offset="0%" stopColor="#FBBF24" />
+          <stop offset="100%" stopColor="#D97706" />
+        </linearGradient>
+      </defs>
+      <g stroke={`url(#${id})`} strokeWidth="1.6" fill="none">
+        <line x1="22" y1="6" x2="6" y2="16" />
+        <line x1="22" y1="6" x2="38" y2="16" />
+        <line x1="6" y1="16" x2="22" y2="38" />
+        <line x1="38" y1="16" x2="22" y2="38" />
+        <line x1="6" y1="16" x2="38" y2="16" />
+        <line x1="22" y1="6" x2="22" y2="38" />
+      </g>
+      <circle cx="22" cy="6" r="3" fill={`url(#${id})`} />
+      <circle cx="6" cy="16" r="3" fill={`url(#${id})`} />
+      <circle cx="38" cy="16" r="3" fill={`url(#${id})`} />
+      <circle cx="22" cy="38" r="3" fill={`url(#${id})`} />
+    </svg>
+  );
+};

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -4,18 +4,19 @@ import {
   LayoutDashboard,
   Settings,
   Server,
-  Box,
-  FileText,
-  Database,
+  Boxes,
+  ScrollText,
+  Route,
+  Terminal,
   LogOut,
   AlertTriangle,
   Key,
   PanelLeftClose,
   PanelLeftOpen,
-  ChevronRight,
-  PieChart,
-  Plug,
+  Gauge,
+  PlugZap,
   UserCircle2,
+  Search,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { api } from '../../lib/api';
@@ -26,17 +27,15 @@ import { Button } from '../ui/Button';
 import { Tooltip } from '../ui/Tooltip';
 import { CompactBalancesCard, CompactQuotasCard } from '../quota';
 import type { QuotaCheckerInfo } from '../../types/quota';
-
-import logo from '../../assets/plexus_logo_transparent.png';
+import { PlexusMark } from './PlexusMark';
 
 interface SidebarProps {
-  /** desktop = fixed aside with collapse rail; drawer = flush content rendered inside a Drawer. */
   mode?: 'desktop' | 'drawer';
 }
 
 interface NavItemProps {
   to: string;
-  icon: React.ComponentType<{ size: number }>;
+  icon: React.ComponentType<{ size: number; className?: string }>;
   label: string;
   collapsed: boolean;
 }
@@ -45,24 +44,31 @@ const NavItem: React.FC<NavItemProps> = ({ to, icon: Icon, label, collapsed }) =
   const navLink = (
     <NavLink
       to={to}
+      end={to === '/'}
       className={({ isActive }) =>
         clsx(
-          'flex items-center gap-3 py-1.5 px-2 rounded-md font-body text-sm font-medium text-text-secondary no-underline cursor-pointer transition-all duration-fast border border-transparent hover:bg-bg-hover hover:text-text',
+          'group relative flex items-center gap-2.5 py-2 px-2.5 rounded-md font-body text-[13px] font-medium text-text-secondary no-underline cursor-pointer transition-all duration-fast hover:bg-bg-hover hover:text-text',
           collapsed && 'justify-center',
-          isActive &&
-            'bg-bg-glass text-primary border-border-glass backdrop-blur-md shadow-nav-active'
+          isActive && 'bg-amber-500/10 text-amber-300'
         )
       }
     >
-      <Icon size={20} />
-      <span
-        className={clsx(
-          'transition-opacity duration-fast',
-          collapsed && 'opacity-0 w-0 overflow-hidden'
-        )}
-      >
-        {label}
-      </span>
+      {({ isActive }) => (
+        <>
+          {isActive && !collapsed && (
+            <span className="absolute -left-3 top-1.5 bottom-1.5 w-0.5 rounded-sm bg-gradient-to-b from-secondary to-primary" />
+          )}
+          <Icon size={16} className="flex-shrink-0" />
+          <span
+            className={clsx(
+              'transition-opacity duration-fast',
+              collapsed && 'opacity-0 w-0 overflow-hidden'
+            )}
+          >
+            {label}
+          </span>
+        </>
+      )}
     </NavLink>
   );
 
@@ -75,30 +81,31 @@ const NavItem: React.FC<NavItemProps> = ({ to, icon: Icon, label, collapsed }) =
   );
 };
 
+const NavSection: React.FC<{ title: string; collapsed: boolean }> = ({ title, collapsed }) => (
+  <div
+    className={clsx(
+      'px-2.5 pt-2 pb-1 font-mono text-[10px] uppercase tracking-[0.08em] text-text-muted font-medium transition-opacity duration-fast',
+      collapsed && 'opacity-0 h-0 overflow-hidden pt-0 pb-0'
+    )}
+  >
+    {title}
+  </div>
+);
+
 export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
   const appVersion: string =
     // @ts-expect-error — replaced at build time by build.ts
     process.env.APP_VERSION || 'dev';
   const [debugMode, setDebugMode] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
-
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
-  const [mainExpanded, setMainExpanded] = useState(true);
-  const [balancesExpanded, setBalancesExpanded] = useState(true);
-  const [quotasExpanded, setQuotasExpanded] = useState(true);
-  const [configExpanded, setConfigExpanded] = useState(true);
-  const [devToolsExpanded, setDevToolsExpanded] = useState(false);
   const [quotas, setQuotas] = useState<QuotaCheckerInfo[]>([]);
   const { logout, isAdmin, isLimited, principal } = useAuth();
   const { isCollapsed, toggleSidebar, isMobileOpen, closeMobile } = useSidebar();
   const location = useLocation();
 
-  // Drawer mode always renders expanded; desktop respects user preference.
   const collapsed = mode === 'desktop' && isCollapsed;
 
-  // Auto-close drawer on navigation. Only fires on pathname *changes*, not on
-  // initial mount — otherwise opening the drawer would immediately close it,
-  // since the drawer-mode Sidebar mounts with location.pathname already set.
   const lastPathnameRef = useRef(location.pathname);
   useEffect(() => {
     const pathChanged = lastPathnameRef.current !== location.pathname;
@@ -122,24 +129,18 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
     return () => clearInterval(interval);
   }, []);
 
-  // Parse CalVer tag: YYYY.MM.DD.N or vX.Y.Z (legacy semver)
-  // Returns [year, month, day, counter] for CalVer, null for invalid
   const parseVersionTag = (tag: string): [number, number, number, number] | null => {
-    // Try CalVer: YYYY.MM.DD.N
     const calverMatch = tag.match(/^(\d{4})\.(\d{2})\.(\d{2})\.(\d+)$/);
     if (calverMatch) {
       return [
-        parseInt(calverMatch[1]!, 10), // year
-        parseInt(calverMatch[2]!, 10), // month
-        parseInt(calverMatch[3]!, 10), // day
-        parseInt(calverMatch[4]!, 10), // counter
+        parseInt(calverMatch[1]!, 10),
+        parseInt(calverMatch[2]!, 10),
+        parseInt(calverMatch[3]!, 10),
+        parseInt(calverMatch[4]!, 10),
       ];
     }
-    // Try legacy semver: vX.Y.Z (convert to CalVer-like for comparison)
     const semverMatch = tag.match(/^v(\d+)\.(\d+)\.(\d+)$/);
     if (semverMatch) {
-      // Treat as 0.0.0 with special counter for backward compatibility
-      // This ensures old semver tags always compare as older than CalVer
       return [0, 0, 0, parseInt(semverMatch[1] + semverMatch[2] + semverMatch[3]!, 10)];
     }
     return null;
@@ -149,7 +150,6 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
     const parsedA = parseVersionTag(a);
     const parsedB = parseVersionTag(b);
     if (!parsedA || !parsedB) return 0;
-    // Compare year, month, day, then counter
     for (let i = 0; i < 4; i++) {
       if (parsedA[i]! !== parsedB[i]!) {
         return parsedA[i]! - parsedB[i]!;
@@ -212,31 +212,35 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
   const allowanceQuotas = quotas.filter((q) => q.meters.some((m) => m.kind === 'allowance'));
 
   const isDrawer = mode === 'drawer';
+  const initials = principal?.role === 'admin'
+    ? 'AD'
+    : (principal?.keyName || 'KU').slice(0, 2).toUpperCase();
 
   return (
     <aside
       data-collapsed={collapsed}
       className={clsx(
-        'bg-bg-surface flex flex-col overflow-y-auto overflow-x-hidden border-r border-border',
+        'glass-bg flex flex-col overflow-y-auto overflow-x-hidden',
         isDrawer
-          ? 'h-full w-full border-r-0'
+          ? 'h-full w-full'
           : 'hidden md:flex fixed left-0 top-0 h-screen z-sidebar transition-[width] duration-300',
-        !isDrawer && (collapsed ? 'w-[64px]' : 'w-[200px]')
+        !isDrawer && (collapsed ? 'w-[64px]' : 'w-[220px]')
       )}
     >
-      <div className="px-4 py-3 border-b border-border flex items-center justify-between gap-2">
+      {/* Brand header */}
+      <div className="px-4 pt-4 pb-3 flex items-center justify-between gap-2">
         <div
           className={clsx(
-            'flex items-center gap-2 min-w-0 transition-opacity duration-fast',
+            'flex items-center gap-2.5 min-w-0 transition-opacity duration-fast',
             collapsed && 'opacity-0 w-0 overflow-hidden'
           )}
         >
-          <img src={logo} alt="" className="w-6 h-6 flex-shrink-0" />
-          <div className="flex flex-col min-w-0">
-            <h1 className="font-heading text-lg font-bold m-0 bg-clip-text text-transparent bg-gradient-to-br from-primary to-secondary truncate">
+          <PlexusMark size={28} />
+          <div className="flex flex-col leading-tight min-w-0">
+            <span className="text-[1.05rem] font-semibold amber-grad-text font-heading tracking-tight truncate">
               Plexus
-            </h1>
-            <div className="flex items-center gap-1 text-[10px] leading-none text-text-muted">
+            </span>
+            <div className="flex items-center gap-1 text-[9px] uppercase tracking-[0.16em] text-text-muted font-mono leading-none">
               <span>{appVersion}</span>
               {isOutdated && (
                 <Tooltip content={`Update available: ${latestVersion}`} position="bottom">
@@ -244,7 +248,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
                     className="inline-flex text-primary"
                     aria-label={`Outdated version. Latest is ${latestVersion}`}
                   >
-                    <AlertTriangle size={11} />
+                    <AlertTriangle size={10} />
                   </span>
                 </Tooltip>
               )}
@@ -257,273 +261,155 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
             className="p-1.5 rounded-md hover:bg-bg-hover transition-colors duration-fast text-text-secondary hover:text-text flex-shrink-0 focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
             aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
-            {collapsed ? <PanelLeftOpen size={18} /> : <PanelLeftClose size={18} />}
+            {collapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
           </button>
         )}
         {isDrawer && (
           <button
             onClick={closeMobile}
-            className="p-1.5 rounded-md hover:bg-bg-hover transition-colors duration-fast text-text-secondary hover:text-text flex-shrink-0 focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
+            className="p-1.5 rounded-md hover:bg-bg-hover transition-colors duration-fast text-text-secondary hover:text-text flex-shrink-0"
             aria-label="Close navigation"
           >
-            <PanelLeftClose size={18} />
+            <PanelLeftClose size={16} />
           </button>
         )}
       </div>
 
-      <nav className="flex-1 py-2 px-2 flex flex-col gap-1">
-        <div className="px-2">
+      {/* Search button */}
+      {!collapsed && (
+        <div className="px-3 pt-1 pb-2">
           <button
-            onClick={() => setMainExpanded(!mainExpanded)}
-            className="w-full flex items-center justify-between mb-1 group"
+            type="button"
+            className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-slate-800/40 hover:bg-slate-700/50 text-xs text-slate-400 transition-colors border border-slate-800"
           >
-            <h3
-              className={clsx(
-                'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
-                collapsed && 'opacity-0 h-0 overflow-hidden'
-              )}
-            >
-              Main
-            </h3>
-            {!collapsed && (
-              <ChevronRight
-                size={14}
-                className={clsx(
-                  'text-text-muted transition-transform duration-fast group-hover:text-text',
-                  mainExpanded && 'rotate-90'
-                )}
-              />
-            )}
+            <Search size={14} />
+            <span>Search</span>
+            <span className="ml-auto font-mono text-[10px] px-1 py-px rounded bg-slate-900/80 border border-slate-700">
+              ⌘K
+            </span>
           </button>
-          {(mainExpanded || collapsed) && (
-            <>
-              <NavItem to="/" icon={LayoutDashboard} label="Dashboard" collapsed={collapsed} />
-              <NavItem to="/logs" icon={FileText} label="Logs" collapsed={collapsed} />
-              {isAdmin && (
-                <NavItem to="/quotas" icon={PieChart} label="Quotas" collapsed={collapsed} />
-              )}
-              {isLimited && (
-                <NavItem to="/me" icon={UserCircle2} label="My Key" collapsed={collapsed} />
-              )}
-            </>
-          )}
         </div>
+      )}
 
-        {isAdmin && balanceQuotas.length > 0 && (
-          <div className="mt-4 px-2">
-            <button
-              onClick={() => setBalancesExpanded(!balancesExpanded)}
-              className="w-full flex items-center justify-between mb-1 group"
-            >
-              <h3
-                className={clsx(
-                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
-                  collapsed && 'opacity-0 h-0 overflow-hidden'
-                )}
-              >
+      {/* Main nav */}
+      <nav className="flex-1 px-3 pb-2 flex flex-col gap-0.5">
+        <NavSection title="Main" collapsed={collapsed} />
+        <NavItem to="/" icon={LayoutDashboard} label="Dashboard" collapsed={collapsed} />
+        <NavItem to="/logs" icon={ScrollText} label="Logs" collapsed={collapsed} />
+        <NavItem to="/errors" icon={AlertTriangle} label="Errors" collapsed={collapsed} />
+        {isLimited && (
+          <NavItem to="/me" icon={UserCircle2} label="My Key" collapsed={collapsed} />
+        )}
+
+        {/* Balances widget */}
+        {isAdmin && balanceQuotas.length > 0 && !collapsed && (
+          <div className="mt-3 px-2.5 py-2.5 rounded-lg bg-slate-900/60 border border-slate-800">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-[10px] uppercase tracking-wider text-text-muted font-medium">
                 Balances
-              </h3>
-              {!collapsed && (
-                <ChevronRight
-                  size={14}
-                  className={clsx(
-                    'text-text-muted transition-transform duration-fast group-hover:text-text',
-                    balancesExpanded && 'rotate-90'
-                  )}
-                />
-              )}
-            </button>
-            {(balancesExpanded || collapsed) && (
-              <div
-                className={clsx(
-                  'rounded-md bg-bg-card border border-border overflow-hidden transition-opacity duration-fast',
-                  collapsed && 'opacity-0 h-0 overflow-hidden'
-                )}
-              >
-                <CompactBalancesCard balanceQuotas={balanceQuotas} />
-              </div>
-            )}
+              </span>
+            </div>
+            <CompactBalancesCard balanceQuotas={balanceQuotas} />
           </div>
         )}
 
-        {isAdmin && allowanceQuotas.length > 0 && (
-          <div className="mt-4 px-2">
-            <button
-              onClick={() => setQuotasExpanded(!quotasExpanded)}
-              className="w-full flex items-center justify-between mb-1 group"
-            >
-              <h3
-                className={clsx(
-                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
-                  collapsed && 'opacity-0 h-0 overflow-hidden'
-                )}
-              >
+        {/* Quotas widget */}
+        {isAdmin && allowanceQuotas.length > 0 && !collapsed && (
+          <div className="mt-2 px-2.5 py-2.5 rounded-lg bg-slate-900/60 border border-slate-800">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-[10px] uppercase tracking-wider text-text-muted font-medium">
                 Quotas
-              </h3>
-              {!collapsed && (
-                <ChevronRight
-                  size={14}
-                  className={clsx(
-                    'text-text-muted transition-transform duration-fast group-hover:text-text',
-                    quotasExpanded && 'rotate-90'
-                  )}
-                />
-              )}
-            </button>
-            {(quotasExpanded || collapsed) && (
-              <div
-                className={clsx(
-                  'rounded-md bg-bg-card border border-border overflow-hidden transition-opacity duration-fast',
-                  collapsed && 'opacity-0 h-0 overflow-hidden'
-                )}
-              >
-                <CompactQuotasCard allowanceQuotas={allowanceQuotas} />
-              </div>
-            )}
+              </span>
+            </div>
+            <CompactQuotasCard allowanceQuotas={allowanceQuotas} />
           </div>
         )}
 
         {isAdmin && (
-          <div className="mt-4 px-2">
-            <button
-              onClick={() => setConfigExpanded(!configExpanded)}
-              className="w-full flex items-center justify-between mb-1 group"
-            >
-              <h3
-                className={clsx(
-                  'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
-                  collapsed && 'opacity-0 h-0 overflow-hidden'
-                )}
-              >
-                Configuration
-              </h3>
-              {!collapsed && (
-                <ChevronRight
-                  size={14}
-                  className={clsx(
-                    'text-text-muted transition-transform duration-fast group-hover:text-text',
-                    configExpanded && 'rotate-90'
-                  )}
-                />
-              )}
-            </button>
-            {(configExpanded || collapsed) && (
-              <>
-                <NavItem to="/providers" icon={Server} label="Providers" collapsed={collapsed} />
-                <NavItem to="/models" icon={Box} label="Models" collapsed={collapsed} />
-                <NavItem to="/keys" icon={Key} label="Keys" collapsed={collapsed} />
-                <NavItem to="/mcp" icon={Plug} label="MCP" collapsed={collapsed} />
-                <NavItem to="/config" icon={Settings} label="Settings" collapsed={collapsed} />
-              </>
-            )}
-          </div>
+          <>
+            <NavSection title="Configuration" collapsed={collapsed} />
+            <NavItem to="/providers" icon={Server} label="Providers" collapsed={collapsed} />
+            <NavItem to="/models" icon={Boxes} label="Models" collapsed={collapsed} />
+            <NavItem to="/keys" icon={Key} label="Keys" collapsed={collapsed} />
+            <NavItem to="/quotas" icon={Gauge} label="Quotas" collapsed={collapsed} />
+            <NavItem to="/mcp" icon={PlugZap} label="MCP" collapsed={collapsed} />
+            <NavItem to="/config" icon={Settings} label="Settings" collapsed={collapsed} />
+          </>
         )}
 
-        <div className="mt-4 px-2 mt-auto">
-          <button
-            onClick={() => setDevToolsExpanded(!devToolsExpanded)}
-            className="w-full flex items-center justify-between mb-1 group"
-          >
-            <h3
+        <NavSection title="Dev Tools" collapsed={collapsed} />
+        <div className="flex items-center gap-1">
+          <div className="flex-1">
+            <NavItem to="/debug" icon={Route} label="Traces" collapsed={collapsed} />
+          </div>
+          {isAdmin && !collapsed && (
+            <button
+              onClick={handleToggleClick}
               className={clsx(
-                'font-heading text-[11px] font-semibold uppercase tracking-wider text-text-muted transition-opacity duration-fast',
-                collapsed && 'opacity-0 h-0 overflow-hidden'
+                'mr-1 px-1.5 py-0.5 rounded text-[10px] font-semibold transition-all duration-fast flex-shrink-0 font-mono',
+                debugMode
+                  ? 'bg-danger text-white hover:bg-red-700'
+                  : 'bg-slate-700/40 text-text-muted hover:bg-slate-700/60'
               )}
             >
-              Dev Tools
-            </h3>
-            {!collapsed && (
-              <ChevronRight
-                size={14}
-                className={clsx(
-                  'text-text-muted transition-transform duration-fast group-hover:text-text',
-                  devToolsExpanded && 'rotate-90'
-                )}
-              />
-            )}
-          </button>
-          {(devToolsExpanded || collapsed) && (
-            <>
-              <div className="flex items-center justify-between">
-                <NavItem to="/debug" icon={Database} label="Traces" collapsed={collapsed} />
-                {isAdmin && !collapsed && (
-                  <button
-                    onClick={handleToggleClick}
-                    className={clsx(
-                      'ml-2 px-1.5 py-0.5 rounded text-[10px] font-semibold transition-all duration-fast flex-shrink-0',
-                      debugMode
-                        ? 'bg-danger text-white hover:bg-danger/80'
-                        : 'bg-text-muted/20 text-text-muted hover:bg-text-muted/30'
-                    )}
-                  >
-                    {debugMode ? 'ON' : 'OFF'}
-                  </button>
-                )}
-              </div>
-              <NavItem to="/errors" icon={AlertTriangle} label="Errors" collapsed={collapsed} />
-              {isAdmin && (
-                <NavItem
-                  to="/system-logs"
-                  icon={FileText}
-                  label="System Logs"
-                  collapsed={collapsed}
-                />
-              )}
-            </>
+              {debugMode ? 'ON' : 'OFF'}
+            </button>
           )}
-          {principal && !collapsed && (
-            <div className="mt-3 mx-1 px-2 py-1.5 rounded-md bg-bg-card border border-border flex items-center gap-2">
-              <UserCircle2 size={16} className="text-text-muted flex-shrink-0" />
-              <div className="flex-1 min-w-0">
-                <div className="text-xs font-medium text-text truncate">
-                  {principal.role === 'admin' ? 'Admin' : principal.keyName}
-                </div>
-                <div
-                  className={clsx(
-                    'text-[10px] uppercase tracking-wider font-semibold',
-                    principal.role === 'admin' ? 'text-primary' : 'text-text-muted'
-                  )}
-                >
-                  {principal.role === 'admin' ? 'Full access' : 'Limited'}
-                </div>
+        </div>
+        {isAdmin && (
+          <NavItem
+            to="/system-logs"
+            icon={Terminal}
+            label="System Logs"
+            collapsed={collapsed}
+          />
+        )}
+      </nav>
+
+      {/* User pill + logout */}
+      <div className="p-3 border-t border-slate-800/80 mt-auto space-y-2">
+        {principal && !collapsed && (
+          <div className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-slate-900/60 border border-slate-800">
+            <div className="w-7 h-7 rounded-full amber-grad-bg grid place-items-center text-[11px] font-semibold text-amber-950 flex-shrink-0">
+              {initials}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-xs font-medium text-text truncate">
+                {principal.role === 'admin' ? 'Admin' : principal.keyName}
+              </div>
+              <div className="text-[10px] text-text-muted uppercase tracking-wider font-mono">
+                {principal.role === 'admin' ? 'full access' : 'limited'}
               </div>
             </div>
-          )}
-          {(() => {
-            const logoutButton = (
+            <Tooltip content="Sign out" position="top">
               <button
                 onClick={handleLogout}
-                className={clsx(
-                  'flex items-center gap-3 py-2 px-2 rounded-md font-body text-sm font-medium text-danger cursor-pointer transition-all duration-fast border border-transparent w-full bg-transparent hover:text-danger hover:border-danger/30 hover:bg-red-500/10 mt-3',
-                  collapsed && 'justify-center'
-                )}
+                className="p-1 rounded text-text-secondary hover:text-danger hover:bg-red-500/10 transition-colors"
+                aria-label="Sign out"
               >
-                <LogOut size={20} />
-                <span
-                  className={clsx(
-                    'transition-opacity duration-fast',
-                    collapsed && 'opacity-0 w-0 overflow-hidden'
-                  )}
-                >
-                  Logout
-                </span>
+                <LogOut size={14} />
               </button>
-            );
-            return collapsed ? (
-              <Tooltip content="Logout" position="right">
-                {logoutButton}
-              </Tooltip>
-            ) : (
-              logoutButton
-            );
-          })()}
-        </div>
-      </nav>
+            </Tooltip>
+          </div>
+        )}
+        {collapsed && (
+          <Tooltip content="Sign out" position="right">
+            <button
+              onClick={handleLogout}
+              className="w-full flex items-center justify-center py-2 rounded-md text-danger hover:bg-red-500/10 transition-colors"
+              aria-label="Sign out"
+            >
+              <LogOut size={16} />
+            </button>
+          </Tooltip>
+        )}
+      </div>
 
       <Modal
         isOpen={showConfirm}
         onClose={() => setShowConfirm(false)}
         title={debugMode ? 'Disable Debug Mode?' : 'Enable Debug Mode?'}
+        size="sm"
         footer={
           <>
             <Button variant="secondary" onClick={() => setShowConfirm(false)}>
@@ -535,7 +421,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
           </>
         }
       >
-        <p>
+        <p className="text-sm text-text-secondary">
           {debugMode
             ? 'Disabling debug mode will stop capturing full request/response payloads.'
             : 'Enabling debug mode will capture FULL raw request and response payloads, including personal data if present. This can consume significant storage.'}

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -16,7 +16,6 @@ import {
   Gauge,
   PlugZap,
   UserCircle2,
-  Search,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { api } from '../../lib/api';
@@ -47,28 +46,27 @@ const NavItem: React.FC<NavItemProps> = ({ to, icon: Icon, label, collapsed }) =
       end={to === '/'}
       className={({ isActive }) =>
         clsx(
-          'group relative flex items-center gap-2.5 py-2 px-2.5 rounded-md font-body text-[13px] font-medium text-text-secondary no-underline cursor-pointer transition-all duration-fast hover:bg-bg-hover hover:text-text',
+          'group relative flex items-center gap-2.5 py-2 px-2.5 rounded-md font-body text-[13px] font-medium no-underline cursor-pointer transition-all duration-fast',
+          'text-text-secondary hover:bg-bg-hover hover:text-text',
           collapsed && 'justify-center',
-          isActive && 'bg-amber-500/10 text-amber-300'
+          // Active state: amber tint + a left rail via :before pseudo-element
+          // (cleaner than a sibling <span> and avoids NavLink render-prop quirks).
+          isActive &&
+            !collapsed &&
+            'bg-amber-500/10 text-amber-300 before:content-[""] before:absolute before:-left-3 before:top-1.5 before:bottom-1.5 before:w-0.5 before:rounded-sm before:bg-gradient-to-b before:from-secondary before:to-primary',
+          isActive && collapsed && 'bg-amber-500/10 text-amber-300'
         )
       }
     >
-      {({ isActive }) => (
-        <>
-          {isActive && !collapsed && (
-            <span className="absolute -left-3 top-1.5 bottom-1.5 w-0.5 rounded-sm bg-gradient-to-b from-secondary to-primary" />
-          )}
-          <Icon size={16} className="flex-shrink-0" />
-          <span
-            className={clsx(
-              'transition-opacity duration-fast',
-              collapsed && 'opacity-0 w-0 overflow-hidden'
-            )}
-          >
-            {label}
-          </span>
-        </>
-      )}
+      <Icon size={16} className="flex-shrink-0" />
+      <span
+        className={clsx(
+          'transition-opacity duration-fast',
+          collapsed && 'opacity-0 w-0 overflow-hidden'
+        )}
+      >
+        {label}
+      </span>
     </NavLink>
   );
 
@@ -212,18 +210,19 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
   const allowanceQuotas = quotas.filter((q) => q.meters.some((m) => m.kind === 'allowance'));
 
   const isDrawer = mode === 'drawer';
-  const initials = principal?.role === 'admin'
-    ? 'AD'
-    : (principal?.keyName || 'KU').slice(0, 2).toUpperCase();
+  const initials =
+    principal?.role === 'admin' ? 'AD' : (principal?.keyName || 'KU').slice(0, 2).toUpperCase();
 
   return (
     <aside
       data-collapsed={collapsed}
       className={clsx(
-        'glass-bg flex flex-col overflow-y-auto overflow-x-hidden',
+        // Solid background — glass-bg used to let the page content scroll
+        // through visibly. Sidebar must fully obscure what's underneath.
+        'bg-bg-card border-border flex flex-col overflow-y-auto overflow-x-hidden',
         isDrawer
           ? 'h-full w-full'
-          : 'hidden md:flex fixed left-0 top-0 h-screen z-sidebar transition-[width] duration-300',
+          : 'hidden md:flex fixed left-0 top-0 h-screen z-[200] border-r transition-[width] duration-300',
         !isDrawer && (collapsed ? 'w-[64px]' : 'w-[220px]')
       )}
     >
@@ -275,31 +274,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
         )}
       </div>
 
-      {/* Search button */}
-      {!collapsed && (
-        <div className="px-3 pt-1 pb-2">
-          <button
-            type="button"
-            className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-slate-800/40 hover:bg-slate-700/50 text-xs text-slate-400 transition-colors border border-slate-800"
-          >
-            <Search size={14} />
-            <span>Search</span>
-            <span className="ml-auto font-mono text-[10px] px-1 py-px rounded bg-slate-900/80 border border-slate-700">
-              ⌘K
-            </span>
-          </button>
-        </div>
-      )}
-
       {/* Main nav */}
       <nav className="flex-1 px-3 pb-2 flex flex-col gap-0.5">
         <NavSection title="Main" collapsed={collapsed} />
         <NavItem to="/" icon={LayoutDashboard} label="Dashboard" collapsed={collapsed} />
         <NavItem to="/logs" icon={ScrollText} label="Logs" collapsed={collapsed} />
         <NavItem to="/errors" icon={AlertTriangle} label="Errors" collapsed={collapsed} />
-        {isLimited && (
-          <NavItem to="/me" icon={UserCircle2} label="My Key" collapsed={collapsed} />
-        )}
+        {isLimited && <NavItem to="/me" icon={UserCircle2} label="My Key" collapsed={collapsed} />}
 
         {/* Balances widget */}
         {isAdmin && balanceQuotas.length > 0 && !collapsed && (
@@ -357,12 +338,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
           )}
         </div>
         {isAdmin && (
-          <NavItem
-            to="/system-logs"
-            icon={Terminal}
-            label="System Logs"
-            collapsed={collapsed}
-          />
+          <NavItem to="/system-logs" icon={Terminal} label="System Logs" collapsed={collapsed} />
         )}
       </nav>
 

--- a/packages/frontend/src/components/quota/CombinedBalancesCard.tsx
+++ b/packages/frontend/src/components/quota/CombinedBalancesCard.tsx
@@ -39,7 +39,7 @@ export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
     return (
       <div
         key={quota.checkerId}
-        className="px-4 py-3 flex items-center justify-between hover:bg-bg-hover transition-colors"
+        className="flex flex-col gap-3 px-3 py-3 transition-colors hover:bg-bg-hover sm:flex-row sm:items-center sm:justify-between sm:px-4"
       >
         <div className="flex flex-col gap-0.5 min-w-0 flex-1">
           <div className="flex items-center gap-2">
@@ -52,7 +52,7 @@ export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
           </div>
         </div>
 
-        <div className="flex flex-col gap-0.5 px-4 min-w-0">
+        <div className="min-w-0 px-0 sm:px-4">
           {!quota.success ? (
             <div className="flex items-center gap-2 text-danger">
               <AlertTriangle size={14} />
@@ -77,7 +77,7 @@ export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
           )}
         </div>
 
-        <div className="flex-shrink-0">
+        <div className="flex-shrink-0 self-end sm:self-auto">
           <Button
             size="sm"
             variant="ghost"

--- a/packages/frontend/src/components/quota/MeterHistoryModal.tsx
+++ b/packages/frontend/src/components/quota/MeterHistoryModal.tsx
@@ -160,12 +160,12 @@ export const MeterHistoryModal: React.FC<MeterHistoryModalProps> = ({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3 backdrop-blur-sm sm:p-4"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      <div className="bg-bg-card border border-border-glass rounded-xl shadow-2xl w-full max-w-2xl flex flex-col max-h-[90vh]">
+      <div className="flex max-h-[92vh] w-full max-w-2xl flex-col rounded-xl border border-border-glass bg-bg-card shadow-2xl sm:max-h-[90vh]">
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-border-glass">
+        <div className="flex items-center justify-between gap-3 border-b border-border-glass px-4 py-3 sm:px-5 sm:py-4">
           <div className="min-w-0">
             <h2 className="font-heading text-h2 font-semibold text-text truncate">{meter.label}</h2>
             <p className="text-xs text-text-muted mt-0.5 truncate">
@@ -182,7 +182,7 @@ export const MeterHistoryModal: React.FC<MeterHistoryModalProps> = ({
         </div>
 
         {/* Time-range selector */}
-        <div className="flex items-center gap-1 px-5 py-3 border-b border-border-glass">
+        <div className="flex items-center gap-1 overflow-x-auto border-b border-border-glass px-4 py-3 sm:px-5">
           {TIME_RANGES.map((r) => (
             <button
               key={r.key}
@@ -200,10 +200,10 @@ export const MeterHistoryModal: React.FC<MeterHistoryModalProps> = ({
         </div>
 
         {/* Body */}
-        <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-4">
+        <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4 sm:px-5">
           {/* Stats row */}
           {stats && (
-            <div className="grid grid-cols-3 gap-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
               {[
                 { label: 'Current', value: formatTooltip(stats.current) },
                 { label: 'Min', value: formatTooltip(stats.min) },
@@ -223,7 +223,7 @@ export const MeterHistoryModal: React.FC<MeterHistoryModalProps> = ({
           )}
 
           {/* Chart */}
-          <div className="h-52 w-full">
+          <div className="h-48 w-full sm:h-52">
             {error ? (
               <div className="h-full flex items-center justify-center text-sm text-danger">
                 {error}
@@ -300,7 +300,7 @@ export const MeterHistoryModal: React.FC<MeterHistoryModalProps> = ({
         </div>
 
         {/* Footer */}
-        <div className="px-5 py-3 border-t border-border-glass flex justify-end">
+        <div className="flex justify-end border-t border-border-glass px-4 py-3 sm:px-5">
           <Button variant="secondary" size="sm" onClick={onClose}>
             Close
           </Button>

--- a/packages/frontend/src/components/quota/QuotaProgressBar.tsx
+++ b/packages/frontend/src/components/quota/QuotaProgressBar.tsx
@@ -38,9 +38,13 @@ export const QuotaProgressBar: React.FC<QuotaProgressBarProps> = ({
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between gap-2 text-xs">
         <span className="text-text-secondary truncate">{label}</span>
-        {displayValue && <span className="text-text tabular-nums flex-shrink-0">{displayValue}</span>}
+        {displayValue && (
+          <span className="text-text tabular-nums flex-shrink-0">{displayValue}</span>
+        )}
       </div>
-      <div className={clsx('rounded-full bg-bg-subtle overflow-hidden border border-border/30', barH)}>
+      <div
+        className={clsx('rounded-full bg-bg-subtle overflow-hidden border border-border/30', barH)}
+      >
         <div
           className={clsx('h-full rounded-full transition-all duration-500', barColor(status))}
           style={{ width: `${pct}%` }}

--- a/packages/frontend/src/components/ui/Badge.tsx
+++ b/packages/frontend/src/components/ui/Badge.tsx
@@ -57,17 +57,13 @@ export const Badge: React.FC<BadgeProps> = ({
       style={style}
       className={clsx(
         'inline-flex items-center gap-1.5 rounded-full border whitespace-nowrap tnum',
-        secondaryText
-          ? 'px-2 py-1 text-[11px]'
-          : 'px-2 py-0.5 text-[11px] font-medium',
+        secondaryText ? 'px-2 py-1 text-[11px]' : 'px-2 py-0.5 text-[11px] font-medium',
         onClick && 'cursor-pointer hover:opacity-80 transition-opacity duration-fast',
         statusClasses[status],
         className
       )}
     >
-      {!noDot && (
-        <span className="w-1.5 h-1.5 rounded-full bg-current flex-shrink-0" />
-      )}
+      {!noDot && <span className="w-1.5 h-1.5 rounded-full bg-current flex-shrink-0" />}
       {secondaryText ? (
         <div className="flex flex-col items-start leading-tight">
           <span className="font-semibold">{children}</span>

--- a/packages/frontend/src/components/ui/Badge.tsx
+++ b/packages/frontend/src/components/ui/Badge.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
 import { clsx } from 'clsx';
 
-type BadgeStatus = 'connected' | 'disconnected' | 'connecting' | 'error' | 'neutral' | 'warning';
+type BadgeStatus =
+  | 'connected'
+  | 'disconnected'
+  | 'connecting'
+  | 'error'
+  | 'neutral'
+  | 'warning'
+  | 'success'
+  | 'danger'
+  | 'info'
+  | 'violet'
+  | 'cyan';
 
 interface BadgeProps {
   status: BadgeStatus;
@@ -11,15 +22,22 @@ interface BadgeProps {
   onClick?: (e: React.MouseEvent) => void;
   title?: string;
   style?: React.CSSProperties;
+  /** Hide the leading status dot (default shows when secondaryText absent). */
+  noDot?: boolean;
 }
 
 const statusClasses: Record<BadgeStatus, string> = {
-  connected: 'text-success border-success/30 bg-success/15',
-  connecting: 'text-info border-info/30 bg-info/15',
-  disconnected: 'text-danger border-danger/30 bg-danger/15',
-  error: 'text-danger border-danger/30 bg-danger/15',
-  warning: 'text-secondary border-secondary/30 bg-secondary/15',
-  neutral: 'text-text-secondary border-border bg-bg-hover',
+  connected: 'text-emerald-300 border-emerald-500/25 bg-emerald-500/12',
+  success: 'text-emerald-300 border-emerald-500/25 bg-emerald-500/12',
+  connecting: 'text-sky-300 border-sky-500/25 bg-sky-500/12',
+  info: 'text-sky-300 border-sky-500/25 bg-sky-500/12',
+  disconnected: 'text-slate-300 border-slate-500/18 bg-slate-500/10',
+  neutral: 'text-slate-300 border-slate-500/18 bg-slate-500/10',
+  error: 'text-rose-300 border-rose-500/28 bg-rose-500/12',
+  danger: 'text-rose-300 border-rose-500/28 bg-rose-500/12',
+  warning: 'text-amber-300 border-amber-500/28 bg-amber-500/12',
+  violet: 'text-violet-300 border-violet-500/25 bg-violet-500/12',
+  cyan: 'text-cyan-300 border-cyan-500/25 bg-cyan-500/12',
 };
 
 export const Badge: React.FC<BadgeProps> = ({
@@ -30,6 +48,7 @@ export const Badge: React.FC<BadgeProps> = ({
   onClick,
   title,
   style,
+  noDot,
 }) => {
   return (
     <div
@@ -37,18 +56,26 @@ export const Badge: React.FC<BadgeProps> = ({
       title={title}
       style={style}
       className={clsx(
-        'inline-flex items-center gap-2 rounded-full border text-xs font-medium whitespace-nowrap',
-        secondaryText ? 'px-3 py-1' : 'px-3 py-1.5',
+        'inline-flex items-center gap-1.5 rounded-full border whitespace-nowrap tnum',
+        secondaryText
+          ? 'px-2 py-1 text-[11px]'
+          : 'px-2 py-0.5 text-[11px] font-medium',
         onClick && 'cursor-pointer hover:opacity-80 transition-opacity duration-fast',
         statusClasses[status],
         className
       )}
     >
-      <span className="w-1.5 h-1.5 rounded-full bg-current flex-shrink-0" />
-      <div className="flex flex-col items-start leading-tight">
-        <span className="font-semibold">{children}</span>
-        {secondaryText && <span className="text-[9px] opacity-70 mt-0.5">{secondaryText}</span>}
-      </div>
+      {!noDot && (
+        <span className="w-1.5 h-1.5 rounded-full bg-current flex-shrink-0" />
+      )}
+      {secondaryText ? (
+        <div className="flex flex-col items-start leading-tight">
+          <span className="font-semibold">{children}</span>
+          <span className="text-[9px] opacity-70 mt-0.5">{secondaryText}</span>
+        </div>
+      ) : (
+        <span className="font-medium">{children}</span>
+      )}
     </div>
   );
 };

--- a/packages/frontend/src/components/ui/Button.tsx
+++ b/packages/frontend/src/components/ui/Button.tsx
@@ -22,26 +22,27 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <button
       className={clsx(
-        'inline-flex items-center justify-center gap-2 font-body font-medium leading-normal border-0 rounded-md cursor-pointer transition-all duration-fast whitespace-nowrap select-none outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg-deep disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0',
+        'inline-flex items-center justify-center gap-2 font-body font-medium leading-normal border-0 rounded-md cursor-pointer transition-all duration-fast whitespace-nowrap select-none outline-none disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0',
         {
-          'text-black bg-gradient-to-br from-primary to-secondary shadow-glow-primary-sm hover:-translate-y-0.5 hover:shadow-glow-primary':
+          'text-[#1A1006] bg-gradient-to-br from-secondary to-primary shadow-[0_1px_0_rgba(255,255,255,0.2)_inset,0_6px_20px_-10px_rgba(245,158,11,0.5)] hover:brightness-105 hover:-translate-y-px hover:shadow-[0_1px_0_rgba(255,255,255,0.25)_inset,0_12px_28px_-10px_rgba(245,158,11,0.65)]':
             variant === 'primary',
-          'bg-bg-glass text-text border border-border-glass backdrop-blur-md hover:bg-bg-hover hover:border-primary':
+          'bg-slate-700/50 text-text border border-border-2 hover:bg-slate-600/60':
             variant === 'secondary',
-          'bg-transparent text-text hover:bg-amber-500/10': variant === 'ghost',
-          'bg-danger text-white shadow-glow-danger hover:bg-red-700 hover:-translate-y-0.5':
+          'bg-transparent text-text-secondary hover:bg-bg-hover hover:text-text':
+            variant === 'ghost',
+          'bg-danger/12 text-red-300 border border-danger/30 hover:bg-danger/20':
             variant === 'danger',
-          'py-1.5 px-3.5 text-xs': size === 'sm',
-          'py-2.5 px-5 text-sm': size === 'md',
-          'py-3 px-6 text-base': size === 'lg',
-          'h-9 w-9 p-0': size === 'icon',
+          'py-1.5 px-2.5 text-xs gap-1.5': size === 'sm',
+          'py-2 px-3.5 text-sm gap-1.5': size === 'md',
+          'py-2.5 px-4 text-sm': size === 'lg',
+          'h-8 w-8 p-0': size === 'icon',
         },
         className
       )}
       disabled={isLoading || disabled}
       {...props}
     >
-      {isLoading && <Loader2 className="animate-spin" size={16} />}
+      {isLoading && <Loader2 className="animate-spin" size={14} />}
       {!isLoading && leftIcon && <span className="flex items-center">{leftIcon}</span>}
       {children}
     </button>

--- a/packages/frontend/src/components/ui/Card.tsx
+++ b/packages/frontend/src/components/ui/Card.tsx
@@ -30,18 +30,27 @@ export const Card: React.FC<CardProps> = ({
       {(title || extra) && (
         <div
           className={clsx(
-            'flex items-center justify-between gap-3 border-b border-border',
-            dense ? 'px-4 py-3' : 'px-4 py-3 sm:px-5'
+            // flex-wrap so a long `extra` (e.g. "Analyze Concurrency" + auto-refresh
+            // status) drops to its own line on narrow viewports instead of
+            // overflowing the card.
+            'flex items-start justify-between gap-2 sm:gap-3 flex-wrap border-b border-border sm:items-center',
+            dense ? 'px-3 py-2.5 sm:px-4 sm:py-3' : 'px-3 py-2.5 sm:px-5 sm:py-3'
           )}
         >
           {title && (
-            <h3 className="font-heading text-sm font-semibold text-text m-0 truncate">{title}</h3>
+            <h3 className="font-heading text-[13px] sm:text-sm font-semibold text-text m-0 truncate min-w-0 leading-tight">
+              {title}
+            </h3>
           )}
-          {extra && <div className="flex-shrink-0">{extra}</div>}
+          {extra && (
+            <div className="min-w-0 max-w-full flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+              {extra}
+            </div>
+          )}
         </div>
       )}
       {!flush && (
-        <div className={clsx('max-w-full', dense ? 'p-3 sm:p-4' : 'p-4 sm:p-5')}>{children}</div>
+        <div className={clsx('max-w-full', dense ? 'p-3 sm:p-4' : 'p-3 sm:p-5')}>{children}</div>
       )}
       {flush && <div className="max-w-full">{children}</div>}
     </div>

--- a/packages/frontend/src/components/ui/Card.tsx
+++ b/packages/frontend/src/components/ui/Card.tsx
@@ -22,7 +22,7 @@ export const Card: React.FC<CardProps> = ({
   return (
     <div
       className={clsx(
-        'glass-bg backdrop-blur-md rounded-lg overflow-hidden transition-all duration-fast max-w-full shadow-[0_8px_32px_rgba(0,0,0,0.25)]',
+        'bg-bg-card border border-border rounded-lg overflow-hidden transition-all duration-fast max-w-full',
         className
       )}
       {...props}
@@ -30,20 +30,18 @@ export const Card: React.FC<CardProps> = ({
       {(title || extra) && (
         <div
           className={clsx(
-            'flex items-center justify-between gap-3 border-b border-border-glass',
-            dense ? 'px-4 py-3' : 'px-4 py-4 sm:px-5 sm:py-4'
+            'flex items-center justify-between gap-3 border-b border-border',
+            dense ? 'px-4 py-3' : 'px-4 py-3 sm:px-5'
           )}
         >
           {title && (
-            <h3 className="font-heading text-h3 font-semibold text-text m-0 truncate">{title}</h3>
+            <h3 className="font-heading text-sm font-semibold text-text m-0 truncate">{title}</h3>
           )}
           {extra && <div className="flex-shrink-0">{extra}</div>}
         </div>
       )}
       {!flush && (
-        <div className={clsx('max-w-full', dense ? 'p-3 sm:p-4' : 'p-4 sm:p-5 md:p-6')}>
-          {children}
-        </div>
+        <div className={clsx('max-w-full', dense ? 'p-3 sm:p-4' : 'p-4 sm:p-5')}>{children}</div>
       )}
       {flush && <div className="max-w-full">{children}</div>}
     </div>

--- a/packages/frontend/src/components/ui/Drawer.tsx
+++ b/packages/frontend/src/components/ui/Drawer.tsx
@@ -42,16 +42,16 @@ export const Drawer: React.FC<DrawerProps> = ({
       aria-label={ariaLabel}
     >
       <div
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm animate-[fadeIn_0.2s_ease]"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-[fadeIn_0.2s_ease]"
         onClick={onClose}
       />
       <div
         className={clsx(
-          'absolute top-0 bottom-0 z-drawer flex w-[280px] max-w-[85vw] flex-col bg-bg-surface border-border shadow-modal outline-none',
+          'absolute top-0 bottom-0 z-drawer flex glass-bg shadow-2xl outline-none',
           side === 'left' &&
-            'left-0 border-r animate-[drawerSlideLeft_250ms_cubic-bezier(0.22,1,0.36,1)]',
+            'left-0 w-[260px] max-w-[85vw] animate-[drawerSlideLeft_250ms_cubic-bezier(0.22,1,0.36,1)] flex-col',
           side === 'right' &&
-            'right-0 border-l animate-[drawerSlideRight_250ms_cubic-bezier(0.22,1,0.36,1)]',
+            'right-0 w-full max-w-[560px] animate-[drawerSlideRight_250ms_cubic-bezier(0.22,1,0.36,1)] flex-col',
           className
         )}
         onClick={(e) => e.stopPropagation()}

--- a/packages/frontend/src/components/ui/Drawer.tsx
+++ b/packages/frontend/src/components/ui/Drawer.tsx
@@ -35,23 +35,21 @@ export const Drawer: React.FC<DrawerProps> = ({
   if (!open) return null;
 
   return createPortal(
-    <div
-      className="fixed inset-0 z-drawer-backdrop"
-      role="dialog"
-      aria-modal="true"
-      aria-label={ariaLabel}
-    >
+    <div className="fixed inset-0 z-[300]" role="dialog" aria-modal="true" aria-label={ariaLabel}>
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-[fadeIn_0.2s_ease]"
         onClick={onClose}
       />
       <div
         className={clsx(
-          'absolute top-0 bottom-0 z-drawer flex glass-bg shadow-2xl outline-none',
+          // Solid background — glass-bg let underlying page content (Dashboard
+          // title, page tabs) bleed through the drawer when open. Backdrop blur
+          // alone isn't enough on mobile browsers.
+          'absolute top-0 bottom-0 z-[310] flex bg-bg-card border-border shadow-2xl outline-none',
           side === 'left' &&
-            'left-0 w-[260px] max-w-[85vw] animate-[drawerSlideLeft_250ms_cubic-bezier(0.22,1,0.36,1)] flex-col',
+            'left-0 w-[260px] max-w-[85vw] border-r animate-[drawerSlideLeft_250ms_cubic-bezier(0.22,1,0.36,1)] flex-col',
           side === 'right' &&
-            'right-0 w-full max-w-[560px] animate-[drawerSlideRight_250ms_cubic-bezier(0.22,1,0.36,1)] flex-col',
+            'right-0 w-full max-w-[560px] border-l animate-[drawerSlideRight_250ms_cubic-bezier(0.22,1,0.36,1)] flex-col',
           className
         )}
         onClick={(e) => e.stopPropagation()}

--- a/packages/frontend/src/components/ui/Input.tsx
+++ b/packages/frontend/src/components/ui/Input.tsx
@@ -39,12 +39,13 @@ export const Input: React.FC<InputProps> = ({
           id={inputId}
           aria-invalid={!!error}
           className={clsx(
-            'w-full py-2.5 font-body text-sm text-text bg-bg-glass border rounded-md outline-none transition-all duration-fast backdrop-blur-md placeholder:text-text-muted',
-            'focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25',
+            'w-full py-2 font-body text-sm text-text bg-slate-900/60 border rounded-md outline-none transition-all duration-fast placeholder:text-text-muted',
+            'hover:border-border-2',
+            'focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.18)]',
             'disabled:opacity-50 disabled:cursor-not-allowed',
-            leadingIcon ? 'pl-10' : 'pl-3.5',
-            trailingAction ? 'pr-10' : 'pr-3.5',
-            error ? 'border-danger' : 'border-border-glass',
+            leadingIcon ? 'pl-9' : 'pl-3',
+            trailingAction ? 'pr-10' : 'pr-3',
+            error ? 'border-danger' : 'border-border',
             className
           )}
           {...props}

--- a/packages/frontend/src/components/ui/Modal.tsx
+++ b/packages/frontend/src/components/ui/Modal.tsx
@@ -32,45 +32,41 @@ export const Modal: React.FC<ModalProps> = ({
     return () => document.removeEventListener('keydown', handleEsc);
   }, [isOpen, onClose]);
 
-  const handleBackdropClick = () => {
-    // Don't close when clicking on the backdrop
-  };
-
   if (!isOpen) return null;
 
   return createPortal(
     <div
-      className="fixed inset-0 z-modal flex items-center justify-center p-4 sm:p-5 bg-black/70 backdrop-blur-md animate-[fadeIn_0.2s_ease]"
-      onClick={handleBackdropClick}
+      className="fixed inset-0 z-modal flex items-center justify-center p-4 sm:p-5 bg-black/60 backdrop-blur-sm animate-[fadeIn_0.2s_ease]"
+      onClick={onClose}
       role="dialog"
       aria-modal="true"
       aria-label={title}
     >
       <div
         className={clsx(
-          'bg-bg-surface border border-border-glass rounded-xl w-full max-h-[90vh] overflow-hidden flex flex-col shadow-modal animate-[slideUp_0.3s_ease]',
+          'glass-bg rounded-2xl w-full max-h-[90vh] overflow-hidden flex flex-col shadow-2xl animate-[slideUp_0.3s_ease]',
           {
-            'max-w-[420px]': size === 'sm',
-            'max-w-[640px]': size === 'md',
-            'max-w-[960px]': size === 'lg',
+            'max-w-md': size === 'sm',
+            'max-w-xl': size === 'md',
+            'max-w-3xl': size === 'lg',
           }
         )}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between gap-4 p-4 sm:p-5 md:p-6 border-b border-border-glass">
-          <h2 className="font-heading text-h2 font-semibold text-text m-0 truncate">{title}</h2>
+        <div className="flex items-center justify-between gap-4 p-5 border-b border-white/5">
+          <h2 className="font-heading text-base font-semibold text-text m-0 truncate">{title}</h2>
           <button
             type="button"
-            className="flex-shrink-0 bg-transparent border-0 text-text-muted cursor-pointer rounded-md p-1 transition-colors duration-fast hover:text-text focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
+            className="flex-shrink-0 bg-transparent border-0 text-text-secondary cursor-pointer rounded-md p-1.5 transition-colors duration-fast hover:text-text hover:bg-bg-hover focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
             onClick={onClose}
             aria-label="Close"
           >
-            <X size={20} />
+            <X size={16} />
           </button>
         </div>
-        <div className="p-4 sm:p-5 md:p-6 lg:p-8 overflow-y-auto flex-1">{children}</div>
+        <div className="p-5 overflow-y-auto flex-1">{children}</div>
         {footer && (
-          <div className="flex flex-wrap items-center justify-end gap-3 px-4 py-4 sm:px-5 sm:py-5 md:px-6 border-t border-border-glass">
+          <div className="flex flex-wrap items-center justify-end gap-2 px-5 py-4 border-t border-white/5">
             {footer}
           </div>
         )}

--- a/packages/frontend/src/components/ui/Modal.tsx
+++ b/packages/frontend/src/components/ui/Modal.tsx
@@ -36,25 +36,25 @@ export const Modal: React.FC<ModalProps> = ({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-modal flex items-center justify-center p-4 sm:p-5 bg-black/60 backdrop-blur-sm animate-[fadeIn_0.2s_ease]"
-      onClick={onClose}
+      className="fixed inset-0 z-[410] flex items-center justify-center p-3 sm:p-5 bg-black/60 backdrop-blur-sm animate-[fadeIn_0.2s_ease]"
       role="dialog"
       aria-modal="true"
       aria-label={title}
     >
       <div
         className={clsx(
-          'glass-bg rounded-2xl w-full max-h-[90vh] overflow-hidden flex flex-col shadow-2xl animate-[slideUp_0.3s_ease]',
+          'glass-bg w-full max-h-[92vh] overflow-hidden rounded-xl flex flex-col shadow-2xl animate-[slideUp_0.3s_ease] sm:max-h-[90vh] sm:rounded-2xl',
           {
             'max-w-md': size === 'sm',
             'max-w-xl': size === 'md',
             'max-w-3xl': size === 'lg',
           }
         )}
-        onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between gap-4 p-5 border-b border-white/5">
-          <h2 className="font-heading text-base font-semibold text-text m-0 truncate">{title}</h2>
+        <div className="flex items-center justify-between gap-3 p-4 border-b border-white/5 sm:p-5">
+          <h2 className="min-w-0 font-heading text-base font-semibold text-text m-0 truncate">
+            {title}
+          </h2>
           <button
             type="button"
             className="flex-shrink-0 bg-transparent border-0 text-text-secondary cursor-pointer rounded-md p-1.5 transition-colors duration-fast hover:text-text hover:bg-bg-hover focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2"
@@ -64,9 +64,9 @@ export const Modal: React.FC<ModalProps> = ({
             <X size={16} />
           </button>
         </div>
-        <div className="p-5 overflow-y-auto flex-1">{children}</div>
+        <div className="p-4 overflow-y-auto flex-1 sm:p-5">{children}</div>
         {footer && (
-          <div className="flex flex-wrap items-center justify-end gap-2 px-5 py-4 border-t border-white/5">
+          <div className="flex flex-wrap items-center justify-end gap-2 px-4 py-3 border-t border-white/5 sm:px-5 sm:py-4">
             {footer}
           </div>
         )}

--- a/packages/frontend/src/components/ui/Select.tsx
+++ b/packages/frontend/src/components/ui/Select.tsx
@@ -46,10 +46,11 @@ export function Select<V extends string = string>({
           onChange={(e) => onChange(e.target.value as V)}
           aria-invalid={!!error}
           className={clsx(
-            'w-full appearance-none py-2.5 pl-3.5 pr-10 font-body text-sm text-text bg-bg-glass border rounded-md outline-none transition-all duration-fast backdrop-blur-md cursor-pointer',
-            'focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/25',
+            'w-full appearance-none py-2 pl-3 pr-9 font-body text-sm text-text bg-slate-900/60 border rounded-md outline-none transition-all duration-fast cursor-pointer',
+            'hover:border-border-2',
+            'focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.18)]',
             'disabled:opacity-50 disabled:cursor-not-allowed',
-            error ? 'border-danger' : 'border-border-glass',
+            error ? 'border-danger' : 'border-border',
             className
           )}
           {...rest}
@@ -66,7 +67,7 @@ export function Select<V extends string = string>({
           ))}
         </select>
         <ChevronDown
-          size={16}
+          size={14}
           className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-muted"
         />
       </div>

--- a/packages/frontend/src/components/ui/SortableCard.tsx
+++ b/packages/frontend/src/components/ui/SortableCard.tsx
@@ -164,7 +164,7 @@ export const SortableCard: React.FC<SortableCardProps> = ({ card, isOverlay = fa
       style={style}
       data-testid={`sortable-card-${card.id}`}
       data-dragging={isDragging ? 'true' : 'false'}
-      className={clsx('relative group', isDragging && 'opacity-50')}
+      className={clsx('relative group min-w-0 max-w-full', isDragging && 'opacity-50')}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
@@ -197,7 +197,7 @@ export const SortableCard: React.FC<SortableCardProps> = ({ card, isOverlay = fa
       <div
         data-testid="drag-handle"
         className={clsx(
-          'absolute left-2 top-1/2 -translate-y-1/2 z-10 p-1 rounded cursor-grab active:cursor-grabbing transition-opacity duration-200',
+          'absolute left-2 top-1/2 z-10 hidden -translate-y-1/2 rounded p-1 cursor-grab transition-opacity duration-200 active:cursor-grabbing md:block',
           isHovered || isDragging ? 'opacity-100' : 'opacity-0'
         )}
         {...listeners}
@@ -217,7 +217,7 @@ export const SortableCard: React.FC<SortableCardProps> = ({ card, isOverlay = fa
        * The `pl-8` (padding-left: 2rem) creates space for the absolutely-positioned
        * grip handle so that card content does not overlap with it.
        */}
-      <div data-testid="sortable-card" className="pl-8">
+      <div data-testid="sortable-card" className="min-w-0 max-w-full md:pl-8">
         <Card
           title={card.title}
           extra={card.extra}

--- a/packages/frontend/src/components/ui/Switch.tsx
+++ b/packages/frontend/src/components/ui/Switch.tsx
@@ -29,24 +29,25 @@ export const Switch: React.FC<SwitchProps> = ({
         if (!disabled) onChange(!checked);
       }}
       className={clsx(
-        'group relative inline-block flex-shrink-0 rounded-full border border-border-glass bg-border transition-colors duration-fast outline-none',
-        'data-[checked=true]:bg-success data-[checked=true]:border-transparent',
+        'group relative inline-block flex-shrink-0 rounded-full border transition-colors duration-fast outline-none',
+        'border-border-2 bg-slate-800',
+        'data-[checked=true]:bg-gradient-to-br data-[checked=true]:from-secondary data-[checked=true]:to-primary data-[checked=true]:border-amber-500/60',
         'focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg-deep',
         'disabled:opacity-50 disabled:cursor-not-allowed',
         !disabled && 'cursor-pointer',
         {
-          'h-[18px] w-8': size === 'sm',
-          'h-6 w-11': size === 'md',
+          'h-[18px] w-[30px]': size === 'sm',
+          'h-5 w-[34px]': size === 'md',
         }
       )}
     >
       <span
         aria-hidden="true"
         className={clsx(
-          'absolute left-0.5 top-0.5 inline-block rounded-full bg-white shadow-sm transition-transform duration-fast',
+          'absolute top-px left-px inline-block rounded-full bg-slate-400 group-data-[checked=true]:bg-white transition-transform duration-fast',
           {
-            'h-3.5 w-3.5 group-data-[checked=true]:translate-x-[14px]': size === 'sm',
-            'h-5 w-5 group-data-[checked=true]:translate-x-5': size === 'md',
+            'h-3.5 w-3.5 group-data-[checked=true]:translate-x-3': size === 'sm',
+            'h-4 w-4 group-data-[checked=true]:translate-x-3.5': size === 'md',
           }
         )}
       />

--- a/packages/frontend/src/components/ui/Tabs.tsx
+++ b/packages/frontend/src/components/ui/Tabs.tsx
@@ -43,7 +43,7 @@ export function Tabs<V extends string = string>({
       role="tablist"
       aria-label={ariaLabel}
       className={clsx(
-        'flex items-center gap-1 overflow-x-auto',
+        'flex items-center gap-0.5 sm:gap-1 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden',
         variant === 'underline' && 'border-b border-border-glass',
         className
       )}
@@ -62,13 +62,13 @@ export function Tabs<V extends string = string>({
             onKeyDown={(e) => handleKeyDown(e, idx)}
             disabled={item.disabled}
             className={clsx(
-              'flex-shrink-0 inline-flex items-center gap-2 font-body text-sm font-medium transition-all duration-fast whitespace-nowrap focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2 disabled:opacity-40 disabled:cursor-not-allowed',
-              variant === 'underline' && 'px-4 py-2.5 border-b-2 -mb-px',
+              'flex-shrink-0 inline-flex items-center gap-1.5 sm:gap-2 font-body text-xs sm:text-sm font-medium transition-all duration-fast whitespace-nowrap focus-visible:outline-2 focus-visible:outline focus-visible:outline-primary focus-visible:outline-offset-2 disabled:opacity-40 disabled:cursor-not-allowed',
+              variant === 'underline' && 'px-3 py-2 sm:px-4 sm:py-2.5 border-b-2 -mb-px',
               variant === 'underline' && active && 'text-primary border-primary',
               variant === 'underline' &&
                 !active &&
                 'text-text-secondary border-transparent hover:text-text',
-              variant === 'pills' && 'px-3.5 py-1.5 rounded-md',
+              variant === 'pills' && 'px-3 py-1.5 sm:px-3.5 rounded-md',
               variant === 'pills' &&
                 active &&
                 'bg-bg-glass text-primary border border-border-glass',

--- a/packages/frontend/src/components/ui/Tooltip.tsx
+++ b/packages/frontend/src/components/ui/Tooltip.tsx
@@ -23,7 +23,7 @@ export const Tooltip: React.FC<TooltipProps> = ({ content, children, position = 
         <div
           role="tooltip"
           className={clsx(
-            'absolute z-tooltip px-2 py-1 bg-bg-surface border border-border-2 rounded-md shadow-lg whitespace-nowrap text-[11px] text-text pointer-events-none font-mono',
+            'absolute z-[500] px-2 py-1 bg-bg-surface border border-border-2 rounded-md shadow-lg whitespace-nowrap text-[11px] text-text pointer-events-none font-mono',
             position === 'right' && 'left-full top-1/2 -translate-y-1/2 ml-2',
             position === 'left' && 'right-full top-1/2 -translate-y-1/2 mr-2',
             position === 'top' && 'bottom-full left-1/2 -translate-x-1/2 mb-2',

--- a/packages/frontend/src/components/ui/Tooltip.tsx
+++ b/packages/frontend/src/components/ui/Tooltip.tsx
@@ -4,7 +4,7 @@ import { clsx } from 'clsx';
 interface TooltipProps {
   content: React.ReactNode;
   children: React.ReactNode;
-  position?: 'bottom' | 'right';
+  position?: 'bottom' | 'right' | 'top' | 'left';
 }
 
 export const Tooltip: React.FC<TooltipProps> = ({ content, children, position = 'bottom' }) => {
@@ -23,8 +23,10 @@ export const Tooltip: React.FC<TooltipProps> = ({ content, children, position = 
         <div
           role="tooltip"
           className={clsx(
-            'absolute z-tooltip px-3 py-2 bg-bg-surface border border-border rounded-md shadow-lg whitespace-nowrap text-xs text-text pointer-events-none',
+            'absolute z-tooltip px-2 py-1 bg-bg-surface border border-border-2 rounded-md shadow-lg whitespace-nowrap text-[11px] text-text pointer-events-none font-mono',
             position === 'right' && 'left-full top-1/2 -translate-y-1/2 ml-2',
+            position === 'left' && 'right-full top-1/2 -translate-y-1/2 mr-2',
+            position === 'top' && 'bottom-full left-1/2 -translate-x-1/2 mb-2',
             position === 'bottom' && 'top-full left-1/2 -translate-x-1/2 mt-2'
           )}
         >

--- a/packages/frontend/src/contexts/ToastContext.tsx
+++ b/packages/frontend/src/contexts/ToastContext.tsx
@@ -97,7 +97,7 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     <ToastContext.Provider value={value}>
       {children}
       {createPortal(
-        <div className="fixed top-4 right-4 z-toast flex flex-col gap-2 max-w-[90vw] sm:max-w-sm pointer-events-none">
+        <div className="fixed top-4 right-4 z-[600] flex flex-col gap-2 max-w-[90vw] sm:max-w-sm pointer-events-none">
           {toasts.map((toast) => (
             <div
               key={toast.id}
@@ -131,7 +131,7 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       {confirmState &&
         createPortal(
           <div
-            className="fixed inset-0 z-modal flex items-center justify-center p-4 bg-black/70 backdrop-blur-md"
+            className="fixed inset-0 z-[410] flex items-center justify-center p-4 bg-black/70 backdrop-blur-md"
             onClick={() => resolveConfirm(false)}
             role="dialog"
             aria-modal="true"

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -4,10 +4,11 @@
 @theme {
   /* Colors. */
   --color-bg-deep: #000000;
-  --color-bg-surface: #0F172A;
-  --color-bg-card: rgba(15, 23, 42, 0.8);
-  --color-bg-glass: rgba(30, 41, 59, 0.6);
-  --color-bg-hover: rgba(51, 65, 85, 0.5);
+  --color-bg-surface: #0B1020;
+  --color-bg-card: #0F172A;
+  --color-bg-card-2: #111A30;
+  --color-bg-glass: rgba(15, 23, 42, 0.72);
+  --color-bg-hover: rgba(51, 65, 85, 0.45);
 
   --color-primary: #F59E0B;
   --color-secondary: #FBBF24;
@@ -22,18 +23,20 @@
   --color-text-secondary: #94A3B8;
   --color-text-muted: #64748B;
 
-  --color-border: #334155;
-  --color-border-glass: rgba(255, 255, 255, 0.1);
+  --color-border: #1E293B;
+  --color-border-2: #334155;
+  --color-border-glass: rgba(255, 255, 255, 0.08);
   --color-glow: rgba(245, 158, 11, 0.3);
 
-  --color-terminal-bg: #0F172A;
+  --color-terminal-bg: #05070D;
   --color-terminal-fg: #E2E8F0;
 
   /* Fonts */
-  --font-heading: 'Space Grotesk', sans-serif;
-  --font-body: 'DM Sans', sans-serif;
+  --font-heading: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  --font-body: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
-  /* Spacing (using --space-* prefix to avoid conflict with Tailwind's --spacing-* which drives max-width utilities) */
+  /* Spacing */
   --space-xxs: 2px;
   --space-xs: 4px;
   --space-sm: 8px;
@@ -50,7 +53,7 @@
   --radius-lg: 16px;
   --radius-xl: 20px;
 
-  /* Typography scale (responsive via clamp) */
+  /* Typography scale */
   --text-caption: 0.75rem;
   --text-body: 0.875rem;
   --text-body-lg: 1rem;
@@ -60,7 +63,7 @@
   --text-h1: clamp(1.5rem, 1.3rem + 1vw, 2rem);
   --text-display: clamp(2rem, 1.6rem + 2vw, 3rem);
 
-  /* Z-index scale — one source of truth. */
+  /* Z-index scale. */
   --z-dropdown: 100;
   --z-sidebar: 200;
   --z-drawer-backdrop: 300;
@@ -77,26 +80,56 @@
   --duration: 250ms;
   --duration-slow: 400ms;
 
-  /* Shadows — semantic names replace magic rgba values. */
-  --shadow-glow-primary: 0 6px 20px rgba(245, 158, 11, 0.4);
-  --shadow-glow-primary-sm: 0 4px 12px rgba(245, 158, 11, 0.3);
+  /* Shadows */
+  --shadow-glow-primary: 0 8px 22px -10px rgba(245, 158, 11, 0.55);
+  --shadow-glow-primary-sm: 0 6px 20px -10px rgba(245, 158, 11, 0.5);
   --shadow-glow-danger: 0 4px 12px rgba(239, 68, 68, 0.3);
   --shadow-nav-active: 0 2px 8px rgba(245, 158, 11, 0.15);
   --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.5);
 }
 
-/* Custom Utilities based on variables */
+/* Custom utilities */
 @utility glass-bg {
-  background-color: rgba(15, 23, 42, 0.7);
-  backdrop-filter: blur(16px);
+  background: rgba(15, 23, 42, 0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 @utility glass-blur {
-  backdrop-filter: blur(16px);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
 }
 
-/* Base Reset */
+@utility amber-grad-text {
+  background: linear-gradient(135deg, #FBBF24 0%, #F59E0B 60%, #D97706 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+@utility amber-grad-bg {
+  background: linear-gradient(135deg, #FBBF24 0%, #F59E0B 60%, #D97706 100%);
+}
+
+@utility surface-card {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+@utility surface-quiet {
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+@utility tnum {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+/* Base reset */
 @layer base {
   *,
   *::before,
@@ -111,45 +144,69 @@
     font-size: var(--text-body);
     line-height: 1.5;
     background-color: var(--color-bg-deep);
+    background-image:
+      radial-gradient(1100px 600px at 12% -10%, rgba(245, 158, 11, 0.06), transparent 60%),
+      radial-gradient(900px 500px at 110% 10%, rgba(139, 92, 246, 0.05), transparent 60%);
     color: var(--color-text);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+  }
+
+  h1, h2, h3, h4, h5 {
+    font-family: var(--font-heading);
+    letter-spacing: -0.01em;
   }
 
   /* Scrollbar */
   ::-webkit-scrollbar {
-    width: 0.375rem;
-    height: 0.375rem;
+    width: 10px;
+    height: 10px;
   }
 
   ::-webkit-scrollbar-track {
-    background-color: var(--color-bg-surface);
+    background: transparent;
   }
 
   ::-webkit-scrollbar-thumb {
-    background: linear-gradient(180deg, var(--color-primary), var(--color-secondary));
-    border-radius: 3px;
+    background: #1E293B;
+    border-radius: 999px;
+    border: 2px solid var(--color-bg-deep);
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background-color: var(--color-primary);
+    background: #334155;
   }
 
   /* Selection */
   ::selection {
     background-color: var(--color-primary);
-    color: #000000;
+    color: #1A1006;
+  }
+
+  /* Focus rings */
+  *:focus {
+    outline: none;
+  }
+  *:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
+  button:focus-visible,
+  a:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible {
+    box-shadow: 0 0 0 2px #000, 0 0 0 4px var(--color-primary);
+    outline: none;
   }
 }
 
 /* Keyframes */
 @keyframes pulse-fade {
-  0% {
-    background-color: rgba(245, 158, 11, 0.2);
-  }
-  100% {
-    background-color: transparent;
-  }
+  0% { background-color: rgba(245, 158, 11, 0.2); }
+  100% { background-color: transparent; }
 }
 
 @keyframes fadeIn {
@@ -169,9 +226,13 @@
 
 @keyframes slideIn {
   from {
-    background-color: rgba(245, 158, 11, 0.25);
+    opacity: 0;
+    transform: translateY(-4px);
+    background-color: rgba(245, 158, 11, 0.18);
   }
   to {
+    opacity: 1;
+    transform: none;
     background-color: transparent;
   }
 }
@@ -186,7 +247,32 @@
   to { transform: translateX(0); }
 }
 
-/* Utility class for new log row animation */
+@keyframes pulse-dot {
+  0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.6); }
+  70% { box-shadow: 0 0 0 8px rgba(16, 185, 129, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+/* Utility classes */
 @utility animate-slide-in {
-  animation: slideIn 1.5s ease-out forwards;
+  animation: slideIn 0.9s ease-out;
+}
+
+@utility animate-float {
+  animation: float 6s ease-in-out infinite;
+}
+
+@utility live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  display: inline-block;
+  background: #10B981;
+  box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.7);
+  animation: pulse-dot 1.6s infinite;
 }

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -7,6 +7,7 @@
   --color-bg-surface: #0B1020;
   --color-bg-card: #0F172A;
   --color-bg-card-2: #111A30;
+  --color-bg-subtle: #0B1324;
   --color-bg-glass: rgba(15, 23, 42, 0.72);
   --color-bg-hover: rgba(51, 65, 85, 0.45);
 
@@ -90,7 +91,11 @@
 
 /* Custom utilities */
 @utility glass-bg {
-  background: rgba(15, 23, 42, 0.72);
+  /* Opacity bumped from 0.72 → 0.92 so sticky headers (AppBar, page headers)
+     actually obscure content scrolling under them. backdrop-filter alone isn't
+     enough on mobile browsers where it's often disabled or limited; the alpha
+     channel does the real work. */
+  background: rgba(15, 23, 42, 0.92);
   backdrop-filter: blur(20px) saturate(140%);
   -webkit-backdrop-filter: blur(20px) saturate(140%);
   border: 1px solid rgba(255, 255, 255, 0.08);

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -469,12 +469,11 @@ export const Config = () => {
   };
 
   return (
-    <div className="flex flex-col min-h-full">
+    <PageContainer>
       <PageHeader
-        title="Settings"
-        subtitle="Gateway configuration"
+        title="Configuration"
+        subtitle="View current system configuration (read-only). Use the Providers, Models, and Keys pages to make changes."
       />
-      <PageContainer>
 
       <div className="flex flex-col gap-6">
         <Card
@@ -952,7 +951,6 @@ export const Config = () => {
           </div>
         </Card>
       </div>
-      </PageContainer>
-    </div>
+    </PageContainer>
   );
 };

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -469,11 +469,12 @@ export const Config = () => {
   };
 
   return (
-    <PageContainer>
+    <div className="flex flex-col min-h-full">
       <PageHeader
-        title="Configuration"
-        subtitle="View current system configuration (read-only). Use the Providers, Models, and Keys pages to make changes."
+        title="Settings"
+        subtitle="Gateway configuration"
       />
+      <PageContainer>
 
       <div className="flex flex-col gap-6">
         <Card
@@ -951,6 +952,7 @@ export const Config = () => {
           </div>
         </Card>
       </div>
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 };

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -78,14 +78,14 @@ export const Dashboard = () => {
 
   return (
     <div className="flex flex-col min-h-full">
-      <div className="sticky top-0 z-20 glass-bg border-b border-white/5">
-        <div className="px-4 sm:px-6 lg:px-8 pt-4">
-          <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+      <div className="sticky top-12 md:top-0 z-20 bg-bg-card border-b border-border">
+        <div className="px-3 sm:px-6 lg:px-8 pt-3 sm:pt-4">
+          <div className="flex items-center justify-between gap-3 mb-2.5 sm:mb-3 flex-wrap">
             <div>
-              <h1 className="font-heading text-xl sm:text-2xl font-semibold tracking-tight m-0">
+              <h1 className="font-heading text-lg sm:text-2xl font-semibold tracking-tight m-0 leading-tight">
                 Dashboard
               </h1>
-              <p className="text-xs text-text-secondary mt-0.5">
+              <p className="text-[11px] sm:text-xs text-text-secondary mt-0.5">
                 Real-time gateway traffic across all providers
               </p>
             </div>
@@ -95,12 +95,15 @@ export const Dashboard = () => {
             onChange={setTab}
             items={tabs}
             variant="underline"
+            className="-mx-3 px-3 sm:mx-0 sm:px-0"
             aria-label="Dashboard sections"
           />
         </div>
       </div>
 
-      <div className="flex-1 px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 pb-8">
+      {/* No padding here — each tab component (LiveTab/UsageTab/PerformanceTab/
+          OverallTab) provides its own page padding so we don't double-pad on mobile. */}
+      <div className="flex-1">
         {activeTab === 'overall' && isLimited && <OverallTab />}
         {activeTab === 'live' && (
           <LiveTab

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Zap, BarChart2, Gauge, LayoutDashboard } from 'lucide-react';
+import { Zap, BarChart3, Gauge, LayoutDashboard } from 'lucide-react';
 import { LiveTab } from '../components/dashboard/tabs/LiveTab';
 import { UsageTab } from '../components/dashboard/tabs/UsageTab';
 import { PerformanceTab } from '../components/dashboard/tabs/PerformanceTab';
@@ -26,7 +26,7 @@ const BASE_TABS = [
     value: 'usage' as const,
     label: (
       <span className="inline-flex items-center gap-2">
-        <BarChart2 size={14} /> Usage Analytics
+        <BarChart3 size={14} /> Usage Analytics
       </span>
     ),
   },
@@ -77,15 +77,27 @@ export const Dashboard = () => {
   }, [activeTab]);
 
   return (
-    <div className="flex flex-col min-h-full -mx-4 sm:-mx-6 lg:-mx-8 -mt-4 sm:-mt-6 lg:-mt-8">
-      <div className="sticky top-0 z-10 border-b border-border-glass bg-bg-surface/80 backdrop-blur-md px-2 sm:px-4">
-        <Tabs<TabId>
-          value={activeTab}
-          onChange={setTab}
-          items={tabs}
-          variant="underline"
-          aria-label="Dashboard sections"
-        />
+    <div className="flex flex-col min-h-full">
+      <div className="sticky top-0 z-20 glass-bg border-b border-white/5">
+        <div className="px-4 sm:px-6 lg:px-8 pt-4">
+          <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+            <div>
+              <h1 className="font-heading text-xl sm:text-2xl font-semibold tracking-tight m-0">
+                Dashboard
+              </h1>
+              <p className="text-xs text-text-secondary mt-0.5">
+                Real-time gateway traffic across all providers
+              </p>
+            </div>
+          </div>
+          <Tabs<TabId>
+            value={activeTab}
+            onChange={setTab}
+            items={tabs}
+            variant="underline"
+            aria-label="Dashboard sections"
+          />
+        </div>
       </div>
 
       <div className="flex-1 px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 pb-8">

--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -297,7 +297,7 @@ export const Debug: React.FC = () => {
                   </Button>
 
                   {isFilterOpen && (
-                    <div className="absolute right-0 top-full mt-2 w-72 bg-bg-surface border border-border-glass rounded-lg shadow-lg z-50 p-4">
+                    <div className="absolute left-0 top-full z-50 mt-2 w-[calc(100vw-2rem)] max-w-72 rounded-lg border border-border-glass bg-bg-surface p-4 shadow-lg sm:left-auto sm:right-0">
                       <div className="flex items-center justify-between mb-3">
                         <span className="text-sm font-medium text-text">Provider Filter</span>
                         {selectedProviders.length > 0 && (
@@ -401,10 +401,10 @@ export const Debug: React.FC = () => {
         />
       </div>
 
-      <div className="flex flex-col md:flex-row flex-1 overflow-hidden border-t border-border-glass">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden border-t border-border-glass md:flex-row">
         {/* Left Pane: Request List */}
-        <div className="w-full md:w-[320px] border-b md:border-b-0 md:border-r border-border-glass bg-bg-surface flex flex-col shrink-0 max-h-[40vh] md:max-h-none">
-          <div className="p-4 border-b border-border-glass">
+        <div className="flex max-h-[34vh] w-full shrink-0 flex-col border-b border-border-glass bg-bg-surface md:max-h-none md:w-[320px] md:border-b-0 md:border-r">
+          <div className="border-b border-border-glass p-3 sm:p-4">
             <span className="text-xs font-bold text-text-muted uppercase tracking-wider">
               Recent Requests
             </span>
@@ -429,7 +429,7 @@ export const Debug: React.FC = () => {
                     </div>
                     <button
                       onClick={(e) => handleDelete(e, log.requestId)}
-                      className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger group-hover:opacity-100 opacity-0 transition-opacity"
+                      className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger opacity-100 md:opacity-0 md:group-hover:opacity-100"
                       title="Delete log"
                     >
                       <Trash2 size={12} />
@@ -450,15 +450,17 @@ export const Debug: React.FC = () => {
         </div>
 
         {/* Right Pane: Details */}
-        <div className="flex-1 bg-bg-deep overflow-y-auto flex flex-col relative">
+        <div className="relative flex min-h-0 flex-1 flex-col overflow-y-auto bg-bg-deep">
           {selectedId && detail ? (
             <div className="flex flex-col">
-              <div className="sticky top-0 z-10 bg-bg-surface border-b border-border-glass px-4 py-3 flex items-center justify-between">
-                <div className="flex flex-col gap-1">
+              <div className="sticky top-0 z-10 flex flex-col gap-2 border-b border-border-glass bg-bg-surface px-3 py-3 sm:px-4">
+                <div className="flex min-w-0 flex-col gap-1">
                   <span className="text-xs font-bold uppercase tracking-wider text-text-muted">
                     Selected Trace
                   </span>
-                  <span className="text-xs font-mono text-text-secondary">{detail.requestId}</span>
+                  <span className="break-all text-xs font-mono text-text-secondary">
+                    {detail.requestId}
+                  </span>
                 </div>
               </div>
               <AccordionPanel
@@ -574,12 +576,12 @@ const AccordionPanel: React.FC<{
   return (
     <div className="border-b border-border-glass bg-bg-surface">
       <div
-        className="px-4 py-3 cursor-pointer flex justify-between items-center bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
+        className="flex cursor-pointer items-center justify-between gap-3 bg-bg-hover px-3 py-3 transition-colors duration-200 select-none hover:bg-bg-glass sm:px-4"
         onClick={() => setIsOpen(!isOpen)}
       >
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           {isOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-          <span className={clsx('text-[11px] font-bold uppercase tracking-wider', color)}>
+          <span className={clsx('truncate text-[11px] font-bold uppercase tracking-wider', color)}>
             {title}
           </span>
         </div>
@@ -597,7 +599,7 @@ const AccordionPanel: React.FC<{
           isOpen ? 'max-h-[500px]' : 'max-h-0'
         )}
       >
-        <div className="h-[400px] bg-[#1e1e1e]">
+        <div className="h-[280px] bg-[#1e1e1e] sm:h-[400px]">
           <Editor
             height="100%"
             defaultLanguage="json"

--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -265,14 +265,14 @@ export const Debug: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col min-h-[calc(100vh-8rem)] -mx-4 sm:-mx-6 lg:-mx-8 -mt-4 sm:-mt-6 lg:-mt-8">
-      <div className="px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 pb-3 shrink-0">
+    <div className="flex flex-col min-h-[calc(100vh-3rem)]">
+      <div className="shrink-0">
         <PageHeader
-          title="Debug Traces"
+          title="Traces"
           subtitle={
             principal?.role === 'limited' && principal.keyName
               ? `Traces for key "${principal.keyName}" only. Toggle capture in My Key.`
-              : 'Inspect full request/response lifecycles.'
+              : 'Distributed spans · OTLP'
           }
           actions={
             <>

--- a/packages/frontend/src/pages/DetailedUsage.tsx
+++ b/packages/frontend/src/pages/DetailedUsage.tsx
@@ -1142,7 +1142,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
           in the current time window. Each card shows a label, value, and icon.
           Errors are highlighted in red when count > 0.
       ------------------------------------------------------------------- */}
-      <div className="mb-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-8 gap-3">
+      <div className="mb-6 grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-8">
         {stats.map((stat, i) => (
           <div key={i} className="glass-bg rounded-lg p-3 flex flex-col gap-1">
             <div className="flex justify-between items-start">
@@ -1170,7 +1170,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
              -- Only visible when groupBy='time' (categorical views use pie)
       ------------------------------------------------------------------- */}
       <Card className="mb-6" title="Chart Configuration">
-        <div className="flex flex-wrap gap-4">
+        <div className="grid grid-cols-1 gap-4 lg:flex lg:flex-wrap">
           {/* --- Time Range Selector --- */}
           <div className="flex flex-col gap-2">
             <span className="text-xs font-semibold text-text-muted uppercase">Time Range</span>
@@ -1191,7 +1191,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
           {/* --- Group By Selector --- */}
           <div className="flex flex-col gap-2">
             <span className="text-xs font-semibold text-text-muted uppercase">Group By</span>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               {[
                 { k: 'time', l: 'Time' },
                 { k: 'provider', l: 'Provider' },
@@ -1213,7 +1213,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
           {/* --- Chart Type Picker --- */}
           <div className="flex flex-col gap-2">
             <span className="text-xs font-semibold text-text-muted uppercase">Chart Type</span>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               {[
                 { k: 'area', i: LineChartIcon, l: 'Area' },
                 { k: 'line', i: LineChartIcon, l: 'Line' },
@@ -1238,7 +1238,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
           {/* --- View Mode Toggle (Chart vs List) --- */}
           <div className="flex flex-col gap-2">
             <span className="text-xs font-semibold text-text-muted uppercase">View</span>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <Button
                 size="sm"
                 variant={viewMode === 'chart' ? 'primary' : 'secondary'}
@@ -1312,7 +1312,58 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
           title="Raw Request Log"
           extra={<span className="text-xs text-text-secondary">{records.length} requests</span>}
         >
-          <div className="overflow-x-auto max-h-125 overflow-y-auto">
+          <div className="max-h-125 space-y-3 overflow-y-auto md:hidden">
+            {records.slice(0, 100).map((r, i) => (
+              <article key={i} className="rounded-md border border-border-glass bg-bg-subtle p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-xs font-medium text-text">
+                      {new Date(r.date).toLocaleString()}
+                    </div>
+                    <div className="mt-1 truncate text-xs text-text-muted">
+                      {r.provider || 'unknown'} /{' '}
+                      {r.incomingModelAlias || r.selectedModelName || 'unknown'}
+                    </div>
+                  </div>
+                  <span
+                    className={`shrink-0 text-xs font-semibold ${
+                      r.responseStatus === 'success' ? 'text-green-500' : 'text-red-500'
+                    }`}
+                  >
+                    {r.responseStatus}
+                  </span>
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                  <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Tokens
+                    </div>
+                    <div className="font-medium text-text">
+                      {formatTokens((r.tokensInput || 0) + (r.tokensOutput || 0))}
+                    </div>
+                  </div>
+                  <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted">Cost</div>
+                    <div className="font-medium text-text">{formatCost(r.costTotal || 0, 4)}</div>
+                  </div>
+                  <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Duration
+                    </div>
+                    <div className="font-medium text-text">{formatMs(r.durationMs || 0)}</div>
+                  </div>
+                  <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted">TPS</div>
+                    <div className="font-medium text-text">
+                      {formatNumber(r.tokensPerSec || 0, 1)}
+                    </div>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <div className="hidden max-h-125 overflow-x-auto overflow-y-auto md:block">
             <table className="w-full text-sm">
               <thead className="sticky top-0 bg-bg-card">
                 <tr className="text-left border-b border-border-glass text-text-secondary">
@@ -1371,7 +1422,41 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
       ------------------------------------------------------------------- */}
       {groupBy !== 'time' && aggregatedData.length > 0 && (
         <Card className="mt-6" title="Detailed Breakdown">
-          <div className="overflow-x-auto">
+          <div className="space-y-3 md:hidden">
+            {aggregatedData.map((row, i) => (
+              <article key={i} className="rounded-md border border-border-glass bg-bg-subtle p-3">
+                <div className="truncate font-heading text-sm font-semibold text-text">
+                  {row.name}
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                  <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Requests
+                    </div>
+                    <div className="font-medium text-text">{formatNumber(row.requests, 0)}</div>
+                  </div>
+                  <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Success
+                    </div>
+                    <div className="font-medium text-green-500">{row.successRate.toFixed(1)}%</div>
+                  </div>
+                  <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Tokens
+                    </div>
+                    <div className="font-medium text-text">{formatTokens(row.tokens)}</div>
+                  </div>
+                  <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                    <div className="text-[10px] uppercase tracking-wider text-text-muted">Cost</div>
+                    <div className="font-medium text-text">{formatCost(row.cost, 6)}</div>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <div className="hidden overflow-x-auto md:block">
             <table className="w-full text-sm">
               <thead>
                 <tr className="text-left border-b border-border-glass text-text-secondary">

--- a/packages/frontend/src/pages/Errors.tsx
+++ b/packages/frontend/src/pages/Errors.tsx
@@ -160,6 +160,7 @@ export const Errors: React.FC = () => {
                 <Button
                   onClick={handleDeleteAll}
                   variant="danger"
+                  size="sm"
                   leftIcon={<Trash2 size={16} />}
                   disabled={errors.length === 0}
                 >
@@ -169,6 +170,7 @@ export const Errors: React.FC = () => {
               <Button
                 onClick={fetchErrors}
                 variant="secondary"
+                size="sm"
                 leftIcon={<RefreshCw size={16} className={clsx(loading && 'animate-spin')} />}
               >
                 Refresh
@@ -178,10 +180,10 @@ export const Errors: React.FC = () => {
         />
       </div>
 
-      <div className="flex flex-col md:flex-row flex-1 overflow-hidden border-t border-border-glass">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden border-t border-border-glass md:flex-row">
         {/* Left Pane: Error List */}
-        <div className="w-full md:w-[320px] border-b md:border-b-0 md:border-r border-border-glass bg-bg-surface flex flex-col shrink-0 max-h-[40vh] md:max-h-none">
-          <div className="p-4 border-b border-border-glass">
+        <div className="flex max-h-[34vh] w-full shrink-0 flex-col border-b border-border-glass bg-bg-surface md:max-h-none md:w-[320px] md:border-b-0 md:border-r">
+          <div className="border-b border-border-glass p-3 sm:p-4">
             <span className="text-xs font-bold text-text-muted uppercase tracking-wider">
               Recent Errors
             </span>
@@ -197,7 +199,7 @@ export const Errors: React.FC = () => {
                 )}
               >
                 <div className="w-full">
-                  <div className="flex items-center gap-2 mb-1 justify-between items-center">
+                  <div className="flex items-center gap-2 mb-1 justify-between">
                     <div className="flex items-center gap-2">
                       <Clock size={14} className="text-[var(--color-text-muted)]" />
                       <span className="text-xs font-mono text-text-muted">
@@ -206,7 +208,7 @@ export const Errors: React.FC = () => {
                     </div>
                     <button
                       onClick={(e) => handleDelete(e, err.requestId)}
-                      className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger group-hover:opacity-100 opacity-0 transition-opacity"
+                      className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger opacity-100 md:opacity-0 md:group-hover:opacity-100"
                       title="Delete error log"
                     >
                       <Trash2 size={12} />
@@ -230,17 +232,19 @@ export const Errors: React.FC = () => {
         </div>
 
         {/* Right Pane: Details */}
-        <div className="flex-1 bg-bg-deep overflow-y-auto flex flex-col relative">
+        <div className="relative flex min-h-0 flex-1 flex-col overflow-y-auto bg-bg-deep">
           {selectedId && selectedError ? (
             <div className="flex flex-col">
-              <div className="p-4 border-b border-[var(--color-border)] mb-4">
-                <h3 className="text-lg font-semibold text-red-500 mb-2">Error Details</h3>
-                <div className="grid grid-cols-2 gap-4 text-sm">
-                  <div>
+              <div className="mb-3 border-b border-[var(--color-border)] p-3 sm:mb-4 sm:p-4">
+                <h3 className="mb-2 text-base font-semibold text-red-500 sm:text-lg">
+                  Error Details
+                </h3>
+                <div className="grid grid-cols-1 gap-2 text-xs sm:grid-cols-2 sm:gap-4 sm:text-sm">
+                  <div className="min-w-0">
                     <span className="text-[var(--color-text-muted)]">Request ID:</span>
-                    <span className="ml-2 font-mono">{selectedError.requestId}</span>
+                    <span className="ml-2 break-all font-mono">{selectedError.requestId}</span>
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <span className="text-[var(--color-text-muted)]">Time:</span>
                     <span className="ml-2">{new Date(selectedError.date).toLocaleString()}</span>
                   </div>
@@ -253,33 +257,33 @@ export const Errors: React.FC = () => {
                         <h4 className="text-sm font-semibold text-yellow-500 mb-2">
                           Routing Information
                         </h4>
-                        <div className="grid grid-cols-2 gap-4 text-sm">
+                        <div className="grid grid-cols-1 gap-2 text-xs sm:grid-cols-2 sm:gap-4 sm:text-sm">
                           {details.provider && (
-                            <div>
+                            <div className="min-w-0">
                               <span className="text-[var(--color-text-muted)]">Provider:</span>
-                              <span className="ml-2 font-mono text-blue-400">
+                              <span className="ml-2 break-all font-mono text-blue-400">
                                 {details.provider}
                               </span>
                             </div>
                           )}
                           {details.targetModel && (
-                            <div>
+                            <div className="min-w-0">
                               <span className="text-[var(--color-text-muted)]">Target Model:</span>
-                              <span className="ml-2 font-mono text-blue-400">
+                              <span className="ml-2 break-all font-mono text-blue-400">
                                 {details.targetModel}
                               </span>
                             </div>
                           )}
                           {details.targetApiType && (
-                            <div>
+                            <div className="min-w-0">
                               <span className="text-[var(--color-text-muted)]">Target API:</span>
-                              <span className="ml-2 font-mono text-blue-400">
+                              <span className="ml-2 break-all font-mono text-blue-400">
                                 {details.targetApiType}
                               </span>
                             </div>
                           )}
                           {details.statusCode && (
-                            <div>
+                            <div className="min-w-0">
                               <span className="text-[var(--color-text-muted)]">Status Code:</span>
                               <span className="ml-2 font-mono text-red-400">
                                 {details.statusCode}
@@ -287,7 +291,7 @@ export const Errors: React.FC = () => {
                             </div>
                           )}
                           {details.url && (
-                            <div className="col-span-2">
+                            <div className="sm:col-span-2">
                               <span className="text-[var(--color-text-muted)]">Request URL:</span>
                               <div className="ml-2 font-mono text-xs text-blue-400 break-all mt-1">
                                 {details.url}
@@ -445,7 +449,7 @@ const AccordionPanel: React.FC<{
   return (
     <div className="border-b border-border-glass bg-bg-surface">
       <div
-        className="px-4 py-3 cursor-pointer flex justify-between items-center bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
+        className="flex cursor-pointer select-none items-center justify-between bg-bg-hover px-3 py-2.5 transition-colors duration-200 hover:bg-bg-glass sm:px-4 sm:py-3"
         onClick={() => setIsOpen(!isOpen)}
       >
         <div className="flex items-center gap-2">
@@ -468,7 +472,7 @@ const AccordionPanel: React.FC<{
           isOpen ? 'max-h-[500px]' : 'max-h-0'
         )}
       >
-        <div className="h-[400px] bg-[#1e1e1e]">
+        <div className="h-[280px] bg-[#1e1e1e] sm:h-[400px]">
           <Editor
             height="100%"
             defaultLanguage={language}

--- a/packages/frontend/src/pages/Errors.tsx
+++ b/packages/frontend/src/pages/Errors.tsx
@@ -140,19 +140,19 @@ export const Errors: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col min-h-[calc(100vh-8rem)] -mx-4 sm:-mx-6 lg:-mx-8 -mt-4 sm:-mt-6 lg:-mt-8">
-      <div className="px-4 sm:px-6 lg:px-8 pt-4 sm:pt-6 pb-3 shrink-0">
+    <div className="flex flex-col min-h-[calc(100vh-3rem)]">
+      <div className="shrink-0">
         <PageHeader
           title={
-            <span className="inline-flex items-center gap-2 text-danger">
-              <AlertTriangle size={24} />
-              Inference Errors
+            <span className="inline-flex items-center gap-2">
+              <AlertTriangle size={20} className="text-rose-400" />
+              Errors
             </span>
           }
           subtitle={
             principal?.role === 'limited' && principal.keyName
-              ? `Errors for key "${principal.keyName}" only.`
-              : 'Investigate failed requests and exceptions.'
+              ? `Errors for key "${principal.keyName}" only`
+              : 'Grouped by signature · last 24h'
           }
           actions={
             <>

--- a/packages/frontend/src/pages/Keys.tsx
+++ b/packages/frontend/src/pages/Keys.tsx
@@ -321,679 +321,888 @@ export const Keys = () => {
       </PageHeader>
 
       <PageContainer>
-
-      {/* Hidden old tabs (to avoid further JSX restructuring) */}
-      <div className="hidden">
-        <div>
-          <button
-            className={`px-4 py-2 font-body text-sm font-medium transition-colors ${
-              activeTab === 'keys'
-                ? 'text-primary border-b-2 border-primary'
-                : 'text-text-secondary hover:text-text'
-            }`}
-            onClick={() => setActiveTab('keys')}
-          >
-            API Keys ({keys.length})
-          </button>
-          <button
-            className={`px-4 py-2 font-body text-sm font-medium transition-colors ${
-              activeTab === 'quotas'
-                ? 'text-primary border-b-2 border-primary'
-                : 'text-text-secondary hover:text-text'
-            }`}
-            onClick={() => setActiveTab('quotas')}
-          >
-            Quotas ({Object.keys(quotas).length})
-          </button>
+        {/* Hidden old tabs (to avoid further JSX restructuring) */}
+        <div className="hidden">
+          <div>
+            <button
+              className={`px-4 py-2 font-body text-sm font-medium transition-colors ${
+                activeTab === 'keys'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'text-text-secondary hover:text-text'
+              }`}
+              onClick={() => setActiveTab('keys')}
+            >
+              API Keys ({keys.length})
+            </button>
+            <button
+              className={`px-4 py-2 font-body text-sm font-medium transition-colors ${
+                activeTab === 'quotas'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'text-text-secondary hover:text-text'
+              }`}
+              onClick={() => setActiveTab('quotas')}
+            >
+              Quotas ({Object.keys(quotas).length})
+            </button>
+          </div>
         </div>
-      </div>
 
-      {/* Search */}
-      <Card className="mb-6">
-        <div style={{ position: 'relative' }}>
-          <Search
-            size={16}
-            style={{
-              position: 'absolute',
-              left: '12px',
-              top: '50%',
-              transform: 'translateY(-50%)',
-              color: 'var(--color-text-secondary)',
-            }}
-          />
-          <Input
-            placeholder={activeTab === 'keys' ? 'Search keys...' : 'Search quotas...'}
-            style={{ paddingLeft: '36px' }}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-        </div>
-      </Card>
+        {/* Search */}
+        <Card className="mb-6">
+          <div style={{ position: 'relative' }}>
+            <Search
+              size={16}
+              style={{
+                position: 'absolute',
+                left: '12px',
+                top: '50%',
+                transform: 'translateY(-50%)',
+                color: 'var(--color-text-secondary)',
+              }}
+            />
+            <Input
+              placeholder={activeTab === 'keys' ? 'Search keys...' : 'Search quotas...'}
+              style={{ paddingLeft: '36px' }}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+        </Card>
 
-      {/* Keys Tab */}
-      {activeTab === 'keys' && (
-        <Card title="Active Keys" className="mb-6">
-          <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
-            <table className="w-full border-collapse font-body text-[13px]">
-              <thead>
-                <tr>
-                  <th
-                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                    style={{ paddingLeft: '24px' }}
-                  >
-                    Key Name
-                  </th>
-                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                    Secret
-                  </th>
-                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                    Quota
-                  </th>
-                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th
-                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                    style={{ paddingRight: '24px', textAlign: 'right' }}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredKeys.map((key) => {
+        {/* Keys Tab */}
+        {activeTab === 'keys' && (
+          <Card title="Active Keys" className="mb-6">
+            <div className="space-y-3 md:hidden">
+              {filteredKeys.length === 0 ? (
+                <div className="py-10 text-center text-sm text-text-muted">No keys found</div>
+              ) : (
+                filteredKeys.map((key) => {
                   const status = quotaStatuses[key.key];
                   const usagePercent = status ? getQuotaUsagePercent(status) : 0;
 
                   return (
-                    <tr key={key.key} className="hover:bg-bg-hover">
-                      <td
-                        className="px-4 py-3 text-left border-b border-border-glass text-text"
-                        style={{ fontWeight: 600, paddingLeft: '24px' }}
-                      >
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                          {key.key}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                          <span
-                            style={{
-                              fontFamily: 'monospace',
-                              fontSize: '12px',
-                              backgroundColor: 'var(--color-bg-subtle)',
-                              padding: '2px 6px',
-                              borderRadius: '4px',
-                            }}
-                          >
-                            {key.secret.substring(0, 5)}...
-                          </span>
-                          <button
-                            className="bg-transparent border-0 text-text-muted p-1.5 rounded-sm cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-bg-hover hover:text-primary active:scale-95"
-                            onClick={() => handleCopy(key.secret, key.key)}
-                            title="Copy Secret"
-                            style={copiedKey === key.key ? { color: 'var(--color-success)' } : {}}
-                          >
-                            {copiedKey === key.key ? <Check size={14} /> : <Copy size={14} />}
-                          </button>
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                        {key.quota ? (
-                          <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md bg-primary/10 text-primary">
-                            <Shield size={12} />
-                            {key.quota}
-                          </span>
-                        ) : (
-                          <span style={{ color: 'var(--color-text-muted)', fontSize: '13px' }}>
-                            -
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                        {status ? (
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <div
-                              style={{
-                                width: '8px',
-                                height: '8px',
-                                borderRadius: '50%',
-                                backgroundColor: getQuotaStatusColor(usagePercent),
-                              }}
-                            />
-                            <span style={{ fontSize: '12px' }}>
-                              {quotas[key.quota || '']?.limitType === 'cost'
-                                ? `${formatCost(status.current_usage, 5)} / ${formatCost(status.limit || 0, 5)}`
-                                : `${formatNumber(status.current_usage)} / ${formatNumber(status.limit || 0)}`}
-                            </span>
-                            <button
-                              className="bg-transparent border-0 text-text-muted p-1 rounded-sm cursor-pointer hover:text-primary"
-                              onClick={() => handleViewQuotaStatus(key.key)}
-                              title="View details"
-                            >
-                              <BarChart3 size={14} />
-                            </button>
+                    <article
+                      key={key.key}
+                      className="rounded-md border border-border-glass bg-bg-subtle p-3"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <button
+                          type="button"
+                          onClick={() => handleEditKey(key)}
+                          className="min-w-0 flex-1 text-left"
+                        >
+                          <div className="truncate font-heading text-sm font-semibold text-text">
+                            {key.key}
                           </div>
-                        ) : key.quota ? (
-                          <span style={{ color: 'var(--color-text-muted)', fontSize: '13px' }}>
-                            Loading...
-                          </span>
-                        ) : (
-                          <span style={{ color: 'var(--color-text-muted)', fontSize: '13px' }}>
-                            -
-                          </span>
-                        )}
-                      </td>
-                      <td
-                        className="px-4 py-3 text-left border-b border-border-glass text-text"
-                        style={{ paddingRight: '24px', textAlign: 'right' }}
-                      >
-                        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
-                          <Button variant="ghost" size="sm" onClick={() => handleEditKey(key)}>
+                          {key.comment && (
+                            <div className="mt-1 truncate text-xs text-text-muted">
+                              {key.comment}
+                            </div>
+                          )}
+                        </button>
+                        <div className="flex shrink-0 items-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleEditKey(key)}
+                            aria-label={`Edit ${key.key}`}
+                          >
                             <Edit2 size={14} />
                           </Button>
-                          {key.quota && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleDeleteKey(key.key)}
+                            className="text-danger"
+                            aria-label={`Delete ${key.key}`}
+                          >
+                            <Trash2 size={14} />
+                          </Button>
+                        </div>
+                      </div>
+
+                      <div className="mt-3 grid grid-cols-1 gap-2 text-xs sm:grid-cols-2">
+                        <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Secret
+                          </div>
+                          <div className="mt-1 flex items-center gap-2">
+                            <span className="min-w-0 truncate font-mono text-text">
+                              {key.secret.substring(0, 5)}...
+                            </span>
+                            <button
+                              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-text-muted transition-colors hover:bg-bg-hover hover:text-primary"
+                              onClick={() => handleCopy(key.secret, key.key)}
+                              title="Copy secret"
+                              type="button"
+                            >
+                              {copiedKey === key.key ? <Check size={14} /> : <Copy size={14} />}
+                            </button>
+                          </div>
+                        </div>
+                        <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Quota
+                          </div>
+                          <div className="mt-1 truncate font-medium text-text-secondary">
+                            {key.quota || '-'}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="mt-3 rounded border border-border-glass bg-bg-glass px-2 py-2">
+                        {status ? (
+                          <div className="flex flex-col gap-2">
+                            <div className="flex items-center justify-between gap-2 text-xs">
+                              <span className="text-text-muted">Usage</span>
+                              <span className="font-medium text-text">
+                                {quotas[key.quota || '']?.limitType === 'cost'
+                                  ? `${formatCost(status.current_usage, 5)} / ${formatCost(status.limit || 0, 5)}`
+                                  : `${formatNumber(status.current_usage)} / ${formatNumber(status.limit || 0)}`}
+                              </span>
+                            </div>
+                            <div className="h-1.5 overflow-hidden rounded-full bg-bg-hover">
+                              <div
+                                className="h-full rounded-full"
+                                style={{
+                                  width: `${usagePercent}%`,
+                                  backgroundColor: getQuotaStatusColor(usagePercent),
+                                }}
+                              />
+                            </div>
+                            <div className="flex items-center justify-end gap-2">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleViewQuotaStatus(key.key)}
+                                leftIcon={<BarChart3 size={14} />}
+                              >
+                                Details
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleClearQuota(key.key)}
+                                leftIcon={<RefreshCw size={14} />}
+                              >
+                                Reset
+                              </Button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="text-xs text-text-muted">
+                            {key.quota ? 'Loading quota status...' : 'No quota assigned'}
+                          </div>
+                        )}
+                      </div>
+                    </article>
+                  );
+                })
+              )}
+            </div>
+
+            <div className="hidden overflow-x-auto md:block">
+              <table className="w-full border-collapse font-body text-[13px]">
+                <thead>
+                  <tr>
+                    <th
+                      className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                      style={{ paddingLeft: '24px' }}
+                    >
+                      Key Name
+                    </th>
+                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                      Secret
+                    </th>
+                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                      Quota
+                    </th>
+                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                      Status
+                    </th>
+                    <th
+                      className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                      style={{ paddingRight: '24px', textAlign: 'right' }}
+                    >
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredKeys.map((key) => {
+                    const status = quotaStatuses[key.key];
+                    const usagePercent = status ? getQuotaUsagePercent(status) : 0;
+
+                    return (
+                      <tr key={key.key} className="hover:bg-bg-hover">
+                        <td
+                          className="px-4 py-3 text-left border-b border-border-glass text-text"
+                          style={{ fontWeight: 600, paddingLeft: '24px' }}
+                        >
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                            {key.key}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                            <span
+                              style={{
+                                fontFamily: 'monospace',
+                                fontSize: '12px',
+                                backgroundColor: 'var(--color-bg-subtle)',
+                                padding: '2px 6px',
+                                borderRadius: '4px',
+                              }}
+                            >
+                              {key.secret.substring(0, 5)}...
+                            </span>
+                            <button
+                              className="bg-transparent border-0 text-text-muted p-1.5 rounded-sm cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-bg-hover hover:text-primary active:scale-95"
+                              onClick={() => handleCopy(key.secret, key.key)}
+                              title="Copy Secret"
+                              style={copiedKey === key.key ? { color: 'var(--color-success)' } : {}}
+                            >
+                              {copiedKey === key.key ? <Check size={14} /> : <Copy size={14} />}
+                            </button>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                          {key.quota ? (
+                            <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md bg-primary/10 text-primary">
+                              <Shield size={12} />
+                              {key.quota}
+                            </span>
+                          ) : (
+                            <span style={{ color: 'var(--color-text-muted)', fontSize: '13px' }}>
+                              -
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                          {status ? (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                              <div
+                                style={{
+                                  width: '8px',
+                                  height: '8px',
+                                  borderRadius: '50%',
+                                  backgroundColor: getQuotaStatusColor(usagePercent),
+                                }}
+                              />
+                              <span style={{ fontSize: '12px' }}>
+                                {quotas[key.quota || '']?.limitType === 'cost'
+                                  ? `${formatCost(status.current_usage, 5)} / ${formatCost(status.limit || 0, 5)}`
+                                  : `${formatNumber(status.current_usage)} / ${formatNumber(status.limit || 0)}`}
+                              </span>
+                              <button
+                                className="bg-transparent border-0 text-text-muted p-1 rounded-sm cursor-pointer hover:text-primary"
+                                onClick={() => handleViewQuotaStatus(key.key)}
+                                title="View details"
+                              >
+                                <BarChart3 size={14} />
+                              </button>
+                            </div>
+                          ) : key.quota ? (
+                            <span style={{ color: 'var(--color-text-muted)', fontSize: '13px' }}>
+                              Loading...
+                            </span>
+                          ) : (
+                            <span style={{ color: 'var(--color-text-muted)', fontSize: '13px' }}>
+                              -
+                            </span>
+                          )}
+                        </td>
+                        <td
+                          className="px-4 py-3 text-left border-b border-border-glass text-text"
+                          style={{ paddingRight: '24px', textAlign: 'right' }}
+                        >
+                          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+                            <Button variant="ghost" size="sm" onClick={() => handleEditKey(key)}>
+                              <Edit2 size={14} />
+                            </Button>
+                            {key.quota && (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleClearQuota(key.key)}
+                                title="Reset quota"
+                              >
+                                <RefreshCw size={14} />
+                              </Button>
+                            )}
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => handleClearQuota(key.key)}
-                              title="Reset quota"
+                              onClick={() => handleDeleteKey(key.key)}
+                              style={{ color: 'var(--color-danger)' }}
                             >
-                              <RefreshCw size={14} />
+                              <Trash2 size={14} />
                             </Button>
-                          )}
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleDeleteKey(key.key)}
-                            style={{ color: 'var(--color-danger)' }}
-                          >
-                            <Trash2 size={14} />
-                          </Button>
-                        </div>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {filteredKeys.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="text-center text-text-muted p-12">
+                        No keys found
                       </td>
                     </tr>
-                  );
-                })}
-                {filteredKeys.length === 0 && (
-                  <tr>
-                    <td colSpan={5} className="text-center text-text-muted p-12">
-                      No keys found
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </Card>
-      )}
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </Card>
+        )}
 
-      {/* Quotas Tab */}
-      {activeTab === 'quotas' && (
-        <Card title="User Quotas" className="mb-6">
-          <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
-            <table className="w-full border-collapse font-body text-[13px]">
-              <thead>
-                <tr>
-                  <th
-                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                    style={{ paddingLeft: '24px' }}
-                  >
-                    Name
-                  </th>
-                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                    Type
-                  </th>
-                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                    Limit
-                  </th>
-                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                    Keys Using
-                  </th>
-                  <th
-                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                    style={{ paddingRight: '24px', textAlign: 'right' }}
-                  >
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {filteredQuotas.map(([name, quota]) => {
+        {/* Quotas Tab */}
+        {activeTab === 'quotas' && (
+          <Card title="User Quotas" className="mb-6">
+            <div className="space-y-3 md:hidden">
+              {filteredQuotas.length === 0 ? (
+                <div className="py-10 text-center text-sm text-text-muted">
+                  {Object.keys(quotas).length === 0 ? 'No quotas defined yet' : 'No quotas found'}
+                </div>
+              ) : (
+                filteredQuotas.map(([name, quota]) => {
                   const keysUsingQuota = keys.filter((k) => k.quota === name).length;
 
                   return (
-                    <tr key={name} className="hover:bg-bg-hover">
-                      <td
-                        className="px-4 py-3 text-left border-b border-border-glass text-text"
-                        style={{ fontWeight: 600, paddingLeft: '24px' }}
-                      >
-                        {name}
-                      </td>
-                      <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                        <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md bg-bg-subtle text-text-secondary">
-                          {quota.type}
-                          {quota.type === 'rolling' && quota.duration && (
-                            <span className="text-text-muted">({quota.duration})</span>
-                          )}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                        <span className="font-mono text-xs">
-                          {quota.limitType === 'cost'
-                            ? `${formatCost(quota.limit, 5)} ${quota.limitType}`
-                            : `${formatNumber(quota.limit)} ${quota.limitType}`}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                        <span
-                          className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md ${
-                            keysUsingQuota > 0
-                              ? 'bg-primary/10 text-primary'
-                              : 'bg-bg-subtle text-text-muted'
-                          }`}
-                        >
-                          {keysUsingQuota} key{keysUsingQuota !== 1 ? 's' : ''}
-                        </span>
-                      </td>
-                      <td
-                        className="px-4 py-3 text-left border-b border-border-glass text-text"
-                        style={{ paddingRight: '24px', textAlign: 'right' }}
-                      >
-                        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+                    <article
+                      key={name}
+                      className="rounded-md border border-border-glass bg-bg-subtle p-3"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="truncate font-heading text-sm font-semibold text-text">
+                            {name}
+                          </div>
+                          <div className="mt-1 text-xs text-text-muted">
+                            {quota.type}
+                            {quota.type === 'rolling' && quota.duration
+                              ? ` (${quota.duration})`
+                              : ''}
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-1">
                           <Button
                             variant="ghost"
-                            size="sm"
+                            size="icon"
                             onClick={() => handleEditQuota(name, quota)}
+                            aria-label={`Edit ${name}`}
                           >
                             <Edit2 size={14} />
                           </Button>
                           <Button
                             variant="ghost"
-                            size="sm"
+                            size="icon"
                             onClick={() => handleDeleteQuota(name)}
-                            style={{ color: 'var(--color-danger)' }}
+                            className="text-danger"
+                            aria-label={`Delete ${name}`}
                           >
                             <Trash2 size={14} />
                           </Button>
                         </div>
+                      </div>
+                      <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                        <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Limit
+                          </div>
+                          <div className="truncate font-mono text-text">
+                            {quota.limitType === 'cost'
+                              ? `${formatCost(quota.limit, 5)} ${quota.limitType}`
+                              : `${formatNumber(quota.limit)} ${quota.limitType}`}
+                          </div>
+                        </div>
+                        <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Keys
+                          </div>
+                          <div className="truncate font-medium text-text-secondary">
+                            {keysUsingQuota} key{keysUsingQuota !== 1 ? 's' : ''}
+                          </div>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })
+              )}
+            </div>
+
+            <div className="hidden overflow-x-auto md:block">
+              <table className="w-full border-collapse font-body text-[13px]">
+                <thead>
+                  <tr>
+                    <th
+                      className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                      style={{ paddingLeft: '24px' }}
+                    >
+                      Name
+                    </th>
+                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                      Type
+                    </th>
+                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                      Limit
+                    </th>
+                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                      Keys Using
+                    </th>
+                    <th
+                      className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                      style={{ paddingRight: '24px', textAlign: 'right' }}
+                    >
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredQuotas.map(([name, quota]) => {
+                    const keysUsingQuota = keys.filter((k) => k.quota === name).length;
+
+                    return (
+                      <tr key={name} className="hover:bg-bg-hover">
+                        <td
+                          className="px-4 py-3 text-left border-b border-border-glass text-text"
+                          style={{ fontWeight: 600, paddingLeft: '24px' }}
+                        >
+                          {name}
+                        </td>
+                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                          <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md bg-bg-subtle text-text-secondary">
+                            {quota.type}
+                            {quota.type === 'rolling' && quota.duration && (
+                              <span className="text-text-muted">({quota.duration})</span>
+                            )}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                          <span className="font-mono text-xs">
+                            {quota.limitType === 'cost'
+                              ? `${formatCost(quota.limit, 5)} ${quota.limitType}`
+                              : `${formatNumber(quota.limit)} ${quota.limitType}`}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                          <span
+                            className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md ${
+                              keysUsingQuota > 0
+                                ? 'bg-primary/10 text-primary'
+                                : 'bg-bg-subtle text-text-muted'
+                            }`}
+                          >
+                            {keysUsingQuota} key{keysUsingQuota !== 1 ? 's' : ''}
+                          </span>
+                        </td>
+                        <td
+                          className="px-4 py-3 text-left border-b border-border-glass text-text"
+                          style={{ paddingRight: '24px', textAlign: 'right' }}
+                        >
+                          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleEditQuota(name, quota)}
+                            >
+                              <Edit2 size={14} />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleDeleteQuota(name)}
+                              style={{ color: 'var(--color-danger)' }}
+                            >
+                              <Trash2 size={14} />
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {filteredQuotas.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="text-center text-text-muted p-12">
+                        {Object.keys(quotas).length === 0
+                          ? 'No quotas defined yet'
+                          : 'No quotas found'}
                       </td>
                     </tr>
-                  );
-                })}
-                {filteredQuotas.length === 0 && (
-                  <tr>
-                    <td colSpan={5} className="text-center text-text-muted p-12">
-                      {Object.keys(quotas).length === 0
-                        ? 'No quotas defined yet'
-                        : 'No quotas found'}
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </Card>
-      )}
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </Card>
+        )}
 
-      {/* Key Modal */}
-      <Modal
-        isOpen={isKeyModalOpen}
-        onClose={() => setIsKeyModalOpen(false)}
-        title={originalKeyName ? 'Edit Key' : 'Add Key'}
-        size="md"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button variant="ghost" onClick={() => setIsKeyModalOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleSaveKey}
-              isLoading={isSavingKey}
-              disabled={!editingKey.key || !editingKey.secret}
-            >
-              Save Key
-            </Button>
-          </div>
-        }
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-          <div className="flex flex-col gap-2">
-            <Input
-              label="Key Name (ID)"
-              value={editingKey.key}
-              onChange={(e) => setEditingKey({ ...editingKey, key: e.target.value })}
-              placeholder="e.g. production-app-1"
-              disabled={!!originalKeyName}
-            />
-            <p className="text-xs text-text-muted">
-              {originalKeyName
-                ? 'Key ID cannot be changed once created.'
-                : 'A unique identifier for this key.'}
-            </p>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label className="font-body text-[13px] font-medium text-text-secondary">
-              Secret Key
-            </label>
-            <div style={{ display: 'flex', gap: '8px' }}>
-              <Input
-                value={editingKey.secret}
-                onChange={(e) => setEditingKey({ ...editingKey, secret: e.target.value })}
-                placeholder="sk-..."
-                type="password"
-                style={{ flex: 1 }}
-              />
-              <Button variant="secondary" onClick={generateKey} title="Generate new key">
-                <RefreshCw size={16} />
+        {/* Key Modal */}
+        <Modal
+          isOpen={isKeyModalOpen}
+          onClose={() => setIsKeyModalOpen(false)}
+          title={originalKeyName ? 'Edit Key' : 'Add Key'}
+          size="md"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button variant="ghost" onClick={() => setIsKeyModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSaveKey}
+                isLoading={isSavingKey}
+                disabled={!editingKey.key || !editingKey.secret}
+              >
+                Save Key
               </Button>
             </div>
-            <p className="text-xs text-text-muted mt-1">
-              The secret used to authenticate. Click refresh to generate a secure random key.
-            </p>
-          </div>
-
-          <Input
-            label="Comment"
-            value={editingKey.comment || ''}
-            onChange={(e) => setEditingKey({ ...editingKey, comment: e.target.value })}
-            placeholder="Optional description..."
-          />
-
-          <TagSelect
-            label="Excluded Model Aliases"
-            placeholder="Optional: select model aliases to exclude..."
-            options={aliasIds}
-            selected={editingKey.excludedModels || []}
-            onChange={(excludedModels) =>
-              setEditingKey({
-                ...editingKey,
-                excludedModels: excludedModels.length > 0 ? excludedModels : undefined,
-              })
-            }
-          />
-          <p className="text-xs text-text-muted -mt-1">
-            Optional denylist. If set, this key cannot use these model aliases.
-          </p>
-
-          <TagSelect
-            label="Allowed Model Aliases"
-            placeholder="Optional: select model aliases..."
-            options={aliasIds}
-            selected={editingKey.allowedModels || []}
-            onChange={(allowedModels) =>
-              setEditingKey({
-                ...editingKey,
-                allowedModels: allowedModels.length > 0 ? allowedModels : undefined,
-              })
-            }
-          />
-          <p className="text-xs text-text-muted -mt-1">
-            Optional allowlist. If set, this key can only use these configured model aliases.
-          </p>
-
-          <TagSelect
-            label="Excluded Providers"
-            placeholder="Optional: select providers to exclude..."
-            options={providerIds}
-            selected={editingKey.excludedProviders || []}
-            onChange={(excludedProviders) =>
-              setEditingKey({
-                ...editingKey,
-                excludedProviders: excludedProviders.length > 0 ? excludedProviders : undefined,
-              })
-            }
-          />
-          <p className="text-xs text-text-muted -mt-1">
-            Optional denylist. If set, routing will not use these provider IDs.
-          </p>
-
-          <TagSelect
-            label="Allowed Providers"
-            placeholder="Optional: select providers..."
-            options={providerIds}
-            selected={editingKey.allowedProviders || []}
-            onChange={(allowedProviders) =>
-              setEditingKey({
-                ...editingKey,
-                allowedProviders: allowedProviders.length > 0 ? allowedProviders : undefined,
-              })
-            }
-          />
-          <p className="text-xs text-text-muted -mt-1">
-            Optional allowlist. If set, routing is limited to these provider IDs.
-          </p>
-
-          <div className="flex flex-col gap-2">
-            <label className="font-body text-[13px] font-medium text-text-secondary">
-              Quota Assignment
-            </label>
-            <select
-              className="w-full px-3 py-2 bg-bg-subtle border border-border-glass rounded-md font-body text-sm text-text focus:border-primary focus:outline-none"
-              value={editingKey.quota || ''}
-              onChange={(e) => setEditingKey({ ...editingKey, quota: e.target.value || undefined })}
-            >
-              <option value="">&lt;None&gt;</option>
-              {Object.entries(quotas).map(([name, quota]) => (
-                <option key={name} value={name}>
-                  {name} ({quota.type},{' '}
-                  {quota.limitType === 'cost'
-                    ? `${formatCost(quota.limit, 5)} ${quota.limitType}`
-                    : `${quota.limit} ${quota.limitType}`}
-                  )
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-text-muted">
-              Optional: assign a quota to this key. Allowlist/denylist checks run before and during
-              routing.
-            </p>
-          </div>
-        </div>
-      </Modal>
-
-      {/* Quota Modal */}
-      <Modal
-        isOpen={isQuotaModalOpen}
-        onClose={() => setIsQuotaModalOpen(false)}
-        title={originalQuotaName ? 'Edit Quota' : 'Add Quota'}
-        size="md"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button variant="ghost" onClick={() => setIsQuotaModalOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleSaveQuota}
-              isLoading={isSavingQuota}
-              disabled={!editingQuota.name}
-            >
-              Save Quota
-            </Button>
-          </div>
-        }
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-          <div className="flex flex-col gap-2">
-            <Input
-              label="Quota Name"
-              value={editingQuota.name}
-              onChange={(e) => setEditingQuota({ ...editingQuota, name: e.target.value })}
-              placeholder="e.g. daily-1000"
-              disabled={!!originalQuotaName}
-            />
-            <p className="text-xs text-text-muted">
-              {originalQuotaName
-                ? 'Quota name cannot be changed once created.'
-                : 'A unique identifier for this quota. Use lowercase letters, numbers, hyphens.'}
-            </p>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <label className="font-body text-[13px] font-medium text-text-secondary">
-              Quota Type
-            </label>
-            <select
-              className="w-full px-3 py-2 bg-bg-subtle border border-border-glass rounded-md font-body text-sm text-text focus:border-primary focus:outline-none"
-              value={editingQuota.type}
-              onChange={(e) =>
-                setEditingQuota({ ...editingQuota, type: e.target.value as UserQuota['type'] })
-              }
-            >
-              <option value="rolling">Rolling Window</option>
-              <option value="daily">Daily (UTC)</option>
-              <option value="weekly">Weekly (UTC)</option>
-              <option value="monthly">Monthly (UTC)</option>
-            </select>
-            <p className="text-xs text-text-muted">
-              {editingQuota.type === 'rolling' && 'Limits usage over a sliding time window'}
-              {editingQuota.type === 'daily' && 'Resets at midnight UTC each day'}
-              {editingQuota.type === 'weekly' && 'Resets at midnight UTC on Monday'}
-              {editingQuota.type === 'monthly' && 'Resets at midnight UTC on the 1st of each month'}
-            </p>
-          </div>
-
-          {editingQuota.type === 'rolling' && (
+          }
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
             <div className="flex flex-col gap-2">
               <Input
-                label="Duration"
-                value={editingQuota.duration || ''}
-                onChange={(e) => setEditingQuota({ ...editingQuota, duration: e.target.value })}
-                placeholder="e.g. 1h, 30m, 1d"
+                label="Key Name (ID)"
+                value={editingKey.key}
+                onChange={(e) => setEditingKey({ ...editingKey, key: e.target.value })}
+                placeholder="e.g. production-app-1"
+                disabled={!!originalKeyName}
               />
               <p className="text-xs text-text-muted">
-                Duration of the rolling window (e.g., 1h, 30m, 2h30m, 1d)
+                {originalKeyName
+                  ? 'Key ID cannot be changed once created.'
+                  : 'A unique identifier for this key.'}
               </p>
             </div>
-          )}
 
-          <div className="flex flex-col gap-2">
-            <label className="font-body text-[13px] font-medium text-text-secondary">
-              Limit Type
-            </label>
-            <select
-              className="w-full px-3 py-2 bg-bg-subtle border border-border-glass rounded-md font-body text-sm text-text focus:border-primary focus:outline-none"
-              value={editingQuota.limitType}
-              onChange={(e) =>
-                setEditingQuota({
-                  ...editingQuota,
-                  limitType: e.target.value as UserQuota['limitType'],
-                })
-              }
-            >
-              <option value="requests">Requests</option>
-              <option value="tokens">Tokens</option>
-              <option value="cost">Cost ($)</option>
-            </select>
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Input
-              label="Limit"
-              type="number"
-              value={editingQuota.limit}
-              onChange={(e) =>
-                setEditingQuota({ ...editingQuota, limit: parseInt(e.target.value) || 0 })
-              }
-              placeholder="1000"
-            />
-            <p className="text-xs text-text-muted">
-              Maximum {editingQuota.limitType === 'cost' ? 'cost ($)' : editingQuota.limitType}{' '}
-              allowed
-            </p>
-          </div>
-        </div>
-      </Modal>
-
-      {/* Quota Detail Modal */}
-      <Modal
-        isOpen={isQuotaDetailOpen}
-        onClose={() => setIsQuotaDetailOpen(false)}
-        title={`Quota Status: ${selectedQuotaName}`}
-        size="sm"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button variant="ghost" onClick={() => setIsQuotaDetailOpen(false)}>
-              Close
-            </Button>
-            {selectedQuotaStatus && (
-              <Button
-                onClick={() => {
-                  handleClearQuota(selectedQuotaStatus.key);
-                  setIsQuotaDetailOpen(false);
-                }}
-                variant="secondary"
-              >
-                Reset Usage
-              </Button>
-            )}
-          </div>
-        }
-      >
-        {selectedQuotaStatus && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-            <div className="flex items-center gap-3 p-3 bg-bg-subtle rounded-md">
-              {selectedQuotaStatus.allowed ? (
-                <Check className="text-success" size={24} />
-              ) : (
-                <AlertCircle className="text-danger" size={24} />
-              )}
-              <div>
-                <p className="font-medium text-text">
-                  {selectedQuotaStatus.allowed ? 'Quota Active' : 'Quota Exhausted'}
-                </p>
-                <p className="text-sm text-text-secondary">{selectedQuotaStatus.quota_name}</p>
-              </div>
-            </div>
-
-            <div className="space-y-4">
-              <div>
-                <div className="flex justify-between text-sm mb-1">
-                  <span className="text-text-secondary">Usage</span>
-                  <span className="font-medium text-text">
-                    {quotas[selectedQuotaStatus.quota_name || '']?.limitType === 'cost'
-                      ? `${formatCost(selectedQuotaStatus.current_usage, 5)} / ${formatCost(selectedQuotaStatus.limit || 0, 5)}`
-                      : `${formatNumber(selectedQuotaStatus.current_usage)} / ${formatNumber(selectedQuotaStatus.limit || 0)}`}
-                  </span>
-                </div>
-                <div className="h-2 bg-bg-hover rounded-full overflow-hidden">
-                  <div
-                    className="h-full rounded-full transition-all"
-                    style={{
-                      width: `${Math.min(100, getQuotaUsagePercent(selectedQuotaStatus))}%`,
-                      backgroundColor: getQuotaStatusColor(
-                        getQuotaUsagePercent(selectedQuotaStatus)
-                      ),
-                    }}
+            <div className="flex flex-col gap-2">
+              <label className="font-body text-[13px] font-medium text-text-secondary">
+                Secret Key
+              </label>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <div className="min-w-0 flex-1">
+                  <Input
+                    value={editingKey.secret}
+                    onChange={(e) => setEditingKey({ ...editingKey, secret: e.target.value })}
+                    placeholder="sk-..."
+                    type="password"
                   />
                 </div>
+                <Button
+                  variant="secondary"
+                  onClick={generateKey}
+                  title="Generate new key"
+                  className="w-full sm:w-auto"
+                >
+                  <RefreshCw size={16} />
+                </Button>
+              </div>
+              <p className="text-xs text-text-muted mt-1">
+                The secret used to authenticate. Click refresh to generate a secure random key.
+              </p>
+            </div>
+
+            <Input
+              label="Comment"
+              value={editingKey.comment || ''}
+              onChange={(e) => setEditingKey({ ...editingKey, comment: e.target.value })}
+              placeholder="Optional description..."
+            />
+
+            <TagSelect
+              label="Excluded Model Aliases"
+              placeholder="Optional: select model aliases to exclude..."
+              options={aliasIds}
+              selected={editingKey.excludedModels || []}
+              onChange={(excludedModels) =>
+                setEditingKey({
+                  ...editingKey,
+                  excludedModels: excludedModels.length > 0 ? excludedModels : undefined,
+                })
+              }
+            />
+            <p className="text-xs text-text-muted -mt-1">
+              Optional denylist. If set, this key cannot use these model aliases.
+            </p>
+
+            <TagSelect
+              label="Allowed Model Aliases"
+              placeholder="Optional: select model aliases..."
+              options={aliasIds}
+              selected={editingKey.allowedModels || []}
+              onChange={(allowedModels) =>
+                setEditingKey({
+                  ...editingKey,
+                  allowedModels: allowedModels.length > 0 ? allowedModels : undefined,
+                })
+              }
+            />
+            <p className="text-xs text-text-muted -mt-1">
+              Optional allowlist. If set, this key can only use these configured model aliases.
+            </p>
+
+            <TagSelect
+              label="Excluded Providers"
+              placeholder="Optional: select providers to exclude..."
+              options={providerIds}
+              selected={editingKey.excludedProviders || []}
+              onChange={(excludedProviders) =>
+                setEditingKey({
+                  ...editingKey,
+                  excludedProviders: excludedProviders.length > 0 ? excludedProviders : undefined,
+                })
+              }
+            />
+            <p className="text-xs text-text-muted -mt-1">
+              Optional denylist. If set, routing will not use these provider IDs.
+            </p>
+
+            <TagSelect
+              label="Allowed Providers"
+              placeholder="Optional: select providers..."
+              options={providerIds}
+              selected={editingKey.allowedProviders || []}
+              onChange={(allowedProviders) =>
+                setEditingKey({
+                  ...editingKey,
+                  allowedProviders: allowedProviders.length > 0 ? allowedProviders : undefined,
+                })
+              }
+            />
+            <p className="text-xs text-text-muted -mt-1">
+              Optional allowlist. If set, routing is limited to these provider IDs.
+            </p>
+
+            <div className="flex flex-col gap-2">
+              <label className="font-body text-[13px] font-medium text-text-secondary">
+                Quota Assignment
+              </label>
+              <select
+                className="w-full px-3 py-2 bg-bg-subtle border border-border-glass rounded-md font-body text-sm text-text focus:border-primary focus:outline-none"
+                value={editingKey.quota || ''}
+                onChange={(e) =>
+                  setEditingKey({ ...editingKey, quota: e.target.value || undefined })
+                }
+              >
+                <option value="">&lt;None&gt;</option>
+                {Object.entries(quotas).map(([name, quota]) => (
+                  <option key={name} value={name}>
+                    {name} ({quota.type},{' '}
+                    {quota.limitType === 'cost'
+                      ? `${formatCost(quota.limit, 5)} ${quota.limitType}`
+                      : `${quota.limit} ${quota.limitType}`}
+                    )
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-text-muted">
+                Optional: assign a quota to this key. Allowlist/denylist checks run before and
+                during routing.
+              </p>
+            </div>
+          </div>
+        </Modal>
+
+        {/* Quota Modal */}
+        <Modal
+          isOpen={isQuotaModalOpen}
+          onClose={() => setIsQuotaModalOpen(false)}
+          title={originalQuotaName ? 'Edit Quota' : 'Add Quota'}
+          size="md"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button variant="ghost" onClick={() => setIsQuotaModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSaveQuota}
+                isLoading={isSavingQuota}
+                disabled={!editingQuota.name}
+              >
+                Save Quota
+              </Button>
+            </div>
+          }
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div className="flex flex-col gap-2">
+              <Input
+                label="Quota Name"
+                value={editingQuota.name}
+                onChange={(e) => setEditingQuota({ ...editingQuota, name: e.target.value })}
+                placeholder="e.g. daily-1000"
+                disabled={!!originalQuotaName}
+              />
+              <p className="text-xs text-text-muted">
+                {originalQuotaName
+                  ? 'Quota name cannot be changed once created.'
+                  : 'A unique identifier for this quota. Use lowercase letters, numbers, hyphens.'}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <label className="font-body text-[13px] font-medium text-text-secondary">
+                Quota Type
+              </label>
+              <select
+                className="w-full px-3 py-2 bg-bg-subtle border border-border-glass rounded-md font-body text-sm text-text focus:border-primary focus:outline-none"
+                value={editingQuota.type}
+                onChange={(e) =>
+                  setEditingQuota({ ...editingQuota, type: e.target.value as UserQuota['type'] })
+                }
+              >
+                <option value="rolling">Rolling Window</option>
+                <option value="daily">Daily (UTC)</option>
+                <option value="weekly">Weekly (UTC)</option>
+                <option value="monthly">Monthly (UTC)</option>
+              </select>
+              <p className="text-xs text-text-muted">
+                {editingQuota.type === 'rolling' && 'Limits usage over a sliding time window'}
+                {editingQuota.type === 'daily' && 'Resets at midnight UTC each day'}
+                {editingQuota.type === 'weekly' && 'Resets at midnight UTC on Monday'}
+                {editingQuota.type === 'monthly' &&
+                  'Resets at midnight UTC on the 1st of each month'}
+              </p>
+            </div>
+
+            {editingQuota.type === 'rolling' && (
+              <div className="flex flex-col gap-2">
+                <Input
+                  label="Duration"
+                  value={editingQuota.duration || ''}
+                  onChange={(e) => setEditingQuota({ ...editingQuota, duration: e.target.value })}
+                  placeholder="e.g. 1h, 30m, 1d"
+                />
+                <p className="text-xs text-text-muted">
+                  Duration of the rolling window (e.g., 1h, 30m, 2h30m, 1d)
+                </p>
+              </div>
+            )}
+
+            <div className="flex flex-col gap-2">
+              <label className="font-body text-[13px] font-medium text-text-secondary">
+                Limit Type
+              </label>
+              <select
+                className="w-full px-3 py-2 bg-bg-subtle border border-border-glass rounded-md font-body text-sm text-text focus:border-primary focus:outline-none"
+                value={editingQuota.limitType}
+                onChange={(e) =>
+                  setEditingQuota({
+                    ...editingQuota,
+                    limitType: e.target.value as UserQuota['limitType'],
+                  })
+                }
+              >
+                <option value="requests">Requests</option>
+                <option value="tokens">Tokens</option>
+                <option value="cost">Cost ($)</option>
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Input
+                label="Limit"
+                type="number"
+                value={editingQuota.limit}
+                onChange={(e) =>
+                  setEditingQuota({ ...editingQuota, limit: parseInt(e.target.value) || 0 })
+                }
+                placeholder="1000"
+              />
+              <p className="text-xs text-text-muted">
+                Maximum {editingQuota.limitType === 'cost' ? 'cost ($)' : editingQuota.limitType}{' '}
+                allowed
+              </p>
+            </div>
+          </div>
+        </Modal>
+
+        {/* Quota Detail Modal */}
+        <Modal
+          isOpen={isQuotaDetailOpen}
+          onClose={() => setIsQuotaDetailOpen(false)}
+          title={`Quota Status: ${selectedQuotaName}`}
+          size="sm"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button variant="ghost" onClick={() => setIsQuotaDetailOpen(false)}>
+                Close
+              </Button>
+              {selectedQuotaStatus && (
+                <Button
+                  onClick={() => {
+                    handleClearQuota(selectedQuotaStatus.key);
+                    setIsQuotaDetailOpen(false);
+                  }}
+                  variant="secondary"
+                >
+                  Reset Usage
+                </Button>
+              )}
+            </div>
+          }
+        >
+          {selectedQuotaStatus && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+              <div className="flex items-center gap-3 p-3 bg-bg-subtle rounded-md">
+                {selectedQuotaStatus.allowed ? (
+                  <Check className="text-success" size={24} />
+                ) : (
+                  <AlertCircle className="text-danger" size={24} />
+                )}
+                <div>
+                  <p className="font-medium text-text">
+                    {selectedQuotaStatus.allowed ? 'Quota Active' : 'Quota Exhausted'}
+                  </p>
+                  <p className="text-sm text-text-secondary">{selectedQuotaStatus.quota_name}</p>
+                </div>
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
-                <div className="p-3 bg-bg-subtle rounded-md">
-                  <p className="text-xs text-text-secondary mb-1">Remaining</p>
-                  <p className="font-mono text-lg text-text">
-                    {selectedQuotaStatus.remaining !== null
-                      ? quotas[selectedQuotaStatus.quota_name || '']?.limitType === 'cost'
-                        ? formatCost(selectedQuotaStatus.remaining, 5)
-                        : formatNumber(selectedQuotaStatus.remaining)
-                      : '-'}
-                  </p>
+              <div className="space-y-4">
+                <div>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span className="text-text-secondary">Usage</span>
+                    <span className="font-medium text-text">
+                      {quotas[selectedQuotaStatus.quota_name || '']?.limitType === 'cost'
+                        ? `${formatCost(selectedQuotaStatus.current_usage, 5)} / ${formatCost(selectedQuotaStatus.limit || 0, 5)}`
+                        : `${formatNumber(selectedQuotaStatus.current_usage)} / ${formatNumber(selectedQuotaStatus.limit || 0)}`}
+                    </span>
+                  </div>
+                  <div className="h-2 bg-bg-hover rounded-full overflow-hidden">
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{
+                        width: `${Math.min(100, getQuotaUsagePercent(selectedQuotaStatus))}%`,
+                        backgroundColor: getQuotaStatusColor(
+                          getQuotaUsagePercent(selectedQuotaStatus)
+                        ),
+                      }}
+                    />
+                  </div>
                 </div>
-                <div className="p-3 bg-bg-subtle rounded-md">
-                  <p className="text-xs text-text-secondary mb-1">Resets At</p>
-                  <p className="font-mono text-sm text-text">
-                    {selectedQuotaStatus.resets_at
-                      ? new Date(selectedQuotaStatus.resets_at).toLocaleString()
-                      : '-'}
-                  </p>
+
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
+                  <div className="p-3 bg-bg-subtle rounded-md">
+                    <p className="text-xs text-text-secondary mb-1">Remaining</p>
+                    <p className="font-mono text-lg text-text">
+                      {selectedQuotaStatus.remaining !== null
+                        ? quotas[selectedQuotaStatus.quota_name || '']?.limitType === 'cost'
+                          ? formatCost(selectedQuotaStatus.remaining, 5)
+                          : formatNumber(selectedQuotaStatus.remaining)
+                        : '-'}
+                    </p>
+                  </div>
+                  <div className="p-3 bg-bg-subtle rounded-md">
+                    <p className="text-xs text-text-secondary mb-1">Resets At</p>
+                    <p className="font-mono text-sm text-text">
+                      {selectedQuotaStatus.resets_at
+                        ? new Date(selectedQuotaStatus.resets_at).toLocaleString()
+                        : '-'}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
-      </Modal>
+          )}
+        </Modal>
       </PageContainer>
     </div>
   );

--- a/packages/frontend/src/pages/Keys.tsx
+++ b/packages/frontend/src/pages/Keys.tsx
@@ -294,24 +294,22 @@ export const Keys = () => {
   };
 
   return (
-    <PageContainer>
+    <div className="flex flex-col min-h-full">
       <PageHeader
         title="Access Control"
-        subtitle="Manage API keys and user quotas."
+        subtitle="API keys issued for downstream consumers"
         actions={
           activeTab === 'keys' ? (
-            <Button leftIcon={<Plus size={16} />} onClick={handleAddNewKey}>
-              Add Key
+            <Button leftIcon={<Plus size={14} />} onClick={handleAddNewKey} size="sm">
+              Create key
             </Button>
           ) : (
-            <Button leftIcon={<Plus size={16} />} onClick={handleAddNewQuota}>
-              Add Quota
+            <Button leftIcon={<Plus size={14} />} onClick={handleAddNewQuota} size="sm">
+              Add quota
             </Button>
           )
         }
-      />
-
-      <div className="mb-6">
+      >
         <Tabs
           value={activeTab}
           onChange={(v) => setActiveTab(v as 'keys' | 'quotas')}
@@ -320,7 +318,9 @@ export const Keys = () => {
             { value: 'quotas', label: `Quotas (${Object.keys(quotas).length})` },
           ]}
         />
-      </div>
+      </PageHeader>
+
+      <PageContainer>
 
       {/* Hidden old tabs (to avoid further JSX restructuring) */}
       <div className="hidden">
@@ -994,6 +994,7 @@ export const Keys = () => {
           </div>
         )}
       </Modal>
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 };

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -37,14 +37,10 @@ export const Login: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-6 bg-bg-deep">
+    <div className="min-h-screen flex items-center justify-center bg-bg-deep p-4 sm:p-6">
       {/* Background mesh */}
       <div className="fixed inset-0 pointer-events-none opacity-50" aria-hidden="true">
-        <svg
-          viewBox="0 0 800 600"
-          preserveAspectRatio="xMidYMid slice"
-          className="w-full h-full"
-        >
+        <svg viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice" className="w-full h-full">
           <g stroke="rgba(245,158,11,0.10)" strokeWidth="0.5" fill="none">
             <path d="M0 200 C 200 100, 600 300, 800 180" />
             <path d="M0 320 C 220 220, 580 420, 800 300" />
@@ -60,7 +56,7 @@ export const Login: React.FC = () => {
 
       <main className="relative w-full max-w-md">
         {/* Logo + wordmark */}
-        <div className="flex items-center justify-center gap-3 mb-8">
+        <div className="mb-6 flex flex-wrap items-center justify-center gap-3 sm:mb-8">
           <div className="animate-float">
             <PlexusMark size={44} />
           </div>
@@ -75,7 +71,7 @@ export const Login: React.FC = () => {
         </div>
 
         {/* Card */}
-        <div className="glass-bg rounded-2xl p-7 sm:p-8 shadow-2xl">
+        <div className="glass-bg rounded-xl p-5 shadow-2xl sm:rounded-2xl sm:p-8">
           <div className="mb-6">
             <h1 className="font-heading text-2xl font-semibold tracking-tight mb-1.5">Sign in</h1>
             <p className="text-sm text-text-secondary leading-relaxed">
@@ -142,7 +138,7 @@ export const Login: React.FC = () => {
             </Button>
           </form>
 
-          <div className="mt-6 pt-5 border-t border-white/5 flex items-center justify-between text-[11px] text-text-muted">
+          <div className="mt-6 flex flex-col gap-2 border-t border-white/5 pt-5 text-[11px] text-text-muted sm:flex-row sm:items-center sm:justify-between">
             <span className="inline-flex items-center gap-1.5">
               <ShieldCheck size={14} />
               End-to-end encrypted

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -1,20 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { ArrowRight, AlertCircle, Eye, EyeOff, KeyRound, ShieldCheck } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
-import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
-import { Input } from '../components/ui/Input';
-import { FormField } from '../components/ui/FormField';
-import logo from '../assets/plexus_logo_transparent.png';
+import { PlexusMark } from '../components/layout/PlexusMark';
 
 export const Login: React.FC = () => {
   const [key, setKey] = useState('');
+  const [showKey, setShowKey] = useState(false);
   const { login, isAuthenticated } = useAuth();
   const [error, setError] = useState('');
   const navigate = useNavigate();
   const location = useLocation();
 
   const from = (location.state as any)?.from?.pathname || '/';
+  const appVersion: string =
+    // @ts-expect-error — replaced at build time by build.ts
+    process.env.APP_VERSION || 'dev';
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -30,24 +32,59 @@ export const Login: React.FC = () => {
     }
     const valid = await login(key.trim());
     if (!valid) {
-      setError('Invalid key');
+      setError('Invalid key. Verify the prefix and try again.');
     }
   };
 
   return (
-    <div className="min-h-screen bg-bg-deep flex items-center justify-center p-4 sm:p-6">
-      <div className="w-full max-w-md">
-        <div className="text-center mb-8">
-          <img src={logo} alt="Plexus" className="h-14 sm:h-16 mx-auto mb-4" />
-          <h1 className="font-heading text-h1 font-bold text-text m-0">Sign in</h1>
-          <p className="mt-2 text-sm text-text-secondary">
-            Enter your admin key for full access, or an API key secret for a scoped view of your
-            key's activity.
-          </p>
+    <div className="min-h-screen flex items-center justify-center p-6 bg-bg-deep">
+      {/* Background mesh */}
+      <div className="fixed inset-0 pointer-events-none opacity-50" aria-hidden="true">
+        <svg
+          viewBox="0 0 800 600"
+          preserveAspectRatio="xMidYMid slice"
+          className="w-full h-full"
+        >
+          <g stroke="rgba(245,158,11,0.10)" strokeWidth="0.5" fill="none">
+            <path d="M0 200 C 200 100, 600 300, 800 180" />
+            <path d="M0 320 C 220 220, 580 420, 800 300" />
+            <path d="M0 440 C 200 340, 600 540, 800 420" />
+          </g>
+          <circle cx="160" cy="200" r="3" fill="#F59E0B" opacity="0.7" />
+          <circle cx="380" cy="260" r="3" fill="#FBBF24" opacity="0.7" />
+          <circle cx="640" cy="220" r="3" fill="#F59E0B" opacity="0.7" />
+          <circle cx="240" cy="380" r="3" fill="#FBBF24" opacity="0.5" />
+          <circle cx="560" cy="420" r="3" fill="#F59E0B" opacity="0.5" />
+        </svg>
+      </div>
+
+      <main className="relative w-full max-w-md">
+        {/* Logo + wordmark */}
+        <div className="flex items-center justify-center gap-3 mb-8">
+          <div className="animate-float">
+            <PlexusMark size={44} />
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-bold amber-grad-text font-heading tracking-tight">
+              Plexus
+            </span>
+            <span className="text-[10px] uppercase tracking-[0.18em] text-text-muted font-mono">
+              {appVersion}
+            </span>
+          </div>
         </div>
 
-        <Card>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* Card */}
+        <div className="glass-bg rounded-2xl p-7 sm:p-8 shadow-2xl">
+          <div className="mb-6">
+            <h1 className="font-heading text-2xl font-semibold tracking-tight mb-1.5">Sign in</h1>
+            <p className="text-sm text-text-secondary leading-relaxed">
+              Enter your admin key for full access, or an API key secret for a scoped view of your
+              key's activity.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
             <input
               type="text"
               name="username"
@@ -57,31 +94,66 @@ export const Login: React.FC = () => {
               tabIndex={-1}
               aria-hidden="true"
             />
-            <FormField
-              label="Admin key or API key secret"
-              htmlFor="adminKey"
-              error={error || undefined}
-            >
-              <Input
-                id="adminKey"
-                type="password"
-                autoComplete="current-password"
-                value={key}
-                onChange={(e) => {
-                  setKey(e.target.value);
-                  if (error) setError('');
-                }}
-                placeholder="sk-admin-... or sk-..."
-                autoFocus
-              />
-            </FormField>
+            <div>
+              <label
+                htmlFor="adminKey"
+                className="block text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wider"
+              >
+                Admin key or API key secret
+              </label>
+              <div className="relative">
+                <KeyRound
+                  size={16}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none"
+                />
+                <input
+                  id="adminKey"
+                  type={showKey ? 'text' : 'password'}
+                  autoComplete="current-password"
+                  value={key}
+                  onChange={(e) => {
+                    setKey(e.target.value);
+                    if (error) setError('');
+                  }}
+                  placeholder="sk-admin-•••• or sk-•••••••••••••"
+                  autoFocus
+                  className="w-full bg-slate-900/60 border border-border rounded-md py-3 pl-10 pr-10 text-text font-mono text-sm placeholder:text-text-muted hover:border-border-2 focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.18)] focus:outline-none transition-all duration-fast"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowKey((v) => !v)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-md hover:bg-slate-700/50 text-text-secondary"
+                  aria-label={showKey ? 'Hide key' : 'Show key'}
+                >
+                  {showKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                </button>
+              </div>
+              {error && (
+                <div className="mt-2 flex items-start gap-2 text-xs text-rose-300 bg-rose-500/10 border border-rose-500/30 rounded-lg p-2.5">
+                  <AlertCircle size={14} className="mt-0.5 flex-none" />
+                  <span>{error}</span>
+                </div>
+              )}
+            </div>
 
-            <Button type="submit" className="w-full">
-              Access Dashboard
+            <Button type="submit" variant="primary" className="w-full py-3 text-sm font-semibold">
+              <span>Access Dashboard</span>
+              <ArrowRight size={14} />
             </Button>
           </form>
-        </Card>
-      </div>
+
+          <div className="mt-6 pt-5 border-t border-white/5 flex items-center justify-between text-[11px] text-text-muted">
+            <span className="inline-flex items-center gap-1.5">
+              <ShieldCheck size={14} />
+              End-to-end encrypted
+            </span>
+          </div>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-text-muted">
+          © 2026 Plexus · Unified LLM Gateway
+        </p>
+      </main>
     </div>
   );
 };

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -27,8 +27,6 @@ import { DateTimePicker } from '../components/ui/DateTimePicker';
 import {
   ChevronLeft,
   ChevronRight,
-  PlayCircle,
-  Circle,
   Trash2,
   Bug,
   Zap,
@@ -59,6 +57,8 @@ import {
   Plane,
   Eye,
   ScanSearch,
+  PlayCircle,
+  Circle,
   X,
 } from 'lucide-react';
 import { clsx } from 'clsx';
@@ -392,12 +392,9 @@ export const Logs = () => {
     try {
       const d = new Date(dateStr);
       if (isNaN(d.getTime())) return { time: 'Invalid', date: 'Date' };
-      const year = d.getFullYear();
-      const month = String(d.getMonth() + 1).padStart(2, '0');
-      const day = String(d.getDate()).padStart(2, '0');
       return {
         time: d.toLocaleTimeString(),
-        date: `${year}-${month}-${day}`,
+        date: d.toISOString().split('T')[0],
       };
     } catch (e) {
       return { time: 'Error', date: 'Date' };
@@ -407,93 +404,92 @@ export const Logs = () => {
   const selectedRetryHistory = parseRetryHistory(selectedRetryLog?.retryHistory);
 
   return (
-    <PageContainer>
+    <div className="flex flex-col min-h-full">
       <PageHeader
         title="Logs"
         subtitle={
           principal?.role === 'limited' && principal.keyName
-            ? `Scoped to key "${principal.keyName}".`
-            : undefined
+            ? `Scoped to key "${principal.keyName}"`
+            : 'All API requests routed through the gateway'
         }
-      />
-
-      <Card flush>
-        <div className="p-3 sm:p-4 border-b border-border-glass">
-          <form
-            onSubmit={handleSearch}
-            className="flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3 justify-between"
-          >
-            <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 min-w-0 flex-1">
-              {/* The apiKey filter is redundant for limited users — backend
-                  force-scopes results to their key. */}
-              {!isLimited && (
-                <div className="w-full sm:w-60">
-                  <SearchInput
-                    placeholder="Filter by Key..."
-                    value={filters.apiKey}
-                    onChange={(v) => setFilters({ ...filters, apiKey: v })}
-                  />
-                </div>
-              )}
-              <div className="w-full sm:w-60">
-                <SearchInput
-                  placeholder="Filter by Model..."
-                  value={filters.incomingModelAlias}
-                  onChange={(v) => setFilters({ ...filters, incomingModelAlias: v })}
-                />
-              </div>
-              <div className="w-full sm:w-48">
-                <SearchInput
-                  placeholder="Filter by Provider..."
-                  value={filters.provider}
-                  onChange={(v) => setFilters({ ...filters, provider: v })}
-                />
-              </div>
-              <div className="w-full sm:w-auto flex items-center gap-2">
-                <div className="flex items-center gap-2">
-                  <PlayCircle size={24} color="#94a3b8" />
-                  <DateTimePicker
-                    value={filters.startDate}
-                    onChange={(v) => setFilters((prev) => ({ ...prev, startDate: v }))}
-                    placeholder="Start date"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <Circle size={24} color="#94a3b8" />
-                  <DateTimePicker
-                    value={filters.endDate}
-                    onChange={(v) => setFilters((prev) => ({ ...prev, endDate: v }))}
-                    placeholder="End date"
-                  />
-                </div>
-                {(filters.startDate || filters.endDate) && (
-                  <button
-                    type="button"
-                    onClick={() => setFilters({ ...filters, startDate: '', endDate: '' })}
-                    className="rounded-md text-text-muted hover:text-text hover:bg-bg-hover transition-colors duration-fast bg-transparent border-0 cursor-pointer"
-                    title="Clear date filters"
-                  >
-                    <X size={14} />
-                  </button>
-                )}
-              </div>
-              <Button type="submit" variant="primary">
-                Search
-              </Button>
+        actions={
+          isAdmin ? (
+            <Button
+              onClick={handleDeleteAll}
+              variant="danger"
+              size="sm"
+              leftIcon={<Trash2 size={14} />}
+              disabled={logs.length === 0}
+              type="button"
+            >
+              Delete All
+            </Button>
+          ) : undefined
+        }
+      >
+        <form
+          onSubmit={handleSearch}
+          className="flex flex-col sm:flex-row sm:flex-wrap gap-2 items-stretch sm:items-end"
+        >
+          {!isLimited && (
+            <div className="w-full sm:w-56">
+              <SearchInput
+                placeholder="Filter by key…"
+                value={filters.apiKey}
+                onChange={(v) => setFilters({ ...filters, apiKey: v })}
+              />
             </div>
-            {isAdmin && (
-              <Button
-                onClick={handleDeleteAll}
-                variant="danger"
-                leftIcon={<Trash2 size={16} />}
-                disabled={logs.length === 0}
+          )}
+          <div className="w-full sm:w-56">
+            <SearchInput
+              placeholder="Filter by model…"
+              value={filters.incomingModelAlias}
+              onChange={(v) => setFilters({ ...filters, incomingModelAlias: v })}
+            />
+          </div>
+          <div className="w-full sm:w-44">
+            <SearchInput
+              placeholder="Filter by provider…"
+              value={filters.provider}
+              onChange={(v) => setFilters({ ...filters, provider: v })}
+            />
+          </div>
+          <div className="w-full sm:w-auto flex items-center gap-2">
+            <div className="flex items-center gap-2">
+              <PlayCircle size={24} color="#94a3b8" />
+              <DateTimePicker
+                value={filters.startDate}
+                onChange={(v) => setFilters((prev) => ({ ...prev, startDate: v }))}
+                placeholder="Start date"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Circle size={24} color="#94a3b8" />
+              <DateTimePicker
+                value={filters.endDate}
+                onChange={(v) => setFilters((prev) => ({ ...prev, endDate: v }))}
+                placeholder="End date"
+              />
+            </div>
+            {(filters.startDate || filters.endDate) && (
+              <button
                 type="button"
+                onClick={() => setFilters({ ...filters, startDate: '', endDate: '' })}
+                className="rounded-md text-text-muted hover:text-text hover:bg-bg-hover transition-colors duration-fast bg-transparent border-0 cursor-pointer"
+                title="Clear date filters"
               >
-                Delete All
-              </Button>
+                <X size={14} />
+              </button>
             )}
-          </form>
-        </div>
+          </div>
+          <Button type="submit" variant="primary" size="sm">
+            Search
+          </Button>
+        </form>
+      </PageHeader>
+
+      <PageContainer>
+        <Card flush>
 
         <div className="overflow-x-auto -mx-3 px-3">
           <table className="w-full border-collapse font-body text-[13px]">
@@ -1163,20 +1159,22 @@ export const Logs = () => {
           </table>
         </div>
 
-        <div className="flex justify-end items-center mt-5 gap-3">
-          <span style={{ fontSize: '14px', color: 'var(--color-text-secondary)' }}>
+        <div className="flex justify-end items-center px-3 py-3 gap-3 border-t border-border">
+          <span className="text-xs text-text-secondary font-mono">
             Page {currentPage} of {Math.max(1, totalPages)}
           </span>
           <div className="flex gap-1">
             <Button
-              variant="secondary"
+              variant="ghost"
+              size="icon"
               disabled={offset === 0}
               onClick={() => setOffset(Math.max(0, offset - limit))}
             >
               <ChevronLeft size={16} />
             </Button>
             <Button
-              variant="secondary"
+              variant="ghost"
+              size="icon"
               disabled={offset + limit >= total}
               onClick={() => setOffset(offset + limit)}
             >
@@ -1185,6 +1183,7 @@ export const Logs = () => {
           </div>
         </div>
       </Card>
+      </PageContainer>
 
       <Modal
         isOpen={isRetryModalOpen}
@@ -1320,6 +1319,6 @@ export const Logs = () => {
           cannot be undone.
         </p>
       </Modal>
-    </PageContainer>
+    </div>
   );
 };

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -482,7 +482,7 @@ export const Logs = () => {
               </button>
             )}
           </div>
-          <Button type="submit" variant="primary" size="sm">
+          <Button type="submit" variant="primary" size="sm" className="w-full sm:w-auto">
             Search
           </Button>
         </form>
@@ -490,699 +490,870 @@ export const Logs = () => {
 
       <PageContainer>
         <Card flush>
+          <div className="space-y-3 p-3 lg:hidden">
+            {loading ? (
+              <div className="rounded-lg border border-border-glass bg-bg-subtle p-4 text-center text-sm text-text-secondary">
+                Loading...
+              </div>
+            ) : logs.length === 0 ? (
+              <div className="rounded-lg border border-border-glass bg-bg-subtle p-4 text-center text-sm text-text-secondary">
+                No logs found
+              </div>
+            ) : (
+              logs.map((log) => {
+                const formatted = formatDateSafely(log.date);
+                const totalTokens =
+                  Number(log.tokensInput || 0) +
+                  Number(log.tokensOutput || 0) +
+                  Number(log.tokensCached || 0) +
+                  Number(log.tokensCacheWrite || 0) +
+                  Number(log.tokensReasoning || 0);
+                const status = log.responseStatus || (log.hasError ? 'error' : 'unknown');
+                const statusClass =
+                  status === 'success'
+                    ? 'border-success/30 bg-emerald-500/15 text-success'
+                    : status === 'pending'
+                      ? 'border-warning/30 bg-yellow-500/15 text-warning'
+                      : 'border-danger/30 bg-red-500/15 text-danger';
 
-        <div className="overflow-x-auto -mx-3 px-3">
-          <table className="w-full border-collapse font-body text-[13px]">
-            <thead>
-              <tr className="text-center border-b border-border">
-                <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                  {renderSortableHeader('Date', 'date')}
-                </th>
-                <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                  {renderSortableHeader('Key', 'apiKey')}
-                </th>
-                <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                  API
-                </th>
-                <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                  {renderSortableHeader('Model', 'incomingModelAlias')}
-                </th>
-                {/* <th style={{ padding: '6px' }}>Provider</th> */}
-                <th
-                  className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap"
-                  style={{ width: '125px' }}
-                >
-                  Tokens
-                </th>
-                <th
-                  className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap"
-                  style={{ minWidth: '70px' }}
-                >
-                  {renderSortableHeader('Cost', 'costTotal')}
-                </th>
-                <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                  {renderSortableHeader('Perf', 'durationMs')}
-                </th>
-                <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                  Meta
-                </th>
-                <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                  Status
-                </th>
-                <th className="px-2 py-1.5 text-center border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                  <div style={{ display: 'flex', justifyContent: 'center' }}>
-                    <Trash2 size={12} />
-                  </div>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {loading ? (
-                <tr>
-                  <td colSpan={11} className="p-5 text-center">
-                    Loading...
-                  </td>
-                </tr>
-              ) : logs.length === 0 ? (
-                <tr>
-                  <td colSpan={11} className="p-5 text-center">
-                    No logs found
-                  </td>
-                </tr>
-              ) : (
-                logs.map((log) => (
-                  <tr
+                return (
+                  <article
                     key={log.requestId}
                     className={clsx(
-                      'group border-b border-border-glass hover:bg-bg-hover',
-                      log.requestId === newestLogId && 'animate-slide-in'
+                      'rounded-lg border border-border-glass bg-bg-card p-3 shadow-sm',
+                      log.requestId === newestLogId && 'animate-slide-in',
+                      log.responseStatus === 'pending' && 'bg-yellow-500/5'
                     )}
-                    style={{
-                      height: '86px',
-                      backgroundColor:
-                        log.responseStatus === 'pending' ? 'rgba(234, 179, 8, 0.08)' : undefined,
-                    }}
                   >
-                    <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                      <div style={{ display: 'flex', flexDirection: 'column' }}>
-                        {(() => {
-                          const formatted = formatDateSafely(log.date);
-                          return (
-                            <>
-                              <span style={{ fontWeight: '500' }}>{formatted.time}</span>
-                              <span
-                                style={{
-                                  color: 'var(--color-text-secondary)',
-                                  fontSize: '0.85em',
-                                  whiteSpace: 'nowrap',
-                                }}
-                              >
-                                {formatted.date}
-                              </span>
-                            </>
-                          );
-                        })()}
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="font-mono text-xs font-medium text-text">
+                          {formatted.time}
+                        </div>
+                        <div className="font-mono text-[11px] text-text-muted">
+                          {formatted.date}
+                        </div>
                       </div>
-                    </td>
-                    <td
-                      className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle"
-                      title={log.sourceIp ? `IP: ${log.sourceIp}` : undefined}
-                      style={log.sourceIp ? { cursor: 'help' } : undefined}
-                    >
-                      <div style={{ display: 'flex', flexDirection: 'column' }}>
-                        <span style={{ fontWeight: '500' }}>{log.apiKey || '-'}</span>
-                        {log.attribution && (
-                          <span
-                            style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}
-                          >
-                            {log.attribution}
-                          </span>
+                      <span
+                        className={clsx(
+                          'inline-flex shrink-0 items-center rounded-md border px-2 py-1 text-[11px] font-semibold capitalize',
+                          statusClass
                         )}
-                      </div>
-                    </td>
-                    <td
-                      className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap"
-                      title={`Incoming: ${log.incomingApiType || '?'} → Outgoing: ${log.outgoingApiType || '?'} • ${log.isStreamed ? 'Streamed' : 'Non-streamed'} • ${log.isPassthrough ? 'Direct/Passthrough' : 'Translated'}`}
-                      style={{ cursor: 'help' }}
-                    >
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                        {/* API type icons */}
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
-                          <div style={{ width: '16px', display: 'flex', justifyContent: 'center' }}>
-                            {log.incomingApiType === 'embeddings' ? (
-                              <Variable size={16} className="text-green-500" />
-                            ) : log.incomingApiType === 'transcriptions' ? (
-                              <AudioLines size={16} className="text-purple-500" />
-                            ) : log.incomingApiType === 'speech' ? (
-                              <Volume2 size={16} className="text-orange-500" />
-                            ) : log.incomingApiType === 'images' ? (
-                              <ImageIcon size={16} className="text-fuchsia-500" />
-                            ) : log.incomingApiType === 'responses' ? (
-                              <MessagesSquare size={16} className="text-cyan-500" />
-                            ) : log.incomingApiType === 'oauth' ? (
-                              <ShieldCheck size={16} className="text-emerald-500" />
-                            ) : log.incomingApiType && apiLogos[log.incomingApiType] ? (
-                              <img
-                                src={apiLogos[log.incomingApiType]}
-                                alt={log.incomingApiType}
-                                style={{ width: '16px', height: '16px' }}
-                              />
-                            ) : (
-                              '?'
-                            )}
-                          </div>
-                          <span style={{ width: '14px', textAlign: 'center' }}>→</span>
-                          <div style={{ width: '16px', display: 'flex', justifyContent: 'center' }}>
-                            {log.outgoingApiType === 'embeddings' ? (
-                              <Variable size={16} className="text-green-500" />
-                            ) : log.outgoingApiType === 'transcriptions' ? (
-                              <AudioLines size={16} className="text-purple-500" />
-                            ) : log.outgoingApiType === 'speech' ? (
-                              <Volume2 size={16} className="text-orange-500" />
-                            ) : log.outgoingApiType === 'images' ? (
-                              <ImageIcon size={16} className="text-fuchsia-500" />
-                            ) : log.outgoingApiType === 'responses' ? (
-                              <MessagesSquare size={16} className="text-cyan-500" />
-                            ) : log.outgoingApiType === 'oauth' ? (
-                              <ShieldCheck size={16} className="text-emerald-500" />
-                            ) : log.outgoingApiType && apiLogos[log.outgoingApiType] ? (
-                              <img
-                                src={apiLogos[log.outgoingApiType]}
-                                alt={log.outgoingApiType}
-                                style={{ width: '16px', height: '16px' }}
-                              />
-                            ) : (
-                              '?'
-                            )}
-                          </div>
-                        </div>
-                        <div
-                          style={{
-                            borderTop: '1px solid var(--color-border-glass)',
-                            margin: '1px 4px',
-                            width: '44px',
-                          }}
-                        ></div>
-                        {/* Streaming/Passthrough icons */}
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
-                          <div style={{ width: '16px', display: 'flex', justifyContent: 'center' }}>
-                            {log.isStreamed ? (
-                              <Zap size={12} className="text-blue-400" />
-                            ) : (
-                              <ZapOff size={12} className="text-gray-400" />
-                            )}
-                          </div>
-                          <span style={{ width: '14px' }}></span>
-                          <div style={{ width: '16px', display: 'flex', justifyContent: 'center' }}>
-                            {log.isPassthrough ? (
-                              <MoveHorizontal size={12} className="text-yellow-500" />
-                            ) : (
-                              <Languages size={12} className="text-purple-400" />
-                            )}
-                          </div>
-                        </div>
+                      >
+                        {status}
+                      </span>
+                    </div>
 
-                        {/* Vision Fallthrough icons */}
-                        {(log.isVisionFallthrough || log.isDescriptorRequest) && (
-                          <div
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '2px',
-                              marginTop: '2px',
-                            }}
+                    <div className="mt-3 space-y-2">
+                      <div className="min-w-0">
+                        <div className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+                          Model
+                        </div>
+                        <div className="truncate text-sm font-medium text-text">
+                          {log.incomingModelAlias || '-'}
+                        </div>
+                        <div className="truncate text-xs text-text-secondary">
+                          {log.provider || '-'}:{log.selectedModelName || '-'}
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-2 gap-2 text-xs">
+                        <div className="rounded-md bg-bg-subtle p-2">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Key
+                          </div>
+                          <div className="truncate text-text">{log.apiKey || '-'}</div>
+                        </div>
+                        <div className="rounded-md bg-bg-subtle p-2">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            API
+                          </div>
+                          <div className="truncate text-text">
+                            {log.incomingApiType || '?'} {'->'} {log.outgoingApiType || '?'}
+                          </div>
+                        </div>
+                        <div className="rounded-md bg-bg-subtle p-2">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Tokens
+                          </div>
+                          <div className="text-text">{formatLargeNumber(totalTokens)}</div>
+                        </div>
+                        <div className="rounded-md bg-bg-subtle p-2">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Cost
+                          </div>
+                          <div className="text-text">
+                            {log.costTotal == null || log.costTotal === 0
+                              ? '-'
+                              : formatCost(log.costTotal)}
+                          </div>
+                        </div>
+                        <div className="rounded-md bg-bg-subtle p-2">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Latency
+                          </div>
+                          <div className="text-text">{formatMs(log.durationMs)}</div>
+                        </div>
+                        <div className="rounded-md bg-bg-subtle p-2">
+                          <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                            Meta
+                          </div>
+                          <div className="text-text">
+                            {log.messageCount || 0} msg / {log.toolCallsCount || 0} tools
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-border-glass pt-3">
+                      <span className="min-w-0 truncate font-mono text-[11px] text-text-muted">
+                        {log.requestId}
+                      </span>
+                      <div className="flex items-center gap-1.5">
+                        {log.hasError && (
+                          <Button
+                            size="sm"
+                            variant="danger"
+                            onClick={() =>
+                              navigate('/errors', { state: { requestId: log.requestId } })
+                            }
                           >
+                            <AlertTriangle size={12} />
+                            Error
+                          </Button>
+                        )}
+                        {log.hasDebug && (
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            onClick={() =>
+                              navigate('/debug', { state: { requestId: log.requestId } })
+                            }
+                          >
+                            <Bug size={12} />
+                            Debug
+                          </Button>
+                        )}
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleDelete(log.requestId)}
+                          className="text-danger"
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })
+            )}
+          </div>
+
+          <div className="hidden overflow-x-auto lg:block">
+            <table className="w-full border-collapse font-body text-[13px]">
+              <thead>
+                <tr className="text-center border-b border-border">
+                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                    {renderSortableHeader('Date', 'date')}
+                  </th>
+                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                    {renderSortableHeader('Key', 'apiKey')}
+                  </th>
+                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                    API
+                  </th>
+                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                    {renderSortableHeader('Model', 'incomingModelAlias')}
+                  </th>
+                  {/* <th style={{ padding: '6px' }}>Provider</th> */}
+                  <th
+                    className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap"
+                    style={{ width: '125px' }}
+                  >
+                    Tokens
+                  </th>
+                  <th
+                    className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap"
+                    style={{ minWidth: '70px' }}
+                  >
+                    {renderSortableHeader('Cost', 'costTotal')}
+                  </th>
+                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                    {renderSortableHeader('Perf', 'durationMs')}
+                  </th>
+                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                    Meta
+                  </th>
+                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                    Status
+                  </th>
+                  <th className="px-2 py-1.5 text-center border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                    <div style={{ display: 'flex', justifyContent: 'center' }}>
+                      <Trash2 size={12} />
+                    </div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr>
+                    <td colSpan={11} className="p-5 text-center">
+                      Loading...
+                    </td>
+                  </tr>
+                ) : logs.length === 0 ? (
+                  <tr>
+                    <td colSpan={11} className="p-5 text-center">
+                      No logs found
+                    </td>
+                  </tr>
+                ) : (
+                  logs.map((log) => (
+                    <tr
+                      key={log.requestId}
+                      className={clsx(
+                        'group border-b border-border-glass hover:bg-bg-hover',
+                        log.requestId === newestLogId && 'animate-slide-in'
+                      )}
+                      style={{
+                        height: '86px',
+                        backgroundColor:
+                          log.responseStatus === 'pending' ? 'rgba(234, 179, 8, 0.08)' : undefined,
+                      }}
+                    >
+                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                        <div style={{ display: 'flex', flexDirection: 'column' }}>
+                          {(() => {
+                            const formatted = formatDateSafely(log.date);
+                            return (
+                              <>
+                                <span style={{ fontWeight: '500' }}>{formatted.time}</span>
+                                <span
+                                  style={{
+                                    color: 'var(--color-text-secondary)',
+                                    fontSize: '0.85em',
+                                    whiteSpace: 'nowrap',
+                                  }}
+                                >
+                                  {formatted.date}
+                                </span>
+                              </>
+                            );
+                          })()}
+                        </div>
+                      </td>
+                      <td
+                        className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle"
+                        title={log.sourceIp ? `IP: ${log.sourceIp}` : undefined}
+                        style={log.sourceIp ? { cursor: 'help' } : undefined}
+                      >
+                        <div style={{ display: 'flex', flexDirection: 'column' }}>
+                          <span style={{ fontWeight: '500' }}>{log.apiKey || '-'}</span>
+                          {log.attribution && (
+                            <span
+                              style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}
+                            >
+                              {log.attribution}
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td
+                        className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap"
+                        title={`Incoming: ${log.incomingApiType || '?'} → Outgoing: ${log.outgoingApiType || '?'} • ${log.isStreamed ? 'Streamed' : 'Non-streamed'} • ${log.isPassthrough ? 'Direct/Passthrough' : 'Translated'}`}
+                        style={{ cursor: 'help' }}
+                      >
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                          {/* API type icons */}
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
                             <div
                               style={{ width: '16px', display: 'flex', justifyContent: 'center' }}
                             >
-                              {log.isVisionFallthrough && (
-                                <div
-                                  title={`Vision Fallthrough${log.visionFallthroughModel ? ` via ${log.visionFallthroughModel}` : ''} (Images converted to text)`}
-                                >
-                                  <ScanSearch size={12} className="text-amber-500" />
-                                </div>
+                              {log.incomingApiType === 'embeddings' ? (
+                                <Variable size={16} className="text-green-500" />
+                              ) : log.incomingApiType === 'transcriptions' ? (
+                                <AudioLines size={16} className="text-purple-500" />
+                              ) : log.incomingApiType === 'speech' ? (
+                                <Volume2 size={16} className="text-orange-500" />
+                              ) : log.incomingApiType === 'images' ? (
+                                <ImageIcon size={16} className="text-fuchsia-500" />
+                              ) : log.incomingApiType === 'responses' ? (
+                                <MessagesSquare size={16} className="text-cyan-500" />
+                              ) : log.incomingApiType === 'oauth' ? (
+                                <ShieldCheck size={16} className="text-emerald-500" />
+                              ) : log.incomingApiType && apiLogos[log.incomingApiType] ? (
+                                <img
+                                  src={apiLogos[log.incomingApiType]}
+                                  alt={log.incomingApiType}
+                                  style={{ width: '16px', height: '16px' }}
+                                />
+                              ) : (
+                                '?'
+                              )}
+                            </div>
+                            <span style={{ width: '14px', textAlign: 'center' }}>→</span>
+                            <div
+                              style={{ width: '16px', display: 'flex', justifyContent: 'center' }}
+                            >
+                              {log.outgoingApiType === 'embeddings' ? (
+                                <Variable size={16} className="text-green-500" />
+                              ) : log.outgoingApiType === 'transcriptions' ? (
+                                <AudioLines size={16} className="text-purple-500" />
+                              ) : log.outgoingApiType === 'speech' ? (
+                                <Volume2 size={16} className="text-orange-500" />
+                              ) : log.outgoingApiType === 'images' ? (
+                                <ImageIcon size={16} className="text-fuchsia-500" />
+                              ) : log.outgoingApiType === 'responses' ? (
+                                <MessagesSquare size={16} className="text-cyan-500" />
+                              ) : log.outgoingApiType === 'oauth' ? (
+                                <ShieldCheck size={16} className="text-emerald-500" />
+                              ) : log.outgoingApiType && apiLogos[log.outgoingApiType] ? (
+                                <img
+                                  src={apiLogos[log.outgoingApiType]}
+                                  alt={log.outgoingApiType}
+                                  style={{ width: '16px', height: '16px' }}
+                                />
+                              ) : (
+                                '?'
+                              )}
+                            </div>
+                          </div>
+                          <div
+                            style={{
+                              borderTop: '1px solid var(--color-border-glass)',
+                              margin: '1px 4px',
+                              width: '44px',
+                            }}
+                          ></div>
+                          {/* Streaming/Passthrough icons */}
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
+                            <div
+                              style={{ width: '16px', display: 'flex', justifyContent: 'center' }}
+                            >
+                              {log.isStreamed ? (
+                                <Zap size={12} className="text-blue-400" />
+                              ) : (
+                                <ZapOff size={12} className="text-gray-400" />
                               )}
                             </div>
                             <span style={{ width: '14px' }}></span>
                             <div
                               style={{ width: '16px', display: 'flex', justifyContent: 'center' }}
                             >
-                              {log.isDescriptorRequest && (
-                                <div title="Descriptor Request (Generated image description)">
-                                  <Eye size={12} className="text-blue-500" />
-                                </div>
+                              {log.isPassthrough ? (
+                                <MoveHorizontal size={12} className="text-yellow-500" />
+                              ) : (
+                                <Languages size={12} className="text-purple-400" />
                               )}
                             </div>
                           </div>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                        <div className="group/model flex items-center gap-1">
-                          <span>{log.incomingModelAlias || '-'}</span>
-                          {log.incomingModelAlias && log.incomingModelAlias !== '-' && (
-                            <button
-                              onClick={async () => {
-                                if (!isClipboardAvailable()) return;
-                                await copyToClipboard(log.incomingModelAlias || '');
+
+                          {/* Vision Fallthrough icons */}
+                          {(log.isVisionFallthrough || log.isDescriptorRequest) && (
+                            <div
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '2px',
+                                marginTop: '2px',
                               }}
-                              className="opacity-0 group-hover/model:opacity-100 transition-opacity bg-transparent border-0 cursor-pointer p-0 flex items-center disabled:opacity-0"
-                              title={
-                                isClipboardAvailable()
-                                  ? 'Copy incoming model alias'
-                                  : 'Copy requires HTTPS'
-                              }
-                              disabled={!isClipboardAvailable()}
                             >
-                              <Copy size={12} className="text-text-secondary hover:text-text" />
-                            </button>
+                              <div
+                                style={{ width: '16px', display: 'flex', justifyContent: 'center' }}
+                              >
+                                {log.isVisionFallthrough && (
+                                  <div
+                                    title={`Vision Fallthrough${log.visionFallthroughModel ? ` via ${log.visionFallthroughModel}` : ''} (Images converted to text)`}
+                                  >
+                                    <ScanSearch size={12} className="text-amber-500" />
+                                  </div>
+                                )}
+                              </div>
+                              <span style={{ width: '14px' }}></span>
+                              <div
+                                style={{ width: '16px', display: 'flex', justifyContent: 'center' }}
+                              >
+                                {log.isDescriptorRequest && (
+                                  <div title="Descriptor Request (Generated image description)">
+                                    <Eye size={12} className="text-blue-500" />
+                                  </div>
+                                )}
+                              </div>
+                            </div>
                           )}
                         </div>
-                        <div className="group/selected flex items-center gap-1">
-                          <span style={{ color: 'var(--color-text-secondary)', fontSize: '0.9em' }}>
-                            {log.provider || '-'}:{log.selectedModelName || '-'}
-                          </span>
-                          {log.selectedModelName && log.selectedModelName !== '-' && (
-                            <button
-                              onClick={async () => {
-                                if (!isClipboardAvailable()) return;
-                                await copyToClipboard(log.selectedModelName || '');
-                              }}
-                              className="opacity-0 group-hover/selected:opacity-100 transition-opacity bg-transparent border-0 cursor-pointer p-0 flex items-center disabled:opacity-0"
-                              title={
-                                isClipboardAvailable()
-                                  ? 'Copy selected model name'
-                                  : 'Copy requires HTTPS'
-                              }
-                              disabled={!isClipboardAvailable()}
+                      </td>
+                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                          <div className="group/model flex items-center gap-1">
+                            <span>{log.incomingModelAlias || '-'}</span>
+                            {log.incomingModelAlias && log.incomingModelAlias !== '-' && (
+                              <button
+                                onClick={async () => {
+                                  if (!isClipboardAvailable()) return;
+                                  await copyToClipboard(log.incomingModelAlias || '');
+                                }}
+                                className="opacity-0 group-hover/model:opacity-100 transition-opacity bg-transparent border-0 cursor-pointer p-0 flex items-center disabled:opacity-0"
+                                title={
+                                  isClipboardAvailable()
+                                    ? 'Copy incoming model alias'
+                                    : 'Copy requires HTTPS'
+                                }
+                                disabled={!isClipboardAvailable()}
+                              >
+                                <Copy size={12} className="text-text-secondary hover:text-text" />
+                              </button>
+                            )}
+                          </div>
+                          <div className="group/selected flex items-center gap-1">
+                            <span
+                              style={{ color: 'var(--color-text-secondary)', fontSize: '0.9em' }}
                             >
-                              <Copy size={10} className="text-text-secondary hover:text-text" />
-                            </button>
+                              {log.provider || '-'}:{log.selectedModelName || '-'}
+                            </span>
+                            {log.selectedModelName && log.selectedModelName !== '-' && (
+                              <button
+                                onClick={async () => {
+                                  if (!isClipboardAvailable()) return;
+                                  await copyToClipboard(log.selectedModelName || '');
+                                }}
+                                className="opacity-0 group-hover/selected:opacity-100 transition-opacity bg-transparent border-0 cursor-pointer p-0 flex items-center disabled:opacity-0"
+                                title={
+                                  isClipboardAvailable()
+                                    ? 'Copy selected model name'
+                                    : 'Copy requires HTTPS'
+                                }
+                                disabled={!isClipboardAvailable()}
+                              >
+                                <Copy size={10} className="text-text-secondary hover:text-text" />
+                              </button>
+                            )}
+                          </div>
+                          {log.isVisionFallthrough && log.visionFallthroughModel && (
+                            <div
+                              className="group/vft flex items-center gap-1"
+                              title="Vision fallthrough descriptor model"
+                            >
+                              <ScanSearch size={10} className="text-amber-500 shrink-0" />
+                              <span
+                                style={{ color: 'var(--color-text-secondary)', fontSize: '0.8em' }}
+                              >
+                                {log.visionFallthroughModel}
+                              </span>
+                              <button
+                                onClick={async () => {
+                                  if (!isClipboardAvailable()) return;
+                                  await copyToClipboard(log.visionFallthroughModel || '');
+                                }}
+                                className="opacity-0 group-hover/vft:opacity-100 transition-opacity bg-transparent border-0 cursor-pointer p-0 flex items-center disabled:opacity-0"
+                                title={
+                                  isClipboardAvailable()
+                                    ? 'Copy fallthrough model name'
+                                    : 'Copy requires HTTPS'
+                                }
+                                disabled={!isClipboardAvailable()}
+                              >
+                                <Copy size={10} className="text-text-secondary hover:text-text" />
+                              </button>
+                            </div>
                           )}
                         </div>
-                        {log.isVisionFallthrough && log.visionFallthroughModel && (
-                          <div
-                            className="group/vft flex items-center gap-1"
-                            title="Vision fallthrough descriptor model"
-                          >
-                            <ScanSearch size={10} className="text-amber-500 shrink-0" />
-                            <span
-                              style={{ color: 'var(--color-text-secondary)', fontSize: '0.8em' }}
-                            >
-                              {log.visionFallthroughModel}
-                            </span>
-                            <button
-                              onClick={async () => {
-                                if (!isClipboardAvailable()) return;
-                                await copyToClipboard(log.visionFallthroughModel || '');
-                              }}
-                              className="opacity-0 group-hover/vft:opacity-100 transition-opacity bg-transparent border-0 cursor-pointer p-0 flex items-center disabled:opacity-0"
-                              title={
-                                isClipboardAvailable()
-                                  ? 'Copy fallthrough model name'
-                                  : 'Copy requires HTTPS'
-                              }
-                              disabled={!isClipboardAvailable()}
-                            >
-                              <Copy size={10} className="text-text-secondary hover:text-text" />
-                            </button>
+                      </td>
+                      <td
+                        className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle"
+                        title={`Input: ${(log.tokensInput || 0) === 0 ? '-' : formatLargeNumber(log.tokensInput || 0)} • Output: ${(log.tokensOutput || 0) === 0 ? '-' : formatLargeNumber(log.tokensOutput || 0)} • Reasoning: ${(log.tokensReasoning || 0) === 0 ? '-' : formatLargeNumber(log.tokensReasoning || 0)} • Cached: ${(log.tokensCached || 0) === 0 ? '-' : formatLargeNumber(log.tokensCached || 0)} • Cache Write: ${(log.tokensCacheWrite || 0) === 0 ? '-' : formatLargeNumber(log.tokensCacheWrite || 0)}${log.tokensEstimated ? ' • * = Estimated' : ''}`}
+                        style={{ cursor: 'help' }}
+                      >
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                          {/* Row 1: Input and Reasoning */}
+                          <div style={{ display: 'flex', gap: '16px' }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              <CloudUpload size={12} className="text-blue-400" />
+                              <span
+                                style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '30px' }}
+                              >
+                                {(log.tokensInput || 0) === 0
+                                  ? '-'
+                                  : formatLargeNumber(log.tokensInput || 0)}
+                                {log.tokensEstimated ? (
+                                  <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
+                                ) : null}
+                              </span>
+                            </div>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              <BrainCog size={12} className="text-purple-400" />
+                              <span
+                                style={{
+                                  color: 'var(--color-text-secondary)',
+                                  fontSize: '0.85em',
+                                  minWidth: '30px',
+                                }}
+                              >
+                                {(log.tokensReasoning || 0) === 0
+                                  ? '-'
+                                  : formatLargeNumber(log.tokensReasoning || 0)}
+                                {log.tokensEstimated ? (
+                                  <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
+                                ) : null}
+                              </span>
+                            </div>
                           </div>
-                        )}
-                      </div>
-                    </td>
-                    <td
-                      className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle"
-                      title={`Input: ${(log.tokensInput || 0) === 0 ? '-' : formatLargeNumber(log.tokensInput || 0)} • Output: ${(log.tokensOutput || 0) === 0 ? '-' : formatLargeNumber(log.tokensOutput || 0)} • Reasoning: ${(log.tokensReasoning || 0) === 0 ? '-' : formatLargeNumber(log.tokensReasoning || 0)} • Cached: ${(log.tokensCached || 0) === 0 ? '-' : formatLargeNumber(log.tokensCached || 0)} • Cache Write: ${(log.tokensCacheWrite || 0) === 0 ? '-' : formatLargeNumber(log.tokensCacheWrite || 0)}${log.tokensEstimated ? ' • * = Estimated' : ''}`}
-                      style={{ cursor: 'help' }}
-                    >
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                        {/* Row 1: Input and Reasoning */}
-                        <div style={{ display: 'flex', gap: '16px' }}>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <CloudUpload size={12} className="text-blue-400" />
-                            <span
-                              style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '30px' }}
-                            >
-                              {(log.tokensInput || 0) === 0
-                                ? '-'
-                                : formatLargeNumber(log.tokensInput || 0)}
-                              {log.tokensEstimated ? (
-                                <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
-                              ) : null}
-                            </span>
+                          {/* Row 2: Output and Cache */}
+                          <div style={{ display: 'flex', gap: '16px' }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              <CloudDownload size={12} className="text-green-400" />
+                              <span
+                                style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '30px' }}
+                              >
+                                {(log.tokensOutput || 0) === 0
+                                  ? '-'
+                                  : formatLargeNumber(log.tokensOutput || 0)}
+                                {log.tokensEstimated ? (
+                                  <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
+                                ) : null}
+                              </span>
+                            </div>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              <PackageOpen size={12} className="text-orange-400" />
+                              <span
+                                style={{
+                                  color: 'var(--color-text-secondary)',
+                                  fontSize: '0.85em',
+                                  minWidth: '30px',
+                                }}
+                              >
+                                {(log.tokensCached || 0) === 0
+                                  ? '-'
+                                  : formatLargeNumber(log.tokensCached || 0)}
+                                {log.tokensEstimated ? (
+                                  <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
+                                ) : null}
+                              </span>
+                            </div>
                           </div>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <BrainCog size={12} className="text-purple-400" />
-                            <span
-                              style={{
-                                color: 'var(--color-text-secondary)',
-                                fontSize: '0.85em',
-                                minWidth: '30px',
-                              }}
-                            >
-                              {(log.tokensReasoning || 0) === 0
-                                ? '-'
-                                : formatLargeNumber(log.tokensReasoning || 0)}
-                              {log.tokensEstimated ? (
-                                <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
-                              ) : null}
-                            </span>
-                          </div>
-                        </div>
-                        {/* Row 2: Output and Cache */}
-                        <div style={{ display: 'flex', gap: '16px' }}>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <CloudDownload size={12} className="text-green-400" />
-                            <span
-                              style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '30px' }}
-                            >
-                              {(log.tokensOutput || 0) === 0
-                                ? '-'
-                                : formatLargeNumber(log.tokensOutput || 0)}
-                              {log.tokensEstimated ? (
-                                <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
-                              ) : null}
-                            </span>
-                          </div>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <PackageOpen size={12} className="text-orange-400" />
-                            <span
-                              style={{
-                                color: 'var(--color-text-secondary)',
-                                fontSize: '0.85em',
-                                minWidth: '30px',
-                              }}
-                            >
-                              {(log.tokensCached || 0) === 0
-                                ? '-'
-                                : formatLargeNumber(log.tokensCached || 0)}
-                              {log.tokensEstimated ? (
-                                <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
-                              ) : null}
-                            </span>
+                          {/* Row 3: Cache Write */}
+                          <div style={{ display: 'flex', gap: '16px' }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              <PencilLine size={12} className="text-fuchsia-400" />
+                              <span
+                                style={{
+                                  color: 'var(--color-text-secondary)',
+                                  fontSize: '0.85em',
+                                  minWidth: '30px',
+                                }}
+                              >
+                                {(log.tokensCacheWrite || 0) === 0
+                                  ? '-'
+                                  : formatLargeNumber(log.tokensCacheWrite || 0)}
+                                {log.tokensEstimated ? (
+                                  <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
+                                ) : null}
+                              </span>
+                            </div>
                           </div>
                         </div>
-                        {/* Row 3: Cache Write */}
-                        <div style={{ display: 'flex', gap: '16px' }}>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            <PencilLine size={12} className="text-fuchsia-400" />
-                            <span
-                              style={{
-                                color: 'var(--color-text-secondary)',
-                                fontSize: '0.85em',
-                                minWidth: '30px',
-                              }}
-                            >
-                              {(log.tokensCacheWrite || 0) === 0
-                                ? '-'
-                                : formatLargeNumber(log.tokensCacheWrite || 0)}
-                              {log.tokensEstimated ? (
-                                <sup style={{ fontSize: '0.7em', opacity: 0.6 }}>*</sup>
-                              ) : null}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="px-2 py-1.5 border-b border-border-glass text-text align-middle">
-                      {log.costTotal !== undefined && log.costTotal !== null ? (
-                        <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-                          {/* Left side: Total cost */}
-                          <div style={{ minWidth: '50px' }}>
-                            {log.costSource ? (
-                              <CostToolTip source={log.costSource} costMetadata={log.costMetadata}>
-                                <span style={{ fontWeight: '500', cursor: 'help' }}>
+                      </td>
+                      <td className="px-2 py-1.5 border-b border-border-glass text-text align-middle">
+                        {log.costTotal !== undefined && log.costTotal !== null ? (
+                          <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+                            {/* Left side: Total cost */}
+                            <div style={{ minWidth: '50px' }}>
+                              {log.costSource ? (
+                                <CostToolTip
+                                  source={log.costSource}
+                                  costMetadata={log.costMetadata}
+                                >
+                                  <span style={{ fontWeight: '500', cursor: 'help' }}>
+                                    {log.costTotal === 0 ? '∅' : formatCost(log.costTotal)}
+                                  </span>
+                                </CostToolTip>
+                              ) : (
+                                <span style={{ fontWeight: '500' }}>
                                   {log.costTotal === 0 ? '∅' : formatCost(log.costTotal)}
                                 </span>
-                              </CostToolTip>
-                            ) : (
-                              <span style={{ fontWeight: '500' }}>
-                                {log.costTotal === 0 ? '∅' : formatCost(log.costTotal)}
-                              </span>
-                            )}
-                          </div>
-                          {/* Right side: Breakdown */}
-                          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                              <CloudUpload size={10} className="text-blue-400" />
-                              <span
-                                style={{
-                                  color: 'var(--color-text-secondary)',
-                                  fontSize: '0.85em',
-                                  minWidth: '35px',
-                                }}
-                              >
-                                {log.costInput === 0 ? '∅' : formatCost(log.costInput || 0)}
-                              </span>
+                              )}
                             </div>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                              <CloudDownload size={10} className="text-green-400" />
-                              <span
-                                style={{
-                                  color: 'var(--color-text-secondary)',
-                                  fontSize: '0.85em',
-                                  minWidth: '35px',
-                                }}
-                              >
-                                {log.costOutput === 0 ? '∅' : formatCost(log.costOutput || 0)}
-                              </span>
-                            </div>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                              <PackageOpen size={10} className="text-orange-400" />
-                              <span
-                                style={{
-                                  color: 'var(--color-text-secondary)',
-                                  fontSize: '0.85em',
-                                  minWidth: '35px',
-                                }}
-                              >
-                                {log.costCached === 0 ? '∅' : formatCost(log.costCached || 0)}
-                              </span>
-                            </div>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                              <PencilLine size={10} className="text-fuchsia-400" />
-                              <span
-                                style={{
-                                  color: 'var(--color-text-secondary)',
-                                  fontSize: '0.85em',
-                                  minWidth: '35px',
-                                }}
-                              >
-                                {log.costCacheWrite === 0
-                                  ? '∅'
-                                  : formatCost(log.costCacheWrite || 0)}
-                              </span>
+                            {/* Right side: Breakdown */}
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                <CloudUpload size={10} className="text-blue-400" />
+                                <span
+                                  style={{
+                                    color: 'var(--color-text-secondary)',
+                                    fontSize: '0.85em',
+                                    minWidth: '35px',
+                                  }}
+                                >
+                                  {log.costInput === 0 ? '∅' : formatCost(log.costInput || 0)}
+                                </span>
+                              </div>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                <CloudDownload size={10} className="text-green-400" />
+                                <span
+                                  style={{
+                                    color: 'var(--color-text-secondary)',
+                                    fontSize: '0.85em',
+                                    minWidth: '35px',
+                                  }}
+                                >
+                                  {log.costOutput === 0 ? '∅' : formatCost(log.costOutput || 0)}
+                                </span>
+                              </div>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                <PackageOpen size={10} className="text-orange-400" />
+                                <span
+                                  style={{
+                                    color: 'var(--color-text-secondary)',
+                                    fontSize: '0.85em',
+                                    minWidth: '35px',
+                                  }}
+                                >
+                                  {log.costCached === 0 ? '∅' : formatCost(log.costCached || 0)}
+                                </span>
+                              </div>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                <PencilLine size={10} className="text-fuchsia-400" />
+                                <span
+                                  style={{
+                                    color: 'var(--color-text-secondary)',
+                                    fontSize: '0.85em',
+                                    minWidth: '35px',
+                                  }}
+                                >
+                                  {log.costCacheWrite === 0
+                                    ? '∅'
+                                    : formatCost(log.costCacheWrite || 0)}
+                                </span>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      ) : (
-                        <span style={{ color: 'var(--color-text-secondary)', fontSize: '1.2em' }}>
-                          ∅
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                      <div style={{ display: 'flex', flexDirection: 'column' }}>
-                        <span>Duration: {formatMs(log.durationMs)}</span>
-                        <span
-                          style={{
-                            color: 'var(--color-text-secondary)',
-                            fontSize: '0.85em',
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          {log.ttftMs && log.ttftMs > 0 ? `TTFT: ${formatMs(log.ttftMs)}` : ''}
-                        </span>
-                        <span
-                          style={{
-                            color: 'var(--color-text-secondary)',
-                            fontSize: '0.85em',
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          {log.tokensPerSec && log.tokensPerSec > 0
-                            ? `TPS: ${formatTPS(log.tokensPerSec)}`
-                            : ''}
-                        </span>
-                      </div>
-                    </td>
-                    <td
-                      className="px-2 py-1.5 text-center border-b border-border-glass text-text align-middle"
-                      title={
-                        log.kwhUsed != null && log.kwhUsed > 0
-                          ? `Energy: ${formatEnergy(log.kwhUsed)} ≈ ${formatSlices(log.kwhUsed / KWH_PER_SLICE)} toast slices`
-                          : undefined
-                      }
-                      style={
-                        log.kwhUsed != null && log.kwhUsed > 0 ? { cursor: 'help' } : undefined
-                      }
-                    >
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                        {/* Row 1: Messages and Tool calls */}
-                        <div style={{ display: 'flex', gap: '16px' }}>
-                          <div
-                            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                            className="text-blue-400"
+                        ) : (
+                          <span style={{ color: 'var(--color-text-secondary)', fontSize: '1.2em' }}>
+                            ∅
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                        <div style={{ display: 'flex', flexDirection: 'column' }}>
+                          <span>Duration: {formatMs(log.durationMs)}</span>
+                          <span
+                            style={{
+                              color: 'var(--color-text-secondary)',
+                              fontSize: '0.85em',
+                              whiteSpace: 'nowrap',
+                            }}
                           >
-                            <MessagesSquare size={12} />
-                            <span
-                              style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '20px' }}
-                            >
-                              {log.messageCount || 0}
-                            </span>
-                          </div>
-                          <div
-                            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                            className="text-green-400"
+                            {log.ttftMs && log.ttftMs > 0 ? `TTFT: ${formatMs(log.ttftMs)}` : ''}
+                          </span>
+                          <span
+                            style={{
+                              color: 'var(--color-text-secondary)',
+                              fontSize: '0.85em',
+                              whiteSpace: 'nowrap',
+                            }}
                           >
-                            <PlugZap size={12} />
-                            <span
-                              style={{
-                                color: 'var(--color-text-secondary)',
-                                fontSize: '0.85em',
-                                minWidth: '20px',
-                              }}
-                            >
-                              {log.toolCallsCount || 0}
-                            </span>
-                          </div>
+                            {log.tokensPerSec && log.tokensPerSec > 0
+                              ? `TPS: ${formatTPS(log.tokensPerSec)}`
+                              : ''}
+                          </span>
                         </div>
-                        {/* Row 2: Tools defined and Finish reason */}
-                        <div style={{ display: 'flex', gap: '16px' }}>
-                          <div
-                            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                            className="text-orange-400"
-                          >
-                            <Wrench size={12} />
-                            <span
-                              style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '20px' }}
-                            >
-                              {log.toolsDefined || 0}
-                            </span>
-                          </div>
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                            {log.finishReason === 'end_turn' ? (
-                              <CirclePause size={12} className="text-yellow-500" />
-                            ) : log.finishReason === 'stop' ? (
-                              <Octagon size={12} className="text-red-500" />
-                            ) : log.finishReason === 'tool_calls' ? (
-                              <Hammer size={12} className="text-purple-500" />
-                            ) : log.finishReason === 'length' ||
-                              log.finishReason === 'max_tokens' ? (
-                              <RulerDimensionLine size={12} className="text-pink-400" />
-                            ) : (
-                              <ChevronDown size={12} className="text-gray-400" />
-                            )}
-                            <span
-                              style={{
-                                color: 'var(--color-text-secondary)',
-                                fontSize: '0.85em',
-                                minWidth: '20px',
-                              }}
-                            >
-                              {log.finishReason || '-'}
-                            </span>
-                          </div>
-                        </div>
-                        {/* Row 3: Retry indicator */}
-                        {log.attemptCount && log.attemptCount > 1 && (
+                      </td>
+                      <td
+                        className="px-2 py-1.5 text-center border-b border-border-glass text-text align-middle"
+                        title={
+                          log.kwhUsed != null && log.kwhUsed > 0
+                            ? `Energy: ${formatEnergy(log.kwhUsed)} ≈ ${formatSlices(log.kwhUsed / KWH_PER_SLICE)} toast slices`
+                            : undefined
+                        }
+                        style={
+                          log.kwhUsed != null && log.kwhUsed > 0 ? { cursor: 'help' } : undefined
+                        }
+                      >
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                          {/* Row 1: Messages and Tool calls */}
                           <div style={{ display: 'flex', gap: '16px' }}>
-                            <button
-                              type="button"
-                              onClick={() => handleRetryDetails(log)}
+                            <div
                               style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-                              className="text-orange-500 bg-transparent border-0 p-0 cursor-pointer hover:text-orange-400 transition-colors"
-                              title="View retry history"
+                              className="text-blue-400"
                             >
-                              <RotateCcw size={12} />
+                              <MessagesSquare size={12} />
                               <span
                                 style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '20px' }}
                               >
-                                {log.attemptCount}x
+                                {log.messageCount || 0}
                               </span>
-                            </button>
+                            </div>
+                            <div
+                              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                              className="text-green-400"
+                            >
+                              <PlugZap size={12} />
+                              <span
+                                style={{
+                                  color: 'var(--color-text-secondary)',
+                                  fontSize: '0.85em',
+                                  minWidth: '20px',
+                                }}
+                              >
+                                {log.toolCallsCount || 0}
+                              </span>
+                            </div>
                           </div>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
-                      <div className="flex gap-2 items-center">
-                        {log.hasError && (
-                          <button
-                            onClick={() =>
-                              navigate('/errors', { state: { requestId: log.requestId } })
-                            }
-                            className={clsx(
-                              'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium cursor-pointer transition-all duration-200 border',
-                              'text-danger border-danger/30 bg-red-500/15 hover:bg-red-500/25'
-                            )}
-                            style={{ width: '52px' }}
-                            title="View Error Details"
-                          >
-                            <AlertTriangle size={12} />
-                            <span style={{ fontWeight: 600 }}>✗</span>
-                          </button>
-                        )}
-                        {log.hasDebug && (
-                          <button
-                            onClick={() =>
-                              navigate('/debug', { state: { requestId: log.requestId } })
-                            }
-                            className={clsx(
-                              'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium cursor-pointer transition-all duration-200 border',
-                              'text-blue-400 border-blue-400/30 bg-blue-500/15 hover:bg-blue-500/25'
-                            )}
-                            style={{ width: '52px' }}
-                            title="View Debug Trace"
-                          >
-                            <Bug size={12} />
-                            <span style={{ fontWeight: 600 }}>✓</span>
-                          </button>
-                        )}
-                        {!log.hasError && !log.hasDebug && (
-                          <div
-                            className={clsx(
-                              'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
-                              log.responseStatus === 'success'
-                                ? 'text-success border-success/30 bg-emerald-500/15'
-                                : log.responseStatus === 'pending'
-                                  ? 'text-warning border-warning/30 bg-yellow-500/15'
-                                  : 'text-danger border-danger/30 bg-red-500/15'
-                            )}
-                            style={{ width: '52px' }}
-                          >
-                            {log.responseStatus === 'success' ? (
-                              <span style={{ fontWeight: 600 }}>✓</span>
-                            ) : log.responseStatus === 'pending' ? (
-                              <Plane size={12} className="animate-pulse" />
-                            ) : (
+                          {/* Row 2: Tools defined and Finish reason */}
+                          <div style={{ display: 'flex', gap: '16px' }}>
+                            <div
+                              style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                              className="text-orange-400"
+                            >
+                              <Wrench size={12} />
+                              <span
+                                style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '20px' }}
+                              >
+                                {log.toolsDefined || 0}
+                              </span>
+                            </div>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              {log.finishReason === 'end_turn' ? (
+                                <CirclePause size={12} className="text-yellow-500" />
+                              ) : log.finishReason === 'stop' ? (
+                                <Octagon size={12} className="text-red-500" />
+                              ) : log.finishReason === 'tool_calls' ? (
+                                <Hammer size={12} className="text-purple-500" />
+                              ) : log.finishReason === 'length' ||
+                                log.finishReason === 'max_tokens' ? (
+                                <RulerDimensionLine size={12} className="text-pink-400" />
+                              ) : (
+                                <ChevronDown size={12} className="text-gray-400" />
+                              )}
+                              <span
+                                style={{
+                                  color: 'var(--color-text-secondary)',
+                                  fontSize: '0.85em',
+                                  minWidth: '20px',
+                                }}
+                              >
+                                {log.finishReason || '-'}
+                              </span>
+                            </div>
+                          </div>
+                          {/* Row 3: Retry indicator */}
+                          {log.attemptCount && log.attemptCount > 1 && (
+                            <div style={{ display: 'flex', gap: '16px' }}>
+                              <button
+                                type="button"
+                                onClick={() => handleRetryDetails(log)}
+                                style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                                className="text-orange-500 bg-transparent border-0 p-0 cursor-pointer hover:text-orange-400 transition-colors"
+                                title="View retry history"
+                              >
+                                <RotateCcw size={12} />
+                                <span
+                                  style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '20px' }}
+                                >
+                                  {log.attemptCount}x
+                                </span>
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
+                        <div className="flex gap-2 items-center">
+                          {log.hasError && (
+                            <button
+                              onClick={() =>
+                                navigate('/errors', { state: { requestId: log.requestId } })
+                              }
+                              className={clsx(
+                                'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium cursor-pointer transition-all duration-200 border',
+                                'text-danger border-danger/30 bg-red-500/15 hover:bg-red-500/25'
+                              )}
+                              style={{ width: '52px' }}
+                              title="View Error Details"
+                            >
+                              <AlertTriangle size={12} />
                               <span style={{ fontWeight: 600 }}>✗</span>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
-                      <button
-                        onClick={() => handleDelete(log.requestId)}
-                        className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger group-hover:opacity-100 opacity-0"
-                        title="Delete log"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-
-        <div className="flex justify-end items-center px-3 py-3 gap-3 border-t border-border">
-          <span className="text-xs text-text-secondary font-mono">
-            Page {currentPage} of {Math.max(1, totalPages)}
-          </span>
-          <div className="flex gap-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              disabled={offset === 0}
-              onClick={() => setOffset(Math.max(0, offset - limit))}
-            >
-              <ChevronLeft size={16} />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              disabled={offset + limit >= total}
-              onClick={() => setOffset(offset + limit)}
-            >
-              <ChevronRight size={16} />
-            </Button>
+                            </button>
+                          )}
+                          {log.hasDebug && (
+                            <button
+                              onClick={() =>
+                                navigate('/debug', { state: { requestId: log.requestId } })
+                              }
+                              className={clsx(
+                                'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium cursor-pointer transition-all duration-200 border',
+                                'text-blue-400 border-blue-400/30 bg-blue-500/15 hover:bg-blue-500/25'
+                              )}
+                              style={{ width: '52px' }}
+                              title="View Debug Trace"
+                            >
+                              <Bug size={12} />
+                              <span style={{ fontWeight: 600 }}>✓</span>
+                            </button>
+                          )}
+                          {!log.hasError && !log.hasDebug && (
+                            <div
+                              className={clsx(
+                                'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
+                                log.responseStatus === 'success'
+                                  ? 'text-success border-success/30 bg-emerald-500/15'
+                                  : log.responseStatus === 'pending'
+                                    ? 'text-warning border-warning/30 bg-yellow-500/15'
+                                    : 'text-danger border-danger/30 bg-red-500/15'
+                              )}
+                              style={{ width: '52px' }}
+                            >
+                              {log.responseStatus === 'success' ? (
+                                <span style={{ fontWeight: 600 }}>✓</span>
+                              ) : log.responseStatus === 'pending' ? (
+                                <Plane size={12} className="animate-pulse" />
+                              ) : (
+                                <span style={{ fontWeight: 600 }}>✗</span>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
+                        <button
+                          onClick={() => handleDelete(log.requestId)}
+                          className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger group-hover:opacity-100 opacity-0"
+                          title="Delete log"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
           </div>
-        </div>
-      </Card>
+
+          <div className="flex items-center justify-between gap-3 border-t border-border px-3 py-3 sm:justify-end">
+            <span className="text-xs text-text-secondary font-mono">
+              Page {currentPage} of {Math.max(1, totalPages)}
+            </span>
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - limit))}
+              >
+                <ChevronLeft size={16} />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled={offset + limit >= total}
+                onClick={() => setOffset(offset + limit)}
+              >
+                <ChevronRight size={16} />
+              </Button>
+            </div>
+          </div>
+        </Card>
       </PageContainer>
 
       <Modal

--- a/packages/frontend/src/pages/Mcp.tsx
+++ b/packages/frontend/src/pages/Mcp.tsx
@@ -292,21 +292,20 @@ export const McpPage: React.FC = () => {
   }
 
   return (
-    <PageContainer>
+    <div className="flex flex-col min-h-full">
       <PageHeader
-        title="MCP Servers"
-        subtitle="Configure Model Context Protocol upstream servers and review their call logs."
+        title="MCP servers"
+        subtitle="Model Context Protocol connections — exposes tools and resources to clients"
+        actions={
+          <Button leftIcon={<Plus size={14} />} onClick={handleAddNew} size="sm">
+            Add server
+          </Button>
+        }
       />
-      <div className="flex flex-col gap-6">
-        {/* ── Servers Config Card ── */}
-        <Card
-          title="MCP Servers"
-          extra={
-            <Button leftIcon={<Plus size={16} />} onClick={handleAddNew}>
-              Add MCP Server
-            </Button>
-          }
-        >
+      <PageContainer>
+      <div className="flex flex-col gap-5">
+        {/* Servers Config Card */}
+        <Card title="MCP Servers">
           {serverNames.length === 0 ? (
             <div className="p-4 text-text-secondary text-center">
               No MCP servers configured. Click "Add MCP Server" to create one.
@@ -864,7 +863,8 @@ export const McpPage: React.FC = () => {
           <p>Are you sure you want to delete this MCP log entry?</p>
         </Modal>
       </div>
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 };
 

--- a/packages/frontend/src/pages/Mcp.tsx
+++ b/packages/frontend/src/pages/Mcp.tsx
@@ -303,566 +303,720 @@ export const McpPage: React.FC = () => {
         }
       />
       <PageContainer>
-      <div className="flex flex-col gap-5">
-        {/* Servers Config Card */}
-        <Card title="MCP Servers">
-          {serverNames.length === 0 ? (
-            <div className="p-4 text-text-secondary text-center">
-              No MCP servers configured. Click "Add MCP Server" to create one.
-            </div>
-          ) : (
-            <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
-              <table className="w-full border-collapse font-body text-[13px]">
-                <thead>
-                  <tr>
-                    <th
-                      className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                      style={{ paddingLeft: '24px' }}
-                    >
-                      Name
-                    </th>
-                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                      Upstream URL
-                    </th>
-                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                      Status
-                    </th>
-                    <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                      Headers
-                    </th>
-                    <th
-                      className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                      style={{ paddingRight: '24px', textAlign: 'right' }}
-                    >
-                      Actions
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
+        <div className="flex flex-col gap-5">
+          {/* Servers Config Card */}
+          <Card title="MCP Servers">
+            {serverNames.length === 0 ? (
+              <div className="p-4 text-text-secondary text-center">
+                No MCP servers configured. Click "Add MCP Server" to create one.
+              </div>
+            ) : (
+              <>
+                <div className="space-y-3 md:hidden">
                   {serverNames.map((name) => {
                     const server = servers[name];
                     const headerCount = server.headers ? Object.keys(server.headers).length : 0;
+
                     return (
-                      <tr
+                      <article
                         key={name}
-                        onClick={() => handleEdit(name)}
-                        style={{ cursor: 'pointer' }}
-                        className="hover:bg-bg-hover"
+                        className="rounded-md border border-border-glass bg-bg-subtle p-3"
                       >
-                        <td
-                          className="px-4 py-3 text-left border-b border-border-glass text-text"
-                          style={{ paddingLeft: '24px' }}
-                        >
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <Edit2 size={12} style={{ opacity: 0.5 }} />
-                            <div style={{ fontWeight: 600 }}>{name}</div>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                          <div
-                            style={{
-                              maxWidth: '400px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap',
-                            }}
+                        <div className="flex items-start justify-between gap-3">
+                          <button
+                            type="button"
+                            onClick={() => handleEdit(name)}
+                            className="min-w-0 flex-1 text-left"
                           >
-                            {server.upstream_url}
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                          <div onClick={(e) => e.stopPropagation()}>
+                            <div className="flex min-w-0 items-center gap-2">
+                              <Edit2 size={12} className="shrink-0 opacity-60" />
+                              <span className="truncate font-heading text-sm font-semibold text-text">
+                                {name}
+                              </span>
+                            </div>
+                            <div className="mt-1 break-all text-xs text-text-muted">
+                              {server.upstream_url}
+                            </div>
+                          </button>
+                          <div className="flex shrink-0 items-center gap-2">
                             <Switch
                               checked={server.enabled !== false}
                               onChange={(val) => handleToggleEnabled(name, val)}
                               size="sm"
                             />
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                          {headerCount > 0 ? `${headerCount} header(s)` : '-'}
-                        </td>
-                        <td
-                          className="px-4 py-3 text-left border-b border-border-glass text-text"
-                          style={{ paddingRight: '24px', textAlign: 'right' }}
-                        >
-                          <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
                             <Button
-                              size="sm"
+                              size="icon"
                               variant="ghost"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleDelete(name);
-                              }}
-                              style={{ color: 'var(--color-danger)' }}
+                              onClick={() => handleDelete(name)}
+                              className="text-danger"
+                              aria-label={`Delete ${name}`}
                             >
                               <Trash2 size={14} />
                             </Button>
                           </div>
-                        </td>
-                      </tr>
+                        </div>
+                        <div className="mt-3 rounded border border-border-glass bg-bg-glass px-2 py-1.5 text-xs">
+                          <span className="text-text-muted">Headers: </span>
+                          <span className="font-medium text-text-secondary">
+                            {headerCount > 0 ? `${headerCount} configured` : '-'}
+                          </span>
+                        </div>
+                      </article>
                     );
                   })}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </Card>
+                </div>
 
-        {/* ── Usage Logs Card ── */}
-        <Card className="glass-bg rounded-lg p-3 max-w-full shadow-xl overflow-hidden flex flex-col gap-2">
-          <div className="mb-2">
-            <h2 className="font-heading text-lg font-semibold text-text m-0 mb-3">
-              MCP Usage Logs
-            </h2>
-            <form onSubmit={handleLogSearch} className="flex gap-2 justify-between">
-              <div className="flex gap-2">
-                <div className="relative w-50">
-                  <Search
-                    size={16}
-                    style={{
-                      position: 'absolute',
-                      left: '10px',
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                      color: 'var(--color-text-secondary)',
-                    }}
-                  />
-                  <Input
-                    placeholder="Filter by Server..."
-                    value={logsFilters.serverName}
-                    onChange={(e) => setLogsFilters({ ...logsFilters, serverName: e.target.value })}
-                    style={{ paddingLeft: '32px' }}
-                  />
+                <div className="hidden overflow-x-auto md:block">
+                  <table className="w-full border-collapse font-body text-[13px]">
+                    <thead>
+                      <tr>
+                        <th
+                          className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                          style={{ paddingLeft: '24px' }}
+                        >
+                          Name
+                        </th>
+                        <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                          Upstream URL
+                        </th>
+                        <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                          Status
+                        </th>
+                        <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                          Headers
+                        </th>
+                        <th
+                          className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                          style={{ paddingRight: '24px', textAlign: 'right' }}
+                        >
+                          Actions
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {serverNames.map((name) => {
+                        const server = servers[name];
+                        const headerCount = server.headers ? Object.keys(server.headers).length : 0;
+                        return (
+                          <tr
+                            key={name}
+                            onClick={() => handleEdit(name)}
+                            style={{ cursor: 'pointer' }}
+                            className="hover:bg-bg-hover"
+                          >
+                            <td
+                              className="px-4 py-3 text-left border-b border-border-glass text-text"
+                              style={{ paddingLeft: '24px' }}
+                            >
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                                <Edit2 size={12} style={{ opacity: 0.5 }} />
+                                <div style={{ fontWeight: 600 }}>{name}</div>
+                              </div>
+                            </td>
+                            <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                              <div
+                                style={{
+                                  maxWidth: '400px',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {server.upstream_url}
+                              </div>
+                            </td>
+                            <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                              <div onClick={(e) => e.stopPropagation()}>
+                                <Switch
+                                  checked={server.enabled !== false}
+                                  onChange={(val) => handleToggleEnabled(name, val)}
+                                  size="sm"
+                                />
+                              </div>
+                            </td>
+                            <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                              {headerCount > 0 ? `${headerCount} header(s)` : '-'}
+                            </td>
+                            <td
+                              className="px-4 py-3 text-left border-b border-border-glass text-text"
+                              style={{ paddingRight: '24px', textAlign: 'right' }}
+                            >
+                              <div
+                                style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}
+                              >
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleDelete(name);
+                                  }}
+                                  style={{ color: 'var(--color-danger)' }}
+                                >
+                                  <Trash2 size={14} />
+                                </Button>
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
                 </div>
-                <div className="relative w-44">
-                  <Filter
-                    size={16}
-                    style={{
-                      position: 'absolute',
-                      left: '10px',
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                      color: 'var(--color-text-secondary)',
-                    }}
-                  />
-                  <Input
-                    placeholder="Filter by Key..."
-                    value={logsFilters.apiKey}
-                    onChange={(e) => setLogsFilters({ ...logsFilters, apiKey: e.target.value })}
-                    style={{ paddingLeft: '32px' }}
-                  />
-                </div>
-                <Button type="submit" variant="primary">
-                  Search
-                </Button>
-              </div>
-              <Button
-                onClick={handleDeleteAllLogs}
-                variant="danger"
-                className="flex items-center gap-2"
-                disabled={logs.length === 0}
-                type="button"
+              </>
+            )}
+          </Card>
+
+          {/* ── Usage Logs Card ── */}
+          <Card className="glass-bg rounded-lg p-3 max-w-full shadow-xl overflow-hidden flex flex-col gap-2">
+            <div className="mb-2">
+              <h2 className="font-heading text-lg font-semibold text-text m-0 mb-3">
+                MCP Usage Logs
+              </h2>
+              <form
+                onSubmit={handleLogSearch}
+                className="flex flex-col gap-2 lg:flex-row lg:justify-between"
               >
-                <Trash2 size={16} />
-                Delete All
-              </Button>
-            </form>
-          </div>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <div className="relative w-full sm:w-50">
+                    <Search
+                      size={16}
+                      style={{
+                        position: 'absolute',
+                        left: '10px',
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        color: 'var(--color-text-secondary)',
+                      }}
+                    />
+                    <Input
+                      placeholder="Filter by Server..."
+                      value={logsFilters.serverName}
+                      onChange={(e) =>
+                        setLogsFilters({ ...logsFilters, serverName: e.target.value })
+                      }
+                      style={{ paddingLeft: '32px' }}
+                    />
+                  </div>
+                  <div className="relative w-full sm:w-44">
+                    <Filter
+                      size={16}
+                      style={{
+                        position: 'absolute',
+                        left: '10px',
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        color: 'var(--color-text-secondary)',
+                      }}
+                    />
+                    <Input
+                      placeholder="Filter by Key..."
+                      value={logsFilters.apiKey}
+                      onChange={(e) => setLogsFilters({ ...logsFilters, apiKey: e.target.value })}
+                      style={{ paddingLeft: '32px' }}
+                    />
+                  </div>
+                  <Button type="submit" variant="primary" className="w-full sm:w-auto">
+                    Search
+                  </Button>
+                </div>
+                <Button
+                  onClick={handleDeleteAllLogs}
+                  variant="danger"
+                  className="flex w-full items-center gap-2 sm:w-auto"
+                  disabled={logs.length === 0}
+                  type="button"
+                >
+                  <Trash2 size={16} />
+                  Delete All
+                </Button>
+              </form>
+            </div>
 
-          <div className="overflow-x-auto -mx-3 px-3">
-            <table className="w-full border-collapse font-body text-[13px]">
-              <thead>
-                <tr className="text-center border-b border-border">
-                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                    Date
-                  </th>
-                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                    Key
-                  </th>
-                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                    Server
-                  </th>
-                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                    Method
-                  </th>
-                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                    RPC Method
-                  </th>
-                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                    Duration
-                  </th>
-                  <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                    Status
-                  </th>
-                  <th className="px-2 py-1.5 text-center border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                    <div className="flex justify-center">
-                      <Trash2 size={12} />
+            <div className="space-y-3 lg:hidden">
+              {logsLoading ? (
+                <div className="py-8 text-center text-sm text-text-secondary">Loading...</div>
+              ) : logs.length === 0 ? (
+                <div className="py-8 text-center text-sm text-text-secondary">
+                  No MCP logs found
+                </div>
+              ) : (
+                logs.map((log) => (
+                  <article
+                    key={log.request_id}
+                    className="rounded-md border border-border-glass bg-bg-subtle p-3"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-xs font-medium text-text">
+                          {new Date(log.created_at).toLocaleString()}
+                        </div>
+                        <div className="mt-1 truncate text-xs text-text-muted">
+                          {log.api_key || '-'} {log.attribution ? `(${log.attribution})` : ''}
+                        </div>
+                      </div>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => handleDeleteLog(log.request_id)}
+                        className="text-danger"
+                        aria-label="Delete MCP log"
+                      >
+                        <Trash2 size={14} />
+                      </Button>
                     </div>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {logsLoading ? (
-                  <tr>
-                    <td colSpan={8} className="p-5 text-center">
-                      Loading...
-                    </td>
-                  </tr>
-                ) : logs.length === 0 ? (
-                  <tr>
-                    <td colSpan={8} className="p-5 text-center text-text-secondary">
-                      No MCP logs found
-                    </td>
-                  </tr>
-                ) : (
-                  logs.map((log) => (
-                    <tr
-                      key={log.request_id}
-                      className="group border-b border-border-glass hover:bg-bg-hover"
-                    >
-                      {/* Date */}
-                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                        <div className="flex flex-col">
-                          <span className="font-medium">
-                            {new Date(log.created_at).toLocaleTimeString()}
-                          </span>
-                          <span className="text-text-secondary" style={{ fontSize: '0.85em' }}>
-                            {new Date(log.created_at).toISOString().split('T')[0]}
-                          </span>
-                        </div>
-                      </td>
 
-                      {/* Key / Attribution */}
-                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
-                        <div className="flex flex-col">
-                          <span className="font-medium">{log.api_key || '-'}</span>
-                          {log.attribution && (
-                            <span className="text-text-secondary" style={{ fontSize: '0.85em' }}>
-                              {log.attribution}
+                    <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                      <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                          Server
+                        </div>
+                        <div className="truncate font-medium text-text-secondary">
+                          {log.server_name}
+                        </div>
+                      </div>
+                      <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                          Method
+                        </div>
+                        <div className="truncate font-medium text-text-secondary">
+                          {log.method} {log.is_streamed ? 'streamed' : 'buffered'}
+                        </div>
+                      </div>
+                      <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                          RPC
+                        </div>
+                        <div className="truncate font-mono text-text">
+                          {log.jsonrpc_method || '-'}
+                        </div>
+                      </div>
+                      <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                          Duration
+                        </div>
+                        <div className="truncate font-medium text-text">
+                          {log.duration_ms != null ? formatMs(log.duration_ms) : '-'}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex items-center justify-between gap-3 rounded border border-border-glass bg-bg-glass px-2 py-2 text-xs">
+                      <span className={clsx('font-semibold', statusColor(log.response_status))}>
+                        Status {log.response_status ?? '?'}
+                      </span>
+                      {log.error_message && (
+                        <span className="min-w-0 truncate text-danger" title={log.error_message}>
+                          {log.error_message}
+                        </span>
+                      )}
+                    </div>
+                  </article>
+                ))
+              )}
+            </div>
+
+            <div className="hidden overflow-x-auto lg:block">
+              <table className="w-full border-collapse font-body text-[13px]">
+                <thead>
+                  <tr className="text-center border-b border-border">
+                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                      Date
+                    </th>
+                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                      Key
+                    </th>
+                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                      Server
+                    </th>
+                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                      Method
+                    </th>
+                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                      RPC Method
+                    </th>
+                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                      Duration
+                    </th>
+                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                      Status
+                    </th>
+                    <th className="px-2 py-1.5 text-center border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                      <div className="flex justify-center">
+                        <Trash2 size={12} />
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {logsLoading ? (
+                    <tr>
+                      <td colSpan={8} className="p-5 text-center">
+                        Loading...
+                      </td>
+                    </tr>
+                  ) : logs.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="p-5 text-center text-text-secondary">
+                        No MCP logs found
+                      </td>
+                    </tr>
+                  ) : (
+                    logs.map((log) => (
+                      <tr
+                        key={log.request_id}
+                        className="group border-b border-border-glass hover:bg-bg-hover"
+                      >
+                        {/* Date */}
+                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                          <div className="flex flex-col">
+                            <span className="font-medium">
+                              {new Date(log.created_at).toLocaleTimeString()}
                             </span>
-                          )}
-                        </div>
-                      </td>
-
-                      {/* Server */}
-                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                        <div className="flex flex-col">
-                          <span className="font-medium">{log.server_name}</span>
-                          <span
-                            className="text-text-secondary"
-                            style={{
-                              fontSize: '0.85em',
-                              maxWidth: '200px',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {log.upstream_url}
-                          </span>
-                        </div>
-                      </td>
-
-                      {/* HTTP Method */}
-                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                        <div className="flex flex-col gap-1">
-                          <span
-                            className={clsx(
-                              'text-xs font-semibold',
-                              log.method === 'GET'
-                                ? 'text-blue-400'
-                                : log.method === 'POST'
-                                  ? 'text-green-400'
-                                  : 'text-red-400'
-                            )}
-                          >
-                            {log.method}
-                          </span>
-                          <div className="flex items-center gap-1">
-                            {log.is_streamed ? (
-                              <Zap size={11} className="text-blue-400" />
-                            ) : (
-                              <ZapOff size={11} className="text-gray-400" />
-                            )}
-                            <span className="text-text-secondary" style={{ fontSize: '0.8em' }}>
-                              {log.is_streamed ? 'streamed' : 'buffered'}
+                            <span className="text-text-secondary" style={{ fontSize: '0.85em' }}>
+                              {new Date(log.created_at).toISOString().split('T')[0]}
                             </span>
                           </div>
-                        </div>
-                      </td>
+                        </td>
 
-                      {/* JSON-RPC Method + Tool Name */}
-                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                        <div className="flex flex-col gap-0.5">
-                          <span className="font-mono text-xs">
-                            {log.jsonrpc_method || <span className="text-text-secondary">-</span>}
-                          </span>
-                          {log.tool_name && (
-                            <span className="font-mono text-xs text-info" title={log.tool_name}>
-                              {log.tool_name}
-                            </span>
-                          )}
-                        </div>
-                      </td>
-
-                      {/* Duration */}
-                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                        <span>{log.duration_ms != null ? formatMs(log.duration_ms) : '-'}</span>
-                      </td>
-
-                      {/* Status */}
-                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
-                        <div className="flex flex-col gap-1">
-                          {log.error_code ? (
-                            <div
-                              className={clsx(
-                                'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
-                                'text-danger border-danger/30 bg-red-500/15'
-                              )}
-                              style={{ width: '52px' }}
-                            >
-                              <AlertTriangle size={12} />
-                              <span className="font-semibold">{log.response_status ?? '?'}</span>
-                            </div>
-                          ) : (
-                            <div
-                              className={clsx(
-                                'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
-                                log.response_status != null &&
-                                  log.response_status >= 200 &&
-                                  log.response_status < 300
-                                  ? 'text-success border-success/30 bg-emerald-500/15'
-                                  : 'text-danger border-danger/30 bg-red-500/15'
-                              )}
-                              style={{ width: '52px' }}
-                            >
-                              <CheckCircle size={12} />
-                              <span
-                                className={clsx('font-semibold', statusColor(log.response_status))}
-                              >
-                                {log.response_status ?? '?'}
+                        {/* Key / Attribution */}
+                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
+                          <div className="flex flex-col">
+                            <span className="font-medium">{log.api_key || '-'}</span>
+                            {log.attribution && (
+                              <span className="text-text-secondary" style={{ fontSize: '0.85em' }}>
+                                {log.attribution}
                               </span>
-                            </div>
-                          )}
-                          {log.error_message && (
+                            )}
+                          </div>
+                        </td>
+
+                        {/* Server */}
+                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                          <div className="flex flex-col">
+                            <span className="font-medium">{log.server_name}</span>
                             <span
-                              className="text-danger"
+                              className="text-text-secondary"
                               style={{
-                                fontSize: '0.78em',
-                                maxWidth: '160px',
+                                fontSize: '0.85em',
+                                maxWidth: '200px',
                                 overflow: 'hidden',
                                 textOverflow: 'ellipsis',
                                 whiteSpace: 'nowrap',
-                                display: 'block',
                               }}
-                              title={log.error_message}
                             >
-                              {log.error_message}
+                              {log.upstream_url}
                             </span>
-                          )}
-                        </div>
-                      </td>
+                          </div>
+                        </td>
 
-                      {/* Delete */}
-                      <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
-                        <button
-                          onClick={() => handleDeleteLog(log.request_id)}
-                          className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger group-hover:opacity-100 opacity-0"
-                          title="Delete log"
-                        >
-                          <Trash2 size={14} />
-                        </button>
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
+                        {/* HTTP Method */}
+                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                          <div className="flex flex-col gap-1">
+                            <span
+                              className={clsx(
+                                'text-xs font-semibold',
+                                log.method === 'GET'
+                                  ? 'text-blue-400'
+                                  : log.method === 'POST'
+                                    ? 'text-green-400'
+                                    : 'text-red-400'
+                              )}
+                            >
+                              {log.method}
+                            </span>
+                            <div className="flex items-center gap-1">
+                              {log.is_streamed ? (
+                                <Zap size={11} className="text-blue-400" />
+                              ) : (
+                                <ZapOff size={11} className="text-gray-400" />
+                              )}
+                              <span className="text-text-secondary" style={{ fontSize: '0.8em' }}>
+                                {log.is_streamed ? 'streamed' : 'buffered'}
+                              </span>
+                            </div>
+                          </div>
+                        </td>
 
-          <div className="flex justify-end items-center mt-3 gap-3">
-            <span style={{ fontSize: '14px', color: 'var(--color-text-secondary)' }}>
-              Page {logsCurrentPage} of {Math.max(1, logsTotalPages)}
-            </span>
-            <div className="flex gap-1">
-              <Button
-                variant="secondary"
-                disabled={logsOffset === 0}
-                onClick={() => setLogsOffset(Math.max(0, logsOffset - logsLimit))}
-              >
-                <ChevronLeft size={16} />
-              </Button>
-              <Button
-                variant="secondary"
-                disabled={logsOffset + logsLimit >= logsTotal}
-                onClick={() => setLogsOffset(logsOffset + logsLimit)}
-              >
-                <ChevronRight size={16} />
-              </Button>
+                        {/* JSON-RPC Method + Tool Name */}
+                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                          <div className="flex flex-col gap-0.5">
+                            <span className="font-mono text-xs">
+                              {log.jsonrpc_method || <span className="text-text-secondary">-</span>}
+                            </span>
+                            {log.tool_name && (
+                              <span className="font-mono text-xs text-info" title={log.tool_name}>
+                                {log.tool_name}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+
+                        {/* Duration */}
+                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                          <span>{log.duration_ms != null ? formatMs(log.duration_ms) : '-'}</span>
+                        </td>
+
+                        {/* Status */}
+                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
+                          <div className="flex flex-col gap-1">
+                            {log.error_code ? (
+                              <div
+                                className={clsx(
+                                  'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
+                                  'text-danger border-danger/30 bg-red-500/15'
+                                )}
+                                style={{ width: '52px' }}
+                              >
+                                <AlertTriangle size={12} />
+                                <span className="font-semibold">{log.response_status ?? '?'}</span>
+                              </div>
+                            ) : (
+                              <div
+                                className={clsx(
+                                  'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
+                                  log.response_status != null &&
+                                    log.response_status >= 200 &&
+                                    log.response_status < 300
+                                    ? 'text-success border-success/30 bg-emerald-500/15'
+                                    : 'text-danger border-danger/30 bg-red-500/15'
+                                )}
+                                style={{ width: '52px' }}
+                              >
+                                <CheckCircle size={12} />
+                                <span
+                                  className={clsx(
+                                    'font-semibold',
+                                    statusColor(log.response_status)
+                                  )}
+                                >
+                                  {log.response_status ?? '?'}
+                                </span>
+                              </div>
+                            )}
+                            {log.error_message && (
+                              <span
+                                className="text-danger"
+                                style={{
+                                  fontSize: '0.78em',
+                                  maxWidth: '160px',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                  display: 'block',
+                                }}
+                                title={log.error_message}
+                              >
+                                {log.error_message}
+                              </span>
+                            )}
+                          </div>
+                        </td>
+
+                        {/* Delete */}
+                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
+                          <button
+                            onClick={() => handleDeleteLog(log.request_id)}
+                            className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger opacity-100 lg:opacity-0 lg:group-hover:opacity-100"
+                            title="Delete log"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
             </div>
-          </div>
-        </Card>
 
-        {/* ── Server Edit/Add Modal ── */}
-        <Modal
-          isOpen={isModalOpen}
-          onClose={() => setIsModalOpen(false)}
-          title={editingServerName ? `Edit ${editingServerName}` : 'Add MCP Server'}
-          footer={
-            <>
-              <Button variant="secondary" onClick={() => setIsModalOpen(false)}>
-                Cancel
-              </Button>
-              <Button variant="primary" onClick={handleSave} disabled={isSaving}>
-                {isSaving ? 'Saving...' : 'Save'}
-              </Button>
-            </>
-          }
-        >
-          <div className="space-y-4">
-            {!editingServerName && (
+            <div className="flex flex-col items-stretch gap-3 mt-3 sm:flex-row sm:items-center sm:justify-end">
+              <span style={{ fontSize: '14px', color: 'var(--color-text-secondary)' }}>
+                Page {logsCurrentPage} of {Math.max(1, logsTotalPages)}
+              </span>
+              <div className="flex gap-1">
+                <Button
+                  variant="secondary"
+                  disabled={logsOffset === 0}
+                  onClick={() => setLogsOffset(Math.max(0, logsOffset - logsLimit))}
+                >
+                  <ChevronLeft size={16} />
+                </Button>
+                <Button
+                  variant="secondary"
+                  disabled={logsOffset + logsLimit >= logsTotal}
+                  onClick={() => setLogsOffset(logsOffset + logsLimit)}
+                >
+                  <ChevronRight size={16} />
+                </Button>
+              </div>
+            </div>
+          </Card>
+
+          {/* ── Server Edit/Add Modal ── */}
+          <Modal
+            isOpen={isModalOpen}
+            onClose={() => setIsModalOpen(false)}
+            title={editingServerName ? `Edit ${editingServerName}` : 'Add MCP Server'}
+            footer={
+              <>
+                <Button variant="secondary" onClick={() => setIsModalOpen(false)}>
+                  Cancel
+                </Button>
+                <Button variant="primary" onClick={handleSave} disabled={isSaving}>
+                  {isSaving ? 'Saving...' : 'Save'}
+                </Button>
+              </>
+            }
+          >
+            <div className="space-y-4">
+              {!editingServerName && (
+                <Input
+                  label="Server Name"
+                  value={serverNameInput}
+                  onChange={(e) =>
+                    setServerNameInput(e.target.value.toLowerCase().replace(/[^a-z0-9-_]/g, ''))
+                  }
+                  placeholder="my-mcp-server"
+                />
+              )}
+
               <Input
-                label="Server Name"
-                value={serverNameInput}
+                label="Upstream URL"
+                value={editingServer.upstream_url}
                 onChange={(e) =>
-                  setServerNameInput(e.target.value.toLowerCase().replace(/[^a-z0-9-_]/g, ''))
+                  setEditingServer({ ...editingServer, upstream_url: e.target.value })
                 }
-                placeholder="my-mcp-server"
+                placeholder="https://mcp.example.com/mcp"
               />
-            )}
 
-            <Input
-              label="Upstream URL"
-              value={editingServer.upstream_url}
-              onChange={(e) => setEditingServer({ ...editingServer, upstream_url: e.target.value })}
-              placeholder="https://mcp.example.com/mcp"
-            />
-
-            <div className="flex items-center gap-2">
-              <div className="flex-1">
-                <Input
-                  label="Header Key"
-                  value={headerKey}
-                  onChange={(e) => setHeaderKey(e.target.value)}
-                  placeholder="Authorization"
-                />
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+                <div className="min-w-0 flex-1">
+                  <Input
+                    label="Header Key"
+                    value={headerKey}
+                    onChange={(e) => setHeaderKey(e.target.value)}
+                    placeholder="Authorization"
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <Input
+                    label="Header Value"
+                    value={headerValue}
+                    onChange={(e) => setHeaderValue(e.target.value)}
+                    placeholder="Bearer token..."
+                  />
+                </div>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={addHeader}
+                  className="w-full sm:w-auto"
+                >
+                  <PlusCircle size={16} />
+                </Button>
               </div>
-              <div className="flex-1">
-                <Input
-                  label="Header Value"
-                  value={headerValue}
-                  onChange={(e) => setHeaderValue(e.target.value)}
-                  placeholder="Bearer token..."
-                />
-              </div>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={addHeader}
-                style={{ marginTop: '20px' }}
-              >
-                <PlusCircle size={16} />
-              </Button>
-            </div>
 
-            {editingServer.headers && Object.keys(editingServer.headers).length > 0 && (
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-text-secondary">
-                  Configured Headers
-                </label>
-                {Object.entries(editingServer.headers).map(([key, value]) => (
-                  <div key={key} className="flex items-center gap-2 p-2 bg-bg-hover rounded-md">
-                    <span className="flex-1 font-mono text-xs">{key}</span>
-                    <span className="flex-1 font-mono text-xs text-text-secondary truncate">
-                      {value}
-                    </span>
-                    <button
-                      onClick={() => removeHeader(key)}
-                      className="p-1 hover:bg-bg-surface rounded"
+              {editingServer.headers && Object.keys(editingServer.headers).length > 0 && (
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-text-secondary">
+                    Configured Headers
+                  </label>
+                  {Object.entries(editingServer.headers).map(([key, value]) => (
+                    <div
+                      key={key}
+                      className="flex flex-col gap-2 p-2 bg-bg-hover rounded-md sm:flex-row sm:items-center"
                     >
-                      <MinusCircle size={14} className="text-danger" />
-                    </button>
-                  </div>
-                ))}
+                      <span className="min-w-0 flex-1 break-all font-mono text-xs">{key}</span>
+                      <span className="flex-1 font-mono text-xs text-text-secondary truncate">
+                        {value}
+                      </span>
+                      <button
+                        onClick={() => removeHeader(key)}
+                        className="p-1 hover:bg-bg-surface rounded"
+                      >
+                        <MinusCircle size={14} className="text-danger" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </Modal>
+
+          {/* ── Delete All Logs Modal ── */}
+          <Modal
+            isOpen={isDeleteLogsModalOpen}
+            onClose={() => setIsDeleteLogsModalOpen(false)}
+            title="Confirm Deletion"
+            footer={
+              <>
+                <Button variant="secondary" onClick={() => setIsDeleteLogsModalOpen(false)}>
+                  Cancel
+                </Button>
+                <Button variant="danger" onClick={confirmDeleteAllLogs} disabled={isDeletingLogs}>
+                  {isDeletingLogs ? 'Deleting...' : 'Delete Logs'}
+                </Button>
+              </>
+            }
+          >
+            <div className="flex flex-col gap-4">
+              <p>Select which MCP logs you would like to delete:</p>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <input
+                  type="radio"
+                  id="mcp-delete-older"
+                  name="deleteLogsMode"
+                  checked={deleteLogsMode === 'older'}
+                  onChange={() => setDeleteLogsMode('older')}
+                />
+                <label htmlFor="mcp-delete-older">Delete logs older than</label>
+                <Input
+                  type="number"
+                  min="1"
+                  value={olderThanDays}
+                  onChange={(e) => setOlderThanDays(parseInt(e.target.value) || 1)}
+                  style={{ width: '60px', padding: '4px 8px' }}
+                  disabled={deleteLogsMode !== 'older'}
+                />
+                <span>days</span>
               </div>
-            )}
-          </div>
-        </Modal>
 
-        {/* ── Delete All Logs Modal ── */}
-        <Modal
-          isOpen={isDeleteLogsModalOpen}
-          onClose={() => setIsDeleteLogsModalOpen(false)}
-          title="Confirm Deletion"
-          footer={
-            <>
-              <Button variant="secondary" onClick={() => setIsDeleteLogsModalOpen(false)}>
-                Cancel
-              </Button>
-              <Button variant="danger" onClick={confirmDeleteAllLogs} disabled={isDeletingLogs}>
-                {isDeletingLogs ? 'Deleting...' : 'Delete Logs'}
-              </Button>
-            </>
-          }
-        >
-          <div className="flex flex-col gap-4">
-            <p>Select which MCP logs you would like to delete:</p>
-
-            <div className="flex items-center gap-2">
-              <input
-                type="radio"
-                id="mcp-delete-older"
-                name="deleteLogsMode"
-                checked={deleteLogsMode === 'older'}
-                onChange={() => setDeleteLogsMode('older')}
-              />
-              <label htmlFor="mcp-delete-older">Delete logs older than</label>
-              <Input
-                type="number"
-                min="1"
-                value={olderThanDays}
-                onChange={(e) => setOlderThanDays(parseInt(e.target.value) || 1)}
-                style={{ width: '60px', padding: '4px 8px' }}
-                disabled={deleteLogsMode !== 'older'}
-              />
-              <span>days</span>
+              <div className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  id="mcp-delete-all"
+                  name="deleteLogsMode"
+                  checked={deleteLogsMode === 'all'}
+                  onChange={() => setDeleteLogsMode('all')}
+                />
+                <label htmlFor="mcp-delete-all" style={{ color: 'var(--color-danger)' }}>
+                  Delete ALL logs (Cannot be undone)
+                </label>
+              </div>
             </div>
+          </Modal>
 
-            <div className="flex items-center gap-2">
-              <input
-                type="radio"
-                id="mcp-delete-all"
-                name="deleteLogsMode"
-                checked={deleteLogsMode === 'all'}
-                onChange={() => setDeleteLogsMode('all')}
-              />
-              <label htmlFor="mcp-delete-all" style={{ color: 'var(--color-danger)' }}>
-                Delete ALL logs (Cannot be undone)
-              </label>
-            </div>
-          </div>
-        </Modal>
-
-        {/* ── Single Log Delete Modal ── */}
-        <Modal
-          isOpen={isSingleDeleteModalOpen}
-          onClose={() => setIsSingleDeleteModalOpen(false)}
-          title="Confirm Deletion"
-          footer={
-            <>
-              <Button variant="secondary" onClick={() => setIsSingleDeleteModalOpen(false)}>
-                Cancel
-              </Button>
-              <Button variant="danger" onClick={confirmDeleteSingleLog} disabled={isDeletingLogs}>
-                {isDeletingLogs ? 'Deleting...' : 'Delete Log'}
-              </Button>
-            </>
-          }
-        >
-          <p>Are you sure you want to delete this MCP log entry?</p>
-        </Modal>
-      </div>
+          {/* ── Single Log Delete Modal ── */}
+          <Modal
+            isOpen={isSingleDeleteModalOpen}
+            onClose={() => setIsSingleDeleteModalOpen(false)}
+            title="Confirm Deletion"
+            footer={
+              <>
+                <Button variant="secondary" onClick={() => setIsSingleDeleteModalOpen(false)}>
+                  Cancel
+                </Button>
+                <Button variant="danger" onClick={confirmDeleteSingleLog} disabled={isDeletingLogs}>
+                  {isDeletingLogs ? 'Deleting...' : 'Delete Log'}
+                </Button>
+              </>
+            }
+          >
+            <p>Are you sure you want to delete this MCP log entry?</p>
+          </Modal>
+        </div>
       </PageContainer>
     </div>
   );

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -899,62 +899,64 @@ export const Models = () => {
   );
 
   return (
-    <PageContainer>
+    <div className="flex flex-col min-h-full">
       <PageHeader
         title="Models"
-        subtitle={
-          <span className="inline-flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center gap-2 px-3 py-1 rounded-md bg-bg-glass border border-border-glass">
-              <Eye size={14} className="text-text-secondary" />
-              <span className="text-xs font-medium text-text-secondary">Vision Fall Through:</span>
-              <select
-                className="bg-transparent border-none text-xs text-text outline-none focus:ring-0 cursor-pointer max-w-[140px]"
-                value={globalDescriptorModel}
-                onChange={(e) => setGlobalDescriptorModel(e.target.value)}
-              >
-                <option value="">(None)</option>
-                {sortedAliases.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.id}
-                  </option>
-                ))}
-              </select>
-              <button
-                onClick={handleSaveDescriptor}
-                disabled={isSavingDescriptor}
-                className="ml-1 text-text-secondary hover:text-primary transition-colors disabled:opacity-50"
-                title="Save descriptor model"
-                type="button"
-              >
-                {isSavingDescriptor ? (
-                  <Loader2 size={14} className="animate-spin" />
-                ) : (
-                  <Save size={14} />
-                )}
-              </button>
-            </span>
-          </span>
-        }
+        subtitle="Aliases that map gateway models to upstream provider models"
         actions={
           <>
-            <div className="w-full sm:w-64">
-              <SearchInput placeholder="Search models..." value={search} onChange={setSearch} />
-            </div>
             <Button
               variant="danger"
-              leftIcon={<Trash2 size={16} />}
+              size="sm"
+              leftIcon={<Trash2 size={14} />}
               onClick={() => setIsDeleteAllModalOpen(true)}
               disabled={aliases.length === 0}
             >
               Delete All
             </Button>
-            <Button leftIcon={<Plus size={16} />} onClick={handleAddNew}>
-              Add Model
+            <Button leftIcon={<Plus size={14} />} onClick={handleAddNew} size="sm">
+              Add model
             </Button>
           </>
         }
-      />
+      >
+        <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 items-stretch sm:items-center">
+          <div className="w-full sm:w-72">
+            <SearchInput placeholder="Search by alias, upstream id, tag…" value={search} onChange={setSearch} />
+          </div>
+          <span className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-slate-900/60 border border-border">
+            <Eye size={14} className="text-text-secondary" />
+            <span className="text-xs font-medium text-text-secondary">Vision Fall Through:</span>
+            <select
+              className="bg-transparent border-none text-xs text-text outline-none focus:ring-0 cursor-pointer max-w-[140px]"
+              value={globalDescriptorModel}
+              onChange={(e) => setGlobalDescriptorModel(e.target.value)}
+            >
+              <option value="">(None)</option>
+              {sortedAliases.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.id}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={handleSaveDescriptor}
+              disabled={isSavingDescriptor}
+              className="ml-1 text-text-secondary hover:text-primary transition-colors disabled:opacity-50"
+              title="Save descriptor model"
+              type="button"
+            >
+              {isSavingDescriptor ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Save size={14} />
+              )}
+            </button>
+          </span>
+        </div>
+      </PageHeader>
 
+      <PageContainer>
       <Card className="mb-6">
         <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
           <table className="w-full border-collapse font-body text-[13px]">
@@ -2410,6 +2412,7 @@ export const Models = () => {
           </div>,
           document.body
         )}
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 };

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -13,6 +13,7 @@ import {
 } from '../lib/api';
 import { useModels } from '../hooks/useModels';
 import { AliasTableRow } from '../components/models/AliasTableRow';
+import { ModelTypeBadge } from '../components/models/ModelTypeBadge';
 import { MetadataOverrideForm } from '../components/models/MetadataOverrideForm';
 import { Input } from '../components/ui/Input';
 import { Card } from '../components/ui/Card';
@@ -39,6 +40,7 @@ import {
   Eye,
   AlertTriangle,
   Cpu,
+  Play,
 } from 'lucide-react';
 
 export const Models = () => {
@@ -922,13 +924,17 @@ export const Models = () => {
       >
         <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 items-stretch sm:items-center">
           <div className="w-full sm:w-72">
-            <SearchInput placeholder="Search by alias, upstream id, tag…" value={search} onChange={setSearch} />
+            <SearchInput
+              placeholder="Search by alias, upstream id, tag…"
+              value={search}
+              onChange={setSearch}
+            />
           </div>
-          <span className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-slate-900/60 border border-border">
+          <span className="inline-flex w-full flex-wrap items-center gap-2 rounded-md border border-border bg-slate-900/60 px-3 py-1.5 sm:w-auto">
             <Eye size={14} className="text-text-secondary" />
             <span className="text-xs font-medium text-text-secondary">Vision Fall Through:</span>
             <select
-              className="bg-transparent border-none text-xs text-text outline-none focus:ring-0 cursor-pointer max-w-[140px]"
+              className="min-w-0 flex-1 cursor-pointer border-none bg-transparent text-xs text-text outline-none focus:ring-0 sm:max-w-[140px]"
               value={globalDescriptorModel}
               onChange={(e) => setGlobalDescriptorModel(e.target.value)}
             >
@@ -957,771 +963,941 @@ export const Models = () => {
       </PageHeader>
 
       <PageContainer>
-      <Card className="mb-6">
-        <div className="overflow-x-auto -mx-4 sm:-mx-5 md:-mx-6">
-          <table className="w-full border-collapse font-body text-[13px]">
-            <thead>
-              <tr>
-                <th
-                  className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                  style={{ paddingLeft: '24px' }}
-                >
-                  Alias
-                </th>
-                <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                  Type
-                </th>
-                <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                  Aliases
-                </th>
-                <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                  Selector
-                </th>
-                <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                  Metadata
-                </th>
-                <th
-                  className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                  style={{ paddingRight: '24px' }}
-                >
-                  Targets
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredAliases.map((alias) => (
-                <AliasTableRow
+        <Card className="mb-6">
+          <div className="space-y-3 md:hidden">
+            {filteredAliases.length === 0 ? (
+              <div className="py-10 text-center text-sm text-text-muted">No aliases found</div>
+            ) : (
+              filteredAliases.map((alias) => (
+                <article
                   key={alias.id}
-                  alias={alias}
-                  providers={providers}
-                  cooldowns={cooldowns}
-                  testStates={testStates}
-                  onEdit={handleEdit}
-                  onDelete={handleDeleteClick}
-                  onToggleTarget={handleToggleTarget}
-                  onTestTarget={handleTestTarget}
-                />
-              ))}
-              {filteredAliases.length === 0 && (
-                <tr>
-                  <td colSpan={5} className="text-center text-text-muted p-12">
-                    No aliases found
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </Card>
-
-      <Modal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        title={originalId ? 'Edit Model' : 'Add Model'}
-        size="lg"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button variant="ghost" onClick={() => setIsModalOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleSave} isLoading={isSaving}>
-              Save Changes
-            </Button>
-          </div>
-        }
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '-8px' }}>
-          <div className="grid grid-cols-4 gap-4">
-            <div className="flex flex-col gap-1">
-              <label className="font-body text-[13px] font-medium text-text-secondary">
-                Primary Name (ID)
-              </label>
-              <input
-                className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                value={editingAlias.id}
-                onChange={(e) => setEditingAlias({ ...editingAlias, id: e.target.value })}
-                placeholder="e.g. gpt-4-turbo"
-              />
-            </div>
-
-            <div className="flex flex-col gap-1">
-              <label className="font-body text-[13px] font-medium text-text-secondary">
-                Model Type
-              </label>
-              <select
-                className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                value={editingAlias.type || 'chat'}
-                onChange={(e) =>
-                  setEditingAlias({
-                    ...editingAlias,
-                    type: e.target.value as
-                      | 'chat'
-                      | 'embeddings'
-                      | 'transcriptions'
-                      | 'speech'
-                      | 'image'
-                      | 'responses',
-                  })
-                }
-              >
-                <option value="chat">Chat</option>
-                <option value="embeddings">Embeddings</option>
-                <option value="transcriptions">Transcriptions</option>
-                <option value="speech">Speech</option>
-                <option value="image">Image</option>
-                <option value="responses">Responses</option>
-              </select>
-            </div>
-
-            <div className="flex flex-col gap-1">
-              <label className="font-body text-[13px] font-medium text-text-secondary">
-                Selector Strategy
-              </label>
-              <select
-                className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                value={editingAlias.selector || 'random'}
-                onChange={(e) => setEditingAlias({ ...editingAlias, selector: e.target.value })}
-              >
-                <option value="random">Random</option>
-                <option value="in_order">In Order</option>
-                <option value="cost">Lowest Cost</option>
-                <option value="latency">Lowest Latency</option>
-                <option value="usage">Usage Balanced</option>
-                <option value="performance">Best Performance</option>
-              </select>
-            </div>
-
-            <div className="flex flex-col gap-1">
-              <label className="font-body text-[13px] font-medium text-text-secondary">
-                Priority
-              </label>
-              <select
-                className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                value={editingAlias.priority || 'selector'}
-                onChange={(e) =>
-                  setEditingAlias({ ...editingAlias, priority: e.target.value as any })
-                }
-              >
-                <option value="selector">Selector</option>
-                <option value="api_match">API Match</option>
-              </select>
-            </div>
-          </div>
-
-          <p className="text-xs text-text-muted" style={{ marginTop: '-4px' }}>
-            Priority: "Selector" uses the strategy above. "API Match" matches provider type to
-            incoming request format.
-          </p>
-
-          <div className="h-px bg-border-glass" style={{ margin: '4px 0' }}></div>
-
-          {/* Model Architecture accordion */}
-          <div className="border border-border-glass rounded-sm overflow-hidden">
-            <button
-              type="button"
-              onClick={() => setIsArchitectureOpen((o) => !o)}
-              className="w-full flex items-center justify-between px-3 py-2 bg-bg-subtle hover:bg-bg-hover transition-colors duration-150 text-left"
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                <Cpu size={13} className="text-text-muted" />
-                <span className="font-body text-[13px] font-medium text-text-secondary">
-                  Model Architecture
-                </span>
-                {editingAlias.model_architecture?.total_params && (
-                  <span className="inline-flex items-center rounded px-2 py-0.5 text-[10px] font-medium border border-border-glass text-primary bg-bg-hover">
-                    {editingAlias.model_architecture.total_params}B params
-                  </span>
-                )}
-              </div>
-              {isArchitectureOpen ? (
-                <ChevronDown size={14} className="text-text-muted" />
-              ) : (
-                <ChevronRight size={14} className="text-text-muted" />
-              )}
-            </button>
-
-            {isArchitectureOpen && (
-              <div
-                className="px-3 py-3 border-t border-border-glass"
-                style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
-              >
-                <p className="font-body text-[11px] text-text-muted">
-                  Fetch model architecture from Hugging Face or enter manually. These values are
-                  used for energy calculation.
-                </p>
-
-                {/* Display currently saved architecture values */}
-                {editingAlias.model_architecture?.total_params && (
-                  <div className="px-3 py-2 bg-bg-subtle border border-border-glass rounded-md">
-                    <div className="font-body text-[11px] font-medium text-text-secondary mb-1">
-                      Currently Saved:
-                    </div>
-                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-text">
-                      {editingAlias.model_architecture.total_params && (
-                        <span>{editingAlias.model_architecture.total_params}B params</span>
-                      )}
-                      {editingAlias.model_architecture.active_params && (
-                        <span>({editingAlias.model_architecture.active_params}B active)</span>
-                      )}
-                      {editingAlias.model_architecture.layers && (
-                        <span>{editingAlias.model_architecture.layers} layers</span>
-                      )}
-                      {editingAlias.model_architecture.heads && (
-                        <span>{editingAlias.model_architecture.heads} heads</span>
-                      )}
-                      {editingAlias.model_architecture.dtype && (
-                        <span className="text-primary">
-                          {editingAlias.model_architecture.dtype.toUpperCase()}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {/* HuggingFace Model ID input and fetch button */}
-                <div className="flex gap-2 items-end">
-                  <div className="flex-1">
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Hugging Face Model ID
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      value={hfModelId}
-                      onChange={(e) => setHfModelId(e.target.value)}
-                      placeholder="e.g. meta-llama/Llama-3.1-70B-Instruct"
-                      onKeyDown={(e) => e.key === 'Enter' && fetchHfModelArchitecture()}
-                    />
-                  </div>
-                  <Button
-                    onClick={fetchHfModelArchitecture}
-                    isLoading={isFetchingHfModel}
-                    disabled={isFetchingHfModel}
-                    variant="secondary"
-                  >
-                    Fetch from HF
-                  </Button>
-                </div>
-
-                {hfFetchError && (
-                  <div className="text-xs text-danger bg-danger/10 border border-danger/20 rounded px-3 py-2">
-                    {hfFetchError}
-                  </div>
-                )}
-
-                <div className="grid grid-cols-2 gap-2 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Total Params (B)
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="0.1"
-                      min="0"
-                      value={editingAlias.model_architecture?.total_params || ''}
-                      onChange={(e) =>
-                        setEditingAlias({
-                          ...editingAlias,
-                          model_architecture: {
-                            ...editingAlias.model_architecture,
-                            total_params: parseFloat(e.target.value) || undefined,
-                          },
-                        })
-                      }
-                      placeholder="e.g. 1.76"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Active Params (B)
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="0.1"
-                      min="0"
-                      value={editingAlias.model_architecture?.active_params || ''}
-                      onChange={(e) =>
-                        setEditingAlias({
-                          ...editingAlias,
-                          model_architecture: {
-                            ...editingAlias.model_architecture,
-                            active_params: parseFloat(e.target.value) || undefined,
-                          },
-                        })
-                      }
-                      placeholder="e.g. 1.76"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Layers
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="1"
-                      min="1"
-                      value={editingAlias.model_architecture?.layers || ''}
-                      onChange={(e) =>
-                        setEditingAlias({
-                          ...editingAlias,
-                          model_architecture: {
-                            ...editingAlias.model_architecture,
-                            layers: parseInt(e.target.value, 10) || undefined,
-                          },
-                        })
-                      }
-                      placeholder="e.g. 120"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Heads
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="1"
-                      min="1"
-                      value={editingAlias.model_architecture?.heads || ''}
-                      onChange={(e) =>
-                        setEditingAlias({
-                          ...editingAlias,
-                          model_architecture: {
-                            ...editingAlias.model_architecture,
-                            heads: parseInt(e.target.value, 10) || undefined,
-                          },
-                        })
-                      }
-                      placeholder="e.g. 96"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      KV LoRA Rank
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="1"
-                      min="1"
-                      value={editingAlias.model_architecture?.kv_lora_rank || ''}
-                      onChange={(e) =>
-                        setEditingAlias({
-                          ...editingAlias,
-                          model_architecture: {
-                            ...editingAlias.model_architecture,
-                            kv_lora_rank: parseInt(e.target.value, 10) || undefined,
-                          },
-                        })
-                      }
-                      placeholder="e.g. 128"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      RoPE Head Dim
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="1"
-                      min="1"
-                      value={editingAlias.model_architecture?.qk_rope_head_dim || ''}
-                      onChange={(e) =>
-                        setEditingAlias({
-                          ...editingAlias,
-                          model_architecture: {
-                            ...editingAlias.model_architecture,
-                            qk_rope_head_dim: parseInt(e.target.value, 10) || undefined,
-                          },
-                        })
-                      }
-                      placeholder="e.g. 96"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Context Length
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="1"
-                      min="1"
-                      value={editingAlias.model_architecture?.context_length || ''}
-                      onChange={(e) =>
-                        setEditingAlias({
-                          ...editingAlias,
-                          model_architecture: {
-                            ...editingAlias.model_architecture,
-                            context_length: parseInt(e.target.value, 10) || undefined,
-                          },
-                        })
-                      }
-                      placeholder="e.g. 128000"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Data Type
-                    </label>
-                    <select
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      value={editingAlias.model_architecture?.dtype || ''}
-                      onChange={(e) =>
-                        setEditingAlias({
-                          ...editingAlias,
-                          model_architecture: {
-                            ...editingAlias.model_architecture,
-                            dtype: (e.target.value as any) || undefined,
-                          },
-                        })
-                      }
+                  className="rounded-md border border-border-glass bg-bg-subtle p-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <button
+                      type="button"
+                      onClick={() => handleEdit(alias)}
+                      className="min-w-0 flex-1 text-left"
                     >
-                      <option value="">Default (FP16)</option>
-                      <option value="fp16">FP16</option>
-                      <option value="bf16">BF16</option>
-                      <option value="fp8">FP8</option>
-                      <option value="fp8_e4m3">FP8 E4M3</option>
-                      <option value="fp8_e5m2">FP8 E5M2</option>
-                      <option value="nvfp4">NVFP4</option>
-                      <option value="int4">INT4</option>
-                      <option value="int8">INT8</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Advanced accordion */}
-          <div className="border border-border-glass rounded-sm overflow-hidden">
-            <button
-              type="button"
-              onClick={() => setIsAdvancedOpen((o) => !o)}
-              className="w-full flex items-center justify-between px-3 py-2 bg-bg-subtle hover:bg-bg-hover transition-colors duration-150 text-left"
-            >
-              <span className="font-body text-[13px] font-medium text-text-secondary">
-                Advanced
-              </span>
-              {isAdvancedOpen ? (
-                <ChevronDown size={14} className="text-text-muted" />
-              ) : (
-                <ChevronRight size={14} className="text-text-muted" />
-              )}
-            </button>
-
-            {isAdvancedOpen && (
-              <div
-                className="px-3 py-3 border-t border-border-glass"
-                style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}
-              >
-                {/* ── Behaviors ── */}
-                <div>
-                  <label
-                    className="font-body text-[13px] font-medium text-text-secondary"
-                    style={{ display: 'block', marginBottom: '6px' }}
-                  >
-                    Behaviors
-                  </label>
-                  <div className="flex items-center justify-between py-1">
-                    <div>
-                      <span className="font-body text-[13px] text-text">
-                        Strip Adaptive Thinking
-                      </span>
-                      <p className="font-body text-[11px] text-text-muted mt-0.5">
-                        On the <code className="text-primary">/v1/messages</code> path, remove{' '}
-                        <code className="text-primary">thinking</code> when set to{' '}
-                        <code className="text-primary">adaptive</code> so the provider uses its
-                        default behaviour.
-                      </p>
-                    </div>
-                    <Switch
-                      checked={getBehavior('strip_adaptive_thinking')}
-                      onChange={(val) => setBehavior('strip_adaptive_thinking', val)}
-                      size="sm"
-                    />
-                  </div>
-
-                  <div className="flex items-center justify-between py-1">
-                    <div>
-                      <span className="font-body text-[13px] text-text">Vision Fallthrough</span>
-                      <p className="font-body text-[11px] text-text-muted mt-0.5">
-                        If the request contains images and the target model is text-only, use the
-                        descriptor model to convert images to text.
-                      </p>
-                    </div>
-                    <Switch
-                      checked={editingAlias.use_image_fallthrough || false}
-                      onChange={(val) =>
-                        setEditingAlias({ ...editingAlias, use_image_fallthrough: val })
-                      }
-                      size="sm"
-                    />
-                  </div>
-
-                  <div className="flex items-center justify-between py-1">
-                    <div>
-                      <span className="font-body text-[13px] text-text">Enforce Limits</span>
-                      <p className="font-body text-[11px] text-text-muted mt-0.5">
-                        Reject oversized prompts locally (400 context_length_exceeded) before
-                        dispatch. Uses a fast heuristic estimator with a 10% safety margin, and
-                        reserves the smaller of max_tokens and the model's max completion for the
-                        response. Requires a known context_length in metadata (override or catalog).
-                      </p>
-                      {editingAlias.enforce_limits &&
-                        !editingAlias.metadata?.overrides?.context_length &&
-                        !editingAlias.metadata?.overrides?.top_provider?.context_length && (
-                          <p
-                            className="font-body text-[11px] mt-1 flex items-center gap-1"
-                            style={{ color: 'var(--color-warning)' }}
-                          >
-                            <AlertTriangle size={12} />
-                            No context_length found in metadata — this toggle will have no effect
-                            until a metadata source with a known context_length is configured.
-                          </p>
+                      <div className="truncate font-heading text-sm font-semibold text-text">
+                        {alias.id}
+                      </div>
+                      <div className="mt-1 flex flex-wrap items-center gap-2">
+                        <ModelTypeBadge type={alias.type} />
+                        {alias.metadata && (
+                          <span className="inline-flex rounded border border-border-glass px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary">
+                            {alias.metadata.source}
+                          </span>
                         )}
-                    </div>
-                    <Switch
-                      checked={editingAlias.enforce_limits || false}
-                      onChange={(val) => setEditingAlias({ ...editingAlias, enforce_limits: val })}
-                      size="sm"
-                    />
-                  </div>
-                </div>
-
-                <div className="h-px bg-border-glass"></div>
-
-                {/* ── Additional Aliases ── */}
-                <div>
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      marginBottom: '4px',
-                    }}
-                  >
-                    <label
-                      className="font-body text-[13px] font-medium text-text-secondary"
-                      style={{ marginBottom: 0 }}
-                    >
-                      Additional Aliases
-                    </label>
+                      </div>
+                    </button>
                     <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={addAlias}
-                      leftIcon={<Plus size={14} />}
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleDeleteClick(alias)}
+                      className="text-danger"
+                      aria-label={`Delete ${alias.id}`}
                     >
-                      Add Alias
+                      <Trash2 size={14} />
                     </Button>
                   </div>
 
-                  {(!editingAlias.aliases || editingAlias.aliases.length === 0) && (
-                    <div className="text-text-muted italic text-center text-sm py-2">
-                      No additional aliases
-                    </div>
-                  )}
-
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                    {editingAlias.aliases?.map((alias, idx) => (
-                      <div key={idx} style={{ display: 'flex', gap: '8px' }}>
-                        <Input
-                          value={alias}
-                          onChange={(e) => updateAlias(idx, e.target.value)}
-                          placeholder="e.g. gpt4"
-                          style={{ flex: 1 }}
-                        />
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => removeAlias(idx)}
-                          style={{ color: 'var(--color-danger)' }}
-                        >
-                          <Trash2 size={16} />
-                        </Button>
+                  <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                    <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                      <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                        Selector
                       </div>
-                    ))}
+                      <div className="truncate font-medium capitalize text-text-secondary">
+                        {alias.selector || 'random'} / {alias.priority || 'selector'}
+                      </div>
+                    </div>
+                    <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                      <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                        Aliases
+                      </div>
+                      <div className="truncate font-medium text-text-secondary">
+                        {alias.aliases?.length ? alias.aliases.join(', ') : '-'}
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
+
+                  <div className="mt-3">
+                    <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+                      Targets
+                    </div>
+                    {alias.targets.length === 0 ? (
+                      <div className="rounded border border-border-glass bg-bg-glass px-2 py-2 text-xs italic text-text-muted">
+                        No targets configured
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        {alias.targets.map((t, i) => {
+                          const provider = providers.find((p) => p.id === t.provider);
+                          const isProviderDisabled = provider?.enabled === false;
+                          const isTargetDisabled = t.enabled === false;
+                          const isDisabled = isProviderDisabled || isTargetDisabled;
+                          const testKey = `${alias.id}-${i}`;
+                          const testState = testStates[testKey];
+                          const cooldown = cooldowns.find(
+                            (c) => c.provider === t.provider && c.model === t.model && !c.accountId
+                          );
+                          const cooldownMinutes = cooldown
+                            ? Math.ceil(cooldown.timeRemainingMs / 60000)
+                            : 0;
+
+                          return (
+                            <div
+                              key={`${t.provider}-${t.model}-${i}`}
+                              className={`rounded border border-border-glass bg-bg-glass px-2 py-2 ${
+                                isDisabled ? 'opacity-70' : ''
+                              }`}
+                            >
+                              <div className="flex items-start justify-between gap-2">
+                                <div className="min-w-0 flex-1">
+                                  <div
+                                    className={`truncate text-xs font-medium ${
+                                      isDisabled
+                                        ? 'text-danger line-through'
+                                        : 'text-text-secondary'
+                                    }`}
+                                  >
+                                    {t.provider || 'No provider'}{' '}
+                                    <span className="text-text-muted">-&gt;</span>{' '}
+                                    {t.model || 'No model'}
+                                  </div>
+                                  {isProviderDisabled && (
+                                    <div className="mt-1 text-[11px] text-danger">
+                                      Provider disabled
+                                    </div>
+                                  )}
+                                  {cooldown && (
+                                    <div className="mt-1 text-[11px] font-medium text-warning">
+                                      Cooldown {cooldownMinutes}m
+                                    </div>
+                                  )}
+                                  {testState?.showResult && testState.message && (
+                                    <div
+                                      className={`mt-1 text-[11px] italic ${
+                                        testState.result === 'success'
+                                          ? 'text-success'
+                                          : 'text-danger'
+                                      }`}
+                                    >
+                                      {testState.message}
+                                    </div>
+                                  )}
+                                </div>
+                                <div className="flex shrink-0 items-center gap-2">
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      if (isDisabled) return;
+                                      let testApiTypes: string[] = ['chat'];
+                                      if (alias.type === 'embeddings')
+                                        testApiTypes = ['embeddings'];
+                                      else if (alias.type === 'image') testApiTypes = ['images'];
+                                      else if (alias.type === 'responses')
+                                        testApiTypes = ['responses'];
+
+                                      handleTestTarget(
+                                        alias.id,
+                                        i,
+                                        t.provider,
+                                        t.model,
+                                        testApiTypes
+                                      );
+                                    }}
+                                    disabled={isDisabled}
+                                    className="flex h-7 w-7 items-center justify-center rounded text-primary transition-colors hover:bg-bg-hover disabled:cursor-not-allowed disabled:opacity-40"
+                                    aria-label={`Test ${alias.id} target ${i + 1}`}
+                                  >
+                                    {testState?.loading ? (
+                                      <Loader2 size={14} className="animate-spin" />
+                                    ) : testState?.showResult && testState.result === 'success' ? (
+                                      <CheckCircle size={14} className="text-success" />
+                                    ) : testState?.showResult && testState.result === 'error' ? (
+                                      <AlertTriangle size={14} className="text-danger" />
+                                    ) : (
+                                      <Play size={14} />
+                                    )}
+                                  </button>
+                                  <Switch
+                                    checked={t.enabled !== false}
+                                    onChange={(val) => handleToggleTarget(alias, i, val)}
+                                    size="sm"
+                                    disabled={isProviderDisabled}
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </article>
+              ))
             )}
           </div>
 
-          <div className="h-px bg-border-glass" style={{ margin: '4px 0' }}></div>
-
-          {/* Metadata accordion */}
-          <div className="border border-border-glass rounded-sm overflow-hidden">
-            <button
-              type="button"
-              onClick={() => setIsMetadataOpen((o) => !o)}
-              className="w-full flex items-center justify-between px-3 py-2 bg-bg-subtle hover:bg-bg-hover transition-colors duration-150 text-left"
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                <BookOpen size={13} className="text-text-muted" />
-                <span className="font-body text-[13px] font-medium text-text-secondary">
-                  Metadata
-                </span>
-                {editingAlias.metadata && (
-                  <span className="inline-flex items-center rounded px-2 py-0.5 text-[10px] font-medium border border-border-glass text-primary bg-bg-hover">
-                    {editingAlias.metadata.source}
-                  </span>
+          <div className="hidden overflow-x-auto md:block">
+            <table className="w-full border-collapse font-body text-[13px]">
+              <thead>
+                <tr>
+                  <th
+                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                    style={{ paddingLeft: '24px' }}
+                  >
+                    Alias
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Type
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Aliases
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Selector
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Metadata
+                  </th>
+                  <th
+                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                    style={{ paddingRight: '24px' }}
+                  >
+                    Targets
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredAliases.map((alias) => (
+                  <AliasTableRow
+                    key={alias.id}
+                    alias={alias}
+                    providers={providers}
+                    cooldowns={cooldowns}
+                    testStates={testStates}
+                    onEdit={handleEdit}
+                    onDelete={handleDeleteClick}
+                    onToggleTarget={handleToggleTarget}
+                    onTestTarget={handleTestTarget}
+                  />
+                ))}
+                {filteredAliases.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="text-center text-text-muted p-12">
+                      No aliases found
+                    </td>
+                  </tr>
                 )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <Modal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          title={originalId ? 'Edit Model' : 'Add Model'}
+          size="lg"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button variant="ghost" onClick={() => setIsModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleSave} isLoading={isSaving}>
+                Save Changes
+              </Button>
+            </div>
+          }
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '-8px' }}>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <div className="flex flex-col gap-1">
+                <label className="font-body text-[13px] font-medium text-text-secondary">
+                  Primary Name (ID)
+                </label>
+                <input
+                  className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                  value={editingAlias.id}
+                  onChange={(e) => setEditingAlias({ ...editingAlias, id: e.target.value })}
+                  placeholder="e.g. gpt-4-turbo"
+                />
               </div>
-              {isMetadataOpen ? (
-                <ChevronDown size={14} className="text-text-muted" />
-              ) : (
-                <ChevronRight size={14} className="text-text-muted" />
-              )}
-            </button>
 
-            {isMetadataOpen && (
-              <div
-                className="px-3 py-3 border-t border-border-glass"
-                style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
+              <div className="flex flex-col gap-1">
+                <label className="font-body text-[13px] font-medium text-text-secondary">
+                  Model Type
+                </label>
+                <select
+                  className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                  value={editingAlias.type || 'chat'}
+                  onChange={(e) =>
+                    setEditingAlias({
+                      ...editingAlias,
+                      type: e.target.value as
+                        | 'chat'
+                        | 'embeddings'
+                        | 'transcriptions'
+                        | 'speech'
+                        | 'image'
+                        | 'responses',
+                    })
+                  }
+                >
+                  <option value="chat">Chat</option>
+                  <option value="embeddings">Embeddings</option>
+                  <option value="transcriptions">Transcriptions</option>
+                  <option value="speech">Speech</option>
+                  <option value="image">Image</option>
+                  <option value="responses">Responses</option>
+                </select>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label className="font-body text-[13px] font-medium text-text-secondary">
+                  Selector Strategy
+                </label>
+                <select
+                  className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                  value={editingAlias.selector || 'random'}
+                  onChange={(e) => setEditingAlias({ ...editingAlias, selector: e.target.value })}
+                >
+                  <option value="random">Random</option>
+                  <option value="in_order">In Order</option>
+                  <option value="cost">Lowest Cost</option>
+                  <option value="latency">Lowest Latency</option>
+                  <option value="usage">Usage Balanced</option>
+                  <option value="performance">Best Performance</option>
+                </select>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label className="font-body text-[13px] font-medium text-text-secondary">
+                  Priority
+                </label>
+                <select
+                  className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                  value={editingAlias.priority || 'selector'}
+                  onChange={(e) =>
+                    setEditingAlias({ ...editingAlias, priority: e.target.value as any })
+                  }
+                >
+                  <option value="selector">Selector</option>
+                  <option value="api_match">API Match</option>
+                </select>
+              </div>
+            </div>
+
+            <p className="text-xs text-text-muted" style={{ marginTop: '-4px' }}>
+              Priority: "Selector" uses the strategy above. "API Match" matches provider type to
+              incoming request format.
+            </p>
+
+            <div className="h-px bg-border-glass" style={{ margin: '4px 0' }}></div>
+
+            {/* Model Architecture accordion */}
+            <div className="border border-border-glass rounded-sm overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setIsArchitectureOpen((o) => !o)}
+                className="w-full flex items-center justify-between px-3 py-2 bg-bg-subtle hover:bg-bg-hover transition-colors duration-150 text-left"
               >
-                <p className="font-body text-[11px] text-text-muted">
-                  Link this alias to a model in an external catalog. When configured, Plexus
-                  includes enriched metadata (name, context length, pricing, supported parameters)
-                  in the <code className="text-primary">GET /v1/models</code> response.
-                </p>
-
-                {/* Source selector */}
-                <div>
-                  <label
-                    className="font-body text-[12px] font-medium text-text-secondary"
-                    style={{ display: 'block', marginBottom: '4px' }}
-                  >
-                    Source
-                  </label>
-                  <select
-                    className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                    style={{ padding: '5px 8px', height: '30px' }}
-                    value={editingAlias.metadata?.source ?? 'openrouter'}
-                    onChange={(e) => {
-                      const source = e.target.value as MetadataSource;
-                      const prevSource = editingAlias.metadata?.source;
-                      const existingOverrides = editingAlias.metadata?.overrides;
-                      const existingSourcePath = editingAlias.metadata?.source_path;
-                      // Different catalogs use different path formats (e.g.
-                      // openrouter's "openai/gpt-4.1-nano" ≠ models.dev's
-                      // "openai.gpt-4.1-nano"), so a path from the old catalog
-                      // is always wrong under a new one. Only carry the path
-                      // when the source is unchanged or switching to 'custom'
-                      // (where source_path is a free-form label).
-                      const carryPath = prevSource === source || source === 'custom';
-                      const carriedSourcePath = carryPath ? existingSourcePath : undefined;
-                      let next: AliasMetadata;
-                      if (source === 'custom') {
-                        // Seed defaults, then layer any existing overrides on top so
-                        // user-typed values take precedence while missing required
-                        // fields (e.g., name) still have a sensible default. Nested
-                        // objects (architecture/pricing/top_provider) are merged
-                        // field-by-field so a partial user override (e.g. only
-                        // input_modalities) doesn't wipe default sibling fields
-                        // (e.g. output_modalities).
-                        const defaults = buildCustomDefaults(editingAlias.id);
-                        const existing = existingOverrides ?? {};
-                        const mergedOverrides = {
-                          ...defaults,
-                          ...existing,
-                          ...(defaults.pricing || existing.pricing
-                            ? {
-                                pricing: {
-                                  ...(defaults.pricing ?? {}),
-                                  ...(existing.pricing ?? {}),
-                                },
-                              }
-                            : {}),
-                          ...(defaults.architecture || existing.architecture
-                            ? {
-                                architecture: {
-                                  ...(defaults.architecture ?? {}),
-                                  ...(existing.architecture ?? {}),
-                                },
-                              }
-                            : {}),
-                          ...(defaults.top_provider || existing.top_provider
-                            ? {
-                                top_provider: {
-                                  ...(defaults.top_provider ?? {}),
-                                  ...(existing.top_provider ?? {}),
-                                },
-                              }
-                            : {}),
-                        } as MetadataOverrides & { name: string };
-                        next = {
-                          source: 'custom',
-                          ...(carriedSourcePath ? { source_path: carriedSourcePath } : {}),
-                          overrides: mergedOverrides,
-                        };
-                        setIsOverrideOpen(true);
-                      } else {
-                        next = {
-                          source,
-                          source_path: carriedSourcePath ?? '',
-                          ...(existingOverrides ? { overrides: existingOverrides } : {}),
-                        };
-                      }
-                      setEditingAlias({ ...editingAlias, metadata: next });
-                      // Changing catalogs (or switching to custom) can leave
-                      // a pending debounced search from the prior source that
-                      // would overwrite `metadataResults` with stale data; kill
-                      // it before any conditional re-run below.
-                      if (prevSource !== source) {
-                        cancelMetadataDebounce();
-                        setMetadataResults([]);
-                        setShowMetadataDropdown(false);
-                        setIsMetadataSearching(false);
-                      }
-                      // When we dropped the path, also clear the visible model
-                      // query input so it doesn't show a stale value that no
-                      // longer matches metadata.source_path.
-                      if (!carryPath) setMetadataQuery('');
-                      // Re-run search only when we kept the query (same catalog).
-                      if (carryPath && source !== 'custom' && metadataQuery)
-                        handleMetadataSearch(metadataQuery, source);
-                    }}
-                  >
-                    <option value="openrouter">OpenRouter</option>
-                    <option value="models.dev">models.dev</option>
-                    <option value="catwalk">Catwalk (Charm)</option>
-                    <option value="custom">Custom (manual entry)</option>
-                  </select>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                  <Cpu size={13} className="text-text-muted" />
+                  <span className="font-body text-[13px] font-medium text-text-secondary">
+                    Model Architecture
+                  </span>
+                  {editingAlias.model_architecture?.total_params && (
+                    <span className="inline-flex items-center rounded px-2 py-0.5 text-[10px] font-medium border border-border-glass text-primary bg-bg-hover">
+                      {editingAlias.model_architecture.total_params}B params
+                    </span>
+                  )}
                 </div>
+                {isArchitectureOpen ? (
+                  <ChevronDown size={14} className="text-text-muted" />
+                ) : (
+                  <ChevronRight size={14} className="text-text-muted" />
+                )}
+              </button>
 
-                {/* Search / source_path — hidden for 'custom' (no catalog) */}
-                {editingAlias.metadata?.source !== 'custom' && (
-                  <div style={{ position: 'relative' }}>
+              {isArchitectureOpen && (
+                <div
+                  className="px-3 py-3 border-t border-border-glass"
+                  style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
+                >
+                  <p className="font-body text-[11px] text-text-muted">
+                    Fetch model architecture from Hugging Face or enter manually. These values are
+                    used for energy calculation.
+                  </p>
+
+                  {/* Display currently saved architecture values */}
+                  {editingAlias.model_architecture?.total_params && (
+                    <div className="px-3 py-2 bg-bg-subtle border border-border-glass rounded-md">
+                      <div className="font-body text-[11px] font-medium text-text-secondary mb-1">
+                        Currently Saved:
+                      </div>
+                      <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-text">
+                        {editingAlias.model_architecture.total_params && (
+                          <span>{editingAlias.model_architecture.total_params}B params</span>
+                        )}
+                        {editingAlias.model_architecture.active_params && (
+                          <span>({editingAlias.model_architecture.active_params}B active)</span>
+                        )}
+                        {editingAlias.model_architecture.layers && (
+                          <span>{editingAlias.model_architecture.layers} layers</span>
+                        )}
+                        {editingAlias.model_architecture.heads && (
+                          <span>{editingAlias.model_architecture.heads} heads</span>
+                        )}
+                        {editingAlias.model_architecture.dtype && (
+                          <span className="text-primary">
+                            {editingAlias.model_architecture.dtype.toUpperCase()}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* HuggingFace Model ID input and fetch button */}
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+                    <div className="min-w-0 flex-1">
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Hugging Face Model ID
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        value={hfModelId}
+                        onChange={(e) => setHfModelId(e.target.value)}
+                        placeholder="e.g. meta-llama/Llama-3.1-70B-Instruct"
+                        onKeyDown={(e) => e.key === 'Enter' && fetchHfModelArchitecture()}
+                      />
+                    </div>
+                    <Button
+                      onClick={fetchHfModelArchitecture}
+                      isLoading={isFetchingHfModel}
+                      disabled={isFetchingHfModel}
+                      variant="secondary"
+                      className="w-full sm:w-auto"
+                    >
+                      Fetch from HF
+                    </Button>
+                  </div>
+
+                  {hfFetchError && (
+                    <div className="text-xs text-danger bg-danger/10 border border-danger/20 rounded px-3 py-2">
+                      {hfFetchError}
+                    </div>
+                  )}
+
+                  <div className="grid grid-cols-1 gap-2 p-3 border border-border-glass rounded-md bg-bg-subtle sm:grid-cols-2">
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Total Params (B)
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="0.1"
+                        min="0"
+                        value={editingAlias.model_architecture?.total_params || ''}
+                        onChange={(e) =>
+                          setEditingAlias({
+                            ...editingAlias,
+                            model_architecture: {
+                              ...editingAlias.model_architecture,
+                              total_params: parseFloat(e.target.value) || undefined,
+                            },
+                          })
+                        }
+                        placeholder="e.g. 1.76"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Active Params (B)
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="0.1"
+                        min="0"
+                        value={editingAlias.model_architecture?.active_params || ''}
+                        onChange={(e) =>
+                          setEditingAlias({
+                            ...editingAlias,
+                            model_architecture: {
+                              ...editingAlias.model_architecture,
+                              active_params: parseFloat(e.target.value) || undefined,
+                            },
+                          })
+                        }
+                        placeholder="e.g. 1.76"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Layers
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="1"
+                        min="1"
+                        value={editingAlias.model_architecture?.layers || ''}
+                        onChange={(e) =>
+                          setEditingAlias({
+                            ...editingAlias,
+                            model_architecture: {
+                              ...editingAlias.model_architecture,
+                              layers: parseInt(e.target.value, 10) || undefined,
+                            },
+                          })
+                        }
+                        placeholder="e.g. 120"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Heads
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="1"
+                        min="1"
+                        value={editingAlias.model_architecture?.heads || ''}
+                        onChange={(e) =>
+                          setEditingAlias({
+                            ...editingAlias,
+                            model_architecture: {
+                              ...editingAlias.model_architecture,
+                              heads: parseInt(e.target.value, 10) || undefined,
+                            },
+                          })
+                        }
+                        placeholder="e.g. 96"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        KV LoRA Rank
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="1"
+                        min="1"
+                        value={editingAlias.model_architecture?.kv_lora_rank || ''}
+                        onChange={(e) =>
+                          setEditingAlias({
+                            ...editingAlias,
+                            model_architecture: {
+                              ...editingAlias.model_architecture,
+                              kv_lora_rank: parseInt(e.target.value, 10) || undefined,
+                            },
+                          })
+                        }
+                        placeholder="e.g. 128"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        RoPE Head Dim
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="1"
+                        min="1"
+                        value={editingAlias.model_architecture?.qk_rope_head_dim || ''}
+                        onChange={(e) =>
+                          setEditingAlias({
+                            ...editingAlias,
+                            model_architecture: {
+                              ...editingAlias.model_architecture,
+                              qk_rope_head_dim: parseInt(e.target.value, 10) || undefined,
+                            },
+                          })
+                        }
+                        placeholder="e.g. 96"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Context Length
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="1"
+                        min="1"
+                        value={editingAlias.model_architecture?.context_length || ''}
+                        onChange={(e) =>
+                          setEditingAlias({
+                            ...editingAlias,
+                            model_architecture: {
+                              ...editingAlias.model_architecture,
+                              context_length: parseInt(e.target.value, 10) || undefined,
+                            },
+                          })
+                        }
+                        placeholder="e.g. 128000"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Data Type
+                      </label>
+                      <select
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        value={editingAlias.model_architecture?.dtype || ''}
+                        onChange={(e) =>
+                          setEditingAlias({
+                            ...editingAlias,
+                            model_architecture: {
+                              ...editingAlias.model_architecture,
+                              dtype: (e.target.value as any) || undefined,
+                            },
+                          })
+                        }
+                      >
+                        <option value="">Default (FP16)</option>
+                        <option value="fp16">FP16</option>
+                        <option value="bf16">BF16</option>
+                        <option value="fp8">FP8</option>
+                        <option value="fp8_e4m3">FP8 E4M3</option>
+                        <option value="fp8_e5m2">FP8 E5M2</option>
+                        <option value="nvfp4">NVFP4</option>
+                        <option value="int4">INT4</option>
+                        <option value="int8">INT8</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Advanced accordion */}
+            <div className="border border-border-glass rounded-sm overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setIsAdvancedOpen((o) => !o)}
+                className="w-full flex items-center justify-between px-3 py-2 bg-bg-subtle hover:bg-bg-hover transition-colors duration-150 text-left"
+              >
+                <span className="font-body text-[13px] font-medium text-text-secondary">
+                  Advanced
+                </span>
+                {isAdvancedOpen ? (
+                  <ChevronDown size={14} className="text-text-muted" />
+                ) : (
+                  <ChevronRight size={14} className="text-text-muted" />
+                )}
+              </button>
+
+              {isAdvancedOpen && (
+                <div
+                  className="px-3 py-3 border-t border-border-glass"
+                  style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}
+                >
+                  {/* ── Behaviors ── */}
+                  <div>
+                    <label
+                      className="font-body text-[13px] font-medium text-text-secondary"
+                      style={{ display: 'block', marginBottom: '6px' }}
+                    >
+                      Behaviors
+                    </label>
+                    <div className="flex items-center justify-between py-1">
+                      <div>
+                        <span className="font-body text-[13px] text-text">
+                          Strip Adaptive Thinking
+                        </span>
+                        <p className="font-body text-[11px] text-text-muted mt-0.5">
+                          On the <code className="text-primary">/v1/messages</code> path, remove{' '}
+                          <code className="text-primary">thinking</code> when set to{' '}
+                          <code className="text-primary">adaptive</code> so the provider uses its
+                          default behaviour.
+                        </p>
+                      </div>
+                      <Switch
+                        checked={getBehavior('strip_adaptive_thinking')}
+                        onChange={(val) => setBehavior('strip_adaptive_thinking', val)}
+                        size="sm"
+                      />
+                    </div>
+
+                    <div className="flex items-center justify-between py-1">
+                      <div>
+                        <span className="font-body text-[13px] text-text">Vision Fallthrough</span>
+                        <p className="font-body text-[11px] text-text-muted mt-0.5">
+                          If the request contains images and the target model is text-only, use the
+                          descriptor model to convert images to text.
+                        </p>
+                      </div>
+                      <Switch
+                        checked={editingAlias.use_image_fallthrough || false}
+                        onChange={(val) =>
+                          setEditingAlias({ ...editingAlias, use_image_fallthrough: val })
+                        }
+                        size="sm"
+                      />
+                    </div>
+
+                    <div className="flex items-center justify-between py-1">
+                      <div>
+                        <span className="font-body text-[13px] text-text">Enforce Limits</span>
+                        <p className="font-body text-[11px] text-text-muted mt-0.5">
+                          Reject oversized prompts locally (400 context_length_exceeded) before
+                          dispatch. Uses a fast heuristic estimator with a 10% safety margin, and
+                          reserves the smaller of max_tokens and the model's max completion for the
+                          response. Requires a known context_length in metadata (override or
+                          catalog).
+                        </p>
+                        {editingAlias.enforce_limits &&
+                          !editingAlias.metadata?.overrides?.context_length &&
+                          !editingAlias.metadata?.overrides?.top_provider?.context_length && (
+                            <p
+                              className="font-body text-[11px] mt-1 flex items-center gap-1"
+                              style={{ color: 'var(--color-warning)' }}
+                            >
+                              <AlertTriangle size={12} />
+                              No context_length found in metadata — this toggle will have no effect
+                              until a metadata source with a known context_length is configured.
+                            </p>
+                          )}
+                      </div>
+                      <Switch
+                        checked={editingAlias.enforce_limits || false}
+                        onChange={(val) =>
+                          setEditingAlias({ ...editingAlias, enforce_limits: val })
+                        }
+                        size="sm"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="h-px bg-border-glass"></div>
+
+                  {/* ── Additional Aliases ── */}
+                  <div>
+                    <div className="mb-1 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <label
+                        className="font-body text-[13px] font-medium text-text-secondary"
+                        style={{ marginBottom: 0 }}
+                      >
+                        Additional Aliases
+                      </label>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={addAlias}
+                        leftIcon={<Plus size={14} />}
+                      >
+                        Add Alias
+                      </Button>
+                    </div>
+
+                    {(!editingAlias.aliases || editingAlias.aliases.length === 0) && (
+                      <div className="text-text-muted italic text-center text-sm py-2">
+                        No additional aliases
+                      </div>
+                    )}
+
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                      {editingAlias.aliases?.map((alias, idx) => (
+                        <div key={idx} className="flex gap-2">
+                          <div className="min-w-0 flex-1">
+                            <Input
+                              value={alias}
+                              onChange={(e) => updateAlias(idx, e.target.value)}
+                              placeholder="e.g. gpt4"
+                            />
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => removeAlias(idx)}
+                            style={{ color: 'var(--color-danger)' }}
+                          >
+                            <Trash2 size={16} />
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="h-px bg-border-glass" style={{ margin: '4px 0' }}></div>
+
+            {/* Metadata accordion */}
+            <div className="border border-border-glass rounded-sm overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setIsMetadataOpen((o) => !o)}
+                className="w-full flex items-center justify-between px-3 py-2 bg-bg-subtle hover:bg-bg-hover transition-colors duration-150 text-left"
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                  <BookOpen size={13} className="text-text-muted" />
+                  <span className="font-body text-[13px] font-medium text-text-secondary">
+                    Metadata
+                  </span>
+                  {editingAlias.metadata && (
+                    <span className="inline-flex items-center rounded px-2 py-0.5 text-[10px] font-medium border border-border-glass text-primary bg-bg-hover">
+                      {editingAlias.metadata.source}
+                    </span>
+                  )}
+                </div>
+                {isMetadataOpen ? (
+                  <ChevronDown size={14} className="text-text-muted" />
+                ) : (
+                  <ChevronRight size={14} className="text-text-muted" />
+                )}
+              </button>
+
+              {isMetadataOpen && (
+                <div
+                  className="px-3 py-3 border-t border-border-glass"
+                  style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
+                >
+                  <p className="font-body text-[11px] text-text-muted">
+                    Link this alias to a model in an external catalog. When configured, Plexus
+                    includes enriched metadata (name, context length, pricing, supported parameters)
+                    in the <code className="text-primary">GET /v1/models</code> response.
+                  </p>
+
+                  {/* Source selector */}
+                  <div>
                     <label
                       className="font-body text-[12px] font-medium text-text-secondary"
                       style={{ display: 'block', marginBottom: '4px' }}
                     >
-                      Model
-                      {editingAlias.metadata?.source_path && (
-                        <span className="ml-2 font-normal text-text-muted">
-                          ({editingAlias.metadata.source_path})
-                        </span>
-                      )}
+                      Source
                     </label>
-                    <div style={{ position: 'relative', display: 'flex', gap: '4px' }}>
-                      <div ref={metadataInputWrapperRef} style={{ position: 'relative', flex: 1 }}>
-                        <Input
-                          value={metadataQuery}
-                          onChange={(e) => {
-                            const source = editingAlias.metadata?.source ?? 'openrouter';
-                            handleMetadataSearch(e.target.value, source);
-                            // Update rect so portal dropdown follows the input
-                            if (metadataInputWrapperRef.current) {
-                              const r = metadataInputWrapperRef.current.getBoundingClientRect();
-                              setDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width });
-                            }
-                          }}
-                          onFocus={() => {
-                            if (metadataResults.length > 0) {
+                    <select
+                      className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                      style={{ padding: '5px 8px', height: '30px' }}
+                      value={editingAlias.metadata?.source ?? 'openrouter'}
+                      onChange={(e) => {
+                        const source = e.target.value as MetadataSource;
+                        const prevSource = editingAlias.metadata?.source;
+                        const existingOverrides = editingAlias.metadata?.overrides;
+                        const existingSourcePath = editingAlias.metadata?.source_path;
+                        // Different catalogs use different path formats (e.g.
+                        // openrouter's "openai/gpt-4.1-nano" ≠ models.dev's
+                        // "openai.gpt-4.1-nano"), so a path from the old catalog
+                        // is always wrong under a new one. Only carry the path
+                        // when the source is unchanged or switching to 'custom'
+                        // (where source_path is a free-form label).
+                        const carryPath = prevSource === source || source === 'custom';
+                        const carriedSourcePath = carryPath ? existingSourcePath : undefined;
+                        let next: AliasMetadata;
+                        if (source === 'custom') {
+                          // Seed defaults, then layer any existing overrides on top so
+                          // user-typed values take precedence while missing required
+                          // fields (e.g., name) still have a sensible default. Nested
+                          // objects (architecture/pricing/top_provider) are merged
+                          // field-by-field so a partial user override (e.g. only
+                          // input_modalities) doesn't wipe default sibling fields
+                          // (e.g. output_modalities).
+                          const defaults = buildCustomDefaults(editingAlias.id);
+                          const existing = existingOverrides ?? {};
+                          const mergedOverrides = {
+                            ...defaults,
+                            ...existing,
+                            ...(defaults.pricing || existing.pricing
+                              ? {
+                                  pricing: {
+                                    ...(defaults.pricing ?? {}),
+                                    ...(existing.pricing ?? {}),
+                                  },
+                                }
+                              : {}),
+                            ...(defaults.architecture || existing.architecture
+                              ? {
+                                  architecture: {
+                                    ...(defaults.architecture ?? {}),
+                                    ...(existing.architecture ?? {}),
+                                  },
+                                }
+                              : {}),
+                            ...(defaults.top_provider || existing.top_provider
+                              ? {
+                                  top_provider: {
+                                    ...(defaults.top_provider ?? {}),
+                                    ...(existing.top_provider ?? {}),
+                                  },
+                                }
+                              : {}),
+                          } as MetadataOverrides & { name: string };
+                          next = {
+                            source: 'custom',
+                            ...(carriedSourcePath ? { source_path: carriedSourcePath } : {}),
+                            overrides: mergedOverrides,
+                          };
+                          setIsOverrideOpen(true);
+                        } else {
+                          next = {
+                            source,
+                            source_path: carriedSourcePath ?? '',
+                            ...(existingOverrides ? { overrides: existingOverrides } : {}),
+                          };
+                        }
+                        setEditingAlias({ ...editingAlias, metadata: next });
+                        // Changing catalogs (or switching to custom) can leave
+                        // a pending debounced search from the prior source that
+                        // would overwrite `metadataResults` with stale data; kill
+                        // it before any conditional re-run below.
+                        if (prevSource !== source) {
+                          cancelMetadataDebounce();
+                          setMetadataResults([]);
+                          setShowMetadataDropdown(false);
+                          setIsMetadataSearching(false);
+                        }
+                        // When we dropped the path, also clear the visible model
+                        // query input so it doesn't show a stale value that no
+                        // longer matches metadata.source_path.
+                        if (!carryPath) setMetadataQuery('');
+                        // Re-run search only when we kept the query (same catalog).
+                        if (carryPath && source !== 'custom' && metadataQuery)
+                          handleMetadataSearch(metadataQuery, source);
+                      }}
+                    >
+                      <option value="openrouter">OpenRouter</option>
+                      <option value="models.dev">models.dev</option>
+                      <option value="catwalk">Catwalk (Charm)</option>
+                      <option value="custom">Custom (manual entry)</option>
+                    </select>
+                  </div>
+
+                  {/* Search / source_path — hidden for 'custom' (no catalog) */}
+                  {editingAlias.metadata?.source !== 'custom' && (
+                    <div style={{ position: 'relative' }}>
+                      <label
+                        className="font-body text-[12px] font-medium text-text-secondary"
+                        style={{ display: 'block', marginBottom: '4px' }}
+                      >
+                        Model
+                        {editingAlias.metadata?.source_path && (
+                          <span className="ml-2 font-normal text-text-muted">
+                            ({editingAlias.metadata.source_path})
+                          </span>
+                        )}
+                      </label>
+                      <div style={{ position: 'relative', display: 'flex', gap: '4px' }}>
+                        <div
+                          ref={metadataInputWrapperRef}
+                          style={{ position: 'relative', flex: 1 }}
+                        >
+                          <Input
+                            value={metadataQuery}
+                            onChange={(e) => {
+                              const source = editingAlias.metadata?.source ?? 'openrouter';
+                              handleMetadataSearch(e.target.value, source);
+                              // Update rect so portal dropdown follows the input
                               if (metadataInputWrapperRef.current) {
                                 const r = metadataInputWrapperRef.current.getBoundingClientRect();
                                 setDropdownRect({
@@ -1730,688 +1906,701 @@ export const Models = () => {
                                   width: r.width,
                                 });
                               }
-                              setShowMetadataDropdown(true);
-                            }
-                          }}
-                          placeholder={`Search ${editingAlias.metadata?.source ?? 'openrouter'} catalog...`}
-                          style={{
-                            width: '100%',
-                            paddingRight: isMetadataSearching ? '28px' : undefined,
-                          }}
-                          onBlur={() => setShowMetadataDropdown(false)}
-                        />
-                        {isMetadataSearching && (
-                          <Loader2
-                            size={14}
-                            className="animate-spin text-text-muted"
-                            style={{
-                              position: 'absolute',
-                              right: '8px',
-                              top: '50%',
-                              transform: 'translateY(-50%)',
                             }}
+                            onFocus={() => {
+                              if (metadataResults.length > 0) {
+                                if (metadataInputWrapperRef.current) {
+                                  const r = metadataInputWrapperRef.current.getBoundingClientRect();
+                                  setDropdownRect({
+                                    top: r.bottom + 2,
+                                    left: r.left,
+                                    width: r.width,
+                                  });
+                                }
+                                setShowMetadataDropdown(true);
+                              }
+                            }}
+                            placeholder={`Search ${editingAlias.metadata?.source ?? 'openrouter'} catalog...`}
+                            style={{
+                              width: '100%',
+                              paddingRight: isMetadataSearching ? '28px' : undefined,
+                            }}
+                            onBlur={() => setShowMetadataDropdown(false)}
                           />
+                          {isMetadataSearching && (
+                            <Loader2
+                              size={14}
+                              className="animate-spin text-text-muted"
+                              style={{
+                                position: 'absolute',
+                                right: '8px',
+                                top: '50%',
+                                transform: 'translateY(-50%)',
+                              }}
+                            />
+                          )}
+                        </div>
+                        {editingAlias.metadata && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={clearMetadata}
+                            style={{
+                              color: 'var(--color-danger)',
+                              padding: '4px',
+                              minHeight: 'auto',
+                            }}
+                            title="Remove metadata"
+                          >
+                            <X size={14} />
+                          </Button>
                         )}
                       </div>
-                      {editingAlias.metadata && (
+                    </div>
+                  )}
+
+                  {/* Selected metadata preview */}
+                  {editingAlias.metadata &&
+                    (editingAlias.metadata.source === 'custom' ||
+                      editingAlias.metadata.source_path ||
+                      editingAlias.metadata.overrides) && (
+                      <div
+                        className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-2"
+                        style={{ fontSize: '11px', color: 'var(--color-text-secondary)' }}
+                      >
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                          <CheckCircle size={12} className="text-success" />
+                          <span>
+                            {editingAlias.metadata.source === 'custom' ? (
+                              <>
+                                Custom metadata
+                                {editingAlias.metadata.source_path && (
+                                  <>
+                                    :{' '}
+                                    <code className="text-primary">
+                                      {editingAlias.metadata.source_path}
+                                    </code>
+                                  </>
+                                )}
+                              </>
+                            ) : (
+                              <>
+                                Metadata assigned from{' '}
+                                <strong>{editingAlias.metadata.source}</strong>
+                                {editingAlias.metadata.source_path && (
+                                  <>
+                                    :{' '}
+                                    <code className="text-primary">
+                                      {editingAlias.metadata.source_path}
+                                    </code>
+                                  </>
+                                )}
+                              </>
+                            )}
+                            {countOverrides(editingAlias.metadata) > 0 && (
+                              <span className="ml-2 text-text-muted">
+                                + {countOverrides(editingAlias.metadata)} field
+                                {countOverrides(editingAlias.metadata) === 1 ? '' : 's'} overridden
+                              </span>
+                            )}
+                          </span>
+                        </div>
+                      </div>
+                    )}
+
+                  {/* Override toggle + editable form */}
+                  {editingAlias.metadata && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                      {editingAlias.metadata.source !== 'custom' && (
+                        <div
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <label
+                            className="font-body text-[12px] font-medium text-text-secondary"
+                            style={{ marginBottom: 0 }}
+                          >
+                            Override catalog fields
+                          </label>
+                          <Switch
+                            checked={isOverrideOpen}
+                            onChange={(v) => {
+                              setIsOverrideOpen(v);
+                              if (!v) {
+                                // Flipping override off clears any existing overrides.
+                                const current = editingAlias.metadata;
+                                if (current) {
+                                  const { overrides: _o, ...rest } = current;
+                                  setEditingAlias({
+                                    ...editingAlias,
+                                    metadata: rest as AliasMetadata,
+                                  });
+                                }
+                              } else {
+                                // Flipping override on auto-populates the form with
+                                // the catalog's current values so the user sees what
+                                // they're overriding instead of a blank form.
+                                const cur = editingAlias.metadata;
+                                if (cur && cur.source !== 'custom' && cur.source_path) {
+                                  populateOverridesFromCatalog(cur.source, cur.source_path);
+                                }
+                              }
+                            }}
+                          />
+                        </div>
+                      )}
+
+                      {(isOverrideOpen || editingAlias.metadata.source === 'custom') && (
+                        <MetadataOverrideForm
+                          overrides={editingAlias.metadata.overrides ?? {}}
+                          isCustom={editingAlias.metadata.source === 'custom'}
+                          onSetField={setOverrideField}
+                          onSetPricing={setPricingField}
+                          onSetArchitecture={setArchitectureField}
+                          onSetTopProvider={setTopProviderField}
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="h-px bg-border-glass" style={{ margin: '4px 0' }}></div>
+
+            <div>
+              <div className="mb-1 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <label
+                  className="font-body text-[13px] font-medium text-text-secondary"
+                  style={{ marginBottom: 0 }}
+                >
+                  Targets
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={handleOpenAutoAdd}
+                    leftIcon={<Zap size={14} />}
+                  >
+                    Auto Add
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={addTarget}
+                    leftIcon={<Plus size={14} />}
+                  >
+                    Add Target
+                  </Button>
+                </div>
+              </div>
+
+              {editingAlias.targets.length === 0 && (
+                <div className="text-text-muted italic text-center text-sm py-2">
+                  No targets configured (Model will not work)
+                </div>
+              )}
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                {editingAlias.targets.map((target, idx) => {
+                  const isDragging = dragSourceIndex === idx;
+                  const isDragOver = dragOverIndex === idx && !isDragging;
+
+                  return (
+                    <div
+                      key={idx}
+                      draggable
+                      className="flex flex-col gap-2 sm:flex-row sm:items-center"
+                      onDragStart={(e) => handleDragStart(e, idx)}
+                      onDragOver={(e) => handleDragOver(e, idx)}
+                      onDragEnd={handleDragEnd}
+                      onDrop={(e) => handleDrop(e, idx)}
+                      style={{
+                        padding: '4px 8px',
+                        backgroundColor: isDragging
+                          ? 'transparent'
+                          : isDragOver
+                            ? 'rgba(245, 158, 11, 0.05)'
+                            : 'var(--color-bg-subtle)',
+                        borderRadius: 'var(--radius-sm)',
+                        border: isDragging
+                          ? '1px dashed var(--color-border-glass)'
+                          : isDragOver
+                            ? '2px solid var(--color-primary)'
+                            : '1px solid var(--color-border-glass)',
+                        cursor: 'grab',
+                        opacity: isDragging ? 0.4 : 1,
+                        transform: isDragOver ? 'translateY(2px)' : 'none',
+                        transition: 'all 0.2s ease',
+                        position: 'relative',
+                      }}
+                      onDragStartCapture={(e) => {
+                        (e.currentTarget as HTMLDivElement).style.cursor = 'grabbing';
+                      }}
+                      onDragEndCapture={(e) => {
+                        (e.currentTarget as HTMLDivElement).style.cursor = 'grab';
+                      }}
+                    >
+                      {isDragOver && (
+                        <div
+                          style={{
+                            position: 'absolute',
+                            top: dragSourceIndex !== null && dragSourceIndex < idx ? 'auto' : -2,
+                            bottom: dragSourceIndex !== null && dragSourceIndex > idx ? 'auto' : -2,
+                            left: 0,
+                            right: 0,
+                            height: '2px',
+                            backgroundColor: 'var(--color-primary)',
+                            zIndex: 20,
+                          }}
+                        />
+                      )}
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '4px',
+                          color: 'var(--color-text-secondary)',
+                          opacity: 0.8,
+                          marginRight: '4px',
+                          visibility: isDragging ? 'hidden' : 'visible',
+                        }}
+                      >
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            moveTarget(idx, 'up');
+                          }}
+                          disabled={idx === 0}
+                          className="hover:scale-110 hover:text-primary disabled:opacity-30 disabled:hover:scale-100 transition-all duration-200"
+                          style={{
+                            background: 'none',
+                            border: 'none',
+                            padding: '4px',
+                            cursor: idx === 0 ? 'default' : 'pointer',
+                          }}
+                          title="Move Up"
+                        >
+                          <ChevronUp size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            moveTarget(idx, 'down');
+                          }}
+                          disabled={idx === editingAlias.targets.length - 1}
+                          className="hover:scale-110 hover:text-primary disabled:opacity-30 disabled:hover:scale-100 transition-all duration-200"
+                          style={{
+                            background: 'none',
+                            border: 'none',
+                            padding: '4px',
+                            cursor: idx === editingAlias.targets.length - 1 ? 'default' : 'pointer',
+                          }}
+                          title="Move Down"
+                        >
+                          <ChevronDown size={16} />
+                        </button>
+                      </div>
+                      <div
+                        style={{
+                          cursor: 'grab',
+                          color: 'var(--color-text-secondary)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          visibility: isDragging ? 'hidden' : 'visible',
+                        }}
+                      >
+                        <GripVertical size={16} />
+                      </div>
+                      <div
+                        className="w-full sm:w-[120px] sm:max-w-[120px] sm:flex-none"
+                        style={{
+                          visibility: isDragging ? 'hidden' : 'visible',
+                        }}
+                      >
+                        <select
+                          className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                          style={{ padding: '4px 8px', height: '28px' }}
+                          value={target.provider}
+                          onChange={(e) => updateTarget(idx, 'provider', e.target.value)}
+                        >
+                          <option value="">Select Provider...</option>
+                          {providers.map((p) => (
+                            <option key={p.id} value={p.id}>
+                              {p.name}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div
+                        className="w-full min-w-0 sm:flex-1"
+                        style={{ visibility: isDragging ? 'hidden' : 'visible' }}
+                      >
+                        <select
+                          className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                          style={{ padding: '4px 8px', height: '28px' }}
+                          value={target.model}
+                          onChange={(e) => updateTarget(idx, 'model', e.target.value)}
+                          disabled={!target.provider}
+                        >
+                          <option value="">Select Model...</option>
+                          {availableModels
+                            .filter((m) => m.providerId === target.provider)
+                            .map((m) => (
+                              <option key={m.id} value={m.id}>
+                                {m.name}
+                              </option>
+                            ))}
+                        </select>
+                      </div>
+                      <div style={{ visibility: isDragging ? 'hidden' : 'visible' }}>
+                        <Switch
+                          checked={target.enabled !== false}
+                          onChange={(val) => updateTarget(idx, 'enabled', val)}
+                          size="sm"
+                        />
+                      </div>
+                      <div style={{ visibility: isDragging ? 'hidden' : 'visible' }}>
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={clearMetadata}
+                          onClick={() => removeTarget(idx)}
                           style={{
                             color: 'var(--color-danger)',
                             padding: '4px',
                             minHeight: 'auto',
                           }}
-                          title="Remove metadata"
                         >
-                          <X size={14} />
+                          <Trash2 size={14} />
                         </Button>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {/* Selected metadata preview */}
-                {editingAlias.metadata &&
-                  (editingAlias.metadata.source === 'custom' ||
-                    editingAlias.metadata.source_path ||
-                    editingAlias.metadata.overrides) && (
-                    <div
-                      className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-2"
-                      style={{ fontSize: '11px', color: 'var(--color-text-secondary)' }}
-                    >
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                        <CheckCircle size={12} className="text-success" />
-                        <span>
-                          {editingAlias.metadata.source === 'custom' ? (
-                            <>
-                              Custom metadata
-                              {editingAlias.metadata.source_path && (
-                                <>
-                                  :{' '}
-                                  <code className="text-primary">
-                                    {editingAlias.metadata.source_path}
-                                  </code>
-                                </>
-                              )}
-                            </>
-                          ) : (
-                            <>
-                              Metadata assigned from <strong>{editingAlias.metadata.source}</strong>
-                              {editingAlias.metadata.source_path && (
-                                <>
-                                  :{' '}
-                                  <code className="text-primary">
-                                    {editingAlias.metadata.source_path}
-                                  </code>
-                                </>
-                              )}
-                            </>
-                          )}
-                          {countOverrides(editingAlias.metadata) > 0 && (
-                            <span className="ml-2 text-text-muted">
-                              + {countOverrides(editingAlias.metadata)} field
-                              {countOverrides(editingAlias.metadata) === 1 ? '' : 's'} overridden
-                            </span>
-                          )}
-                        </span>
                       </div>
                     </div>
-                  )}
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </Modal>
 
-                {/* Override toggle + editable form */}
-                {editingAlias.metadata && (
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                    {editingAlias.metadata.source !== 'custom' && (
-                      <div
-                        style={{
-                          display: 'flex',
-                          justifyContent: 'space-between',
-                          alignItems: 'center',
-                        }}
+        <Modal
+          isOpen={isAutoAddModalOpen}
+          onClose={() => setIsAutoAddModalOpen(false)}
+          title="Auto Add Targets"
+          size="lg"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button variant="ghost" onClick={() => setIsAutoAddModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleAddSelectedModels} disabled={selectedModels.size === 0}>
+                Add {selectedModels.size} Target{selectedModels.size !== 1 ? 's' : ''}
+              </Button>
+            </div>
+          }
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="min-w-0 flex-1">
+                <Input
+                  placeholder="Search models (e.g. 'gpt-4', 'claude')"
+                  value={substring}
+                  onChange={(e) => setSubstring(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleSearchModels()}
+                />
+              </div>
+              <Button onClick={() => handleSearchModels()} className="w-full sm:w-auto">
+                Search
+              </Button>
+            </div>
+
+            {filteredModels.length > 0 ? (
+              <div
+                style={{
+                  maxHeight: '400px',
+                  overflowY: 'auto',
+                  overflowX: 'auto',
+                  border: '1px solid var(--color-border-glass)',
+                  borderRadius: 'var(--radius-sm)',
+                }}
+              >
+                <table className="w-full border-collapse font-body text-[13px]">
+                  <thead
+                    style={{
+                      position: 'sticky',
+                      top: 0,
+                      backgroundColor: 'var(--color-bg-hover)',
+                      zIndex: 10,
+                    }}
+                  >
+                    <tr>
+                      <th
+                        className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                        style={{ width: '40px' }}
                       >
-                        <label
-                          className="font-body text-[12px] font-medium text-text-secondary"
-                          style={{ marginBottom: 0 }}
-                        >
-                          Override catalog fields
-                        </label>
-                        <Switch
-                          checked={isOverrideOpen}
-                          onChange={(v) => {
-                            setIsOverrideOpen(v);
-                            if (!v) {
-                              // Flipping override off clears any existing overrides.
-                              const current = editingAlias.metadata;
-                              if (current) {
-                                const { overrides: _o, ...rest } = current;
-                                setEditingAlias({
-                                  ...editingAlias,
-                                  metadata: rest as AliasMetadata,
-                                });
-                              }
+                        <input
+                          type="checkbox"
+                          checked={
+                            filteredModels.length > 0 &&
+                            filteredModels.every(
+                              (m) =>
+                                selectedModels.has(`${m.provider.id}|${m.model.id}`) ||
+                                editingAlias.targets.some(
+                                  (t) => t.provider === m.provider.id && t.model === m.model.id
+                                )
+                            )
+                          }
+                          onChange={(e) => {
+                            if (e.target.checked) {
+                              const newSelection = new Set(selectedModels);
+                              filteredModels.forEach((m) => {
+                                const key = `${m.provider.id}|${m.model.id}`;
+                                if (
+                                  !editingAlias.targets.some(
+                                    (t) => t.provider === m.provider.id && t.model === m.model.id
+                                  )
+                                ) {
+                                  newSelection.add(key);
+                                }
+                              });
+                              setSelectedModels(newSelection);
                             } else {
-                              // Flipping override on auto-populates the form with
-                              // the catalog's current values so the user sees what
-                              // they're overriding instead of a blank form.
-                              const cur = editingAlias.metadata;
-                              if (cur && cur.source !== 'custom' && cur.source_path) {
-                                populateOverridesFromCatalog(cur.source, cur.source_path);
-                              }
+                              const newSelection = new Set(selectedModels);
+                              filteredModels.forEach((m) => {
+                                newSelection.delete(`${m.provider.id}|${m.model.id}`);
+                              });
+                              setSelectedModels(newSelection);
                             }
                           }}
                         />
-                      </div>
-                    )}
+                      </th>
+                      <th className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                        Provider
+                      </th>
+                      <th className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                        Model
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredModels.map(({ model, provider }) => {
+                      const key = `${provider.id}|${model.id}`;
+                      const alreadyExists = editingAlias.targets.some(
+                        (t) => t.provider === provider.id && t.model === model.id
+                      );
+                      const isSelected = selectedModels.has(key);
+                      const isDisabled = alreadyExists;
 
-                    {(isOverrideOpen || editingAlias.metadata.source === 'custom') && (
-                      <MetadataOverrideForm
-                        overrides={editingAlias.metadata.overrides ?? {}}
-                        isCustom={editingAlias.metadata.source === 'custom'}
-                        onSetField={setOverrideField}
-                        onSetPricing={setPricingField}
-                        onSetArchitecture={setArchitectureField}
-                        onSetTopProvider={setTopProviderField}
-                      />
-                    )}
-                  </div>
-                )}
+                      return (
+                        <tr
+                          key={key}
+                          className="hover:bg-bg-hover"
+                          style={{ opacity: isDisabled ? 0.5 : 1 }}
+                        >
+                          <td className="px-4 py-3 text-left text-text">
+                            <input
+                              type="checkbox"
+                              checked={isSelected || alreadyExists}
+                              disabled={isDisabled}
+                              onChange={() => handleToggleModelSelection(model.id, provider.id)}
+                            />
+                          </td>
+                          <td className="px-4 py-3 text-left text-text">{provider.name}</td>
+                          <td className="px-4 py-3 text-left text-text">
+                            {model.name}
+                            {alreadyExists && (
+                              <span
+                                style={{
+                                  marginLeft: '8px',
+                                  fontSize: '11px',
+                                  color: 'var(--color-text-secondary)',
+                                  fontStyle: 'italic',
+                                }}
+                              >
+                                (already added)
+                              </span>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            ) : substring ? (
+              <div className="text-text-muted italic text-center text-sm py-8">
+                No models found matching "{substring}"
+              </div>
+            ) : (
+              <div className="text-text-muted italic text-center text-sm py-8">
+                Enter a search term to find models
               </div>
             )}
           </div>
+        </Modal>
 
-          <div className="h-px bg-border-glass" style={{ margin: '4px 0' }}></div>
-
-          <div>
+        <Modal
+          isOpen={isDeleteAllModalOpen}
+          onClose={() => setIsDeleteAllModalOpen(false)}
+          title="Delete All Models"
+          size="sm"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button
+                variant="ghost"
+                onClick={() => setIsDeleteAllModalOpen(false)}
+                disabled={isDeletingAll}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleConfirmDeleteAll} isLoading={isDeletingAll} variant="danger">
+                Delete All
+              </Button>
+            </div>
+          }
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '16px',
+              alignItems: 'center',
+              textAlign: 'center',
+              padding: '16px 0',
+            }}
+          >
             <div
               style={{
+                width: '48px',
+                height: '48px',
+                borderRadius: '50%',
+                backgroundColor: 'rgba(239, 68, 68, 0.1)',
                 display: 'flex',
-                justifyContent: 'space-between',
                 alignItems: 'center',
-                marginBottom: '4px',
+                justifyContent: 'center',
               }}
             >
-              <label
-                className="font-body text-[13px] font-medium text-text-secondary"
-                style={{ marginBottom: 0 }}
+              <Trash2 size={24} style={{ color: 'var(--color-danger)' }} />
+            </div>
+            <div>
+              <p className="text-text" style={{ marginBottom: '8px', fontWeight: 500 }}>
+                Are you sure you want to delete all configured models?
+              </p>
+              <p className="text-text-secondary" style={{ fontSize: '14px' }}>
+                This will permanently remove <strong>{aliases.length}</strong> model alias
+                {aliases.length !== 1 ? 'es' : ''} from the configuration.
+              </p>
+            </div>
+          </div>
+        </Modal>
+
+        <Modal
+          isOpen={isDeleteModalOpen}
+          onClose={() => setIsDeleteModalOpen(false)}
+          title="Delete Model Alias"
+          size="sm"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button
+                variant="ghost"
+                onClick={() => setIsDeleteModalOpen(false)}
+                disabled={isDeleting}
               >
-                Targets
-              </label>
-              <div style={{ display: 'flex', gap: '8px' }}>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  onClick={handleOpenAutoAdd}
-                  leftIcon={<Zap size={14} />}
-                >
-                  Auto Add
-                </Button>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  onClick={addTarget}
-                  leftIcon={<Plus size={14} />}
-                >
-                  Add Target
-                </Button>
-              </div>
+                Cancel
+              </Button>
+              <Button onClick={handleConfirmDelete} isLoading={isDeleting} variant="danger">
+                Delete
+              </Button>
             </div>
-
-            {editingAlias.targets.length === 0 && (
-              <div className="text-text-muted italic text-center text-sm py-2">
-                No targets configured (Model will not work)
-              </div>
-            )}
-
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-              {editingAlias.targets.map((target, idx) => {
-                const isDragging = dragSourceIndex === idx;
-                const isDragOver = dragOverIndex === idx && !isDragging;
-
-                return (
-                  <div
-                    key={idx}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, idx)}
-                    onDragOver={(e) => handleDragOver(e, idx)}
-                    onDragEnd={handleDragEnd}
-                    onDrop={(e) => handleDrop(e, idx)}
-                    style={{
-                      display: 'flex',
-                      gap: '6px',
-                      alignItems: 'center',
-                      padding: '4px 8px',
-                      backgroundColor: isDragging
-                        ? 'transparent'
-                        : isDragOver
-                          ? 'rgba(245, 158, 11, 0.05)'
-                          : 'var(--color-bg-subtle)',
-                      borderRadius: 'var(--radius-sm)',
-                      border: isDragging
-                        ? '1px dashed var(--color-border-glass)'
-                        : isDragOver
-                          ? '2px solid var(--color-primary)'
-                          : '1px solid var(--color-border-glass)',
-                      cursor: 'grab',
-                      opacity: isDragging ? 0.4 : 1,
-                      transform: isDragOver ? 'translateY(2px)' : 'none',
-                      transition: 'all 0.2s ease',
-                      position: 'relative',
-                    }}
-                    onDragStartCapture={(e) => {
-                      (e.currentTarget as HTMLDivElement).style.cursor = 'grabbing';
-                    }}
-                    onDragEndCapture={(e) => {
-                      (e.currentTarget as HTMLDivElement).style.cursor = 'grab';
-                    }}
-                  >
-                    {isDragOver && (
-                      <div
-                        style={{
-                          position: 'absolute',
-                          top: dragSourceIndex !== null && dragSourceIndex < idx ? 'auto' : -2,
-                          bottom: dragSourceIndex !== null && dragSourceIndex > idx ? 'auto' : -2,
-                          left: 0,
-                          right: 0,
-                          height: '2px',
-                          backgroundColor: 'var(--color-primary)',
-                          zIndex: 20,
-                        }}
-                      />
-                    )}
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '4px',
-                        color: 'var(--color-text-secondary)',
-                        opacity: 0.8,
-                        marginRight: '4px',
-                        visibility: isDragging ? 'hidden' : 'visible',
-                      }}
-                    >
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          moveTarget(idx, 'up');
-                        }}
-                        disabled={idx === 0}
-                        className="hover:scale-110 hover:text-primary disabled:opacity-30 disabled:hover:scale-100 transition-all duration-200"
-                        style={{
-                          background: 'none',
-                          border: 'none',
-                          padding: '4px',
-                          cursor: idx === 0 ? 'default' : 'pointer',
-                        }}
-                        title="Move Up"
-                      >
-                        <ChevronUp size={16} />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          moveTarget(idx, 'down');
-                        }}
-                        disabled={idx === editingAlias.targets.length - 1}
-                        className="hover:scale-110 hover:text-primary disabled:opacity-30 disabled:hover:scale-100 transition-all duration-200"
-                        style={{
-                          background: 'none',
-                          border: 'none',
-                          padding: '4px',
-                          cursor: idx === editingAlias.targets.length - 1 ? 'default' : 'pointer',
-                        }}
-                        title="Move Down"
-                      >
-                        <ChevronDown size={16} />
-                      </button>
-                    </div>
-                    <div
-                      style={{
-                        cursor: 'grab',
-                        color: 'var(--color-text-secondary)',
-                        display: 'flex',
-                        alignItems: 'center',
-                        visibility: isDragging ? 'hidden' : 'visible',
-                      }}
-                    >
-                      <GripVertical size={16} />
-                    </div>
-                    <div
-                      style={{
-                        flex: '0 0 120px',
-                        maxWidth: '120px',
-                        visibility: isDragging ? 'hidden' : 'visible',
-                      }}
-                    >
-                      <select
-                        className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                        style={{ padding: '4px 8px', height: '28px' }}
-                        value={target.provider}
-                        onChange={(e) => updateTarget(idx, 'provider', e.target.value)}
-                      >
-                        <option value="">Select Provider...</option>
-                        {providers.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.name}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div style={{ flex: 1, visibility: isDragging ? 'hidden' : 'visible' }}>
-                      <select
-                        className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                        style={{ padding: '4px 8px', height: '28px' }}
-                        value={target.model}
-                        onChange={(e) => updateTarget(idx, 'model', e.target.value)}
-                        disabled={!target.provider}
-                      >
-                        <option value="">Select Model...</option>
-                        {availableModels
-                          .filter((m) => m.providerId === target.provider)
-                          .map((m) => (
-                            <option key={m.id} value={m.id}>
-                              {m.name}
-                            </option>
-                          ))}
-                      </select>
-                    </div>
-                    <div style={{ visibility: isDragging ? 'hidden' : 'visible' }}>
-                      <Switch
-                        checked={target.enabled !== false}
-                        onChange={(val) => updateTarget(idx, 'enabled', val)}
-                        size="sm"
-                      />
-                    </div>
-                    <div style={{ visibility: isDragging ? 'hidden' : 'visible' }}>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => removeTarget(idx)}
-                        style={{ color: 'var(--color-danger)', padding: '4px', minHeight: 'auto' }}
-                      >
-                        <Trash2 size={14} />
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      </Modal>
-
-      <Modal
-        isOpen={isAutoAddModalOpen}
-        onClose={() => setIsAutoAddModalOpen(false)}
-        title="Auto Add Targets"
-        size="lg"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button variant="ghost" onClick={() => setIsAutoAddModalOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleAddSelectedModels} disabled={selectedModels.size === 0}>
-              Add {selectedModels.size} Target{selectedModels.size !== 1 ? 's' : ''}
-            </Button>
-          </div>
-        }
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-          <div style={{ display: 'flex', gap: '8px' }}>
-            <Input
-              placeholder="Search models (e.g. 'gpt-4', 'claude')"
-              value={substring}
-              onChange={(e) => setSubstring(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleSearchModels()}
-              style={{ flex: 1 }}
-            />
-            <Button onClick={() => handleSearchModels()}>Search</Button>
-          </div>
-
-          {filteredModels.length > 0 ? (
+          }
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '16px',
+              alignItems: 'center',
+              textAlign: 'center',
+              padding: '16px 0',
+            }}
+          >
             <div
               style={{
-                maxHeight: '400px',
-                overflowY: 'auto',
+                width: '48px',
+                height: '48px',
+                borderRadius: '50%',
+                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Trash2 size={24} style={{ color: 'var(--color-danger)' }} />
+            </div>
+            <div>
+              <p className="text-text" style={{ marginBottom: '8px', fontWeight: 500 }}>
+                Are you sure you want to delete this alias?
+              </p>
+              <p className="text-text-secondary" style={{ fontSize: '14px' }}>
+                <strong>{aliasToDelete?.id}</strong> will be permanently removed from the
+                configuration.
+              </p>
+            </div>
+          </div>
+        </Modal>
+        {/* Metadata autocomplete portal — rendered outside accordion to avoid overflow:hidden clipping */}
+        {showMetadataDropdown &&
+          metadataResults.length > 0 &&
+          dropdownRect &&
+          createPortal(
+            <div
+              onMouseDown={(e) => e.preventDefault()}
+              style={{
+                position: 'fixed',
+                top: dropdownRect.top,
+                left: dropdownRect.left,
+                width: dropdownRect.width,
+                zIndex: 9999,
+                backgroundColor: '#1E293B',
                 border: '1px solid var(--color-border-glass)',
                 borderRadius: 'var(--radius-sm)',
+                boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                maxHeight: '180px',
+                overflowY: 'auto',
               }}
             >
-              <table className="w-full border-collapse font-body text-[13px]">
-                <thead
-                  style={{
-                    position: 'sticky',
-                    top: 0,
-                    backgroundColor: 'var(--color-bg-hover)',
-                    zIndex: 10,
+              {metadataResults.map((result) => (
+                <button
+                  key={result.id}
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    selectMetadataResult(result);
                   }}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '6px 10px',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    borderBottom: '1px solid var(--color-border-glass)',
+                  }}
+                  className="hover:bg-bg-hover transition-colors"
                 >
-                  <tr>
-                    <th
-                      className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                      style={{ width: '40px' }}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={
-                          filteredModels.length > 0 &&
-                          filteredModels.every(
-                            (m) =>
-                              selectedModels.has(`${m.provider.id}|${m.model.id}`) ||
-                              editingAlias.targets.some(
-                                (t) => t.provider === m.provider.id && t.model === m.model.id
-                              )
-                          )
-                        }
-                        onChange={(e) => {
-                          if (e.target.checked) {
-                            const newSelection = new Set(selectedModels);
-                            filteredModels.forEach((m) => {
-                              const key = `${m.provider.id}|${m.model.id}`;
-                              if (
-                                !editingAlias.targets.some(
-                                  (t) => t.provider === m.provider.id && t.model === m.model.id
-                                )
-                              ) {
-                                newSelection.add(key);
-                              }
-                            });
-                            setSelectedModels(newSelection);
-                          } else {
-                            const newSelection = new Set(selectedModels);
-                            filteredModels.forEach((m) => {
-                              newSelection.delete(`${m.provider.id}|${m.model.id}`);
-                            });
-                            setSelectedModels(newSelection);
-                          }
-                        }}
-                      />
-                    </th>
-                    <th className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                      Provider
-                    </th>
-                    <th className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                      Model
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredModels.map(({ model, provider }) => {
-                    const key = `${provider.id}|${model.id}`;
-                    const alreadyExists = editingAlias.targets.some(
-                      (t) => t.provider === provider.id && t.model === model.id
-                    );
-                    const isSelected = selectedModels.has(key);
-                    const isDisabled = alreadyExists;
-
-                    return (
-                      <tr
-                        key={key}
-                        className="hover:bg-bg-hover"
-                        style={{ opacity: isDisabled ? 0.5 : 1 }}
-                      >
-                        <td className="px-4 py-3 text-left text-text">
-                          <input
-                            type="checkbox"
-                            checked={isSelected || alreadyExists}
-                            disabled={isDisabled}
-                            onChange={() => handleToggleModelSelection(model.id, provider.id)}
-                          />
-                        </td>
-                        <td className="px-4 py-3 text-left text-text">{provider.name}</td>
-                        <td className="px-4 py-3 text-left text-text">
-                          {model.name}
-                          {alreadyExists && (
-                            <span
-                              style={{
-                                marginLeft: '8px',
-                                fontSize: '11px',
-                                color: 'var(--color-text-secondary)',
-                                fontStyle: 'italic',
-                              }}
-                            >
-                              (already added)
-                            </span>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          ) : substring ? (
-            <div className="text-text-muted italic text-center text-sm py-8">
-              No models found matching "{substring}"
-            </div>
-          ) : (
-            <div className="text-text-muted italic text-center text-sm py-8">
-              Enter a search term to find models
-            </div>
+                  <div className="font-body text-[12px] font-medium text-text">{result.name}</div>
+                  <div className="font-body text-[10px] text-text-muted">{result.id}</div>
+                </button>
+              ))}
+            </div>,
+            document.body
           )}
-        </div>
-      </Modal>
-
-      <Modal
-        isOpen={isDeleteAllModalOpen}
-        onClose={() => setIsDeleteAllModalOpen(false)}
-        title="Delete All Models"
-        size="sm"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button
-              variant="ghost"
-              onClick={() => setIsDeleteAllModalOpen(false)}
-              disabled={isDeletingAll}
-            >
-              Cancel
-            </Button>
-            <Button onClick={handleConfirmDeleteAll} isLoading={isDeletingAll} variant="danger">
-              Delete All
-            </Button>
-          </div>
-        }
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '16px',
-            alignItems: 'center',
-            textAlign: 'center',
-            padding: '16px 0',
-          }}
-        >
-          <div
-            style={{
-              width: '48px',
-              height: '48px',
-              borderRadius: '50%',
-              backgroundColor: 'rgba(239, 68, 68, 0.1)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Trash2 size={24} style={{ color: 'var(--color-danger)' }} />
-          </div>
-          <div>
-            <p className="text-text" style={{ marginBottom: '8px', fontWeight: 500 }}>
-              Are you sure you want to delete all configured models?
-            </p>
-            <p className="text-text-secondary" style={{ fontSize: '14px' }}>
-              This will permanently remove <strong>{aliases.length}</strong> model alias
-              {aliases.length !== 1 ? 'es' : ''} from the configuration.
-            </p>
-          </div>
-        </div>
-      </Modal>
-
-      <Modal
-        isOpen={isDeleteModalOpen}
-        onClose={() => setIsDeleteModalOpen(false)}
-        title="Delete Model Alias"
-        size="sm"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button
-              variant="ghost"
-              onClick={() => setIsDeleteModalOpen(false)}
-              disabled={isDeleting}
-            >
-              Cancel
-            </Button>
-            <Button onClick={handleConfirmDelete} isLoading={isDeleting} variant="danger">
-              Delete
-            </Button>
-          </div>
-        }
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '16px',
-            alignItems: 'center',
-            textAlign: 'center',
-            padding: '16px 0',
-          }}
-        >
-          <div
-            style={{
-              width: '48px',
-              height: '48px',
-              borderRadius: '50%',
-              backgroundColor: 'rgba(239, 68, 68, 0.1)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <Trash2 size={24} style={{ color: 'var(--color-danger)' }} />
-          </div>
-          <div>
-            <p className="text-text" style={{ marginBottom: '8px', fontWeight: 500 }}>
-              Are you sure you want to delete this alias?
-            </p>
-            <p className="text-text-secondary" style={{ fontSize: '14px' }}>
-              <strong>{aliasToDelete?.id}</strong> will be permanently removed from the
-              configuration.
-            </p>
-          </div>
-        </div>
-      </Modal>
-      {/* Metadata autocomplete portal — rendered outside accordion to avoid overflow:hidden clipping */}
-      {showMetadataDropdown &&
-        metadataResults.length > 0 &&
-        dropdownRect &&
-        createPortal(
-          <div
-            onMouseDown={(e) => e.preventDefault()}
-            style={{
-              position: 'fixed',
-              top: dropdownRect.top,
-              left: dropdownRect.left,
-              width: dropdownRect.width,
-              zIndex: 9999,
-              backgroundColor: '#1E293B',
-              border: '1px solid var(--color-border-glass)',
-              borderRadius: 'var(--radius-sm)',
-              boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
-              maxHeight: '180px',
-              overflowY: 'auto',
-            }}
-          >
-            {metadataResults.map((result) => (
-              <button
-                key={result.id}
-                type="button"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  selectMetadataResult(result);
-                }}
-                style={{
-                  display: 'block',
-                  width: '100%',
-                  textAlign: 'left',
-                  padding: '6px 10px',
-                  background: 'none',
-                  border: 'none',
-                  cursor: 'pointer',
-                  borderBottom: '1px solid var(--color-border-glass)',
-                }}
-                className="hover:bg-bg-hover transition-colors"
-              >
-                <div className="font-body text-[12px] font-medium text-text">{result.name}</div>
-                <div className="font-body text-[10px] text-text-muted">{result.id}</div>
-              </button>
-            ))}
-          </div>,
-          document.body
-        )}
       </PageContainer>
     </div>
   );

--- a/packages/frontend/src/pages/MyKey.tsx
+++ b/packages/frontend/src/pages/MyKey.tsx
@@ -144,139 +144,146 @@ export const MyKey: React.FC = () => {
         }
       />
       <PageContainer width="standard">
+        <div className="flex flex-col gap-4 sm:gap-6">
+          <Card title="Identity">
+            <dl className="grid grid-cols-1 sm:grid-cols-[max-content_1fr] gap-x-6 gap-y-3 text-sm">
+              <dt className="text-text-muted">Key name</dt>
+              <dd className="font-mono text-text break-all">{info.keyName}</dd>
+              <dt className="text-text-muted">Quota</dt>
+              <dd className="text-text">{info.quotaName || '—'}</dd>
+              <dt className="text-text-muted">Allowed providers</dt>
+              <dd className="text-text break-words">
+                {allowedProviders.length > 0 ? allowedProviders.join(', ') : 'Any (unrestricted)'}
+              </dd>
+              <dt className="text-text-muted">Allowed models</dt>
+              <dd className="text-text break-words">
+                {allowedModels.length > 0 ? allowedModels.join(', ') : 'Any (unrestricted)'}
+              </dd>
+            </dl>
+          </Card>
 
-      <div className="flex flex-col gap-4 sm:gap-6">
-        <Card title="Identity">
-          <dl className="grid grid-cols-1 sm:grid-cols-[max-content_1fr] gap-x-6 gap-y-3 text-sm">
-            <dt className="text-text-muted">Key name</dt>
-            <dd className="font-mono text-text break-all">{info.keyName}</dd>
-            <dt className="text-text-muted">Quota</dt>
-            <dd className="text-text">{info.quotaName || '—'}</dd>
-            <dt className="text-text-muted">Allowed providers</dt>
-            <dd className="text-text break-words">
-              {allowedProviders.length > 0 ? allowedProviders.join(', ') : 'Any (unrestricted)'}
-            </dd>
-            <dt className="text-text-muted">Allowed models</dt>
-            <dd className="text-text break-words">
-              {allowedModels.length > 0 ? allowedModels.join(', ') : 'Any (unrestricted)'}
-            </dd>
-          </dl>
-        </Card>
-
-        <Card title="Comment">
-          <div className="flex flex-col gap-3">
-            <Input
-              value={comment}
-              onChange={(e) => setComment(e.target.value)}
-              placeholder="Free-text note about this key (optional)"
-            />
-            <div className="flex justify-end">
-              <Button
-                onClick={handleSaveComment}
-                disabled={savingComment || (comment.trim() || null) === (info.comment ?? null)}
-                isLoading={savingComment}
-              >
-                Save
-              </Button>
+          <Card title="Comment">
+            <div className="flex flex-col gap-3">
+              <Input
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder="Free-text note about this key (optional)"
+              />
+              <div className="flex justify-stretch sm:justify-end">
+                <Button
+                  onClick={handleSaveComment}
+                  disabled={savingComment || (comment.trim() || null) === (info.comment ?? null)}
+                  isLoading={savingComment}
+                  className="w-full sm:w-auto"
+                >
+                  Save
+                </Button>
+              </div>
             </div>
-          </div>
-        </Card>
+          </Card>
 
-        <Card title="Trace capture">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-            <div className="min-w-0 flex-1">
+          <Card title="Trace capture">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-text">
+                  Capture full request/response payloads for this key only.
+                </p>
+                <p className="text-xs text-text-muted mt-1">
+                  {info.traceEnabledGlobal
+                    ? 'Global tracing is ON (admin) — all requests are captured regardless of this toggle.'
+                    : info.traceEnabled
+                      ? 'Currently capturing traces for this key.'
+                      : 'Tracing is off for this key.'}
+                </p>
+              </div>
+              <Switch
+                checked={!!info.traceEnabled}
+                onChange={handleToggleTrace}
+                disabled={togglingTrace || !!info.traceEnabledGlobal}
+                aria-label="Toggle trace capture"
+              />
+            </div>
+          </Card>
+
+          <Card title="Rotate secret">
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-text-secondary">
+                Generates a new secret for this key. The old secret stops working immediately. Your
+                historical logs, traces, and errors are preserved (they're indexed by key name, not
+                secret).
+              </p>
+              <div className="flex justify-stretch sm:justify-end">
+                <Button
+                  variant="danger"
+                  onClick={() => setShowRotate(true)}
+                  disabled={rotating}
+                  leftIcon={<RotateCw size={16} />}
+                  className="w-full sm:w-auto"
+                >
+                  Rotate secret
+                </Button>
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <Modal
+          isOpen={showRotate}
+          onClose={() => {
+            setShowRotate(false);
+            setNewSecret(null);
+          }}
+          title={newSecret ? 'New secret generated' : 'Rotate secret?'}
+          footer={
+            newSecret ? (
+              <Button
+                onClick={() => {
+                  setShowRotate(false);
+                  setNewSecret(null);
+                }}
+              >
+                Done
+              </Button>
+            ) : (
+              <>
+                <Button
+                  variant="secondary"
+                  onClick={() => setShowRotate(false)}
+                  disabled={rotating}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="danger"
+                  onClick={handleRotate}
+                  disabled={rotating}
+                  isLoading={rotating}
+                >
+                  Rotate now
+                </Button>
+              </>
+            )
+          }
+        >
+          {newSecret ? (
+            <div className="flex flex-col gap-3">
               <p className="text-sm text-text">
-                Capture full request/response payloads for this key only.
+                Copy this secret now — it will not be shown again.
               </p>
-              <p className="text-xs text-text-muted mt-1">
-                {info.traceEnabledGlobal
-                  ? 'Global tracing is ON (admin) — all requests are captured regardless of this toggle.'
-                  : info.traceEnabled
-                    ? 'Currently capturing traces for this key.'
-                    : 'Tracing is off for this key.'}
-              </p>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <code className="flex-1 min-w-0 p-2 bg-bg-card border border-border rounded-md text-xs font-mono break-all">
+                  {newSecret}
+                </code>
+                <CopyButton value={newSecret} variant="icon" />
+              </div>
             </div>
-            <Switch
-              checked={!!info.traceEnabled}
-              onChange={handleToggleTrace}
-              disabled={togglingTrace || !!info.traceEnabledGlobal}
-              aria-label="Toggle trace capture"
-            />
-          </div>
-        </Card>
-
-        <Card title="Rotate secret">
-          <div className="flex flex-col gap-3">
-            <p className="text-sm text-text-secondary">
-              Generates a new secret for this key. The old secret stops working immediately. Your
-              historical logs, traces, and errors are preserved (they're indexed by key name, not
-              secret).
-            </p>
-            <div className="flex justify-end">
-              <Button
-                variant="danger"
-                onClick={() => setShowRotate(true)}
-                disabled={rotating}
-                leftIcon={<RotateCw size={16} />}
-              >
-                Rotate secret
-              </Button>
-            </div>
-          </div>
-        </Card>
-      </div>
-
-      <Modal
-        isOpen={showRotate}
-        onClose={() => {
-          setShowRotate(false);
-          setNewSecret(null);
-        }}
-        title={newSecret ? 'New secret generated' : 'Rotate secret?'}
-        footer={
-          newSecret ? (
-            <Button
-              onClick={() => {
-                setShowRotate(false);
-                setNewSecret(null);
-              }}
-            >
-              Done
-            </Button>
           ) : (
-            <>
-              <Button variant="secondary" onClick={() => setShowRotate(false)} disabled={rotating}>
-                Cancel
-              </Button>
-              <Button
-                variant="danger"
-                onClick={handleRotate}
-                disabled={rotating}
-                isLoading={rotating}
-              >
-                Rotate now
-              </Button>
-            </>
-          )
-        }
-      >
-        {newSecret ? (
-          <div className="flex flex-col gap-3">
-            <p className="text-sm text-text">Copy this secret now — it will not be shown again.</p>
-            <div className="flex gap-2 items-center">
-              <code className="flex-1 min-w-0 p-2 bg-bg-card border border-border rounded-md text-xs font-mono break-all">
-                {newSecret}
-              </code>
-              <CopyButton value={newSecret} variant="icon" />
-            </div>
-          </div>
-        ) : (
-          <p className="text-sm text-text-secondary">
-            The old secret will stop working immediately. Any clients using it will receive 401
-            errors until they are updated with the new secret.
-          </p>
-        )}
-      </Modal>
+            <p className="text-sm text-text-secondary">
+              The old secret will stop working immediately. Any clients using it will receive 401
+              errors until they are updated with the new secret.
+            </p>
+          )}
+        </Modal>
       </PageContainer>
     </div>
   );

--- a/packages/frontend/src/pages/MyKey.tsx
+++ b/packages/frontend/src/pages/MyKey.tsx
@@ -62,25 +62,29 @@ export const MyKey: React.FC = () => {
 
   if (loading) {
     return (
-      <PageContainer width="standard">
+      <div className="flex flex-col min-h-full">
         <PageHeader title="My Key" subtitle="Loading your key details..." />
-        <div className="flex flex-col gap-4">
-          <Skeleton height={140} />
-          <Skeleton height={120} />
-          <Skeleton height={120} />
-        </div>
-      </PageContainer>
+        <PageContainer width="standard">
+          <div className="flex flex-col gap-4">
+            <Skeleton height={140} />
+            <Skeleton height={120} />
+            <Skeleton height={120} />
+          </div>
+        </PageContainer>
+      </div>
     );
   }
 
   if (!info || info.role !== 'limited') {
     return (
-      <PageContainer width="standard">
+      <div className="flex flex-col min-h-full">
         <PageHeader title="My Key" />
-        <Card>
-          <p className="text-danger">Unable to load key info.</p>
-        </Card>
-      </PageContainer>
+        <PageContainer width="standard">
+          <Card>
+            <p className="text-danger">Unable to load key info.</p>
+          </Card>
+        </PageContainer>
+      </div>
     );
   }
 
@@ -129,7 +133,7 @@ export const MyKey: React.FC = () => {
   const allowedModels = info.allowedModels ?? [];
 
   return (
-    <PageContainer width="standard">
+    <div className="flex flex-col min-h-full">
       <PageHeader
         title="My Key"
         subtitle={
@@ -139,6 +143,7 @@ export const MyKey: React.FC = () => {
           </>
         }
       />
+      <PageContainer width="standard">
 
       <div className="flex flex-col gap-4 sm:gap-6">
         <Card title="Identity">
@@ -272,6 +277,7 @@ export const MyKey: React.FC = () => {
           </p>
         )}
       </Modal>
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 };

--- a/packages/frontend/src/pages/Providers.tsx
+++ b/packages/frontend/src/pages/Providers.tsx
@@ -183,7 +183,6 @@ const EMPTY_PROVIDER: Provider = {
   disableCooldown: false,
   estimateTokens: false,
   useClaudeMasking: false,
-  geminiThinkingEnabled: false,
   apiBaseUrl: {},
   headers: {},
   extraBody: {},
@@ -1038,6 +1037,8 @@ export const Providers = () => {
     );
   };
 
+  const sortedProviders = [...providers].sort((a, b) => a.id.localeCompare(b.id));
+
   return (
     <div className="flex flex-col min-h-full">
       <PageHeader
@@ -1050,39 +1051,110 @@ export const Providers = () => {
         }
       />
       <PageContainer>
-      <Card flush>
-        <div className="overflow-x-auto">
-          <table className="w-full border-collapse font-body text-[13px]">
-            <thead>
-              <tr>
-                <th
-                  className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                  style={{ paddingLeft: '24px' }}
-                >
-                  ID / Name
-                </th>
-                <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                  Status
-                </th>
+        <Card flush>
+          <div className="space-y-3 p-3 md:hidden">
+            {sortedProviders.length === 0 ? (
+              <div className="rounded-lg border border-border-glass bg-bg-subtle p-4 text-center text-sm text-text-secondary">
+                No providers configured
+              </div>
+            ) : (
+              sortedProviders.map((p) => {
+                const modelCount = p.models
+                  ? Array.isArray(p.models)
+                    ? p.models.length
+                    : typeof p.models === 'object'
+                      ? Object.keys(p.models).length
+                      : 0
+                  : 0;
 
-                <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                  Models
-                </th>
-                <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                  Quota/Balance
-                </th>
-                <th
-                  className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                  style={{ paddingRight: '24px', textAlign: 'right' }}
-                >
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {[...providers]
-                .sort((a, b) => a.id.localeCompare(b.id))
-                .map((p) => (
+                return (
+                  <article
+                    key={p.id}
+                    onClick={() => handleEdit(p)}
+                    className="rounded-lg border border-border-glass bg-bg-card p-3 transition-colors hover:border-primary/30 hover:bg-bg-hover"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <Edit2 size={12} className="shrink-0 text-text-muted" />
+                          <h3 className="truncate text-sm font-semibold text-text">{p.id}</h3>
+                        </div>
+                        <p className="mt-0.5 truncate text-xs text-text-secondary">{p.name}</p>
+                      </div>
+                      <div onClick={(e) => e.stopPropagation()}>
+                        <Switch
+                          checked={p.enabled !== false}
+                          onChange={(val) => handleToggleEnabled(p, val)}
+                          size="sm"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                      <div className="rounded-md bg-bg-subtle p-2">
+                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                          Models
+                        </div>
+                        <div className="text-text">{modelCount}</div>
+                      </div>
+                      <div className="rounded-md bg-bg-subtle p-2">
+                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                          Quota/Balance
+                        </div>
+                        <div className="mt-1 min-h-5">{getQuotaDisplay(p) || '-'}</div>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex justify-end border-t border-border-glass pt-3">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openDeleteModal(p);
+                        }}
+                        className="text-danger"
+                      >
+                        <Trash2 size={14} />
+                        Delete
+                      </Button>
+                    </div>
+                  </article>
+                );
+              })
+            )}
+          </div>
+
+          <div className="hidden overflow-x-auto md:block">
+            <table className="w-full border-collapse font-body text-[13px]">
+              <thead>
+                <tr>
+                  <th
+                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                    style={{ paddingLeft: '24px' }}
+                  >
+                    ID / Name
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Status
+                  </th>
+
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Models
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Quota/Balance
+                  </th>
+                  <th
+                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                    style={{ paddingRight: '24px', textAlign: 'right' }}
+                  >
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedProviders.map((p) => (
                   <tr
                     key={p.id}
                     onClick={() => handleEdit(p)}
@@ -1143,2746 +1215,2703 @@ export const Providers = () => {
                     </td>
                   </tr>
                 ))}
-            </tbody>
-          </table>
-        </div>
-      </Card>
-
-      <Modal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        title={originalId ? `Edit Provider: ${originalId}` : 'Add Provider'}
-        size="lg"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button variant="ghost" onClick={() => setIsModalOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleSave} isLoading={isSaving} disabled={!!quotaValidationError}>
-              Save Provider
-            </Button>
+              </tbody>
+            </table>
           </div>
-        }
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginTop: '-8px' }}>
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr auto',
-              gap: '12px',
-              alignItems: 'end',
-            }}
-          >
-            <Input
-              label="Unique ID"
-              value={editingProvider.id}
-              onChange={(e) => setEditingProvider({ ...editingProvider, id: e.target.value })}
-              placeholder="e.g. openai"
-              disabled={!!originalId}
-            />
-            <Input
-              label="Display Name"
-              value={editingProvider.name}
-              onChange={(e) => setEditingProvider({ ...editingProvider, name: e.target.value })}
-              placeholder="e.g. OpenAI Production"
-            />
-            <Input
-              label="API Key"
-              type="password"
-              value={editingProvider.apiKey}
-              onChange={(e) => setEditingProvider({ ...editingProvider, apiKey: e.target.value })}
-              placeholder="sk-..."
-              disabled={isOAuthMode}
-            />
-            <div className="flex flex-col gap-2">
-              <label className="font-body text-[13px] font-medium text-text-secondary">
-                Enabled
-              </label>
-              <div style={{ height: '38px', display: 'flex', alignItems: 'center' }}>
-                <Switch
-                  checked={editingProvider.enabled !== false}
-                  onChange={(checked) =>
-                    setEditingProvider({ ...editingProvider, enabled: checked })
-                  }
-                />
+        </Card>
+
+        <Modal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          title={originalId ? `Edit Provider: ${originalId}` : 'Add Provider'}
+          size="lg"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button variant="ghost" onClick={() => setIsModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleSave} isLoading={isSaving} disabled={!!quotaValidationError}>
+                Save Provider
+              </Button>
+            </div>
+          }
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginTop: '-8px' }}>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-[1fr_1fr_1fr_auto] xl:items-end">
+              <Input
+                label="Unique ID"
+                value={editingProvider.id}
+                onChange={(e) => setEditingProvider({ ...editingProvider, id: e.target.value })}
+                placeholder="e.g. openai"
+                disabled={!!originalId}
+              />
+              <Input
+                label="Display Name"
+                value={editingProvider.name}
+                onChange={(e) => setEditingProvider({ ...editingProvider, name: e.target.value })}
+                placeholder="e.g. OpenAI Production"
+              />
+              <Input
+                label="API Key"
+                type="password"
+                value={editingProvider.apiKey}
+                onChange={(e) => setEditingProvider({ ...editingProvider, apiKey: e.target.value })}
+                placeholder="sk-..."
+                disabled={isOAuthMode}
+              />
+              <div className="flex flex-col gap-2">
+                <label className="font-body text-[13px] font-medium text-text-secondary">
+                  Enabled
+                </label>
+                <div style={{ height: '38px', display: 'flex', alignItems: 'center' }}>
+                  <Switch
+                    checked={editingProvider.enabled !== false}
+                    onChange={(checked) =>
+                      setEditingProvider({ ...editingProvider, enabled: checked })
+                    }
+                  />
+                </div>
               </div>
             </div>
-          </div>
 
-          {/* Separator */}
-          <div
-            style={{ height: '1px', background: 'var(--color-border-glass)', margin: '4px 0' }}
-          />
+            {/* Separator */}
+            <div
+              style={{ height: '1px', background: 'var(--color-border-glass)', margin: '4px 0' }}
+            />
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
-            {/* Left: APIs & Base URLs */}
-            <div className="flex flex-col gap-1 border border-border-glass rounded-md p-3 bg-bg-subtle">
-              <div className="flex flex-col gap-1" style={{ marginBottom: '6px' }}>
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+              {/* Left: APIs & Base URLs */}
+              <div className="flex flex-col gap-1 border border-border-glass rounded-md p-3 bg-bg-subtle">
+                <div className="flex flex-col gap-1" style={{ marginBottom: '6px' }}>
+                  <label className="font-body text-[13px] font-medium text-text-secondary">
+                    Connection Type
+                  </label>
+                  <select
+                    className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                    value={isOAuthMode ? 'oauth' : 'url'}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      if (value === 'oauth') {
+                        setEditingProvider({
+                          ...editingProvider,
+                          apiBaseUrl: 'oauth://',
+                          apiKey: 'oauth',
+                          oauthProvider: editingProvider.oauthProvider || OAUTH_PROVIDERS[0].value,
+                          oauthAccount: editingProvider.oauthAccount || '',
+                          type: ['oauth'],
+                        });
+                      } else {
+                        setEditingProvider({
+                          ...editingProvider,
+                          apiBaseUrl: {},
+                          apiKey: '',
+                          oauthProvider: '',
+                          oauthAccount: '',
+                          type: [],
+                        });
+                      }
+                    }}
+                  >
+                    <option value="url">Custom API URL</option>
+                    <option value="oauth">OAuth (pi-ai)</option>
+                  </select>
+                </div>
                 <label className="font-body text-[13px] font-medium text-text-secondary">
-                  Connection Type
+                  Supported APIs & Base URLs
                 </label>
-                <select
-                  className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                  value={isOAuthMode ? 'oauth' : 'url'}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    if (value === 'oauth') {
-                      setEditingProvider({
-                        ...editingProvider,
-                        apiBaseUrl: 'oauth://',
-                        apiKey: 'oauth',
-                        oauthProvider: editingProvider.oauthProvider || OAUTH_PROVIDERS[0].value,
-                        oauthAccount: editingProvider.oauthAccount || '',
-                        type: ['oauth'],
-                      });
-                    } else {
-                      setEditingProvider({
-                        ...editingProvider,
-                        apiBaseUrl: {},
-                        apiKey: '',
-                        oauthProvider: '',
-                        oauthAccount: '',
-                        type: [],
-                      });
-                    }
-                  }}
-                >
-                  <option value="url">Custom API URL</option>
-                  <option value="oauth">OAuth (pi-ai)</option>
-                </select>
-              </div>
-              <label className="font-body text-[13px] font-medium text-text-secondary">
-                Supported APIs & Base URLs
-              </label>
-              <div
-                style={{
-                  fontSize: '11px',
-                  color: 'var(--color-text-secondary)',
-                  marginBottom: '4px',
-                  lineHeight: '1.5',
-                }}
-              >
-                <span style={{ fontStyle: 'italic' }}>API types determine the protocol:</span>
-                <ul style={{ margin: '4px 0 0 0', paddingLeft: '16px' }}>
-                  <li>
-                    <span style={{ fontWeight: 600 }}>chat</span> — OpenAI-compatible endpoints,
-                    including Ollama&apos;s{' '}
-                    <code
-                      style={{
-                        background: 'var(--color-bg-subtle)',
-                        padding: '1px 4px',
-                        borderRadius: '2px',
-                      }}
-                    >
-                      /v1
-                    </code>{' '}
-                    API
-                  </li>
-                  <li>
-                    <span style={{ fontWeight: 600 }}>ollama</span> — Native Ollama API, use the
-                    root URL (e.g.{' '}
-                    <code
-                      style={{
-                        background: 'var(--color-bg-subtle)',
-                        padding: '1px 4px',
-                        borderRadius: '2px',
-                      }}
-                    >
-                      http://localhost:11434
-                    </code>
-                    )
-                  </li>
-                </ul>
-              </div>
-              {isOAuthMode ? (
                 <div
                   style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '8px',
-                    background: 'var(--color-bg-subtle)',
-                    padding: '8px',
-                    borderRadius: 'var(--radius-md)',
+                    fontSize: '11px',
+                    color: 'var(--color-text-secondary)',
+                    marginBottom: '4px',
+                    lineHeight: '1.5',
                   }}
                 >
-                  <div className="flex flex-col gap-1">
-                    <label className="font-body text-[13px] font-medium text-text-secondary">
-                      OAuth Provider
-                    </label>
-                    <select
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                      value={editingProvider.oauthProvider || OAUTH_PROVIDERS[0].value}
+                  <span style={{ fontStyle: 'italic' }}>API types determine the protocol:</span>
+                  <ul style={{ margin: '4px 0 0 0', paddingLeft: '16px' }}>
+                    <li>
+                      <span style={{ fontWeight: 600 }}>chat</span> — OpenAI-compatible endpoints,
+                      including Ollama&apos;s{' '}
+                      <code
+                        style={{
+                          background: 'var(--color-bg-subtle)',
+                          padding: '1px 4px',
+                          borderRadius: '2px',
+                        }}
+                      >
+                        /v1
+                      </code>{' '}
+                      API
+                    </li>
+                    <li>
+                      <span style={{ fontWeight: 600 }}>ollama</span> — Native Ollama API, use the
+                      root URL (e.g.{' '}
+                      <code
+                        style={{
+                          background: 'var(--color-bg-subtle)',
+                          padding: '1px 4px',
+                          borderRadius: '2px',
+                        }}
+                      >
+                        http://localhost:11434
+                      </code>
+                      )
+                    </li>
+                  </ul>
+                </div>
+                {isOAuthMode ? (
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: '8px',
+                      background: 'var(--color-bg-subtle)',
+                      padding: '8px',
+                      borderRadius: 'var(--radius-md)',
+                    }}
+                  >
+                    <div className="flex flex-col gap-1">
+                      <label className="font-body text-[13px] font-medium text-text-secondary">
+                        OAuth Provider
+                      </label>
+                      <select
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                        value={editingProvider.oauthProvider || OAUTH_PROVIDERS[0].value}
+                        onChange={(e) =>
+                          setEditingProvider({
+                            ...editingProvider,
+                            oauthProvider: e.target.value,
+                          })
+                        }
+                      >
+                        {OAUTH_PROVIDERS.map((provider) => (
+                          <option key={provider.value} value={provider.value}>
+                            {provider.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <Input
+                      label="OAuth Account"
+                      value={editingProvider.oauthAccount || ''}
                       onChange={(e) =>
                         setEditingProvider({
                           ...editingProvider,
-                          oauthProvider: e.target.value,
+                          oauthAccount: e.target.value,
                         })
                       }
-                    >
-                      {OAUTH_PROVIDERS.map((provider) => (
-                        <option key={provider.value} value={provider.value}>
-                          {provider.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <Input
-                    label="OAuth Account"
-                    value={editingProvider.oauthAccount || ''}
-                    onChange={(e) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        oauthAccount: e.target.value,
-                      })
-                    }
-                    placeholder="e.g. work, personal, team-a"
-                  />
+                      placeholder="e.g. work, personal, team-a"
+                    />
 
-                  <div
-                    className="border border-border-glass rounded-md p-3 bg-bg-subtle"
-                    style={{ marginTop: '4px' }}
-                  >
                     <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        gap: '12px',
-                        marginBottom: '8px',
-                      }}
+                      className="border border-border-glass rounded-md p-3 bg-bg-subtle"
+                      style={{ marginTop: '4px' }}
                     >
-                      <div>
-                        <div className="font-body text-[13px] font-medium text-text">
-                          OAuth Authentication
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          gap: '12px',
+                          marginBottom: '8px',
+                        }}
+                      >
+                        <div>
+                          <div className="font-body text-[13px] font-medium text-text">
+                            OAuth Authentication
+                          </div>
+                          <div className="text-[11px] text-text-secondary">
+                            Tokens are saved to auth.json after login.
+                          </div>
                         </div>
-                        <div className="text-[11px] text-text-secondary">
-                          Tokens are saved to auth.json after login.
+                        <div className="flex items-center gap-2">
+                          <span
+                            style={{
+                              width: '8px',
+                              height: '8px',
+                              borderRadius: '999px',
+                              background:
+                                oauthStatus === 'success' || (!oauthStatus && oauthCredentialReady)
+                                  ? 'var(--color-success)'
+                                  : oauthStatus === 'error' || oauthStatus === 'cancelled'
+                                    ? 'var(--color-danger)'
+                                    : 'var(--color-text-secondary)',
+                              opacity: oauthCredentialChecking ? 0.6 : 1,
+                            }}
+                          />
+                          <span
+                            className="text-[11px] font-medium text-text-secondary"
+                            style={{ textTransform: 'lowercase' }}
+                          >
+                            {oauthStatusLabel}
+                          </span>
                         </div>
                       </div>
-                      <div className="flex items-center gap-2">
-                        <span
+
+                      {oauthError && (
+                        <div className="text-[11px] text-danger" style={{ marginBottom: '8px' }}>
+                          {oauthError}
+                        </div>
+                      )}
+
+                      {oauthSession?.authInfo && (
+                        <div
                           style={{
-                            width: '8px',
-                            height: '8px',
-                            borderRadius: '999px',
-                            background:
-                              oauthStatus === 'success' || (!oauthStatus && oauthCredentialReady)
-                                ? 'var(--color-success)'
-                                : oauthStatus === 'error' || oauthStatus === 'cancelled'
-                                  ? 'var(--color-danger)'
-                                  : 'var(--color-text-secondary)',
-                            opacity: oauthCredentialChecking ? 0.6 : 1,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '6px',
+                            marginBottom: '8px',
                           }}
-                        />
-                        <span
-                          className="text-[11px] font-medium text-text-secondary"
-                          style={{ textTransform: 'lowercase' }}
                         >
-                          {oauthStatusLabel}
-                        </span>
+                          <Input
+                            label="Authorization URL"
+                            value={oauthSession.authInfo.url}
+                            readOnly
+                          />
+                          {oauthSession.authInfo.instructions && (
+                            <div className="text-[11px] text-text-secondary flex items-center gap-1">
+                              <Info size={12} />
+                              <span>{oauthSession.authInfo.instructions}</span>
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                      {oauthSession?.prompt && (
+                        <div
+                          style={{
+                            display: 'flex',
+                            gap: '8px',
+                            alignItems: 'flex-end',
+                            marginBottom: '8px',
+                          }}
+                        >
+                          <div style={{ flex: 1 }}>
+                            <Input
+                              label={oauthSession.prompt.message}
+                              placeholder={oauthSession.prompt.placeholder}
+                              value={oauthPromptValue}
+                              onChange={(e) => setOauthPromptValue(e.target.value)}
+                            />
+                          </div>
+                          <Button
+                            size="sm"
+                            onClick={handleSubmitPrompt}
+                            disabled={
+                              oauthBusy || (!oauthSession.prompt.allowEmpty && !oauthPromptValue)
+                            }
+                          >
+                            Submit
+                          </Button>
+                        </div>
+                      )}
+
+                      {oauthSession?.status === 'awaiting_manual_code' && (
+                        <div
+                          style={{
+                            display: 'flex',
+                            gap: '8px',
+                            alignItems: 'flex-end',
+                            marginBottom: '8px',
+                          }}
+                        >
+                          <div style={{ flex: 1 }}>
+                            <Input
+                              label="Paste redirect URL or code"
+                              value={oauthManualCode}
+                              onChange={(e) => setOauthManualCode(e.target.value)}
+                              placeholder="https://..."
+                            />
+                          </div>
+                          <Button
+                            size="sm"
+                            onClick={handleSubmitManualCode}
+                            disabled={oauthBusy || !oauthManualCode}
+                          >
+                            Submit
+                          </Button>
+                        </div>
+                      )}
+
+                      {oauthSession?.progress && oauthSession.progress.length > 0 && (
+                        <div style={{ marginBottom: '8px' }}>
+                          <div className="text-[11px] text-text-secondary">Progress</div>
+                          <div className="text-[11px] text-text" style={{ marginTop: '4px' }}>
+                            {(oauthSession?.progress ?? []).slice(-3).map((message, idx) => (
+                              <div key={`${message}-${idx}`}>{message}</div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {oauthStatus === 'success' && (
+                        <div className="text-[11px] text-success" style={{ marginBottom: '8px' }}>
+                          Authentication complete. Tokens saved to auth.json.
+                        </div>
+                      )}
+
+                      <div style={{ display: 'flex', gap: '8px' }}>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          onClick={handleStartOAuth}
+                          isLoading={oauthBusy && !oauthSessionId}
+                          disabled={oauthBusy || (!!oauthSessionId && !oauthIsTerminal)}
+                        >
+                          {oauthSessionId && !oauthIsTerminal
+                            ? 'OAuth in progress'
+                            : oauthCredentialReady
+                              ? 'Restart OAuth'
+                              : 'Start OAuth'}
+                        </Button>
+                        {oauthSessionId && !oauthIsTerminal && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={handleCancelOAuth}
+                            disabled={oauthBusy}
+                          >
+                            Cancel
+                          </Button>
+                        )}
                       </div>
                     </div>
-
-                    {oauthError && (
-                      <div className="text-[11px] text-danger" style={{ marginBottom: '8px' }}>
-                        {oauthError}
-                      </div>
-                    )}
-
-                    {oauthSession?.authInfo && (
+                  </div>
+                ) : (
+                  <div className="border border-border-glass rounded-md overflow-hidden">
+                    <div
+                      className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
+                      onClick={() => setIsApiBaseUrlsOpen(!isApiBaseUrlsOpen)}
+                    >
+                      {isApiBaseUrlsOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                      <label
+                        className="font-body text-[13px] font-medium text-text-secondary"
+                        style={{ marginBottom: 0, flex: 1 }}
+                      >
+                        Base URL Entries
+                      </label>
+                      <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
+                        {Object.keys(getApiBaseUrlMap()).length}
+                      </Badge>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          addApiBaseUrlEntry();
+                        }}
+                        disabled={Object.keys(getApiBaseUrlMap()).length >= KNOWN_APIS.length}
+                      >
+                        <Plus size={14} />
+                      </Button>
+                    </div>
+                    {isApiBaseUrlsOpen && (
                       <div
                         style={{
                           display: 'flex',
                           flexDirection: 'column',
                           gap: '6px',
-                          marginBottom: '8px',
+                          padding: '8px',
+                          borderTop: '1px solid var(--color-border-glass)',
+                          background: 'var(--color-bg-subtle)',
                         }}
                       >
-                        <Input
-                          label="Authorization URL"
-                          value={oauthSession.authInfo.url}
-                          readOnly
-                        />
-                        {oauthSession.authInfo.instructions && (
-                          <div className="text-[11px] text-text-secondary flex items-center gap-1">
-                            <Info size={12} />
-                            <span>{oauthSession.authInfo.instructions}</span>
+                        {Object.entries(getApiBaseUrlMap()).length === 0 && (
+                          <div className="font-body text-[11px] text-text-secondary italic">
+                            No base URLs configured yet.
                           </div>
                         )}
+                        {Object.entries(getApiBaseUrlMap()).map(([apiType, url]) => {
+                          // Detect URL/API type mismatches based on endpoint-shape only
+                          const urlLower = typeof url === 'string' ? url.toLowerCase() : '';
+                          // Native Ollama API paths (not hostname-based, only path-based)
+                          const hasNativeOllamaPath =
+                            urlLower.includes('/api/chat') ||
+                            urlLower.includes('/api/generate') ||
+                            urlLower.includes('/api/embeddings') ||
+                            urlLower.includes('/api/tags');
+                          const hasV1Suffix = urlLower.includes('/v1');
+                          // Warn when native Ollama type is selected but URL has /v1 (OpenAI-compatible)
+                          const showOllamaV1Warning = apiType === 'ollama' && hasV1Suffix;
+                          // Warn when chat type is selected but URL looks like native Ollama (path-based, no /v1)
+                          const showChatOllamaWarning =
+                            apiType === 'chat' && hasNativeOllamaPath && !hasV1Suffix;
+
+                          return (
+                            <div
+                              key={apiType}
+                              className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-start"
+                            >
+                              <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                                <select
+                                  className="w-full py-1.5 px-3 font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                                  value={apiType}
+                                  onChange={(e) =>
+                                    updateApiBaseUrlEntry(
+                                      apiType,
+                                      e.target.value,
+                                      typeof url === 'string' ? url : ''
+                                    )
+                                  }
+                                >
+                                  {KNOWN_APIS.map((knownType) => (
+                                    <option
+                                      key={knownType}
+                                      value={knownType}
+                                      className="bg-bg-surface text-text"
+                                    >
+                                      {knownType}
+                                    </option>
+                                  ))}
+                                </select>
+                                <input
+                                  className="w-full py-1.5 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                                  placeholder={
+                                    apiType === 'ollama'
+                                      ? 'http://localhost:11434'
+                                      : 'https://api.example.com/v1/...'
+                                  }
+                                  value={typeof url === 'string' ? url : ''}
+                                  onChange={(e) =>
+                                    updateApiBaseUrlEntry(apiType, apiType, e.target.value)
+                                  }
+                                />
+                                {showOllamaV1Warning && (
+                                  <div className="flex items-start gap-2 py-1.5 px-2 bg-warning/10 border border-warning/30 rounded-sm">
+                                    <AlertTriangle
+                                      size={14}
+                                      className="text-warning shrink-0 mt-0.5"
+                                    />
+                                    <span className="text-[11px] text-warning">
+                                      <span style={{ fontWeight: 600 }}>native ollama</span> type
+                                      expects root URL (e.g.{' '}
+                                      <code
+                                        style={{
+                                          background: 'var(--color-bg-subtle)',
+                                          padding: '0 3px',
+                                          borderRadius: '2px',
+                                        }}
+                                      >
+                                        http://localhost:11434
+                                      </code>
+                                      ). URLs with{' '}
+                                      <code
+                                        style={{
+                                          background: 'var(--color-bg-subtle)',
+                                          padding: '0 3px',
+                                          borderRadius: '2px',
+                                        }}
+                                      >
+                                        /v1
+                                      </code>{' '}
+                                      are OpenAI-compatible — use{' '}
+                                      <span style={{ fontWeight: 600 }}>chat</span> type instead.
+                                    </span>
+                                  </div>
+                                )}
+                                {showChatOllamaWarning && (
+                                  <div className="flex items-start gap-2 py-1.5 px-2 bg-warning/10 border border-warning/30 rounded-sm">
+                                    <AlertTriangle
+                                      size={14}
+                                      className="text-warning shrink-0 mt-0.5"
+                                    />
+                                    <span className="text-[11px] text-warning">
+                                      This URL contains{' '}
+                                      <code
+                                        style={{
+                                          background: 'var(--color-bg-subtle)',
+                                          padding: '0 3px',
+                                          borderRadius: '2px',
+                                        }}
+                                      >
+                                        /api/
+                                      </code>{' '}
+                                      paths typical of native Ollama. If this is a native Ollama
+                                      endpoint, use <span style={{ fontWeight: 600 }}>ollama</span>{' '}
+                                      type instead.
+                                    </span>
+                                  </div>
+                                )}
+                              </div>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => removeApiBaseUrlEntry(apiType)}
+                                style={{ padding: '4px', marginTop: '4px' }}
+                              >
+                                <Trash2 size={14} style={{ color: 'var(--color-danger)' }} />
+                              </Button>
+                            </div>
+                          );
+                        })}
                       </div>
                     )}
+                  </div>
+                )}
+              </div>
 
-                    {oauthSession?.prompt && (
-                      <div
-                        style={{
-                          display: 'flex',
-                          gap: '8px',
-                          alignItems: 'flex-end',
-                          marginBottom: '8px',
-                        }}
-                      >
-                        <div style={{ flex: 1 }}>
-                          <Input
-                            label={oauthSession.prompt.message}
-                            placeholder={oauthSession.prompt.placeholder}
-                            value={oauthPromptValue}
-                            onChange={(e) => setOauthPromptValue(e.target.value)}
-                          />
-                        </div>
-                        <Button
-                          size="sm"
-                          onClick={handleSubmitPrompt}
-                          disabled={
-                            oauthBusy || (!oauthSession.prompt.allowEmpty && !oauthPromptValue)
-                          }
-                        >
-                          Submit
-                        </Button>
-                      </div>
-                    )}
+              {/* Right: Quota Checker */}
+              <div className="flex flex-col gap-1 border border-border-glass rounded-md p-3 bg-bg-subtle">
+                <label className="font-body text-[13px] font-medium text-text-secondary">
+                  Quota Checker
+                </label>
+                <div className="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-[1fr_120px] sm:items-end">
+                  <div className="flex flex-col gap-1">
+                    <label className="font-body text-[11px] font-medium text-text-secondary">
+                      Type
+                    </label>
+                    <select
+                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                      value={selectedQuotaCheckerType}
+                      onChange={(e) => {
+                        const quotaType = e.target.value;
+                        if (!quotaType) {
+                          setEditingProvider({ ...editingProvider, quotaChecker: undefined });
+                          return;
+                        }
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            type: quotaType,
+                            enabled: true,
+                            intervalMinutes: Math.max(
+                              1,
+                              editingProvider.quotaChecker?.intervalMinutes || 30
+                            ),
+                            options: editingProvider.quotaChecker?.options,
+                          },
+                        });
+                      }}
+                    >
+                      {<option value="">&lt;none&gt;</option>}
+                      {selectableQuotaCheckerTypes.map((type) => (
+                        <option key={type} value={type}>
+                          {type}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="font-body text-[11px] font-medium text-text-secondary">
+                      Interval (min)
+                    </label>
+                    <input
+                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                      type="number"
+                      min={1}
+                      step={1}
+                      value={editingProvider.quotaChecker?.intervalMinutes || 30}
+                      disabled={!selectedQuotaCheckerType}
+                      onChange={(e) => {
+                        const intervalMinutes = Math.max(1, parseInt(e.target.value, 10) || 30);
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            type: selectedQuotaCheckerType,
+                            enabled: selectedQuotaCheckerType
+                              ? editingProvider.quotaChecker?.enabled !== false
+                              : false,
+                            intervalMinutes,
+                          },
+                        });
+                      }}
+                    />
+                  </div>
+                </div>
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: 'var(--color-text-secondary)',
+                    marginTop: '4px',
+                    fontStyle: 'italic',
+                  }}
+                >
+                  {isOAuthMode && oauthCheckerType
+                    ? `Only the '${oauthCheckerType}' checker is available for this OAuth provider.`
+                    : isOAuthMode
+                      ? 'No quota checker is available for this OAuth provider type.'
+                      : selectedQuotaCheckerType
+                        ? 'Quota checker is active for this provider.'
+                        : 'Select <none> to disable provider quota checks.'}
+                </div>
 
-                    {oauthSession?.status === 'awaiting_manual_code' && (
-                      <div
-                        style={{
-                          display: 'flex',
-                          gap: '8px',
-                          alignItems: 'flex-end',
-                          marginBottom: '8px',
-                        }}
-                      >
-                        <div style={{ flex: 1 }}>
-                          <Input
-                            label="Paste redirect URL or code"
-                            value={oauthManualCode}
-                            onChange={(e) => setOauthManualCode(e.target.value)}
-                            placeholder="https://..."
-                          />
-                        </div>
-                        <Button
-                          size="sm"
-                          onClick={handleSubmitManualCode}
-                          disabled={oauthBusy || !oauthManualCode}
-                        >
-                          Submit
-                        </Button>
-                      </div>
-                    )}
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'naga' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <NagaQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
 
-                    {oauthSession?.progress && oauthSession.progress.length > 0 && (
-                      <div style={{ marginBottom: '8px' }}>
-                        <div className="text-[11px] text-text-secondary">Progress</div>
-                        <div className="text-[11px] text-text" style={{ marginTop: '4px' }}>
-                          {(oauthSession?.progress ?? []).slice(-3).map((message, idx) => (
-                            <div key={`${message}-${idx}`}>{message}</div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'synthetic' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <SyntheticQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
 
-                    {oauthStatus === 'success' && (
-                      <div className="text-[11px] text-success" style={{ marginBottom: '8px' }}>
-                        Authentication complete. Tokens saved to auth.json.
-                      </div>
-                    )}
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'nanogpt' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <NanoGPTQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
 
-                    <div style={{ display: 'flex', gap: '8px' }}>
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        onClick={handleStartOAuth}
-                        isLoading={oauthBusy && !oauthSessionId}
-                        disabled={oauthBusy || (!!oauthSessionId && !oauthIsTerminal)}
-                      >
-                        {oauthSessionId && !oauthIsTerminal
-                          ? 'OAuth in progress'
-                          : oauthCredentialReady
-                            ? 'Restart OAuth'
-                            : 'Start OAuth'}
-                      </Button>
-                      {oauthSessionId && !oauthIsTerminal && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={handleCancelOAuth}
-                          disabled={oauthBusy}
-                        >
-                          Cancel
-                        </Button>
-                      )}
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'zai' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <ZAIQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'moonshot' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <MoonshotQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'novita' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <NovitaQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'minimax' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <MiniMaxQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'minimax-coding' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <MiniMaxCodingQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'openrouter' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <OpenRouterQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'kilo' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <KiloQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'poe' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <PoeQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'ollama' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <OllamaQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'wisdomgate' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <WisdomGateQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'kimi-code' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <KimiCodeQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'apertis' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <ApertisQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'antigravity' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <AntigravityQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'gemini-cli' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <GeminiCliQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'neuralwatt' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <NeuralwattQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {selectedQuotaCheckerType && selectedQuotaCheckerType === 'zenmux' && (
+                  <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                    <ZenmuxQuotaConfig
+                      options={editingProvider.quotaChecker?.options || {}}
+                      onChange={(options) =>
+                        setEditingProvider({
+                          ...editingProvider,
+                          quotaChecker: {
+                            ...editingProvider.quotaChecker,
+                            options,
+                          } as Provider['quotaChecker'],
+                        })
+                      }
+                    />
+                  </div>
+                )}
+
+                {quotaValidationError && (
+                  <div className="mt-2 text-xs text-danger bg-danger/10 border border-danger/20 rounded px-3 py-2">
+                    {quotaValidationError}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* GPU Profile section for inference energy calculation */}
+            <div className="flex flex-col gap-2">
+              <label className="font-body text-[13px] font-medium text-text-secondary">
+                GPU Profile
+              </label>
+              <div className="flex gap-3 items-end">
+                <select
+                  className="flex-1 py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                  value={editingProvider.gpu_profile || ''}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (!value) {
+                      // "Default (B200)" selected — resolve B200 preset
+                      const resolved = resolveGpuParams('B200');
+                      setEditingProvider({
+                        ...editingProvider,
+                        gpu_profile: undefined,
+                        gpu_ram_gb: resolved.ram_gb,
+                        gpu_bandwidth_tb_s: resolved.bandwidth_tb_s,
+                        gpu_flops_tflop: resolved.flops_tflop,
+                        gpu_power_draw_watts: resolved.power_draw_watts,
+                      });
+                    } else if (value === 'custom') {
+                      // Custom selected — merge any existing overrides with H100 defaults
+                      const resolved = resolveGpuParams('custom', {
+                        ram_gb: editingProvider.gpu_ram_gb,
+                        bandwidth_tb_s: editingProvider.gpu_bandwidth_tb_s,
+                        flops_tflop: editingProvider.gpu_flops_tflop,
+                        power_draw_watts: editingProvider.gpu_power_draw_watts,
+                      });
+                      setEditingProvider({
+                        ...editingProvider,
+                        gpu_profile: 'custom',
+                        gpu_ram_gb: resolved.ram_gb,
+                        gpu_bandwidth_tb_s: resolved.bandwidth_tb_s,
+                        gpu_flops_tflop: resolved.flops_tflop,
+                        gpu_power_draw_watts: resolved.power_draw_watts,
+                      });
+                    } else {
+                      // Named preset selected — resolve immediately to concrete params
+                      const resolved = resolveGpuParams(value);
+                      setEditingProvider({
+                        ...editingProvider,
+                        gpu_profile: value,
+                        gpu_ram_gb: resolved.ram_gb,
+                        gpu_bandwidth_tb_s: resolved.bandwidth_tb_s,
+                        gpu_flops_tflop: resolved.flops_tflop,
+                        gpu_power_draw_watts: resolved.power_draw_watts,
+                      });
+                    }
+                  }}
+                >
+                  <option value="">Default (B200)</option>
+                  {GPU_PROFILE_OPTIONS.map((profile) => (
+                    <option key={profile.value} value={profile.value}>
+                      {profile.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {editingProvider.gpu_profile === 'custom' && (
+                <div className="mt-2 p-3 border border-border-glass rounded-md bg-bg-subtle">
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        RAM (GB)
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="1"
+                        min="1"
+                        value={editingProvider.gpu_ram_gb || ''}
+                        onChange={(e) =>
+                          setEditingProvider({
+                            ...editingProvider,
+                            gpu_ram_gb: parseFloat(e.target.value) || undefined,
+                          })
+                        }
+                        placeholder="e.g. 80"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Bandwidth (TB/s)
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="0.1"
+                        min="0.1"
+                        value={editingProvider.gpu_bandwidth_tb_s || ''}
+                        onChange={(e) =>
+                          setEditingProvider({
+                            ...editingProvider,
+                            gpu_bandwidth_tb_s: parseFloat(e.target.value) || undefined,
+                          })
+                        }
+                        placeholder="e.g. 3.35"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        FLOPS (TFLOPs)
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="100"
+                        min="1"
+                        value={editingProvider.gpu_flops_tflop || ''}
+                        onChange={(e) =>
+                          setEditingProvider({
+                            ...editingProvider,
+                            gpu_flops_tflop: parseFloat(e.target.value) || undefined,
+                          })
+                        }
+                        placeholder="e.g. 4000"
+                      />
+                    </div>
+                    <div>
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Power Draw (Watts)
+                      </label>
+                      <input
+                        className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        type="number"
+                        step="10"
+                        min="1"
+                        value={editingProvider.gpu_power_draw_watts || ''}
+                        onChange={(e) =>
+                          setEditingProvider({
+                            ...editingProvider,
+                            gpu_power_draw_watts: parseInt(e.target.value, 10) || undefined,
+                          })
+                        }
+                        placeholder="e.g. 700"
+                      />
                     </div>
                   </div>
                 </div>
-              ) : (
-                <div className="border border-border-glass rounded-md overflow-hidden">
-                  <div
-                    className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
-                    onClick={() => setIsApiBaseUrlsOpen(!isApiBaseUrlsOpen)}
-                  >
-                    {isApiBaseUrlsOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                    <label
-                      className="font-body text-[13px] font-medium text-text-secondary"
-                      style={{ marginBottom: 0, flex: 1 }}
-                    >
-                      Base URL Entries
-                    </label>
-                    <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
-                      {Object.keys(getApiBaseUrlMap()).length}
-                    </Badge>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        addApiBaseUrlEntry();
-                      }}
-                      disabled={Object.keys(getApiBaseUrlMap()).length >= KNOWN_APIS.length}
-                    >
-                      <Plus size={14} />
-                    </Button>
-                  </div>
-                  {isApiBaseUrlsOpen && (
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '6px',
-                        padding: '8px',
-                        borderTop: '1px solid var(--color-border-glass)',
-                        background: 'var(--color-bg-subtle)',
-                      }}
-                    >
-                      {Object.entries(getApiBaseUrlMap()).length === 0 && (
-                        <div className="font-body text-[11px] text-text-secondary italic">
-                          No base URLs configured yet.
-                        </div>
-                      )}
-                      {Object.entries(getApiBaseUrlMap()).map(([apiType, url]) => {
-                        // Detect URL/API type mismatches based on endpoint-shape only
-                        const urlLower = typeof url === 'string' ? url.toLowerCase() : '';
-                        // Native Ollama API paths (not hostname-based, only path-based)
-                        const hasNativeOllamaPath =
-                          urlLower.includes('/api/chat') ||
-                          urlLower.includes('/api/generate') ||
-                          urlLower.includes('/api/embeddings') ||
-                          urlLower.includes('/api/tags');
-                        const hasV1Suffix = urlLower.includes('/v1');
-                        // Warn when native Ollama type is selected but URL has /v1 (OpenAI-compatible)
-                        const showOllamaV1Warning = apiType === 'ollama' && hasV1Suffix;
-                        // Warn when chat type is selected but URL looks like native Ollama (path-based, no /v1)
-                        const showChatOllamaWarning =
-                          apiType === 'chat' && hasNativeOllamaPath && !hasV1Suffix;
+              )}
+              <div className="text-[11px] text-text-muted">
+                Used for inference energy calculation. Select a preset or enter custom GPU specs.
+              </div>
+            </div>
 
-                        return (
-                          <div
-                            key={apiType}
-                            style={{
-                              display: 'grid',
-                              gridTemplateColumns: '1fr auto',
-                              gap: '8px',
-                              alignItems: 'start',
-                            }}
-                          >
-                            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                              <select
-                                className="w-full py-1.5 px-3 font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                                value={apiType}
-                                onChange={(e) =>
-                                  updateApiBaseUrlEntry(
-                                    apiType,
-                                    e.target.value,
-                                    typeof url === 'string' ? url : ''
-                                  )
+            {/* Advanced accordion */}
+            <div className="border border-border-glass rounded-sm overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setIsAdvancedOpen((o) => !o)}
+                className="w-full flex items-center justify-between px-3 py-2 bg-bg-subtle hover:bg-bg-hover transition-colors duration-150 text-left"
+              >
+                <span className="font-body text-[13px] font-medium text-text-secondary">
+                  Advanced
+                </span>
+                {isAdvancedOpen ? (
+                  <ChevronDown size={14} className="text-text-muted" />
+                ) : (
+                  <ChevronRight size={14} className="text-text-muted" />
+                )}
+              </button>
+
+              {isAdvancedOpen && (
+                <div
+                  className="px-3 py-3 border-t border-border-glass"
+                  style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
+                >
+                  {/* Discount */}
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-[140px] sm:items-end">
+                    <div className="flex flex-col gap-1">
+                      <label className="font-body text-[11px] font-medium text-text-secondary">
+                        Discount (%)
+                      </label>
+                      <div style={{ position: 'relative' }}>
+                        <input
+                          className="w-full py-2 pl-3 pr-7 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                          type="number"
+                          step="1"
+                          min="0"
+                          max="100"
+                          value={Math.round((editingProvider.discount ?? 0) * 100)}
+                          onChange={(e) => {
+                            const percent = Number(e.target.value || '0');
+                            const clamped = Math.min(100, Math.max(0, percent));
+                            setEditingProvider({ ...editingProvider, discount: clamped / 100 });
+                          }}
+                        />
+                        <span
+                          className="font-body text-[12px] text-text-secondary"
+                          style={{
+                            position: 'absolute',
+                            right: '10px',
+                            top: '50%',
+                            transform: 'translateY(-50%)',
+                            pointerEvents: 'none',
+                          }}
+                        >
+                          %
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Custom Headers */}
+                  <div className="border border-border-glass rounded-md overflow-hidden">
+                    <div
+                      className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
+                      onClick={() => setIsHeadersOpen(!isHeadersOpen)}
+                    >
+                      {isHeadersOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                      <label
+                        className="font-body text-[13px] font-medium text-text-secondary"
+                        style={{ marginBottom: 0, flex: 1 }}
+                      >
+                        Custom Headers
+                      </label>
+                      <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
+                        {Object.keys(editingProvider.headers || {}).length}
+                      </Badge>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          addKV('headers');
+                          setIsHeadersOpen(true);
+                        }}
+                      >
+                        <Plus size={14} />
+                      </Button>
+                    </div>
+                    {isHeadersOpen && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: '4px',
+                          padding: '8px',
+                          borderTop: '1px solid var(--color-border-glass)',
+                          background: 'var(--color-bg-deep)',
+                        }}
+                      >
+                        {Object.entries(editingProvider.headers || {}).length === 0 && (
+                          <div className="font-body text-[11px] text-text-secondary italic">
+                            No custom headers configured.
+                          </div>
+                        )}
+                        {Object.entries(editingProvider.headers || {}).map(([key, val], idx) => (
+                          <div key={idx} style={{ display: 'flex', gap: '6px' }}>
+                            <Input
+                              placeholder="Header Name"
+                              value={key}
+                              onChange={(e) => updateKV('headers', key, e.target.value, val)}
+                              style={{ flex: 1 }}
+                            />
+                            <Input
+                              placeholder="Value"
+                              value={typeof val === 'object' ? JSON.stringify(val) : val}
+                              onChange={(e) => {
+                                const rawValue = e.target.value;
+                                let parsedValue;
+                                try {
+                                  parsedValue = JSON.parse(rawValue);
+                                } catch {
+                                  parsedValue = rawValue;
                                 }
-                              >
-                                {KNOWN_APIS.map((knownType) => (
-                                  <option
-                                    key={knownType}
-                                    value={knownType}
-                                    className="bg-bg-surface text-text"
-                                  >
-                                    {knownType}
-                                  </option>
-                                ))}
-                              </select>
-                              <input
-                                className="w-full py-1.5 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                                placeholder={
-                                  apiType === 'ollama'
-                                    ? 'http://localhost:11434'
-                                    : 'https://api.example.com/v1/...'
-                                }
-                                value={typeof url === 'string' ? url : ''}
-                                onChange={(e) =>
-                                  updateApiBaseUrlEntry(apiType, apiType, e.target.value)
-                                }
-                              />
-                              {showOllamaV1Warning && (
-                                <div className="flex items-start gap-2 py-1.5 px-2 bg-warning/10 border border-warning/30 rounded-sm">
-                                  <AlertTriangle
-                                    size={14}
-                                    className="text-warning shrink-0 mt-0.5"
-                                  />
-                                  <span className="text-[11px] text-warning">
-                                    <span style={{ fontWeight: 600 }}>native ollama</span> type
-                                    expects root URL (e.g.{' '}
-                                    <code
-                                      style={{
-                                        background: 'var(--color-bg-subtle)',
-                                        padding: '0 3px',
-                                        borderRadius: '2px',
-                                      }}
-                                    >
-                                      http://localhost:11434
-                                    </code>
-                                    ). URLs with{' '}
-                                    <code
-                                      style={{
-                                        background: 'var(--color-bg-subtle)',
-                                        padding: '0 3px',
-                                        borderRadius: '2px',
-                                      }}
-                                    >
-                                      /v1
-                                    </code>{' '}
-                                    are OpenAI-compatible — use{' '}
-                                    <span style={{ fontWeight: 600 }}>chat</span> type instead.
-                                  </span>
-                                </div>
-                              )}
-                              {showChatOllamaWarning && (
-                                <div className="flex items-start gap-2 py-1.5 px-2 bg-warning/10 border border-warning/30 rounded-sm">
-                                  <AlertTriangle
-                                    size={14}
-                                    className="text-warning shrink-0 mt-0.5"
-                                  />
-                                  <span className="text-[11px] text-warning">
-                                    This URL contains{' '}
-                                    <code
-                                      style={{
-                                        background: 'var(--color-bg-subtle)',
-                                        padding: '0 3px',
-                                        borderRadius: '2px',
-                                      }}
-                                    >
-                                      /api/
-                                    </code>{' '}
-                                    paths typical of native Ollama. If this is a native Ollama
-                                    endpoint, use <span style={{ fontWeight: 600 }}>ollama</span>{' '}
-                                    type instead.
-                                  </span>
-                                </div>
-                              )}
-                            </div>
+                                updateKV('headers', key, key, parsedValue);
+                              }}
+                              style={{ flex: 1 }}
+                            />
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={() => removeApiBaseUrlEntry(apiType)}
-                              style={{ padding: '4px', marginTop: '4px' }}
+                              onClick={() => removeKV('headers', key)}
+                              style={{ padding: '4px' }}
                             >
                               <Trash2 size={14} style={{ color: 'var(--color-danger)' }} />
                             </Button>
                           </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* Right: Quota Checker */}
-            <div className="flex flex-col gap-1 border border-border-glass rounded-md p-3 bg-bg-subtle">
-              <label className="font-body text-[13px] font-medium text-text-secondary">
-                Quota Checker
-              </label>
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: '1fr 120px',
-                  gap: '8px',
-                  alignItems: 'end',
-                  marginTop: '4px',
-                }}
-              >
-                <div className="flex flex-col gap-1">
-                  <label className="font-body text-[11px] font-medium text-text-secondary">
-                    Type
-                  </label>
-                  <select
-                    className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                    value={selectedQuotaCheckerType}
-                    onChange={(e) => {
-                      const quotaType = e.target.value;
-                      if (!quotaType) {
-                        setEditingProvider({ ...editingProvider, quotaChecker: undefined });
-                        return;
-                      }
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          type: quotaType,
-                          enabled: true,
-                          intervalMinutes: Math.max(
-                            1,
-                            editingProvider.quotaChecker?.intervalMinutes || 30
-                          ),
-                          options: editingProvider.quotaChecker?.options,
-                        },
-                      });
-                    }}
-                  >
-                    {<option value="">&lt;none&gt;</option>}
-                    {selectableQuotaCheckerTypes.map((type) => (
-                      <option key={type} value={type}>
-                        {type}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="font-body text-[11px] font-medium text-text-secondary">
-                    Interval (min)
-                  </label>
-                  <input
-                    className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                    type="number"
-                    min={1}
-                    step={1}
-                    value={editingProvider.quotaChecker?.intervalMinutes || 30}
-                    disabled={!selectedQuotaCheckerType}
-                    onChange={(e) => {
-                      const intervalMinutes = Math.max(1, parseInt(e.target.value, 10) || 30);
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          type: selectedQuotaCheckerType,
-                          enabled: selectedQuotaCheckerType
-                            ? editingProvider.quotaChecker?.enabled !== false
-                            : false,
-                          intervalMinutes,
-                        },
-                      });
-                    }}
-                  />
-                </div>
-              </div>
-              <div
-                style={{
-                  fontSize: '11px',
-                  color: 'var(--color-text-secondary)',
-                  marginTop: '4px',
-                  fontStyle: 'italic',
-                }}
-              >
-                {isOAuthMode && oauthCheckerType
-                  ? `Only the '${oauthCheckerType}' checker is available for this OAuth provider.`
-                  : isOAuthMode
-                    ? 'No quota checker is available for this OAuth provider type.'
-                    : selectedQuotaCheckerType
-                      ? 'Quota checker is active for this provider.'
-                      : 'Select <none> to disable provider quota checks.'}
-              </div>
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'naga' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <NagaQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'synthetic' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <SyntheticQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'nanogpt' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <NanoGPTQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'zai' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <ZAIQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'moonshot' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <MoonshotQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'novita' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <NovitaQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'minimax' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <MiniMaxQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'minimax-coding' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <MiniMaxCodingQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'openrouter' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <OpenRouterQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'kilo' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <KiloQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'poe' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <PoeQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'ollama' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <OllamaQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'wisdomgate' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-subtle">
-                  <WisdomGateQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'kimi-code' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <KimiCodeQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'apertis' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <ApertisQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'antigravity' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <AntigravityQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'gemini-cli' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <GeminiCliQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'neuralwatt' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <NeuralwattQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {selectedQuotaCheckerType && selectedQuotaCheckerType === 'zenmux' && (
-                <div className="mt-3 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                  <ZenmuxQuotaConfig
-                    options={editingProvider.quotaChecker?.options || {}}
-                    onChange={(options) =>
-                      setEditingProvider({
-                        ...editingProvider,
-                        quotaChecker: {
-                          ...editingProvider.quotaChecker,
-                          options,
-                        } as Provider['quotaChecker'],
-                      })
-                    }
-                  />
-                </div>
-              )}
-
-              {quotaValidationError && (
-                <div className="mt-2 text-xs text-danger bg-danger/10 border border-danger/20 rounded px-3 py-2">
-                  {quotaValidationError}
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* GPU Profile section for inference energy calculation */}
-          <div className="flex flex-col gap-2">
-            <label className="font-body text-[13px] font-medium text-text-secondary">
-              GPU Profile
-            </label>
-            <div className="flex gap-3 items-end">
-              <select
-                className="flex-1 py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                value={editingProvider.gpu_profile || ''}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  if (!value) {
-                    // "Default (B200)" selected — resolve B200 preset
-                    const resolved = resolveGpuParams('B200');
-                    setEditingProvider({
-                      ...editingProvider,
-                      gpu_profile: undefined,
-                      gpu_ram_gb: resolved.ram_gb,
-                      gpu_bandwidth_tb_s: resolved.bandwidth_tb_s,
-                      gpu_flops_tflop: resolved.flops_tflop,
-                      gpu_power_draw_watts: resolved.power_draw_watts,
-                    });
-                  } else if (value === 'custom') {
-                    // Custom selected — merge any existing overrides with H100 defaults
-                    const resolved = resolveGpuParams('custom', {
-                      ram_gb: editingProvider.gpu_ram_gb,
-                      bandwidth_tb_s: editingProvider.gpu_bandwidth_tb_s,
-                      flops_tflop: editingProvider.gpu_flops_tflop,
-                      power_draw_watts: editingProvider.gpu_power_draw_watts,
-                    });
-                    setEditingProvider({
-                      ...editingProvider,
-                      gpu_profile: 'custom',
-                      gpu_ram_gb: resolved.ram_gb,
-                      gpu_bandwidth_tb_s: resolved.bandwidth_tb_s,
-                      gpu_flops_tflop: resolved.flops_tflop,
-                      gpu_power_draw_watts: resolved.power_draw_watts,
-                    });
-                  } else {
-                    // Named preset selected — resolve immediately to concrete params
-                    const resolved = resolveGpuParams(value);
-                    setEditingProvider({
-                      ...editingProvider,
-                      gpu_profile: value,
-                      gpu_ram_gb: resolved.ram_gb,
-                      gpu_bandwidth_tb_s: resolved.bandwidth_tb_s,
-                      gpu_flops_tflop: resolved.flops_tflop,
-                      gpu_power_draw_watts: resolved.power_draw_watts,
-                    });
-                  }
-                }}
-              >
-                <option value="">Default (B200)</option>
-                {GPU_PROFILE_OPTIONS.map((profile) => (
-                  <option key={profile.value} value={profile.value}>
-                    {profile.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            {editingProvider.gpu_profile === 'custom' && (
-              <div className="mt-2 p-3 border border-border-glass rounded-md bg-bg-subtle">
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      RAM (GB)
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="1"
-                      min="1"
-                      value={editingProvider.gpu_ram_gb || ''}
-                      onChange={(e) =>
-                        setEditingProvider({
-                          ...editingProvider,
-                          gpu_ram_gb: parseFloat(e.target.value) || undefined,
-                        })
-                      }
-                      placeholder="e.g. 80"
-                    />
+                        ))}
+                      </div>
+                    )}
                   </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Bandwidth (TB/s)
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="0.1"
-                      min="0.1"
-                      value={editingProvider.gpu_bandwidth_tb_s || ''}
-                      onChange={(e) =>
-                        setEditingProvider({
-                          ...editingProvider,
-                          gpu_bandwidth_tb_s: parseFloat(e.target.value) || undefined,
-                        })
-                      }
-                      placeholder="e.g. 3.35"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      FLOPS (TFLOPs)
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="100"
-                      min="1"
-                      value={editingProvider.gpu_flops_tflop || ''}
-                      onChange={(e) =>
-                        setEditingProvider({
-                          ...editingProvider,
-                          gpu_flops_tflop: parseFloat(e.target.value) || undefined,
-                        })
-                      }
-                      placeholder="e.g. 4000"
-                    />
-                  </div>
-                  <div>
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Power Draw (Watts)
-                    </label>
-                    <input
-                      className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      type="number"
-                      step="10"
-                      min="1"
-                      value={editingProvider.gpu_power_draw_watts || ''}
-                      onChange={(e) =>
-                        setEditingProvider({
-                          ...editingProvider,
-                          gpu_power_draw_watts: parseInt(e.target.value, 10) || undefined,
-                        })
-                      }
-                      placeholder="e.g. 700"
-                    />
-                  </div>
-                </div>
-              </div>
-            )}
-            <div className="text-[11px] text-text-muted">
-              Used for inference energy calculation. Select a preset or enter custom GPU specs.
-            </div>
-          </div>
 
-          {/* Advanced accordion */}
-          <div className="border border-border-glass rounded-sm overflow-hidden">
-            <button
-              type="button"
-              onClick={() => setIsAdvancedOpen((o) => !o)}
-              className="w-full flex items-center justify-between px-3 py-2 bg-bg-subtle hover:bg-bg-hover transition-colors duration-150 text-left"
-            >
-              <span className="font-body text-[13px] font-medium text-text-secondary">
-                Advanced
-              </span>
-              {isAdvancedOpen ? (
-                <ChevronDown size={14} className="text-text-muted" />
-              ) : (
-                <ChevronRight size={14} className="text-text-muted" />
-              )}
-            </button>
-
-            {isAdvancedOpen && (
-              <div
-                className="px-3 py-3 border-t border-border-glass"
-                style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
-              >
-                {/* Discount */}
-                <div
-                  style={{
-                    display: 'grid',
-                    gridTemplateColumns: '140px',
-                    gap: '12px',
-                    alignItems: 'end',
-                  }}
-                >
-                  <div className="flex flex-col gap-1">
-                    <label className="font-body text-[11px] font-medium text-text-secondary">
-                      Discount (%)
-                    </label>
-                    <div style={{ position: 'relative' }}>
-                      <input
-                        className="w-full py-2 pl-3 pr-7 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                        type="number"
-                        step="1"
-                        min="0"
-                        max="100"
-                        value={Math.round((editingProvider.discount ?? 0) * 100)}
-                        onChange={(e) => {
-                          const percent = Number(e.target.value || '0');
-                          const clamped = Math.min(100, Math.max(0, percent));
-                          setEditingProvider({ ...editingProvider, discount: clamped / 100 });
-                        }}
-                      />
-                      <span
-                        className="font-body text-[12px] text-text-secondary"
-                        style={{
-                          position: 'absolute',
-                          right: '10px',
-                          top: '50%',
-                          transform: 'translateY(-50%)',
-                          pointerEvents: 'none',
+                  {/* Extra Body Fields */}
+                  <div className="border border-border-glass rounded-md overflow-hidden">
+                    <div
+                      className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
+                      onClick={() => setIsExtraBodyOpen(!isExtraBodyOpen)}
+                    >
+                      {isExtraBodyOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                      <label
+                        className="font-body text-[13px] font-medium text-text-secondary"
+                        style={{ marginBottom: 0, flex: 1 }}
+                      >
+                        Extra Body Fields
+                      </label>
+                      <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
+                        {Object.keys(editingProvider.extraBody || {}).length}
+                      </Badge>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          addKV('extraBody');
+                          setIsExtraBodyOpen(true);
                         }}
                       >
-                        %
+                        <Plus size={14} />
+                      </Button>
+                    </div>
+                    {isExtraBodyOpen && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: '4px',
+                          padding: '8px',
+                          borderTop: '1px solid var(--color-border-glass)',
+                          background: 'var(--color-bg-deep)',
+                        }}
+                      >
+                        {Object.entries(editingProvider.extraBody || {}).length === 0 && (
+                          <div className="font-body text-[11px] text-text-secondary italic">
+                            No extra body fields configured.
+                          </div>
+                        )}
+                        {Object.entries(editingProvider.extraBody || {}).map(([key, val], idx) => (
+                          <div key={idx} style={{ display: 'flex', gap: '6px' }}>
+                            <Input
+                              placeholder="Field Name"
+                              value={key}
+                              onChange={(e) => updateKV('extraBody', key, e.target.value, val)}
+                              style={{ flex: 1 }}
+                            />
+                            <Input
+                              placeholder="Value"
+                              value={typeof val === 'object' ? JSON.stringify(val) : val}
+                              onChange={(e) => {
+                                const rawValue = e.target.value;
+                                let parsedValue;
+                                try {
+                                  parsedValue = JSON.parse(rawValue);
+                                } catch {
+                                  parsedValue = rawValue;
+                                }
+                                updateKV('extraBody', key, key, parsedValue);
+                              }}
+                              style={{ flex: 1 }}
+                            />
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => removeKV('extraBody', key)}
+                              style={{ padding: '4px' }}
+                            >
+                              <Trash2 size={14} style={{ color: 'var(--color-danger)' }} />
+                            </Button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Estimate Tokens */}
+                  <div className="border border-border-glass rounded-md p-3 bg-bg-subtle">
+                    <div className="flex items-center gap-2" style={{ minHeight: '38px' }}>
+                      <Switch
+                        checked={editingProvider.estimateTokens || false}
+                        onChange={(checked) =>
+                          setEditingProvider({ ...editingProvider, estimateTokens: checked })
+                        }
+                      />
+                      <label
+                        className="font-body text-[13px] font-medium text-text"
+                        style={{ marginBottom: 0 }}
+                      >
+                        Estimate Tokens
+                      </label>
+                    </div>
+                    <div
+                      className="font-body text-[11px] text-text-secondary"
+                      style={{ lineHeight: 1.35, marginTop: '4px' }}
+                    >
+                      Enable token estimation only when a provider does not return usage data.
+                      <span className="text-warning" style={{ marginLeft: '6px' }}>
+                        Use sparingly—this is rarely needed.
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Disable Cooldown */}
+                  <div className="border border-border-glass rounded-md p-3 bg-bg-subtle">
+                    <div className="flex items-center gap-2" style={{ minHeight: '38px' }}>
+                      <Switch
+                        checked={editingProvider.disableCooldown || false}
+                        onChange={(checked) =>
+                          setEditingProvider({ ...editingProvider, disableCooldown: checked })
+                        }
+                      />
+                      <label
+                        className="font-body text-[13px] font-medium text-text"
+                        style={{ marginBottom: 0 }}
+                      >
+                        Disable Cooldowns
+                      </label>
+                    </div>
+                    <div
+                      className="font-body text-[11px] text-text-secondary"
+                      style={{ lineHeight: 1.35, marginTop: '4px' }}
+                    >
+                      When enabled, this provider will never be placed on cooldown due to errors —
+                      it will always remain eligible for routing regardless of consecutive failures.
+                      <span className="text-warning" style={{ marginLeft: '6px' }}>
+                        Use only for providers with reliable external rate-limit handling.
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Use Claude Masking */}
+                  <div className="border border-border-glass rounded-md p-3 bg-bg-subtle">
+                    <div className="flex items-center gap-2" style={{ minHeight: '38px' }}>
+                      <Switch
+                        checked={editingProvider.useClaudeMasking || false}
+                        onChange={(checked) =>
+                          setEditingProvider({ ...editingProvider, useClaudeMasking: checked })
+                        }
+                      />
+                      <label
+                        className="font-body text-[13px] font-medium text-text"
+                        style={{ marginBottom: 0 }}
+                      >
+                        Use Claude Masking
+                      </label>
+                    </div>
+                    <div
+                      className="font-body text-[11px] text-text-secondary"
+                      style={{ lineHeight: 1.35, marginTop: '4px' }}
+                    >
+                      When enabled, requests to this Anthropic provider will be masked as Claude
+                      Code CLI sessions — tool names are prefixed to avoid conflicts with built-in
+                      tools, and Claude Code headers are injected. Applies regardless of API key
+                      type or OAuth.
+                      <span className="text-warning" style={{ marginLeft: '6px' }}>
+                        Only effective for Anthropic providers.
                       </span>
                     </div>
                   </div>
                 </div>
-
-                {/* Custom Headers */}
-                <div className="border border-border-glass rounded-md overflow-hidden">
-                  <div
-                    className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
-                    onClick={() => setIsHeadersOpen(!isHeadersOpen)}
-                  >
-                    {isHeadersOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                    <label
-                      className="font-body text-[13px] font-medium text-text-secondary"
-                      style={{ marginBottom: 0, flex: 1 }}
-                    >
-                      Custom Headers
-                    </label>
-                    <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
-                      {Object.keys(editingProvider.headers || {}).length}
-                    </Badge>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        addKV('headers');
-                        setIsHeadersOpen(true);
-                      }}
-                    >
-                      <Plus size={14} />
-                    </Button>
-                  </div>
-                  {isHeadersOpen && (
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '4px',
-                        padding: '8px',
-                        borderTop: '1px solid var(--color-border-glass)',
-                        background: 'var(--color-bg-deep)',
-                      }}
-                    >
-                      {Object.entries(editingProvider.headers || {}).length === 0 && (
-                        <div className="font-body text-[11px] text-text-secondary italic">
-                          No custom headers configured.
-                        </div>
-                      )}
-                      {Object.entries(editingProvider.headers || {}).map(([key, val], idx) => (
-                        <div key={idx} style={{ display: 'flex', gap: '6px' }}>
-                          <Input
-                            placeholder="Header Name"
-                            value={key}
-                            onChange={(e) => updateKV('headers', key, e.target.value, val)}
-                            style={{ flex: 1 }}
-                          />
-                          <Input
-                            placeholder="Value"
-                            value={typeof val === 'object' ? JSON.stringify(val) : val}
-                            onChange={(e) => {
-                              const rawValue = e.target.value;
-                              let parsedValue;
-                              try {
-                                parsedValue = JSON.parse(rawValue);
-                              } catch {
-                                parsedValue = rawValue;
-                              }
-                              updateKV('headers', key, key, parsedValue);
-                            }}
-                            style={{ flex: 1 }}
-                          />
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => removeKV('headers', key)}
-                            style={{ padding: '4px' }}
-                          >
-                            <Trash2 size={14} style={{ color: 'var(--color-danger)' }} />
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                {/* Extra Body Fields */}
-                <div className="border border-border-glass rounded-md overflow-hidden">
-                  <div
-                    className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
-                    onClick={() => setIsExtraBodyOpen(!isExtraBodyOpen)}
-                  >
-                    {isExtraBodyOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                    <label
-                      className="font-body text-[13px] font-medium text-text-secondary"
-                      style={{ marginBottom: 0, flex: 1 }}
-                    >
-                      Extra Body Fields
-                    </label>
-                    <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
-                      {Object.keys(editingProvider.extraBody || {}).length}
-                    </Badge>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        addKV('extraBody');
-                        setIsExtraBodyOpen(true);
-                      }}
-                    >
-                      <Plus size={14} />
-                    </Button>
-                  </div>
-                  {isExtraBodyOpen && (
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '4px',
-                        padding: '8px',
-                        borderTop: '1px solid var(--color-border-glass)',
-                        background: 'var(--color-bg-deep)',
-                      }}
-                    >
-                      {Object.entries(editingProvider.extraBody || {}).length === 0 && (
-                        <div className="font-body text-[11px] text-text-secondary italic">
-                          No extra body fields configured.
-                        </div>
-                      )}
-                      {Object.entries(editingProvider.extraBody || {}).map(([key, val], idx) => (
-                        <div key={idx} style={{ display: 'flex', gap: '6px' }}>
-                          <Input
-                            placeholder="Field Name"
-                            value={key}
-                            onChange={(e) => updateKV('extraBody', key, e.target.value, val)}
-                            style={{ flex: 1 }}
-                          />
-                          <Input
-                            placeholder="Value"
-                            value={typeof val === 'object' ? JSON.stringify(val) : val}
-                            onChange={(e) => {
-                              const rawValue = e.target.value;
-                              let parsedValue;
-                              try {
-                                parsedValue = JSON.parse(rawValue);
-                              } catch {
-                                parsedValue = rawValue;
-                              }
-                              updateKV('extraBody', key, key, parsedValue);
-                            }}
-                            style={{ flex: 1 }}
-                          />
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => removeKV('extraBody', key)}
-                            style={{ padding: '4px' }}
-                          >
-                            <Trash2 size={14} style={{ color: 'var(--color-danger)' }} />
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-
-                {/* Estimate Tokens */}
-                <div className="border border-border-glass rounded-md p-3 bg-bg-subtle">
-                  <div className="flex items-center gap-2" style={{ minHeight: '38px' }}>
-                    <Switch
-                      checked={editingProvider.estimateTokens || false}
-                      onChange={(checked) =>
-                        setEditingProvider({ ...editingProvider, estimateTokens: checked })
-                      }
-                    />
-                    <label
-                      className="font-body text-[13px] font-medium text-text"
-                      style={{ marginBottom: 0 }}
-                    >
-                      Estimate Tokens
-                    </label>
-                  </div>
-                  <div
-                    className="font-body text-[11px] text-text-secondary"
-                    style={{ lineHeight: 1.35, marginTop: '4px' }}
-                  >
-                    Enable token estimation only when a provider does not return usage data.
-                    <span className="text-warning" style={{ marginLeft: '6px' }}>
-                      Use sparingly—this is rarely needed.
-                    </span>
-                  </div>
-                </div>
-
-                {/* Disable Cooldown */}
-                <div className="border border-border-glass rounded-md p-3 bg-bg-subtle">
-                  <div className="flex items-center gap-2" style={{ minHeight: '38px' }}>
-                    <Switch
-                      checked={editingProvider.disableCooldown || false}
-                      onChange={(checked) =>
-                        setEditingProvider({ ...editingProvider, disableCooldown: checked })
-                      }
-                    />
-                    <label
-                      className="font-body text-[13px] font-medium text-text"
-                      style={{ marginBottom: 0 }}
-                    >
-                      Disable Cooldowns
-                    </label>
-                  </div>
-                  <div
-                    className="font-body text-[11px] text-text-secondary"
-                    style={{ lineHeight: 1.35, marginTop: '4px' }}
-                  >
-                    When enabled, this provider will never be placed on cooldown due to errors — it
-                    will always remain eligible for routing regardless of consecutive failures.
-                    <span className="text-warning" style={{ marginLeft: '6px' }}>
-                      Use only for providers with reliable external rate-limit handling.
-                    </span>
-                  </div>
-                </div>
-
-                {/* Use Claude Masking */}
-                <div className="border border-border-glass rounded-md p-3 bg-bg-subtle">
-                  <div className="flex items-center gap-2" style={{ minHeight: '38px' }}>
-                    <Switch
-                      checked={editingProvider.useClaudeMasking || false}
-                      onChange={(checked) =>
-                        setEditingProvider({ ...editingProvider, useClaudeMasking: checked })
-                      }
-                    />
-                    <label
-                      className="font-body text-[13px] font-medium text-text"
-                      style={{ marginBottom: 0 }}
-                    >
-                      Use Claude Masking
-                    </label>
-                  </div>
-                  <div
-                    className="font-body text-[11px] text-text-secondary"
-                    style={{ lineHeight: 1.35, marginTop: '4px' }}
-                  >
-                    When enabled, requests to this Anthropic provider will be masked as Claude Code
-                    CLI sessions — tool names are prefixed to avoid conflicts with built-in tools,
-                    and Claude Code headers are injected. Applies regardless of API key type or
-                    OAuth.
-                    <span className="text-warning" style={{ marginLeft: '6px' }}>
-                      Only effective for Anthropic providers.
-                    </span>
-                  </div>
-                </div>
-
-                {/* Gemini Thinking Replacement */}
-                <div className="border border-border-glass rounded-md p-3 bg-bg-subtle">
-                  <div className="flex items-center gap-2" style={{ minHeight: '38px' }}>
-                    <Switch
-                      checked={editingProvider.geminiThinkingEnabled || false}
-                      onChange={(checked) =>
-                        setEditingProvider({ ...editingProvider, geminiThinkingEnabled: checked })
-                      }
-                    />
-                    <label
-                      className="font-body text-[13px] font-medium text-text"
-                      style={{ marginBottom: 0 }}
-                    >
-                      Enable Gemini Thinking
-                    </label>
-                  </div>
-                  <div
-                    className="font-body text-[11px] text-text-secondary"
-                    style={{ lineHeight: 1.35, marginTop: '4px' }}
-                  >
-                    When enabled, converts incoming reasoning_effort to Gemini's thinkingConfig.
-                    Strips unsupported reasoning field from requests to Gemini's OpenAI-compatible
-                    endpoint.
-                    <span className="text-warning" style={{ marginLeft: '6px' }}>
-                      Only effective for Gemini providers.
-                    </span>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Models Accordion */}
-          <div className="border border-border-glass rounded-md">
-            <div
-              className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
-              onClick={() => setIsModelsOpen(!isModelsOpen)}
-            >
-              {isModelsOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-              <span style={{ fontWeight: 600, fontSize: '13px', flex: 1 }}>Provider Models</span>
-              <Badge status="connected">
-                {Object.keys(editingProvider.models || {}).length} Models
-              </Badge>
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleOpenFetchModels();
-                }}
-                leftIcon={<Download size={14} />}
-                style={{ marginLeft: '8px' }}
-              >
-                Fetch Models
-              </Button>
+              )}
             </div>
-            {isModelsOpen && (
+
+            {/* Models Accordion */}
+            <div className="border border-border-glass rounded-md">
               <div
-                style={{
-                  padding: '8px',
-                  borderTop: '1px solid var(--color-border-glass)',
-                  background: 'var(--color-bg-deep)',
-                }}
+                className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover transition-colors duration-200 select-none hover:bg-bg-glass"
+                onClick={() => setIsModelsOpen(!isModelsOpen)}
               >
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                  {Object.entries(editingProvider.models || {}).map(
-                    ([mId, mCfg]: [string, any]) => (
-                      <div
-                        key={mId}
-                        style={{
-                          border: '1px solid var(--color-border-glass)',
-                          borderRadius: 'var(--radius-sm)',
-                          background: 'var(--color-bg-surface)',
-                        }}
-                      >
+                {isModelsOpen ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                <span style={{ fontWeight: 600, fontSize: '13px', flex: 1 }}>Provider Models</span>
+                <Badge status="connected">
+                  {Object.keys(editingProvider.models || {}).length} Models
+                </Badge>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleOpenFetchModels();
+                  }}
+                  leftIcon={<Download size={14} />}
+                  style={{ marginLeft: '8px' }}
+                >
+                  Fetch Models
+                </Button>
+              </div>
+              {isModelsOpen && (
+                <div
+                  style={{
+                    padding: '8px',
+                    borderTop: '1px solid var(--color-border-glass)',
+                    background: 'var(--color-bg-deep)',
+                  }}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                    {Object.entries(editingProvider.models || {}).map(
+                      ([mId, mCfg]: [string, any]) => (
                         <div
+                          key={mId}
                           style={{
-                            padding: '6px 8px',
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: '8px',
-                            cursor: 'pointer',
+                            border: '1px solid var(--color-border-glass)',
+                            borderRadius: 'var(--radius-sm)',
+                            background: 'var(--color-bg-surface)',
                           }}
-                          onClick={() => setOpenModelIdx(openModelIdx === mId ? null : mId)}
                         >
-                          {openModelIdx === mId ? (
-                            <ChevronDown size={12} />
-                          ) : (
-                            <ChevronRight size={12} />
-                          )}
-                          <span style={{ fontWeight: 600, fontSize: '12px', flex: 1 }}>{mId}</span>
-                          {(() => {
-                            const testKey = `${editingProvider.id}-${mId}`;
-                            const testState = testStates[testKey];
-                            return (
-                              <div
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleTestModel(editingProvider.id, mId, mCfg.type);
-                                }}
-                                className="flex items-center cursor-pointer"
-                                title="Test this model"
-                              >
-                                {testState?.loading ? (
-                                  <Loader2 size={14} className="animate-spin text-text-secondary" />
-                                ) : testState?.showResult && testState.result === 'success' ? (
-                                  <CheckCircle size={14} className="text-success" />
-                                ) : testState?.showResult && testState.result === 'error' ? (
-                                  <XCircle size={14} className="text-danger" />
-                                ) : (
-                                  <Play size={14} className="text-primary opacity-60" />
-                                )}
-                              </div>
-                            );
-                          })()}
-                          {(() => {
-                            const testKey = `${editingProvider.id}-${mId}`;
-                            const testState = testStates[testKey];
-                            return testState?.showResult && testState.message ? (
-                              <span
-                                className={`text-[11px] italic ${testState.result === 'success' ? 'text-success' : 'text-danger'}`}
-                              >
-                                {testState.message}
-                              </span>
-                            ) : null;
-                          })()}
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              removeModel(mId);
-                            }}
-                            style={{ color: 'var(--color-danger)', padding: '2px' }}
-                          >
-                            <X size={12} />
-                          </Button>
-                        </div>
-                        {openModelIdx === mId && (
                           <div
                             style={{
-                              padding: '8px',
-                              borderTop: '1px solid var(--color-border-glass)',
+                              padding: '6px 8px',
                               display: 'flex',
-                              flexDirection: 'column',
-                              gap: '6px',
+                              alignItems: 'center',
+                              gap: '8px',
+                              cursor: 'pointer',
                             }}
+                            onClick={() => setOpenModelIdx(openModelIdx === mId ? null : mId)}
                           >
-                            <ModelIdInput modelId={mId} onCommit={updateModelId} />
-
-                            <div className="grid gap-4 grid-cols-3">
-                              <div className="flex flex-col gap-1">
-                                <label className="font-body text-[13px] font-medium text-text-secondary">
-                                  Model Type
-                                </label>
-                                <select
-                                  className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                                  value={mCfg.type || 'chat'}
-                                  onChange={(e) => {
-                                    const newType = e.target.value as
-                                      | 'chat'
-                                      | 'embeddings'
-                                      | 'transcriptions'
-                                      | 'speech'
-                                      | 'image'
-                                      | 'responses';
-                                    // If switching to embeddings, clear non-embeddings APIs from access_via
-                                    if (newType === 'embeddings') {
-                                      const filteredAccessVia = (mCfg.access_via || []).filter(
-                                        (api: string) => api === 'embeddings'
-                                      );
-                                      updateModelConfig(mId, {
-                                        type: newType,
-                                        access_via:
-                                          filteredAccessVia.length > 0
-                                            ? filteredAccessVia
-                                            : ['embeddings'],
-                                      });
-                                    } else if (newType === 'transcriptions') {
-                                      const filteredAccessVia = (mCfg.access_via || []).filter(
-                                        (api: string) => api === 'transcriptions'
-                                      );
-                                      updateModelConfig(mId, {
-                                        type: newType,
-                                        access_via:
-                                          filteredAccessVia.length > 0
-                                            ? filteredAccessVia
-                                            : ['transcriptions'],
-                                      });
-                                    } else if (newType === 'speech') {
-                                      const filteredAccessVia = (mCfg.access_via || []).filter(
-                                        (api: string) => api === 'speech'
-                                      );
-                                      updateModelConfig(mId, {
-                                        type: newType,
-                                        access_via:
-                                          filteredAccessVia.length > 0
-                                            ? filteredAccessVia
-                                            : ['speech'],
-                                      });
-                                    } else if (newType === 'image') {
-                                      const filteredAccessVia = (mCfg.access_via || []).filter(
-                                        (api: string) => api === 'images'
-                                      );
-                                      updateModelConfig(mId, {
-                                        type: newType,
-                                        access_via:
-                                          filteredAccessVia.length > 0
-                                            ? filteredAccessVia
-                                            : ['images'],
-                                      });
-                                    } else if (newType === 'responses') {
-                                      const filteredAccessVia = (mCfg.access_via || []).filter(
-                                        (api: string) => api === 'responses'
-                                      );
-                                      updateModelConfig(mId, {
-                                        type: newType,
-                                        access_via:
-                                          filteredAccessVia.length > 0
-                                            ? filteredAccessVia
-                                            : ['responses'],
-                                      });
-                                    } else {
-                                      updateModelConfig(mId, { type: newType });
-                                    }
+                            {openModelIdx === mId ? (
+                              <ChevronDown size={12} />
+                            ) : (
+                              <ChevronRight size={12} />
+                            )}
+                            <span style={{ fontWeight: 600, fontSize: '12px', flex: 1 }}>
+                              {mId}
+                            </span>
+                            {(() => {
+                              const testKey = `${editingProvider.id}-${mId}`;
+                              const testState = testStates[testKey];
+                              return (
+                                <div
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleTestModel(editingProvider.id, mId, mCfg.type);
                                   }}
+                                  className="flex items-center cursor-pointer"
+                                  title="Test this model"
                                 >
-                                  <option value="chat">Chat</option>
-                                  <option value="embeddings">Embeddings</option>
-                                  <option value="transcriptions">Transcriptions</option>
-                                  <option value="speech">Speech</option>
-                                  <option value="image">Image</option>
-                                  <option value="responses">Responses</option>
-                                </select>
-                              </div>
-                              <div className="flex flex-col gap-1">
-                                <label className="font-body text-[13px] font-medium text-text-secondary">
-                                  Pricing Source
-                                </label>
-                                <select
-                                  className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
-                                  value={mCfg.pricing?.source || 'simple'}
-                                  onChange={(e) => {
-                                    const newSource = e.target.value;
-                                    let newPricing: any;
-
-                                    // Create a clean pricing object based on the selected source
-                                    if (newSource === 'simple') {
-                                      newPricing = {
-                                        source: 'simple',
-                                        input: mCfg.pricing?.input || 0,
-                                        output: mCfg.pricing?.output || 0,
-                                        cached: mCfg.pricing?.cached || 0,
-                                        cache_write: mCfg.pricing?.cache_write || 0,
-                                      };
-                                    } else if (newSource === 'openrouter') {
-                                      newPricing = {
-                                        source: 'openrouter',
-                                        slug: mCfg.pricing?.slug || '',
-                                        ...(mCfg.pricing?.discount !== undefined && {
-                                          discount: mCfg.pricing.discount,
-                                        }),
-                                      };
-                                    } else if (newSource === 'defined') {
-                                      newPricing = {
-                                        source: 'defined',
-                                        range: mCfg.pricing?.range || [],
-                                      };
-                                    } else if (newSource === 'per_request') {
-                                      newPricing = {
-                                        source: 'per_request',
-                                        amount: mCfg.pricing?.amount || 0,
-                                      };
-                                    }
-
-                                    updateModelConfig(mId, { pricing: newPricing });
-                                  }}
+                                  {testState?.loading ? (
+                                    <Loader2
+                                      size={14}
+                                      className="animate-spin text-text-secondary"
+                                    />
+                                  ) : testState?.showResult && testState.result === 'success' ? (
+                                    <CheckCircle size={14} className="text-success" />
+                                  ) : testState?.showResult && testState.result === 'error' ? (
+                                    <XCircle size={14} className="text-danger" />
+                                  ) : (
+                                    <Play size={14} className="text-primary opacity-60" />
+                                  )}
+                                </div>
+                              );
+                            })()}
+                            {(() => {
+                              const testKey = `${editingProvider.id}-${mId}`;
+                              const testState = testStates[testKey];
+                              return testState?.showResult && testState.message ? (
+                                <span
+                                  className={`text-[11px] italic ${testState.result === 'success' ? 'text-success' : 'text-danger'}`}
                                 >
-                                  <option value="simple">Simple</option>
-                                  <option value="openrouter">OpenRouter</option>
-                                  <option value="defined">Ranges (Complex)</option>
-                                  <option value="per_request">Per Request (Flat Fee)</option>
-                                </select>
-                              </div>
-                              {mCfg.type !== 'embeddings' &&
-                                mCfg.type !== 'transcriptions' &&
-                                mCfg.type !== 'speech' &&
-                                mCfg.type !== 'image' &&
-                                mCfg.type !== 'responses' && (
-                                  <div className="flex flex-col gap-1">
-                                    <label className="font-body text-[13px] font-medium text-text-secondary">
-                                      Access Via (APIs)
-                                    </label>
-                                    <div
-                                      style={{
-                                        fontSize: '11px',
-                                        color: 'var(--color-text-secondary)',
-                                        marginBottom: '4px',
-                                        lineHeight: '1.4',
-                                      }}
-                                    >
-                                      Choose which API protocols this model should use.{' '}
-                                      <span style={{ fontWeight: 600 }}>chat</span> works with most
-                                      providers. Use <span style={{ fontWeight: 600 }}>ollama</span>{' '}
-                                      only for native Ollama API.
-                                    </div>
-                                    <div
-                                      style={{
-                                        display: 'flex',
-                                        gap: '6px',
-                                        flexWrap: 'wrap',
-                                        marginTop: '4px',
-                                      }}
-                                    >
-                                      {KNOWN_APIS.filter((apiType) => {
-                                        if (mCfg.type === 'chat') {
-                                          return [
-                                            'messages',
-                                            'chat',
-                                            'gemini',
-                                            'responses',
-                                            'ollama',
-                                          ].includes(apiType);
-                                        }
-                                        return true;
-                                      }).map((apiType) => {
-                                        const isEmbeddingsModel = mCfg.type === 'embeddings';
-                                        const isTranscriptionsModel =
-                                          mCfg.type === 'transcriptions';
-                                        const isSpeechModel = mCfg.type === 'speech';
-                                        const isImageModel = mCfg.type === 'image';
-                                        const isResponsesModel = mCfg.type === 'responses';
-                                        const isDisabled =
-                                          (isEmbeddingsModel && apiType !== 'embeddings') ||
-                                          (isTranscriptionsModel && apiType !== 'transcriptions') ||
-                                          (isSpeechModel && apiType !== 'speech') ||
-                                          (isImageModel && apiType !== 'images') ||
-                                          (isResponsesModel && apiType !== 'responses');
+                                  {testState.message}
+                                </span>
+                              ) : null;
+                            })()}
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                removeModel(mId);
+                              }}
+                              style={{ color: 'var(--color-danger)', padding: '2px' }}
+                            >
+                              <X size={12} />
+                            </Button>
+                          </div>
+                          {openModelIdx === mId && (
+                            <div
+                              style={{
+                                padding: '8px',
+                                borderTop: '1px solid var(--color-border-glass)',
+                                display: 'flex',
+                                flexDirection: 'column',
+                                gap: '6px',
+                              }}
+                            >
+                              <ModelIdInput modelId={mId} onCommit={updateModelId} />
 
-                                        return (
-                                          <label
-                                            key={apiType}
-                                            style={{
-                                              display: 'flex',
-                                              alignItems: 'center',
-                                              gap: '3px',
-                                              fontSize: '11px',
-                                              opacity: isDisabled ? 0.4 : 1,
-                                              cursor: isDisabled ? 'not-allowed' : 'pointer',
-                                            }}
-                                          >
-                                            <input
-                                              type="checkbox"
-                                              checked={(mCfg.access_via || []).includes(apiType)}
-                                              disabled={isDisabled}
-                                              onChange={() => {
-                                                const current = mCfg.access_via || [];
-                                                const next = current.includes(apiType)
-                                                  ? current.filter((a: string) => a !== apiType)
-                                                  : [...current, apiType];
-                                                updateModelConfig(mId, { access_via: next });
-                                              }}
-                                            />
-                                            <span
-                                              className="inline-flex items-center gap-2 py-1.5 px-3 rounded-xl text-xs font-medium"
-                                              style={{
-                                                ...getApiBadgeStyle(apiType),
-                                                fontSize: '10px',
-                                                padding: '2px 6px',
-                                                opacity: (mCfg.access_via || []).includes(apiType)
-                                                  ? 1
-                                                  : 0.5,
-                                              }}
-                                            >
-                                              {apiType}
-                                            </span>
-                                          </label>
+                              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                                <div className="flex flex-col gap-1">
+                                  <label className="font-body text-[13px] font-medium text-text-secondary">
+                                    Model Type
+                                  </label>
+                                  <select
+                                    className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                                    value={mCfg.type || 'chat'}
+                                    onChange={(e) => {
+                                      const newType = e.target.value as
+                                        | 'chat'
+                                        | 'embeddings'
+                                        | 'transcriptions'
+                                        | 'speech'
+                                        | 'image'
+                                        | 'responses';
+                                      // If switching to embeddings, clear non-embeddings APIs from access_via
+                                      if (newType === 'embeddings') {
+                                        const filteredAccessVia = (mCfg.access_via || []).filter(
+                                          (api: string) => api === 'embeddings'
                                         );
-                                      })}
-                                    </div>
-                                    {(!mCfg.access_via || mCfg.access_via.length === 0) && (
+                                        updateModelConfig(mId, {
+                                          type: newType,
+                                          access_via:
+                                            filteredAccessVia.length > 0
+                                              ? filteredAccessVia
+                                              : ['embeddings'],
+                                        });
+                                      } else if (newType === 'transcriptions') {
+                                        const filteredAccessVia = (mCfg.access_via || []).filter(
+                                          (api: string) => api === 'transcriptions'
+                                        );
+                                        updateModelConfig(mId, {
+                                          type: newType,
+                                          access_via:
+                                            filteredAccessVia.length > 0
+                                              ? filteredAccessVia
+                                              : ['transcriptions'],
+                                        });
+                                      } else if (newType === 'speech') {
+                                        const filteredAccessVia = (mCfg.access_via || []).filter(
+                                          (api: string) => api === 'speech'
+                                        );
+                                        updateModelConfig(mId, {
+                                          type: newType,
+                                          access_via:
+                                            filteredAccessVia.length > 0
+                                              ? filteredAccessVia
+                                              : ['speech'],
+                                        });
+                                      } else if (newType === 'image') {
+                                        const filteredAccessVia = (mCfg.access_via || []).filter(
+                                          (api: string) => api === 'images'
+                                        );
+                                        updateModelConfig(mId, {
+                                          type: newType,
+                                          access_via:
+                                            filteredAccessVia.length > 0
+                                              ? filteredAccessVia
+                                              : ['images'],
+                                        });
+                                      } else if (newType === 'responses') {
+                                        const filteredAccessVia = (mCfg.access_via || []).filter(
+                                          (api: string) => api === 'responses'
+                                        );
+                                        updateModelConfig(mId, {
+                                          type: newType,
+                                          access_via:
+                                            filteredAccessVia.length > 0
+                                              ? filteredAccessVia
+                                              : ['responses'],
+                                        });
+                                      } else {
+                                        updateModelConfig(mId, { type: newType });
+                                      }
+                                    }}
+                                  >
+                                    <option value="chat">Chat</option>
+                                    <option value="embeddings">Embeddings</option>
+                                    <option value="transcriptions">Transcriptions</option>
+                                    <option value="speech">Speech</option>
+                                    <option value="image">Image</option>
+                                    <option value="responses">Responses</option>
+                                  </select>
+                                </div>
+                                <div className="flex flex-col gap-1">
+                                  <label className="font-body text-[13px] font-medium text-text-secondary">
+                                    Pricing Source
+                                  </label>
+                                  <select
+                                    className="w-full py-2 px-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary focus:shadow-[0_0_0_3px_rgba(245,158,11,0.15)]"
+                                    value={mCfg.pricing?.source || 'simple'}
+                                    onChange={(e) => {
+                                      const newSource = e.target.value;
+                                      let newPricing: any;
+
+                                      // Create a clean pricing object based on the selected source
+                                      if (newSource === 'simple') {
+                                        newPricing = {
+                                          source: 'simple',
+                                          input: mCfg.pricing?.input || 0,
+                                          output: mCfg.pricing?.output || 0,
+                                          cached: mCfg.pricing?.cached || 0,
+                                          cache_write: mCfg.pricing?.cache_write || 0,
+                                        };
+                                      } else if (newSource === 'openrouter') {
+                                        newPricing = {
+                                          source: 'openrouter',
+                                          slug: mCfg.pricing?.slug || '',
+                                          ...(mCfg.pricing?.discount !== undefined && {
+                                            discount: mCfg.pricing.discount,
+                                          }),
+                                        };
+                                      } else if (newSource === 'defined') {
+                                        newPricing = {
+                                          source: 'defined',
+                                          range: mCfg.pricing?.range || [],
+                                        };
+                                      } else if (newSource === 'per_request') {
+                                        newPricing = {
+                                          source: 'per_request',
+                                          amount: mCfg.pricing?.amount || 0,
+                                        };
+                                      }
+
+                                      updateModelConfig(mId, { pricing: newPricing });
+                                    }}
+                                  >
+                                    <option value="simple">Simple</option>
+                                    <option value="openrouter">OpenRouter</option>
+                                    <option value="defined">Ranges (Complex)</option>
+                                    <option value="per_request">Per Request (Flat Fee)</option>
+                                  </select>
+                                </div>
+                                {mCfg.type !== 'embeddings' &&
+                                  mCfg.type !== 'transcriptions' &&
+                                  mCfg.type !== 'speech' &&
+                                  mCfg.type !== 'image' &&
+                                  mCfg.type !== 'responses' && (
+                                    <div className="flex flex-col gap-1">
+                                      <label className="font-body text-[13px] font-medium text-text-secondary">
+                                        Access Via (APIs)
+                                      </label>
                                       <div
                                         style={{
                                           fontSize: '11px',
                                           color: 'var(--color-text-secondary)',
-                                          marginTop: '4px',
-                                          fontStyle: 'italic',
+                                          marginBottom: '4px',
+                                          lineHeight: '1.4',
                                         }}
                                       >
-                                        Empty selection — Plexus will use any API type configured
-                                        for this provider.
+                                        Choose which API protocols this model should use.{' '}
+                                        <span style={{ fontWeight: 600 }}>chat</span> works with
+                                        most providers. Use{' '}
+                                        <span style={{ fontWeight: 600 }}>ollama</span> only for
+                                        native Ollama API.
                                       </div>
-                                    )}
-                                    {(() => {
-                                      // Check if provider has an ollama base URL configured
-                                      const providerBaseUrlMap = getApiBaseUrlMap();
-                                      const hasOllamaBaseUrl = Object.entries(
-                                        providerBaseUrlMap
-                                      ).some(
-                                        ([type, url]) =>
-                                          type === 'ollama' && url && url.trim() !== ''
-                                      );
-                                      // Check if model is not opted into ollama access_via
-                                      const accessVia = mCfg.access_via || [];
-                                      const modelMissingOllamaAccess =
-                                        !accessVia.includes('ollama');
+                                      <div
+                                        style={{
+                                          display: 'flex',
+                                          gap: '6px',
+                                          flexWrap: 'wrap',
+                                          marginTop: '4px',
+                                        }}
+                                      >
+                                        {KNOWN_APIS.filter((apiType) => {
+                                          if (mCfg.type === 'chat') {
+                                            return [
+                                              'messages',
+                                              'chat',
+                                              'gemini',
+                                              'responses',
+                                              'ollama',
+                                            ].includes(apiType);
+                                          }
+                                          return true;
+                                        }).map((apiType) => {
+                                          const isEmbeddingsModel = mCfg.type === 'embeddings';
+                                          const isTranscriptionsModel =
+                                            mCfg.type === 'transcriptions';
+                                          const isSpeechModel = mCfg.type === 'speech';
+                                          const isImageModel = mCfg.type === 'image';
+                                          const isResponsesModel = mCfg.type === 'responses';
+                                          const isDisabled =
+                                            (isEmbeddingsModel && apiType !== 'embeddings') ||
+                                            (isTranscriptionsModel &&
+                                              apiType !== 'transcriptions') ||
+                                            (isSpeechModel && apiType !== 'speech') ||
+                                            (isImageModel && apiType !== 'images') ||
+                                            (isResponsesModel && apiType !== 'responses');
 
-                                      if (
-                                        hasOllamaBaseUrl &&
-                                        modelMissingOllamaAccess &&
-                                        mCfg.type !== 'embeddings' &&
-                                        mCfg.type !== 'transcriptions' &&
-                                        mCfg.type !== 'speech' &&
-                                        mCfg.type !== 'image' &&
-                                        mCfg.type !== 'responses'
-                                      ) {
-                                        return (
-                                          <div className="flex items-start gap-2 py-1.5 px-2 bg-info/10 border border-info/30 rounded-sm mt-2">
-                                            <Info size={14} className="text-info shrink-0 mt-0.5" />
-                                            <span className="text-[11px] text-info">
-                                              Provider has a native Ollama URL. If you want this
-                                              model to use native Ollama, select{' '}
-                                              <span style={{ fontWeight: 600 }}>ollama</span> in
-                                              Access Via above.
-                                            </span>
-                                          </div>
+                                          return (
+                                            <label
+                                              key={apiType}
+                                              style={{
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: '3px',
+                                                fontSize: '11px',
+                                                opacity: isDisabled ? 0.4 : 1,
+                                                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                                              }}
+                                            >
+                                              <input
+                                                type="checkbox"
+                                                checked={(mCfg.access_via || []).includes(apiType)}
+                                                disabled={isDisabled}
+                                                onChange={() => {
+                                                  const current = mCfg.access_via || [];
+                                                  const next = current.includes(apiType)
+                                                    ? current.filter((a: string) => a !== apiType)
+                                                    : [...current, apiType];
+                                                  updateModelConfig(mId, { access_via: next });
+                                                }}
+                                              />
+                                              <span
+                                                className="inline-flex items-center gap-2 py-1.5 px-3 rounded-xl text-xs font-medium"
+                                                style={{
+                                                  ...getApiBadgeStyle(apiType),
+                                                  fontSize: '10px',
+                                                  padding: '2px 6px',
+                                                  opacity: (mCfg.access_via || []).includes(apiType)
+                                                    ? 1
+                                                    : 0.5,
+                                                }}
+                                              >
+                                                {apiType}
+                                              </span>
+                                            </label>
+                                          );
+                                        })}
+                                      </div>
+                                      {(!mCfg.access_via || mCfg.access_via.length === 0) && (
+                                        <div
+                                          style={{
+                                            fontSize: '11px',
+                                            color: 'var(--color-text-secondary)',
+                                            marginTop: '4px',
+                                            fontStyle: 'italic',
+                                          }}
+                                        >
+                                          Empty selection — Plexus will use any API type configured
+                                          for this provider.
+                                        </div>
+                                      )}
+                                      {(() => {
+                                        // Check if provider has an ollama base URL configured
+                                        const providerBaseUrlMap = getApiBaseUrlMap();
+                                        const hasOllamaBaseUrl = Object.entries(
+                                          providerBaseUrlMap
+                                        ).some(
+                                          ([type, url]) =>
+                                            type === 'ollama' && url && url.trim() !== ''
                                         );
-                                      }
-                                      return null;
-                                    })()}
+                                        // Check if model is not opted into ollama access_via
+                                        const accessVia = mCfg.access_via || [];
+                                        const modelMissingOllamaAccess =
+                                          !accessVia.includes('ollama');
+
+                                        if (
+                                          hasOllamaBaseUrl &&
+                                          modelMissingOllamaAccess &&
+                                          mCfg.type !== 'embeddings' &&
+                                          mCfg.type !== 'transcriptions' &&
+                                          mCfg.type !== 'speech' &&
+                                          mCfg.type !== 'image' &&
+                                          mCfg.type !== 'responses'
+                                        ) {
+                                          return (
+                                            <div className="flex items-start gap-2 py-1.5 px-2 bg-info/10 border border-info/30 rounded-sm mt-2">
+                                              <Info
+                                                size={14}
+                                                className="text-info shrink-0 mt-0.5"
+                                              />
+                                              <span className="text-[11px] text-info">
+                                                Provider has a native Ollama URL. If you want this
+                                                model to use native Ollama, select{' '}
+                                                <span style={{ fontWeight: 600 }}>ollama</span> in
+                                                Access Via above.
+                                              </span>
+                                            </div>
+                                          );
+                                        }
+                                        return null;
+                                      })()}
+                                    </div>
+                                  )}
+                                {mCfg.type === 'embeddings' && (
+                                  <div className="flex flex-col gap-1">
+                                    <div
+                                      style={{
+                                        fontSize: '11px',
+                                        color: 'var(--color-text-secondary)',
+                                        marginTop: '4px',
+                                        fontStyle: 'italic',
+                                        padding: '8px',
+                                        background: 'var(--color-bg-subtle)',
+                                        borderRadius: 'var(--radius-sm)',
+                                      }}
+                                    >
+                                      <Info className="inline w-3 h-3 mb-0.5 mr-1" />
+                                      Embeddings models automatically use the 'embeddings' API only.
+                                    </div>
                                   </div>
                                 )}
-                              {mCfg.type === 'embeddings' && (
-                                <div className="flex flex-col gap-1">
-                                  <div
-                                    style={{
-                                      fontSize: '11px',
-                                      color: 'var(--color-text-secondary)',
-                                      marginTop: '4px',
-                                      fontStyle: 'italic',
-                                      padding: '8px',
-                                      background: 'var(--color-bg-subtle)',
-                                      borderRadius: 'var(--radius-sm)',
-                                    }}
-                                  >
-                                    <Info className="inline w-3 h-3 mb-0.5 mr-1" />
-                                    Embeddings models automatically use the 'embeddings' API only.
+                                {mCfg.type === 'transcriptions' && (
+                                  <div className="flex flex-col gap-1">
+                                    <div
+                                      style={{
+                                        fontSize: '11px',
+                                        color: 'var(--color-text-secondary)',
+                                        marginTop: '4px',
+                                        fontStyle: 'italic',
+                                        padding: '8px',
+                                        background: 'var(--color-bg-subtle)',
+                                        borderRadius: 'var(--radius-sm)',
+                                      }}
+                                    >
+                                      <Info className="inline w-3 h-3 mb-0.5 mr-1" />
+                                      Transcriptions models automatically use the 'transcriptions'
+                                      API only.
+                                    </div>
                                   </div>
-                                </div>
-                              )}
-                              {mCfg.type === 'transcriptions' && (
-                                <div className="flex flex-col gap-1">
-                                  <div
-                                    style={{
-                                      fontSize: '11px',
-                                      color: 'var(--color-text-secondary)',
-                                      marginTop: '4px',
-                                      fontStyle: 'italic',
-                                      padding: '8px',
-                                      background: 'var(--color-bg-subtle)',
-                                      borderRadius: 'var(--radius-sm)',
-                                    }}
-                                  >
-                                    <Info className="inline w-3 h-3 mb-0.5 mr-1" />
-                                    Transcriptions models automatically use the 'transcriptions' API
-                                    only.
+                                )}
+                                {mCfg.type === 'speech' && (
+                                  <div className="flex flex-col gap-1">
+                                    <div
+                                      style={{
+                                        fontSize: '11px',
+                                        color: 'var(--color-text-secondary)',
+                                        marginTop: '4px',
+                                        fontStyle: 'italic',
+                                        padding: '8px',
+                                        background: 'var(--color-bg-subtle)',
+                                        borderRadius: 'var(--radius-sm)',
+                                      }}
+                                    >
+                                      <Info className="inline w-3 h-3 mb-0.5 mr-1" />
+                                      Speech models automatically use the 'speech' API only.
+                                    </div>
                                   </div>
-                                </div>
-                              )}
-                              {mCfg.type === 'speech' && (
-                                <div className="flex flex-col gap-1">
-                                  <div
-                                    style={{
-                                      fontSize: '11px',
-                                      color: 'var(--color-text-secondary)',
-                                      marginTop: '4px',
-                                      fontStyle: 'italic',
-                                      padding: '8px',
-                                      background: 'var(--color-bg-subtle)',
-                                      borderRadius: 'var(--radius-sm)',
-                                    }}
-                                  >
-                                    <Info className="inline w-3 h-3 mb-0.5 mr-1" />
-                                    Speech models automatically use the 'speech' API only.
+                                )}
+                                {mCfg.type === 'image' && (
+                                  <div className="flex flex-col gap-1">
+                                    <div
+                                      style={{
+                                        fontSize: '11px',
+                                        color: 'var(--color-text-secondary)',
+                                        marginTop: '4px',
+                                        fontStyle: 'italic',
+                                        padding: '8px',
+                                        background: 'var(--color-bg-subtle)',
+                                        borderRadius: 'var(--radius-sm)',
+                                      }}
+                                    >
+                                      <Info className="inline w-3 h-3 mb-0.5 mr-1" />
+                                      Image models automatically use the 'images' API only.
+                                    </div>
                                   </div>
-                                </div>
-                              )}
-                              {mCfg.type === 'image' && (
-                                <div className="flex flex-col gap-1">
-                                  <div
-                                    style={{
-                                      fontSize: '11px',
-                                      color: 'var(--color-text-secondary)',
-                                      marginTop: '4px',
-                                      fontStyle: 'italic',
-                                      padding: '8px',
-                                      background: 'var(--color-bg-subtle)',
-                                      borderRadius: 'var(--radius-sm)',
-                                    }}
-                                  >
-                                    <Info className="inline w-3 h-3 mb-0.5 mr-1" />
-                                    Image models automatically use the 'images' API only.
+                                )}
+                                {mCfg.type === 'responses' && (
+                                  <div className="flex flex-col gap-1">
+                                    <div
+                                      style={{
+                                        fontSize: '11px',
+                                        color: 'var(--color-text-secondary)',
+                                        marginTop: '4px',
+                                        fontStyle: 'italic',
+                                        padding: '8px',
+                                        background: 'var(--color-bg-subtle)',
+                                        borderRadius: 'var(--radius-sm)',
+                                      }}
+                                    >
+                                      <Info className="inline w-3 h-3 mb-0.5 mr-1" />
+                                      Responses models automatically use the 'responses' API only.
+                                    </div>
                                   </div>
-                                </div>
-                              )}
-                              {mCfg.type === 'responses' && (
-                                <div className="flex flex-col gap-1">
-                                  <div
-                                    style={{
-                                      fontSize: '11px',
-                                      color: 'var(--color-text-secondary)',
-                                      marginTop: '4px',
-                                      fontStyle: 'italic',
-                                      padding: '8px',
-                                      background: 'var(--color-bg-subtle)',
-                                      borderRadius: 'var(--radius-sm)',
-                                    }}
-                                  >
-                                    <Info className="inline w-3 h-3 mb-0.5 mr-1" />
-                                    Responses models automatically use the 'responses' API only.
-                                  </div>
-                                </div>
-                              )}
-                            </div>
-
-                            {mCfg.pricing?.source === 'simple' && (
-                              <div
-                                className="grid grid-cols-4 gap-4"
-                                style={{
-                                  background: 'var(--color-bg-subtle)',
-                                  padding: '12px',
-                                  borderRadius: 'var(--radius-sm)',
-                                }}
-                              >
-                                <Input
-                                  label="Input $/M"
-                                  type="number"
-                                  step="0.000001"
-                                  value={mCfg.pricing.input || 0}
-                                  onChange={(e) =>
-                                    updateModelConfig(mId, {
-                                      pricing: {
-                                        ...mCfg.pricing,
-                                        input: parseFloat(e.target.value),
-                                      },
-                                    })
-                                  }
-                                />
-                                <Input
-                                  label="Output $/M"
-                                  type="number"
-                                  step="0.000001"
-                                  value={mCfg.pricing.output || 0}
-                                  onChange={(e) =>
-                                    updateModelConfig(mId, {
-                                      pricing: {
-                                        ...mCfg.pricing,
-                                        output: parseFloat(e.target.value),
-                                      },
-                                    })
-                                  }
-                                />
-                                <Input
-                                  label="Cached $/M"
-                                  type="number"
-                                  step="0.000001"
-                                  value={mCfg.pricing.cached || 0}
-                                  onChange={(e) =>
-                                    updateModelConfig(mId, {
-                                      pricing: {
-                                        ...mCfg.pricing,
-                                        cached: parseFloat(e.target.value),
-                                      },
-                                    })
-                                  }
-                                />
-                                <Input
-                                  label="Cache Write $/M"
-                                  type="number"
-                                  step="0.000001"
-                                  value={mCfg.pricing.cache_write || 0}
-                                  onChange={(e) =>
-                                    updateModelConfig(mId, {
-                                      pricing: {
-                                        ...mCfg.pricing,
-                                        cache_write: parseFloat(e.target.value),
-                                      },
-                                    })
-                                  }
-                                />
+                                )}
                               </div>
-                            )}
 
-                            {mCfg.pricing?.source === 'openrouter' && (
-                              <div
-                                style={{
-                                  background: 'var(--color-bg-subtle)',
-                                  padding: '12px',
-                                  borderRadius: 'var(--radius-sm)',
-                                  display: 'flex',
-                                  gap: '12px',
-                                  alignItems: 'end',
-                                }}
-                              >
-                                <div style={{ flex: '1' }}>
-                                  <OpenRouterSlugInput
-                                    label="OpenRouter Model Slug"
-                                    placeholder="e.g. anthropic/claude-3.5-sonnet or just 'claude-sonnet'"
-                                    value={mCfg.pricing.slug || ''}
-                                    onChange={(value) =>
+                              {mCfg.pricing?.source === 'simple' && (
+                                <div
+                                  className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4"
+                                  style={{
+                                    background: 'var(--color-bg-subtle)',
+                                    padding: '12px',
+                                    borderRadius: 'var(--radius-sm)',
+                                  }}
+                                >
+                                  <Input
+                                    label="Input $/M"
+                                    type="number"
+                                    step="0.000001"
+                                    value={mCfg.pricing.input || 0}
+                                    onChange={(e) =>
                                       updateModelConfig(mId, {
-                                        pricing: { ...mCfg.pricing, slug: value },
+                                        pricing: {
+                                          ...mCfg.pricing,
+                                          input: parseFloat(e.target.value),
+                                        },
+                                      })
+                                    }
+                                  />
+                                  <Input
+                                    label="Output $/M"
+                                    type="number"
+                                    step="0.000001"
+                                    value={mCfg.pricing.output || 0}
+                                    onChange={(e) =>
+                                      updateModelConfig(mId, {
+                                        pricing: {
+                                          ...mCfg.pricing,
+                                          output: parseFloat(e.target.value),
+                                        },
+                                      })
+                                    }
+                                  />
+                                  <Input
+                                    label="Cached $/M"
+                                    type="number"
+                                    step="0.000001"
+                                    value={mCfg.pricing.cached || 0}
+                                    onChange={(e) =>
+                                      updateModelConfig(mId, {
+                                        pricing: {
+                                          ...mCfg.pricing,
+                                          cached: parseFloat(e.target.value),
+                                        },
+                                      })
+                                    }
+                                  />
+                                  <Input
+                                    label="Cache Write $/M"
+                                    type="number"
+                                    step="0.000001"
+                                    value={mCfg.pricing.cache_write || 0}
+                                    onChange={(e) =>
+                                      updateModelConfig(mId, {
+                                        pricing: {
+                                          ...mCfg.pricing,
+                                          cache_write: parseFloat(e.target.value),
+                                        },
                                       })
                                     }
                                   />
                                 </div>
-                                <div style={{ width: '10%', minWidth: '80px' }}>
-                                  <Input
-                                    label="Discount (0-1)"
-                                    type="number"
-                                    step="0.01"
-                                    min="0"
-                                    max="1"
-                                    placeholder=""
-                                    value={mCfg.pricing.discount ?? ''}
-                                    onChange={(e) => {
-                                      const val = e.target.value;
-                                      if (val === '') {
-                                        const { discount, ...rest } = mCfg.pricing;
-                                        updateModelConfig(mId, { pricing: rest });
-                                      } else {
-                                        updateModelConfig(mId, {
-                                          pricing: { ...mCfg.pricing, discount: parseFloat(val) },
-                                        });
-                                      }
-                                    }}
-                                  />
-                                </div>
-                              </div>
-                            )}
+                              )}
 
-                            {mCfg.pricing?.source === 'defined' && (
-                              <div
-                                style={{
-                                  background: 'var(--color-bg-subtle)',
-                                  padding: '12px',
-                                  borderRadius: 'var(--radius-sm)',
-                                  display: 'flex',
-                                  flexDirection: 'column',
-                                  gap: '12px',
-                                }}
-                              >
+                              {mCfg.pricing?.source === 'openrouter' && (
                                 <div
+                                  className="flex flex-col gap-3 sm:flex-row sm:items-end"
                                   style={{
-                                    display: 'flex',
-                                    justifyContent: 'space-between',
-                                    alignItems: 'center',
+                                    background: 'var(--color-bg-subtle)',
+                                    padding: '12px',
+                                    borderRadius: 'var(--radius-sm)',
                                   }}
                                 >
-                                  <label
-                                    className="font-body text-[13px] font-medium text-text-secondary"
-                                    style={{ marginBottom: 0 }}
+                                  <div className="min-w-0 flex-1">
+                                    <OpenRouterSlugInput
+                                      label="OpenRouter Model Slug"
+                                      placeholder="e.g. anthropic/claude-3.5-sonnet or just 'claude-sonnet'"
+                                      value={mCfg.pricing.slug || ''}
+                                      onChange={(value) =>
+                                        updateModelConfig(mId, {
+                                          pricing: { ...mCfg.pricing, slug: value },
+                                        })
+                                      }
+                                    />
+                                  </div>
+                                  <div className="w-full sm:w-24">
+                                    <Input
+                                      label="Discount (0-1)"
+                                      type="number"
+                                      step="0.01"
+                                      min="0"
+                                      max="1"
+                                      placeholder=""
+                                      value={mCfg.pricing.discount ?? ''}
+                                      onChange={(e) => {
+                                        const val = e.target.value;
+                                        if (val === '') {
+                                          const { discount, ...rest } = mCfg.pricing;
+                                          updateModelConfig(mId, { pricing: rest });
+                                        } else {
+                                          updateModelConfig(mId, {
+                                            pricing: { ...mCfg.pricing, discount: parseFloat(val) },
+                                          });
+                                        }
+                                      }}
+                                    />
+                                  </div>
+                                </div>
+                              )}
+
+                              {mCfg.pricing?.source === 'defined' && (
+                                <div
+                                  style={{
+                                    background: 'var(--color-bg-subtle)',
+                                    padding: '12px',
+                                    borderRadius: 'var(--radius-sm)',
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    gap: '12px',
+                                  }}
+                                >
+                                  <div
+                                    style={{
+                                      display: 'flex',
+                                      justifyContent: 'space-between',
+                                      alignItems: 'center',
+                                    }}
                                   >
-                                    Pricing Ranges
-                                  </label>
-                                  <Button
-                                    size="sm"
-                                    variant="secondary"
-                                    onClick={() => {
-                                      const currentRanges = mCfg.pricing.range || [];
+                                    <label
+                                      className="font-body text-[13px] font-medium text-text-secondary"
+                                      style={{ marginBottom: 0 }}
+                                    >
+                                      Pricing Ranges
+                                    </label>
+                                    <Button
+                                      size="sm"
+                                      variant="secondary"
+                                      onClick={() => {
+                                        const currentRanges = mCfg.pricing.range || [];
+                                        updateModelConfig(mId, {
+                                          pricing: {
+                                            ...mCfg.pricing,
+                                            range: [
+                                              ...currentRanges,
+                                              {
+                                                lower_bound: 0,
+                                                upper_bound: 0,
+                                                input_per_m: 0,
+                                                output_per_m: 0,
+                                                cache_write_per_m: 0,
+                                              },
+                                            ],
+                                          },
+                                        });
+                                      }}
+                                      leftIcon={<Plus size={14} />}
+                                    >
+                                      Add Range
+                                    </Button>
+                                  </div>
+
+                                  {(mCfg.pricing.range || []).map((range: any, idx: number) => (
+                                    <div
+                                      key={idx}
+                                      style={{
+                                        border: '1px solid var(--color-border-glass)',
+                                        padding: '12px',
+                                        borderRadius: 'var(--radius-sm)',
+                                        position: 'relative',
+                                      }}
+                                    >
+                                      <Button
+                                        size="sm"
+                                        variant="ghost"
+                                        style={{
+                                          position: 'absolute',
+                                          top: '8px',
+                                          right: '8px',
+                                          color: 'var(--color-danger)',
+                                          padding: '4px',
+                                        }}
+                                        onClick={() => {
+                                          const newRanges = [...mCfg.pricing.range];
+                                          newRanges.splice(idx, 1);
+                                          updateModelConfig(mId, {
+                                            pricing: { ...mCfg.pricing, range: newRanges },
+                                          });
+                                        }}
+                                      >
+                                        <X size={14} />
+                                      </Button>
+
+                                      <div
+                                        className="grid grid-cols-1 gap-4 sm:grid-cols-2"
+                                        style={{ marginBottom: '8px' }}
+                                      >
+                                        <Input
+                                          label="Lower Bound"
+                                          type="number"
+                                          value={range.lower_bound}
+                                          onChange={(e) => {
+                                            const newRanges = [...mCfg.pricing.range];
+                                            newRanges[idx] = {
+                                              ...range,
+                                              lower_bound: parseFloat(e.target.value),
+                                            };
+                                            updateModelConfig(mId, {
+                                              pricing: { ...mCfg.pricing, range: newRanges },
+                                            });
+                                          }}
+                                        />
+                                        <Input
+                                          label="Upper Bound (0 = Infinite)"
+                                          type="number"
+                                          value={
+                                            range.upper_bound === Infinity ? 0 : range.upper_bound
+                                          }
+                                          onChange={(e) => {
+                                            const val = parseFloat(e.target.value);
+                                            const newRanges = [...mCfg.pricing.range];
+                                            newRanges[idx] = {
+                                              ...range,
+                                              upper_bound: val === 0 ? Infinity : val,
+                                            };
+                                            updateModelConfig(mId, {
+                                              pricing: { ...mCfg.pricing, range: newRanges },
+                                            });
+                                          }}
+                                        />
+                                      </div>
+                                      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                                        <Input
+                                          label="Input $/M"
+                                          type="number"
+                                          step="0.000001"
+                                          value={range.input_per_m}
+                                          onChange={(e) => {
+                                            const newRanges = [...mCfg.pricing.range];
+                                            newRanges[idx] = {
+                                              ...range,
+                                              input_per_m: parseFloat(e.target.value),
+                                            };
+                                            updateModelConfig(mId, {
+                                              pricing: { ...mCfg.pricing, range: newRanges },
+                                            });
+                                          }}
+                                        />
+                                        <Input
+                                          label="Output $/M"
+                                          type="number"
+                                          step="0.000001"
+                                          value={range.output_per_m}
+                                          onChange={(e) => {
+                                            const newRanges = [...mCfg.pricing.range];
+                                            newRanges[idx] = {
+                                              ...range,
+                                              output_per_m: parseFloat(e.target.value),
+                                            };
+                                            updateModelConfig(mId, {
+                                              pricing: { ...mCfg.pricing, range: newRanges },
+                                            });
+                                          }}
+                                        />
+                                        <Input
+                                          label="Cached $/M"
+                                          type="number"
+                                          step="0.000001"
+                                          value={range.cached_per_m || 0}
+                                          onChange={(e) => {
+                                            const newRanges = [...mCfg.pricing.range];
+                                            newRanges[idx] = {
+                                              ...range,
+                                              cached_per_m: parseFloat(e.target.value),
+                                            };
+                                            updateModelConfig(mId, {
+                                              pricing: { ...mCfg.pricing, range: newRanges },
+                                            });
+                                          }}
+                                        />
+                                        <Input
+                                          label="Cache Write $/M"
+                                          type="number"
+                                          step="0.000001"
+                                          value={range.cache_write_per_m || 0}
+                                          onChange={(e) => {
+                                            const nextValue = Number(e.target.value);
+                                            const newRanges = [...mCfg.pricing.range];
+                                            newRanges[idx] = {
+                                              ...range,
+                                              cache_write_per_m: Number.isFinite(nextValue)
+                                                ? nextValue
+                                                : 0,
+                                            };
+                                            updateModelConfig(mId, {
+                                              pricing: { ...mCfg.pricing, range: newRanges },
+                                            });
+                                          }}
+                                        />
+                                      </div>
+                                    </div>
+                                  ))}
+                                  {(!mCfg.pricing.range || mCfg.pricing.range.length === 0) && (
+                                    <div className="text-text-muted italic text-center text-sm p-4">
+                                      No ranges defined. Pricing will likely default to 0.
+                                    </div>
+                                  )}
+                                </div>
+                              )}
+
+                              {mCfg.pricing?.source === 'per_request' && (
+                                <div
+                                  className="grid grid-cols-1 gap-4"
+                                  style={{
+                                    background: 'var(--color-bg-subtle)',
+                                    padding: '12px',
+                                    borderRadius: 'var(--radius-sm)',
+                                  }}
+                                >
+                                  <Input
+                                    label="Cost Per Request ($)"
+                                    type="number"
+                                    step="0.000001"
+                                    min="0"
+                                    value={mCfg.pricing.amount || 0}
+                                    onChange={(e) =>
                                       updateModelConfig(mId, {
                                         pricing: {
                                           ...mCfg.pricing,
-                                          range: [
-                                            ...currentRanges,
-                                            {
-                                              lower_bound: 0,
-                                              upper_bound: 0,
-                                              input_per_m: 0,
-                                              output_per_m: 0,
-                                              cache_write_per_m: 0,
-                                            },
-                                          ],
+                                          amount: parseFloat(e.target.value) || 0,
                                         },
-                                      });
-                                    }}
-                                    leftIcon={<Plus size={14} />}
-                                  >
-                                    Add Range
-                                  </Button>
-                                </div>
-
-                                {(mCfg.pricing.range || []).map((range: any, idx: number) => (
+                                      })
+                                    }
+                                  />
                                   <div
-                                    key={idx}
-                                    style={{
-                                      border: '1px solid var(--color-border-glass)',
-                                      padding: '12px',
-                                      borderRadius: 'var(--radius-sm)',
-                                      position: 'relative',
-                                    }}
+                                    className="font-body text-[11px] text-text-secondary"
+                                    style={{ fontStyle: 'italic' }}
                                   >
-                                    <Button
-                                      size="sm"
-                                      variant="ghost"
-                                      style={{
-                                        position: 'absolute',
-                                        top: '8px',
-                                        right: '8px',
-                                        color: 'var(--color-danger)',
-                                        padding: '4px',
-                                      }}
-                                      onClick={() => {
-                                        const newRanges = [...mCfg.pricing.range];
-                                        newRanges.splice(idx, 1);
-                                        updateModelConfig(mId, {
-                                          pricing: { ...mCfg.pricing, range: newRanges },
-                                        });
-                                      }}
-                                    >
-                                      <X size={14} />
-                                    </Button>
-
-                                    <div
-                                      className="grid gap-4 grid-cols-2"
-                                      style={{ marginBottom: '8px' }}
-                                    >
-                                      <Input
-                                        label="Lower Bound"
-                                        type="number"
-                                        value={range.lower_bound}
-                                        onChange={(e) => {
-                                          const newRanges = [...mCfg.pricing.range];
-                                          newRanges[idx] = {
-                                            ...range,
-                                            lower_bound: parseFloat(e.target.value),
-                                          };
-                                          updateModelConfig(mId, {
-                                            pricing: { ...mCfg.pricing, range: newRanges },
-                                          });
-                                        }}
-                                      />
-                                      <Input
-                                        label="Upper Bound (0 = Infinite)"
-                                        type="number"
-                                        value={
-                                          range.upper_bound === Infinity ? 0 : range.upper_bound
-                                        }
-                                        onChange={(e) => {
-                                          const val = parseFloat(e.target.value);
-                                          const newRanges = [...mCfg.pricing.range];
-                                          newRanges[idx] = {
-                                            ...range,
-                                            upper_bound: val === 0 ? Infinity : val,
-                                          };
-                                          updateModelConfig(mId, {
-                                            pricing: { ...mCfg.pricing, range: newRanges },
-                                          });
-                                        }}
-                                      />
-                                    </div>
-                                    <div className="grid grid-cols-4 gap-4">
-                                      <Input
-                                        label="Input $/M"
-                                        type="number"
-                                        step="0.000001"
-                                        value={range.input_per_m}
-                                        onChange={(e) => {
-                                          const newRanges = [...mCfg.pricing.range];
-                                          newRanges[idx] = {
-                                            ...range,
-                                            input_per_m: parseFloat(e.target.value),
-                                          };
-                                          updateModelConfig(mId, {
-                                            pricing: { ...mCfg.pricing, range: newRanges },
-                                          });
-                                        }}
-                                      />
-                                      <Input
-                                        label="Output $/M"
-                                        type="number"
-                                        step="0.000001"
-                                        value={range.output_per_m}
-                                        onChange={(e) => {
-                                          const newRanges = [...mCfg.pricing.range];
-                                          newRanges[idx] = {
-                                            ...range,
-                                            output_per_m: parseFloat(e.target.value),
-                                          };
-                                          updateModelConfig(mId, {
-                                            pricing: { ...mCfg.pricing, range: newRanges },
-                                          });
-                                        }}
-                                      />
-                                      <Input
-                                        label="Cached $/M"
-                                        type="number"
-                                        step="0.000001"
-                                        value={range.cached_per_m || 0}
-                                        onChange={(e) => {
-                                          const newRanges = [...mCfg.pricing.range];
-                                          newRanges[idx] = {
-                                            ...range,
-                                            cached_per_m: parseFloat(e.target.value),
-                                          };
-                                          updateModelConfig(mId, {
-                                            pricing: { ...mCfg.pricing, range: newRanges },
-                                          });
-                                        }}
-                                      />
-                                      <Input
-                                        label="Cache Write $/M"
-                                        type="number"
-                                        step="0.000001"
-                                        value={range.cache_write_per_m || 0}
-                                        onChange={(e) => {
-                                          const nextValue = Number(e.target.value);
-                                          const newRanges = [...mCfg.pricing.range];
-                                          newRanges[idx] = {
-                                            ...range,
-                                            cache_write_per_m: Number.isFinite(nextValue)
-                                              ? nextValue
-                                              : 0,
-                                          };
-                                          updateModelConfig(mId, {
-                                            pricing: { ...mCfg.pricing, range: newRanges },
-                                          });
-                                        }}
-                                      />
-                                    </div>
+                                    A flat fee charged per API call, regardless of token count. The
+                                    full amount is recorded as the request cost.
                                   </div>
-                                ))}
-                                {(!mCfg.pricing.range || mCfg.pricing.range.length === 0) && (
-                                  <div className="text-text-muted italic text-center text-sm p-4">
-                                    No ranges defined. Pricing will likely default to 0.
-                                  </div>
-                                )}
-                              </div>
-                            )}
-
-                            {mCfg.pricing?.source === 'per_request' && (
-                              <div
-                                className="grid grid-cols-1 gap-4"
-                                style={{
-                                  background: 'var(--color-bg-subtle)',
-                                  padding: '12px',
-                                  borderRadius: 'var(--radius-sm)',
-                                }}
-                              >
-                                <Input
-                                  label="Cost Per Request ($)"
-                                  type="number"
-                                  step="0.000001"
-                                  min="0"
-                                  value={mCfg.pricing.amount || 0}
-                                  onChange={(e) =>
-                                    updateModelConfig(mId, {
-                                      pricing: {
-                                        ...mCfg.pricing,
-                                        amount: parseFloat(e.target.value) || 0,
-                                      },
-                                    })
-                                  }
-                                />
-                                <div
-                                  className="font-body text-[11px] text-text-secondary"
-                                  style={{ fontStyle: 'italic' }}
-                                >
-                                  A flat fee charged per API call, regardless of token count. The
-                                  full amount is recorded as the request cost.
-                                </div>
-                              </div>
-                            )}
-
-                            {/* Per-Model Extra Body Fields */}
-                            <div
-                              className="border border-border-glass rounded-md p-3 bg-bg-subtle"
-                              style={{ marginTop: '12px' }}
-                            >
-                              <div
-                                className="flex items-center gap-2 cursor-pointer"
-                                style={{ minHeight: '38px' }}
-                                onClick={() =>
-                                  setIsModelExtraBodyOpen({
-                                    ...isModelExtraBodyOpen,
-                                    [mId]: !isModelExtraBodyOpen[mId],
-                                  })
-                                }
-                              >
-                                {isModelExtraBodyOpen[mId] ? (
-                                  <ChevronDown size={14} />
-                                ) : (
-                                  <ChevronRight size={14} />
-                                )}
-                                <label
-                                  className="font-body text-[13px] font-medium text-text-secondary"
-                                  style={{ marginBottom: 0, flex: 1, cursor: 'pointer' }}
-                                >
-                                  Extra Body Fields
-                                </label>
-                                <Badge
-                                  status="neutral"
-                                  style={{ fontSize: '10px', padding: '2px 8px' }}
-                                >
-                                  {Object.keys(mCfg.extraBody || {}).length}
-                                </Badge>
-                                <Button
-                                  size="sm"
-                                  variant="secondary"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    addModelKV(mId);
-                                    setIsModelExtraBodyOpen({
-                                      ...isModelExtraBodyOpen,
-                                      [mId]: true,
-                                    });
-                                  }}
-                                >
-                                  <Plus size={14} />
-                                </Button>
-                              </div>
-                              {isModelExtraBodyOpen[mId] && (
-                                <div
-                                  style={{
-                                    display: 'flex',
-                                    flexDirection: 'column',
-                                    gap: '4px',
-                                    padding: '8px',
-                                    borderTop: '1px solid var(--color-border-glass)',
-                                    background: 'var(--color-bg-deep)',
-                                  }}
-                                >
-                                  {Object.entries(mCfg.extraBody || {}).length === 0 && (
-                                    <div className="font-body text-[11px] text-text-secondary italic">
-                                      No extra body fields configured.
-                                    </div>
-                                  )}
-                                  {Object.entries(mCfg.extraBody || {}).map(([key, val], idx) => (
-                                    <div key={idx} style={{ display: 'flex', gap: '6px' }}>
-                                      <Input
-                                        placeholder="Field Name"
-                                        value={key}
-                                        onChange={(e) =>
-                                          updateModelKV(mId, key, e.target.value, val)
-                                        }
-                                        style={{ flex: 1 }}
-                                      />
-                                      <Input
-                                        placeholder="Value"
-                                        value={
-                                          typeof val === 'object'
-                                            ? JSON.stringify(val)
-                                            : String(val)
-                                        }
-                                        onChange={(e) => {
-                                          const rawValue = e.target.value;
-                                          let parsedValue;
-                                          try {
-                                            parsedValue = JSON.parse(rawValue);
-                                          } catch {
-                                            parsedValue = rawValue;
-                                          }
-                                          updateModelKV(mId, key, key, parsedValue);
-                                        }}
-                                        style={{ flex: 1 }}
-                                      />
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        onClick={() => removeModelKV(mId, key)}
-                                        style={{ padding: '4px' }}
-                                      >
-                                        <Trash2
-                                          size={14}
-                                          style={{ color: 'var(--color-danger)' }}
-                                        />
-                                      </Button>
-                                    </div>
-                                  ))}
                                 </div>
                               )}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    )
-                  )}
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    leftIcon={<Plus size={14} />}
-                    onClick={addModel}
-                  >
-                    Add Model Mapping
-                  </Button>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      </Modal>
 
-      {/* Fetch Models Modal */}
-      <Modal
-        isOpen={isFetchModelsModalOpen}
-        onClose={() => setIsFetchModelsModalOpen(false)}
-        title="Fetch Models from Provider"
-        size="md"
-        footer={
-          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
-            <Button variant="ghost" onClick={() => setIsFetchModelsModalOpen(false)}>
-              Cancel
-            </Button>
-            <Button onClick={handleAddSelectedModels} disabled={selectedModelIds.size === 0}>
-              Add {selectedModelIds.size} Model{selectedModelIds.size !== 1 ? 's' : ''}
-            </Button>
-          </div>
-        }
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'end' }}>
-            <div style={{ flex: 1 }}>
-              <Input
-                label="Models Endpoint URL"
-                value={modelsUrl}
-                onChange={(e) => setModelsUrl(e.target.value)}
-                placeholder={
-                  isOAuthMode
-                    ? 'OAuth providers use built-in model lists'
-                    : 'https://api.example.com/v1/models'
-                }
-                disabled={isOAuthMode}
-              />
-            </div>
-            <Button
-              onClick={handleFetchModels}
-              isLoading={isFetchingModels}
-              leftIcon={<Download size={16} />}
-            >
-              Fetch
-            </Button>
-          </div>
-
-          {fetchError && (
-            <div
-              style={{
-                padding: '12px',
-                background: 'rgba(239, 68, 68, 0.1)',
-                border: '1px solid rgba(239, 68, 68, 0.3)',
-                borderRadius: 'var(--radius-sm)',
-                color: 'var(--color-danger)',
-                fontSize: '13px',
-              }}
-            >
-              {fetchError}
-            </div>
-          )}
-
-          {fetchedModels.length > 0 && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-              <div
-                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-              >
-                <label className="font-body text-[13px] font-medium text-text-secondary">
-                  Available Models ({fetchedModels.length})
-                </label>
-                <div style={{ display: 'flex', gap: '8px' }}>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => setSelectedModelIds(new Set(fetchedModels.map((m) => m.id)))}
-                  >
-                    Select All
-                  </Button>
-                  <Button size="sm" variant="ghost" onClick={() => setSelectedModelIds(new Set())}>
-                    Clear
-                  </Button>
-                </div>
-              </div>
-
-              <div
-                style={{
-                  maxHeight: '400px',
-                  overflowY: 'auto',
-                  border: '1px solid var(--color-border-glass)',
-                  borderRadius: 'var(--radius-sm)',
-                  background: 'var(--color-bg-deep)',
-                }}
-              >
-                {fetchedModels.map((model) => {
-                  const contextLengthK = model.context_length
-                    ? `${(model.context_length / 1000).toFixed(0)}K`
-                    : null;
-
-                  return (
-                    <div
-                      key={model.id}
-                      style={{
-                        padding: '12px',
-                        borderBottom: '1px solid var(--color-border-glass)',
-                        cursor: 'pointer',
-                        background: selectedModelIds.has(model.id)
-                          ? 'var(--color-bg-hover)'
-                          : 'transparent',
-                        transition: 'background 0.2s',
-                      }}
-                      onClick={() => toggleModelSelection(model.id)}
-                      className="hover:bg-bg-hover"
-                    >
-                      <div style={{ display: 'flex', alignItems: 'start', gap: '12px' }}>
-                        <input
-                          type="checkbox"
-                          checked={selectedModelIds.has(model.id)}
-                          onChange={() => toggleModelSelection(model.id)}
-                          style={{ marginTop: '2px', cursor: 'pointer' }}
-                          onClick={(e) => e.stopPropagation()}
-                        />
-                        <div style={{ flex: 1 }}>
-                          <div
-                            style={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: '8px',
-                              marginBottom: '4px',
-                            }}
-                          >
-                            <span
-                              style={{
-                                fontWeight: 600,
-                                fontSize: '13px',
-                                color: 'var(--color-text)',
-                              }}
-                            >
-                              {model.id}
-                            </span>
-                            {contextLengthK && (
-                              <Badge
-                                status="connected"
-                                style={{ fontSize: '10px', padding: '2px 6px' }}
+                              {/* Per-Model Extra Body Fields */}
+                              <div
+                                className="border border-border-glass rounded-md p-3 bg-bg-subtle"
+                                style={{ marginTop: '12px' }}
                               >
-                                {contextLengthK}
-                              </Badge>
-                            )}
-                          </div>
-                          {model.name && model.name !== model.id && (
-                            <div
-                              style={{
-                                fontSize: '12px',
-                                color: 'var(--color-text-secondary)',
-                                marginBottom: '2px',
-                              }}
-                            >
-                              {model.name}
-                            </div>
-                          )}
-                          {model.description && (
-                            <div
-                              style={{
-                                fontSize: '11px',
-                                color: 'var(--color-text-muted)',
-                                marginTop: '4px',
-                                lineHeight: '1.4',
-                              }}
-                            >
-                              {model.description.length > 150
-                                ? `${model.description.substring(0, 150)}...`
-                                : model.description}
+                                <div
+                                  className="flex items-center gap-2 cursor-pointer"
+                                  style={{ minHeight: '38px' }}
+                                  onClick={() =>
+                                    setIsModelExtraBodyOpen({
+                                      ...isModelExtraBodyOpen,
+                                      [mId]: !isModelExtraBodyOpen[mId],
+                                    })
+                                  }
+                                >
+                                  {isModelExtraBodyOpen[mId] ? (
+                                    <ChevronDown size={14} />
+                                  ) : (
+                                    <ChevronRight size={14} />
+                                  )}
+                                  <label
+                                    className="font-body text-[13px] font-medium text-text-secondary"
+                                    style={{ marginBottom: 0, flex: 1, cursor: 'pointer' }}
+                                  >
+                                    Extra Body Fields
+                                  </label>
+                                  <Badge
+                                    status="neutral"
+                                    style={{ fontSize: '10px', padding: '2px 8px' }}
+                                  >
+                                    {Object.keys(mCfg.extraBody || {}).length}
+                                  </Badge>
+                                  <Button
+                                    size="sm"
+                                    variant="secondary"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      addModelKV(mId);
+                                      setIsModelExtraBodyOpen({
+                                        ...isModelExtraBodyOpen,
+                                        [mId]: true,
+                                      });
+                                    }}
+                                  >
+                                    <Plus size={14} />
+                                  </Button>
+                                </div>
+                                {isModelExtraBodyOpen[mId] && (
+                                  <div
+                                    style={{
+                                      display: 'flex',
+                                      flexDirection: 'column',
+                                      gap: '4px',
+                                      padding: '8px',
+                                      borderTop: '1px solid var(--color-border-glass)',
+                                      background: 'var(--color-bg-deep)',
+                                    }}
+                                  >
+                                    {Object.entries(mCfg.extraBody || {}).length === 0 && (
+                                      <div className="font-body text-[11px] text-text-secondary italic">
+                                        No extra body fields configured.
+                                      </div>
+                                    )}
+                                    {Object.entries(mCfg.extraBody || {}).map(([key, val], idx) => (
+                                      <div key={idx} style={{ display: 'flex', gap: '6px' }}>
+                                        <Input
+                                          placeholder="Field Name"
+                                          value={key}
+                                          onChange={(e) =>
+                                            updateModelKV(mId, key, e.target.value, val)
+                                          }
+                                          style={{ flex: 1 }}
+                                        />
+                                        <Input
+                                          placeholder="Value"
+                                          value={
+                                            typeof val === 'object'
+                                              ? JSON.stringify(val)
+                                              : String(val)
+                                          }
+                                          onChange={(e) => {
+                                            const rawValue = e.target.value;
+                                            let parsedValue;
+                                            try {
+                                              parsedValue = JSON.parse(rawValue);
+                                            } catch {
+                                              parsedValue = rawValue;
+                                            }
+                                            updateModelKV(mId, key, key, parsedValue);
+                                          }}
+                                          style={{ flex: 1 }}
+                                        />
+                                        <Button
+                                          variant="ghost"
+                                          size="sm"
+                                          onClick={() => removeModelKV(mId, key)}
+                                          style={{ padding: '4px' }}
+                                        >
+                                          <Trash2
+                                            size={14}
+                                            style={{ color: 'var(--color-danger)' }}
+                                          />
+                                        </Button>
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
                             </div>
                           )}
                         </div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {!isFetchingModels && fetchedModels.length === 0 && !fetchError && (
-            <div
-              style={{
-                padding: '32px',
-                textAlign: 'center',
-                color: 'var(--color-text-secondary)',
-                fontSize: '13px',
-                fontStyle: 'italic',
-              }}
-            >
-              {isOAuthMode
-                ? 'Click Fetch to load known OAuth models'
-                : 'Enter a URL and click Fetch to load available models'}
-            </div>
-          )}
-        </div>
-      </Modal>
-
-      <Modal
-        isOpen={!!deleteModalProvider}
-        onClose={() => setDeleteModalProvider(null)}
-        title={`Delete Provider: ${deleteModalProvider?.name || deleteModalProvider?.id || ''}`}
-        size="lg"
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-          <div style={{ color: 'var(--color-text-secondary)', fontSize: '14px' }}>
-            Choose how to delete this provider. The action cannot be undone.
-          </div>
-
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
-            <div
-              style={{
-                border: '1px solid var(--color-border)',
-                borderRadius: '8px',
-                padding: '16px',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '12px',
-              }}
-            >
-              <div style={{ fontWeight: 600, fontSize: '15px', color: 'var(--color-danger)' }}>
-                Delete Provider (Cascade)
-              </div>
-              <div style={{ fontSize: '13px', color: 'var(--color-text-secondary)' }}>
-                Removes this provider AND deletes all model alias targets that reference it.
-              </div>
-              {affectedAliases.length > 0 ? (
-                <div style={{ fontSize: '13px' }}>
-                  <div style={{ fontWeight: 500, marginBottom: '4px' }}>
-                    This will affect {affectedAliases.length} model alias(es):
+                      )
+                    )}
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      leftIcon={<Plus size={14} />}
+                      onClick={addModel}
+                    >
+                      Add Model Mapping
+                    </Button>
                   </div>
-                  <ul
-                    style={{
-                      margin: 0,
-                      paddingLeft: '16px',
-                      fontSize: '12px',
-                      color: 'var(--color-text-secondary)',
-                    }}
-                  >
-                    {affectedAliases.map((a) => (
-                      <li key={a.aliasId}>
-                        {a.aliasId} ({a.targetsCount} target(s))
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ) : (
-                <div
-                  style={{
-                    fontSize: '12px',
-                    color: 'var(--color-text-secondary)',
-                    fontStyle: 'italic',
-                  }}
-                >
-                  No model aliases reference this provider.
                 </div>
               )}
+            </div>
+          </div>
+        </Modal>
+
+        {/* Fetch Models Modal */}
+        <Modal
+          isOpen={isFetchModelsModalOpen}
+          onClose={() => setIsFetchModelsModalOpen(false)}
+          title="Fetch Models from Provider"
+          size="md"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button variant="ghost" onClick={() => setIsFetchModelsModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleAddSelectedModels} disabled={selectedModelIds.size === 0}>
+                Add {selectedModelIds.size} Model{selectedModelIds.size !== 1 ? 's' : ''}
+              </Button>
+            </div>
+          }
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+              <div className="min-w-0 flex-1">
+                <Input
+                  label="Models Endpoint URL"
+                  value={modelsUrl}
+                  onChange={(e) => setModelsUrl(e.target.value)}
+                  placeholder={
+                    isOAuthMode
+                      ? 'OAuth providers use built-in model lists'
+                      : 'https://api.example.com/v1/models'
+                  }
+                  disabled={isOAuthMode}
+                />
+              </div>
               <Button
-                onClick={() => handleDelete(true)}
-                isLoading={deleteModalLoading}
+                onClick={handleFetchModels}
+                isLoading={isFetchingModels}
+                leftIcon={<Download size={16} />}
+                className="w-full sm:w-auto"
+              >
+                Fetch
+              </Button>
+            </div>
+
+            {fetchError && (
+              <div
                 style={{
-                  backgroundColor: 'var(--color-danger)',
-                  marginTop: 'auto',
+                  padding: '12px',
+                  background: 'rgba(239, 68, 68, 0.1)',
+                  border: '1px solid rgba(239, 68, 68, 0.3)',
+                  borderRadius: 'var(--radius-sm)',
+                  color: 'var(--color-danger)',
+                  fontSize: '13px',
                 }}
               >
-                Delete (Cascade)
-              </Button>
-            </div>
+                {fetchError}
+              </div>
+            )}
 
-            <div
-              style={{
-                border: '1px solid var(--color-border)',
-                borderRadius: '8px',
-                padding: '16px',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '12px',
-              }}
-            >
-              <div style={{ fontWeight: 600, fontSize: '15px', color: 'var(--color-text)' }}>
-                Delete (Retain Targets)
-              </div>
-              <div style={{ fontSize: '13px', color: 'var(--color-text-secondary)' }}>
-                Removes only the provider. Model alias targets that reference this provider will
-                remain but may cause errors.
-              </div>
-              {affectedAliases.length > 0 && (
+            {fetchedModels.length > 0 && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
                 <div
-                  style={{ fontSize: '12px', color: 'var(--color-warning)', fontStyle: 'italic' }}
+                  style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
                 >
-                  {affectedAliases.length} model alias(es) will have orphaned targets.
+                  <label className="font-body text-[13px] font-medium text-text-secondary">
+                    Available Models ({fetchedModels.length})
+                  </label>
+                  <div style={{ display: 'flex', gap: '8px' }}>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setSelectedModelIds(new Set(fetchedModels.map((m) => m.id)))}
+                    >
+                      Select All
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setSelectedModelIds(new Set())}
+                    >
+                      Clear
+                    </Button>
+                  </div>
                 </div>
-              )}
-              <Button
-                variant="secondary"
-                onClick={() => handleDelete(false)}
-                isLoading={deleteModalLoading}
-                style={{ marginTop: 'auto' }}
+
+                <div
+                  style={{
+                    maxHeight: '400px',
+                    overflowY: 'auto',
+                    border: '1px solid var(--color-border-glass)',
+                    borderRadius: 'var(--radius-sm)',
+                    background: 'var(--color-bg-deep)',
+                  }}
+                >
+                  {fetchedModels.map((model) => {
+                    const contextLengthK = model.context_length
+                      ? `${(model.context_length / 1000).toFixed(0)}K`
+                      : null;
+
+                    return (
+                      <div
+                        key={model.id}
+                        style={{
+                          padding: '12px',
+                          borderBottom: '1px solid var(--color-border-glass)',
+                          cursor: 'pointer',
+                          background: selectedModelIds.has(model.id)
+                            ? 'var(--color-bg-hover)'
+                            : 'transparent',
+                          transition: 'background 0.2s',
+                        }}
+                        onClick={() => toggleModelSelection(model.id)}
+                        className="hover:bg-bg-hover"
+                      >
+                        <div style={{ display: 'flex', alignItems: 'start', gap: '12px' }}>
+                          <input
+                            type="checkbox"
+                            checked={selectedModelIds.has(model.id)}
+                            onChange={() => toggleModelSelection(model.id)}
+                            style={{ marginTop: '2px', cursor: 'pointer' }}
+                            onClick={(e) => e.stopPropagation()}
+                          />
+                          <div style={{ flex: 1 }}>
+                            <div
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '8px',
+                                marginBottom: '4px',
+                              }}
+                            >
+                              <span
+                                style={{
+                                  fontWeight: 600,
+                                  fontSize: '13px',
+                                  color: 'var(--color-text)',
+                                }}
+                              >
+                                {model.id}
+                              </span>
+                              {contextLengthK && (
+                                <Badge
+                                  status="connected"
+                                  style={{ fontSize: '10px', padding: '2px 6px' }}
+                                >
+                                  {contextLengthK}
+                                </Badge>
+                              )}
+                            </div>
+                            {model.name && model.name !== model.id && (
+                              <div
+                                style={{
+                                  fontSize: '12px',
+                                  color: 'var(--color-text-secondary)',
+                                  marginBottom: '2px',
+                                }}
+                              >
+                                {model.name}
+                              </div>
+                            )}
+                            {model.description && (
+                              <div
+                                style={{
+                                  fontSize: '11px',
+                                  color: 'var(--color-text-muted)',
+                                  marginTop: '4px',
+                                  lineHeight: '1.4',
+                                }}
+                              >
+                                {model.description.length > 150
+                                  ? `${model.description.substring(0, 150)}...`
+                                  : model.description}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {!isFetchingModels && fetchedModels.length === 0 && !fetchError && (
+              <div
+                style={{
+                  padding: '32px',
+                  textAlign: 'center',
+                  color: 'var(--color-text-secondary)',
+                  fontSize: '13px',
+                  fontStyle: 'italic',
+                }}
               >
-                Delete (Retain)
+                {isOAuthMode
+                  ? 'Click Fetch to load known OAuth models'
+                  : 'Enter a URL and click Fetch to load available models'}
+              </div>
+            )}
+          </div>
+        </Modal>
+
+        <Modal
+          isOpen={!!deleteModalProvider}
+          onClose={() => setDeleteModalProvider(null)}
+          title={`Delete Provider: ${deleteModalProvider?.name || deleteModalProvider?.id || ''}`}
+          size="lg"
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+            <div style={{ color: 'var(--color-text-secondary)', fontSize: '14px' }}>
+              Choose how to delete this provider. The action cannot be undone.
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div
+                style={{
+                  border: '1px solid var(--color-border)',
+                  borderRadius: '8px',
+                  padding: '16px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '12px',
+                }}
+              >
+                <div style={{ fontWeight: 600, fontSize: '15px', color: 'var(--color-danger)' }}>
+                  Delete Provider (Cascade)
+                </div>
+                <div style={{ fontSize: '13px', color: 'var(--color-text-secondary)' }}>
+                  Removes this provider AND deletes all model alias targets that reference it.
+                </div>
+                {affectedAliases.length > 0 ? (
+                  <div style={{ fontSize: '13px' }}>
+                    <div style={{ fontWeight: 500, marginBottom: '4px' }}>
+                      This will affect {affectedAliases.length} model alias(es):
+                    </div>
+                    <ul
+                      style={{
+                        margin: 0,
+                        paddingLeft: '16px',
+                        fontSize: '12px',
+                        color: 'var(--color-text-secondary)',
+                      }}
+                    >
+                      {affectedAliases.map((a) => (
+                        <li key={a.aliasId}>
+                          {a.aliasId} ({a.targetsCount} target(s))
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : (
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: 'var(--color-text-secondary)',
+                      fontStyle: 'italic',
+                    }}
+                  >
+                    No model aliases reference this provider.
+                  </div>
+                )}
+                <Button
+                  onClick={() => handleDelete(true)}
+                  isLoading={deleteModalLoading}
+                  style={{
+                    backgroundColor: 'var(--color-danger)',
+                    marginTop: 'auto',
+                  }}
+                >
+                  Delete (Cascade)
+                </Button>
+              </div>
+
+              <div
+                style={{
+                  border: '1px solid var(--color-border)',
+                  borderRadius: '8px',
+                  padding: '16px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '12px',
+                }}
+              >
+                <div style={{ fontWeight: 600, fontSize: '15px', color: 'var(--color-text)' }}>
+                  Delete (Retain Targets)
+                </div>
+                <div style={{ fontSize: '13px', color: 'var(--color-text-secondary)' }}>
+                  Removes only the provider. Model alias targets that reference this provider will
+                  remain but may cause errors.
+                </div>
+                {affectedAliases.length > 0 && (
+                  <div
+                    style={{ fontSize: '12px', color: 'var(--color-warning)', fontStyle: 'italic' }}
+                  >
+                    {affectedAliases.length} model alias(es) will have orphaned targets.
+                  </div>
+                )}
+                <Button
+                  variant="secondary"
+                  onClick={() => handleDelete(false)}
+                  isLoading={deleteModalLoading}
+                  style={{ marginTop: 'auto' }}
+                >
+                  Delete (Retain)
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex justify-end">
+              <Button variant="ghost" onClick={() => setDeleteModalProvider(null)}>
+                Cancel
               </Button>
             </div>
           </div>
-
-          <div className="flex justify-end">
-            <Button variant="ghost" onClick={() => setDeleteModalProvider(null)}>
-              Cancel
-            </Button>
-          </div>
-        </div>
-      </Modal>
+        </Modal>
       </PageContainer>
     </div>
   );

--- a/packages/frontend/src/pages/Providers.tsx
+++ b/packages/frontend/src/pages/Providers.tsx
@@ -1039,16 +1039,17 @@ export const Providers = () => {
   };
 
   return (
-    <PageContainer>
+    <div className="flex flex-col min-h-full">
       <PageHeader
         title="Providers"
-        subtitle="Configure upstream inference providers, credentials, and quota checkers."
+        subtitle="Upstream LLM providers routed by the gateway"
         actions={
-          <Button leftIcon={<Plus size={16} />} onClick={handleAddNew}>
-            Add Provider
+          <Button leftIcon={<Plus size={14} />} onClick={handleAddNew} size="sm">
+            Add provider
           </Button>
         }
       />
+      <PageContainer>
       <Card flush>
         <div className="overflow-x-auto">
           <table className="w-full border-collapse font-body text-[13px]">
@@ -3882,6 +3883,7 @@ export const Providers = () => {
           </div>
         </div>
       </Modal>
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 };

--- a/packages/frontend/src/pages/Quotas.tsx
+++ b/packages/frontend/src/pages/Quotas.tsx
@@ -189,77 +189,20 @@ export const Quotas = () => {
       />
 
       <PageContainer>
-
-      {legacyRowCount !== null && (
-        <div className="flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
-          <DatabaseZap size={16} className="mt-0.5 shrink-0 text-amber-400" />
-          <div className="flex-1">
-            <p className="font-medium text-amber-300">
-              Legacy quota data detected ({legacyRowCount.toLocaleString()} row
-              {legacyRowCount !== 1 ? 's' : ''} in{' '}
-              <code className="font-mono">quota_snapshots</code>)
-            </p>
-            <p className="mt-0.5 text-text-secondary">
-              Migrate this historical data into the new meter snapshots table to preserve it.
-            </p>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <Button
-              size="sm"
-              variant="ghost"
-              isLoading={downloading === 'csv'}
-              disabled={downloading !== null}
-              onClick={() => handleDownloadBackup('csv')}
-              leftIcon={<Download size={13} />}
-            >
-              CSV
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              isLoading={downloading === 'sql'}
-              disabled={downloading !== null}
-              onClick={() => handleDownloadBackup('sql')}
-              leftIcon={<Download size={13} />}
-            >
-              SQL
-            </Button>
-            <Button
-              size="sm"
-              variant="secondary"
-              isLoading={migrating}
-              onClick={handleMigrate}
-              leftIcon={<DatabaseZap size={13} />}
-            >
-              Migrate now
-            </Button>
-          </div>
-        </div>
-      )}
-
-      {migrationResult !== null && (
-        <div className="flex items-start gap-3 rounded-lg border border-green-500/40 bg-green-500/10 px-4 py-3 text-sm">
-          <DatabaseZap size={16} className="mt-0.5 shrink-0 text-green-400" />
-          <div className="flex-1">
-            <p className="font-medium text-green-300">
-              Migration complete — {migrationResult.inserted.toLocaleString()} row
-              {migrationResult.inserted !== 1 ? 's' : ''} inserted
-              {migrationResult.skipped > 0
-                ? `, ${migrationResult.skipped.toLocaleString()} already existed`
-                : ''}
-              .
-            </p>
-            {!truncated && (
-              <p className="mt-0.5 text-text-secondary">
-                You can now truncate the old <code className="font-mono">quota_snapshots</code>{' '}
-                table to free up space.
+        {legacyRowCount !== null && (
+          <div className="flex flex-col gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-3 text-sm sm:flex-row sm:items-start sm:px-4">
+            <DatabaseZap size={16} className="mt-0.5 shrink-0 text-amber-400" />
+            <div className="flex-1">
+              <p className="font-medium text-amber-300">
+                Legacy quota data detected ({legacyRowCount.toLocaleString()} row
+                {legacyRowCount !== 1 ? 's' : ''} in{' '}
+                <code className="font-mono">quota_snapshots</code>)
               </p>
-            )}
-          </div>
-          {truncated ? (
-            <span className="text-xs text-text-muted self-center">quota_snapshots truncated</span>
-          ) : (
-            <div className="flex items-center gap-2 shrink-0">
+              <p className="mt-0.5 text-text-secondary">
+                Migrate this historical data into the new meter snapshots table to preserve it.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
               <Button
                 size="sm"
                 variant="ghost"
@@ -280,76 +223,132 @@ export const Quotas = () => {
               >
                 SQL
               </Button>
-              <Button size="sm" variant="danger" isLoading={truncating} onClick={handleTruncate}>
-                Truncate quota_snapshots
+              <Button
+                size="sm"
+                variant="secondary"
+                isLoading={migrating}
+                onClick={handleMigrate}
+                leftIcon={<DatabaseZap size={13} />}
+              >
+                Migrate now
               </Button>
             </div>
-          )}
-        </div>
-      )}
+          </div>
+        )}
 
-      {loading && quotas.length === 0 ? (
-        <div className="flex items-center justify-center h-64 gap-3">
-          <RefreshCw size={20} className="animate-spin text-primary" />
-          <span className="text-text-secondary">Loading quotas...</span>
-        </div>
-      ) : quotas.length === 0 ? (
-        <Card>
-          <EmptyState
-            icon={<Gauge />}
-            title="No quota checkers configured"
-            description="Configure quota checkers in your provider settings to monitor usage."
-          />
-        </Card>
-      ) : (
-        <div className="flex flex-col gap-8">
-          {balanceQuotas.length > 0 && (
-            <section>
-              <CombinedBalancesCard
-                balanceQuotas={balanceQuotas}
-                onRefresh={handleRefresh}
-                refreshing={refreshing}
-              />
-            </section>
-          )}
-
-          {allowanceGroups.length > 0 && (
-            <section>
-              <div className="flex items-center gap-2 mb-4 pb-2 border-b border-border-glass">
-                <Cpu size={18} className="text-primary" />
-                <h2 className="font-heading text-h2 font-semibold text-text">Rate Limits</h2>
+        {migrationResult !== null && (
+          <div className="flex flex-col gap-3 rounded-lg border border-green-500/40 bg-green-500/10 px-3 py-3 text-sm sm:flex-row sm:items-start sm:px-4">
+            <DatabaseZap size={16} className="mt-0.5 shrink-0 text-green-400" />
+            <div className="flex-1">
+              <p className="font-medium text-green-300">
+                Migration complete — {migrationResult.inserted.toLocaleString()} row
+                {migrationResult.inserted !== 1 ? 's' : ''} inserted
+                {migrationResult.skipped > 0
+                  ? `, ${migrationResult.skipped.toLocaleString()} already existed`
+                  : ''}
+                .
+              </p>
+              {!truncated && (
+                <p className="mt-0.5 text-text-secondary">
+                  You can now truncate the old <code className="font-mono">quota_snapshots</code>{' '}
+                  table to free up space.
+                </p>
+              )}
+            </div>
+            {truncated ? (
+              <span className="text-xs text-text-muted self-center">quota_snapshots truncated</span>
+            ) : (
+              <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  isLoading={downloading === 'csv'}
+                  disabled={downloading !== null}
+                  onClick={() => handleDownloadBackup('csv')}
+                  leftIcon={<Download size={13} />}
+                >
+                  CSV
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  isLoading={downloading === 'sql'}
+                  disabled={downloading !== null}
+                  onClick={() => handleDownloadBackup('sql')}
+                  leftIcon={<Download size={13} />}
+                >
+                  SQL
+                </Button>
+                <Button size="sm" variant="danger" isLoading={truncating} onClick={handleTruncate}>
+                  Truncate quota_snapshots
+                </Button>
               </div>
-              <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                {allowanceGroups.map(([checkerType, quotasList]) => {
-                  const displayName = getCheckerDisplayName(
-                    checkerType,
-                    quotasList[0]?.checkerId ?? checkerType
-                  );
-                  return (
-                    <div key={checkerType} className="flex flex-col gap-3">
-                      <h3 className="font-heading text-xs font-semibold text-text-secondary uppercase tracking-wider px-1 border-b border-border-glass pb-2">
-                        {displayName}
-                      </h3>
-                      <div className="flex flex-col gap-3">
-                        {quotasList.map((quota) => renderCheckerCard(quota, displayName))}
+            )}
+          </div>
+        )}
+
+        {loading && quotas.length === 0 ? (
+          <div className="flex items-center justify-center h-64 gap-3">
+            <RefreshCw size={20} className="animate-spin text-primary" />
+            <span className="text-text-secondary">Loading quotas...</span>
+          </div>
+        ) : quotas.length === 0 ? (
+          <Card>
+            <EmptyState
+              icon={<Gauge />}
+              title="No quota checkers configured"
+              description="Configure quota checkers in your provider settings to monitor usage."
+            />
+          </Card>
+        ) : (
+          <div className="flex flex-col gap-8">
+            {balanceQuotas.length > 0 && (
+              <section>
+                <CombinedBalancesCard
+                  balanceQuotas={balanceQuotas}
+                  onRefresh={handleRefresh}
+                  refreshing={refreshing}
+                />
+              </section>
+            )}
+
+            {allowanceGroups.length > 0 && (
+              <section>
+                <div className="flex items-center gap-2 mb-4 pb-2 border-b border-border-glass">
+                  <Cpu size={18} className="text-primary" />
+                  <h2 className="font-heading text-h2 font-semibold text-text">Rate Limits</h2>
+                </div>
+                <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                  {allowanceGroups.map(([checkerType, quotasList]) => {
+                    const displayName = getCheckerDisplayName(
+                      checkerType,
+                      quotasList[0]?.checkerId ?? checkerType
+                    );
+                    return (
+                      <div key={checkerType} className="flex flex-col gap-3">
+                        <h3 className="font-heading text-xs font-semibold text-text-secondary uppercase tracking-wider px-1 border-b border-border-glass pb-2">
+                          {displayName}
+                        </h3>
+                        <div className="flex flex-col gap-3">
+                          {quotasList.map((quota) => renderCheckerCard(quota, displayName))}
+                        </div>
                       </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </section>
-          )}
-        </div>
-      )}
-      {historyTarget && (
-        <MeterHistoryModal
-          isOpen
-          onClose={() => setHistoryTarget(null)}
-          quota={historyTarget.quota}
-          meter={historyTarget.meter}
-          displayName={historyTarget.displayName}
-        />
-      )}
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
+        {historyTarget && (
+          <MeterHistoryModal
+            isOpen
+            onClose={() => setHistoryTarget(null)}
+            quota={historyTarget.quota}
+            meter={historyTarget.meter}
+            displayName={historyTarget.displayName}
+          />
+        )}
       </PageContainer>
     </div>
   );

--- a/packages/frontend/src/pages/Quotas.tsx
+++ b/packages/frontend/src/pages/Quotas.tsx
@@ -171,21 +171,24 @@ export const Quotas = () => {
   };
 
   return (
-    <PageContainer>
+    <div className="flex flex-col min-h-full">
       <PageHeader
-        title="Quota Trackers"
-        subtitle="Monitor provider quotas and rate limits."
+        title="Quotas"
+        subtitle="Provider balances and rate-quota allowances"
         actions={
           <Button
             variant="secondary"
+            size="sm"
             onClick={fetchQuotas}
             disabled={loading}
-            leftIcon={<RefreshCw size={16} className={clsx(loading && 'animate-spin')} />}
+            leftIcon={<RefreshCw size={14} className={clsx(loading && 'animate-spin')} />}
           >
-            Refresh All
+            Refresh all
           </Button>
         }
       />
+
+      <PageContainer>
 
       {legacyRowCount !== null && (
         <div className="flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm">
@@ -347,6 +350,7 @@ export const Quotas = () => {
           displayName={historyTarget.displayName}
         />
       )}
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 };

--- a/packages/frontend/src/pages/SystemLogs.tsx
+++ b/packages/frontend/src/pages/SystemLogs.tsx
@@ -196,176 +196,179 @@ export const SystemLogs: React.FC = () => {
         subtitle="Live tail · stderr+stdout"
       />
       <PageContainer>
-
-      <div className="flex flex-col gap-3 glass-bg rounded-lg overflow-hidden">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b border-border-glass">
-          <h3 className="font-heading text-h3 font-semibold text-text m-0">Live Output</h3>
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="min-w-[120px]">
-              <Select
-                value={selectedLevel}
-                onChange={setSelectedLevel}
-                options={supportedLevels.map((l) => ({ value: l, label: l }))}
-                disabled={isUpdatingLevel}
-              />
-            </div>
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={applyLoggingLevel}
-              disabled={isUpdatingLevel || selectedLevel === currentLevel}
-            >
-              Apply
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={resetLoggingLevel}
-              disabled={isUpdatingLevel || currentLevel === startupLevel}
-              leftIcon={<RotateCcw size={14} />}
-            >
-              Reset
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setIsPaused(!isPaused)}
-              leftIcon={isPaused ? <Play size={14} /> : <Pause size={14} />}
-            >
-              {isPaused ? 'Resume' : 'Pause'}
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={clearLogs}
-              leftIcon={<Trash2 size={14} />}
-            >
-              Clear
-            </Button>
-          </div>
-        </div>
-
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b border-border-glass">
-          <div className="text-xs text-text-secondary">
-            Current level: <span className="text-text font-semibold">{currentLevel}</span> · Startup
-            default: <span className="text-text font-semibold">{startupLevel}</span> · Runtime
-            changes reset on restart.
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="flex flex-wrap items-center gap-1.5">
-              {moduleFilter.length > 0 ? (
-                moduleFilter.map((m) => (
-                  <span
-                    key={m}
-                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary/15 text-primary border border-primary/30"
-                  >
-                    {m}
-                    <button
-                      type="button"
-                      onClick={async () => {
-                        const next = moduleFilter.filter((x) => x !== m);
-                        setModuleFilterState(next);
-                        try {
-                          if (next.length === 0) {
-                            await api.clearModuleFilter();
-                          } else {
-                            await api.setModuleFilter(next);
-                          }
-                        } catch {
-                          setModuleFilterState(moduleFilter);
-                        }
-                      }}
-                      className="bg-transparent border-0 p-0 cursor-pointer text-primary/60 hover:text-primary leading-none"
-                    >
-                      ×
-                    </button>
-                  </span>
-                ))
-              ) : (
-                <span className="text-xs text-text-muted italic">All modules</span>
-              )}
-            </div>
-            <input
-              type="text"
-              value={moduleInput}
-              onChange={(e) => setModuleInput(e.target.value)}
-              onKeyDown={async (e) => {
-                if (e.key === 'Enter' && moduleInput.trim()) {
-                  e.preventDefault();
-                  const mod = moduleInput.trim();
-                  if (!moduleFilter.includes(mod)) {
-                    const next = [...moduleFilter, mod];
-                    setModuleFilterState(next);
-                    setModuleInput('');
-                    try {
-                      await api.setModuleFilter(next);
-                    } catch {
-                      setModuleFilterState(moduleFilter);
-                    }
-                  } else {
-                    setModuleInput('');
-                  }
-                }
-              }}
-              placeholder="Add module..."
-              className="h-7 w-32 text-xs rounded-md border border-border-glass bg-bg px-2 text-text outline-none focus:border-primary transition-colors"
-              disabled={false}
-            />
-            {moduleFilter.length > 0 && (
-              <button
-                type="button"
-                onClick={async () => {
-                  setModuleFilterState([]);
-                  try {
-                    await api.clearModuleFilter();
-                  } catch {
-                    // ignore
-                  }
-                }}
-                className="text-xs text-text-secondary hover:text-danger transition-colors bg-transparent border-0 cursor-pointer"
+        <div className="flex flex-col gap-3 glass-bg rounded-lg overflow-hidden">
+          <div className="flex flex-col gap-3 border-b border-border-glass px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4">
+            <h3 className="font-heading text-h3 font-semibold text-text m-0">Live Output</h3>
+            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+              <div className="w-full sm:min-w-[120px]">
+                <Select
+                  value={selectedLevel}
+                  onChange={setSelectedLevel}
+                  options={supportedLevels.map((l) => ({ value: l, label: l }))}
+                  disabled={isUpdatingLevel}
+                />
+              </div>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={applyLoggingLevel}
+                disabled={isUpdatingLevel || selectedLevel === currentLevel}
+                className="w-full sm:w-auto"
+              >
+                Apply
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={resetLoggingLevel}
+                disabled={isUpdatingLevel || currentLevel === startupLevel}
+                leftIcon={<RotateCcw size={14} />}
+                className="w-full sm:w-auto"
+              >
+                Reset
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setIsPaused(!isPaused)}
+                leftIcon={isPaused ? <Play size={14} /> : <Pause size={14} />}
+                className="w-full sm:w-auto"
+              >
+                {isPaused ? 'Resume' : 'Pause'}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={clearLogs}
+                leftIcon={<Trash2 size={14} />}
+                className="w-full sm:w-auto"
               >
                 Clear
-              </button>
-            )}
+              </Button>
+            </div>
           </div>
-        </div>
 
-        <div className="bg-terminal-bg p-3 overflow-y-auto font-mono text-xs text-terminal-fg h-[60vh] min-h-[320px] max-h-[700px]">
-          {logs.length === 0 && (
-            <div className="text-text-muted italic text-center mt-8">Waiting for logs...</div>
-          )}
-          {logs.map((log, i) => (
-            <div key={i} className="mb-1 break-all py-0.5 px-1 rounded-sm hover:bg-white/5">
-              <span className="text-text-muted mr-2">[{log.timestamp}]</span>
-              <span
-                className={clsx(
-                  'font-bold mr-2',
-                  LEVEL_CLASS[log.level?.toLowerCase()] ?? 'text-text-muted'
+          <div className="flex flex-col gap-3 border-b border-border-glass px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4">
+            <div className="text-xs text-text-secondary">
+              Current level: <span className="text-text font-semibold">{currentLevel}</span> ·
+              Startup default: <span className="text-text font-semibold">{startupLevel}</span> ·
+              Runtime changes reset on restart.
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+              <div className="flex flex-wrap items-center gap-1.5">
+                {moduleFilter.length > 0 ? (
+                  moduleFilter.map((m) => (
+                    <span
+                      key={m}
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary/15 text-primary border border-primary/30"
+                    >
+                      {m}
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          const next = moduleFilter.filter((x) => x !== m);
+                          setModuleFilterState(next);
+                          try {
+                            if (next.length === 0) {
+                              await api.clearModuleFilter();
+                            } else {
+                              await api.setModuleFilter(next);
+                            }
+                          } catch {
+                            setModuleFilterState(moduleFilter);
+                          }
+                        }}
+                        className="bg-transparent border-0 p-0 cursor-pointer text-primary/60 hover:text-primary leading-none"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-xs text-text-muted italic">All modules</span>
                 )}
-              >
-                {log.level?.toUpperCase()}:
-              </span>
-              <span>{log.message}</span>
-              {Object.keys(log).filter((k) => !['level', 'message', 'timestamp'].includes(k))
-                .length > 0 && (
-                <pre className="text-text-muted text-[11px] ml-8 mt-1 whitespace-pre-wrap">
-                  {JSON.stringify(
-                    Object.fromEntries(
-                      Object.entries(log).filter(
-                        ([k]) => !['level', 'message', 'timestamp'].includes(k)
-                      )
-                    ),
-                    null,
-                    2
-                  )}
-                </pre>
+              </div>
+              <input
+                type="text"
+                value={moduleInput}
+                onChange={(e) => setModuleInput(e.target.value)}
+                onKeyDown={async (e) => {
+                  if (e.key === 'Enter' && moduleInput.trim()) {
+                    e.preventDefault();
+                    const mod = moduleInput.trim();
+                    if (!moduleFilter.includes(mod)) {
+                      const next = [...moduleFilter, mod];
+                      setModuleFilterState(next);
+                      setModuleInput('');
+                      try {
+                        await api.setModuleFilter(next);
+                      } catch {
+                        setModuleFilterState(moduleFilter);
+                      }
+                    } else {
+                      setModuleInput('');
+                    }
+                  }
+                }}
+                placeholder="Add module..."
+                className="h-8 w-full rounded-md border border-border-glass bg-bg px-2 text-xs text-text outline-none transition-colors focus:border-primary sm:h-7 sm:w-32"
+                disabled={false}
+              />
+              {moduleFilter.length > 0 && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setModuleFilterState([]);
+                    try {
+                      await api.clearModuleFilter();
+                    } catch {
+                      // ignore
+                    }
+                  }}
+                  className="text-xs text-text-secondary hover:text-danger transition-colors bg-transparent border-0 cursor-pointer"
+                >
+                  Clear
+                </button>
               )}
             </div>
-          ))}
-          <div ref={logsEndRef} />
+          </div>
+
+          <div className="h-[55vh] min-h-[280px] max-h-[700px] overflow-y-auto bg-terminal-bg p-2 font-mono text-xs text-terminal-fg sm:h-[60vh] sm:min-h-[320px] sm:p-3">
+            {logs.length === 0 && (
+              <div className="text-text-muted italic text-center mt-8">Waiting for logs...</div>
+            )}
+            {logs.map((log, i) => (
+              <div key={i} className="mb-1 break-all py-0.5 px-1 rounded-sm hover:bg-white/5">
+                <span className="text-text-muted mr-2">[{log.timestamp}]</span>
+                <span
+                  className={clsx(
+                    'font-bold mr-2',
+                    LEVEL_CLASS[log.level?.toLowerCase()] ?? 'text-text-muted'
+                  )}
+                >
+                  {log.level?.toUpperCase()}:
+                </span>
+                <span>{log.message}</span>
+                {Object.keys(log).filter((k) => !['level', 'message', 'timestamp'].includes(k))
+                  .length > 0 && (
+                  <pre className="text-text-muted text-[11px] ml-8 mt-1 whitespace-pre-wrap">
+                    {JSON.stringify(
+                      Object.fromEntries(
+                        Object.entries(log).filter(
+                          ([k]) => !['level', 'message', 'timestamp'].includes(k)
+                        )
+                      ),
+                      null,
+                      2
+                    )}
+                  </pre>
+                )}
+              </div>
+            ))}
+            <div ref={logsEndRef} />
+          </div>
         </div>
-      </div>
       </PageContainer>
     </div>
   );

--- a/packages/frontend/src/pages/SystemLogs.tsx
+++ b/packages/frontend/src/pages/SystemLogs.tsx
@@ -185,16 +185,17 @@ export const SystemLogs: React.FC = () => {
   };
 
   return (
-    <PageContainer>
+    <div className="flex flex-col min-h-full">
       <PageHeader
         title={
           <span className="inline-flex items-center gap-2">
-            <Terminal size={24} className="text-primary" />
+            <Terminal size={20} className="text-primary" />
             System Logs
           </span>
         }
-        subtitle="Live stream of backend system logs."
+        subtitle="Live tail · stderr+stdout"
       />
+      <PageContainer>
 
       <div className="flex flex-col gap-3 glass-bg rounded-lg overflow-hidden">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b border-border-glass">
@@ -365,6 +366,7 @@ export const SystemLogs: React.FC = () => {
           <div ref={logsEndRef} />
         </div>
       </div>
-    </PageContainer>
+      </PageContainer>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary

Multi-day rebuild of the entire admin console plus a round of mobile/responsive fixes from post-redesign review. Every page redesigned around a single visual language — solid surface treatment, amber→gold accent, JetBrains Mono for telemetry, denser layout for operator workflows. Responsiveness now works cleanly down to 360px.

The functional surface is unchanged — same routes, same API calls, same auth model, same permissions matrix.

## What changed

### Design system foundation
- `globals.css` rebuilt on Tailwind v4 `@theme`. New token set: deep black canvas, slate `#0F172A` cards, `#1E293B` borders, amber→gold gradient reserved for accents.
- JetBrains Mono added as the third font (telemetry, IDs, keys, log lines). Space Grotesk for headings, DM Sans for body.
- Background gets two subtle radial-gradient washes — amber top-left, violet top-right.
- New utilities: `glass-bg`, `glass-blur`, `amber-grad-text`, `amber-grad-bg`, `surface-card`, `surface-quiet`, `tnum`, `live-dot`, `animate-slide-in`, `animate-float`.

### Layout shell
- Sidebar 220px, glass surface treatment originally — now solid `bg-bg-card` (see fixes below).
- New `PlexusMark` component for the geometric logo (sidebar, app bar, login).
- `PageHeader` is sticky-top by default with a second-row slot for filters/tabs/toolbars, applied consistently to every page.
- Mobile drawer matches the desktop sidebar exactly.

### Reusable UI components
Restyled with full backwards-compat on their public APIs:
- **Button** — gradient primary with inset highlight + amber-glow shadow. Tighter sizes (sm/md/lg/icon).
- **Card** — solid `#0F172A` surface, 16px radius, `#1E293B` border. Header now flex-wraps so long extras can drop to a second row on mobile.
- **Input / Select** — `slate-900/60` fill, amber focus ring, tighter padding.
- **Badge** — five new semantic variants (`success`, `danger`, `info`, `violet`, `cyan`).
- **Switch** — amber gradient when on.
- **Modal / Drawer** — `rounded-2xl`. Modal backdrop is inert (clicking outside doesn't dismiss; matches pre-redesign behaviour).
- **Tabs** — horizontal scrollbar chrome suppressed (still scrolls on overflow).
- **Tooltip** — JetBrains Mono, slim padding.

### Pages (all 13)
Login (full rewrite, mesh background SVG), Dashboard (sticky tabs), Logs, Providers, Models, Keys, Quotas, MCP, Settings, System Logs, Traces, Errors, My Key — each ported to the new sticky-header pattern with the visual primitives.

### Mobile + responsiveness fixes
- **`overflow-x-clip` on `<main>` (not `overflow-x-hidden`)** — hidden silently creates a scroll container, breaking `position: sticky` for every page header inside. Clip contains horizontal overflow without that side-effect.
- **Solid surfaces on every "covering" element** (AppBar, Sidebar, Drawer panel, PageHeader sticky strip, Dashboard's inline sticky tab bar) — `backdrop-filter` is unreliable on mobile and translucent surfaces let underlying page content bleed through. Switched to `bg-bg-card`.
- **Dashboard inner padding deduped** — each tab (LiveTab/UsageTab/PerformanceTab/OverallTab) already provides `p-6`, so the Dashboard wrapper no longer double-pads on mobile.
- **PageHeader sticky offset** is `top-14` on mobile (below AppBar) and `top-0` from `md:` up.
- **AnalyzeButton** shows a short label below `md:` (e.g. "Analyze") and the full descriptive label from `md:` up (e.g. "Analyze Velocity Trends") so it doesn't overflow inside cards on mobile.
- **Z-stack made explicit** with arbitrary values: AppBar `z-[200]`, Drawer backdrop `z-[300]`, Drawer panel `z-[310]` — unambiguous regardless of theme tokens.

### UX cleanup
- Removed the non-functional "Search ⌘K" button from the sidebar.
- Removed the AD/initials avatar from the mobile AppBar — decoration that competed with the hamburger and brand mark.
- Sidebar `NavItem` rewritten without `NavLink` render-prop children (which mis-rendered Dashboard/Logs/"Main" section in some conditions). Active-state amber rail is now a `:before` pseudo-element.

### Branding
- New Plexus geometric mark as `plexus-icon.svg`, wired up as primary favicon in `build.ts`. SVG-first for modern browsers; PNG/ICO fallbacks retained. Named `plexus-icon` (not `favicon`) to avoid an output-name collision with `favicon.ico` / `favicon-*.png` during `--compile` bundling.

### Backend / misc
Pending local edits rolled into this PR so the branch reflects the actual working tree:
- `cli/backup`, `services/dispatcher`, `routes/management`, `db/config-repository`
- Frontend `lib/api` — trimmed unused exports
- `Models` / `Logs` / `Mcp` / `Keys` / `Providers` / `Config` — pending local UX tweaks merged in

## Out of scope (intentional)

- No new routes, API endpoints, or schema changes.
- No behavioural changes to auth, scoping, or permissions.
- No new dependencies — purely Tailwind classes + lucide-react icons already in the bundle.

## Test plan

- [ ] `bun run dev` boots backend + frontend cleanly
- [ ] Login (admin key + API key secret paths)
- [ ] All sidebar nav links route correctly for both admin and limited principals
- [ ] Sidebar collapse/expand works (desktop)
- [ ] Mobile hamburger opens drawer; drawer panel is fully opaque (no page content showing through); drawer auto-closes on navigation
- [ ] Resize viewport from 1440px → 360px on every page; no horizontal overflow
- [ ] Dashboard tab bar is visible and stays sticky below the mobile AppBar when scrolling
- [ ] Dashboard tabs (Live / Usage / Performance) all render and update with polling
- [ ] No content visible through AppBar / page headers when scrolling
- [ ] Card extras (e.g. Concurrency / Velocity card headers) wrap cleanly on mobile, "Analyze" button doesn't overflow
- [ ] Modal backdrop click does NOT close the modal (must use ✕ or Esc)
- [ ] Logs filters apply, pagination works, delete-single + delete-all modals open
- [ ] Providers add/edit modal, switch toggles
- [ ] Models row expansion + metadata override form save
- [ ] Keys create modal + drawer detail view
- [ ] Quotas balance/allowance rows
- [ ] MCP add server modal
- [ ] System Logs streams with auto-scroll
- [ ] Traces detail timing waterfall
- [ ] Errors grouped list + detail panel
- [ ] My Key (limited user) — reveal/hide secret, rotate
- [ ] Browser tab favicon shows the new Plexus geometric mark
- [ ] `bun run compile:windows` produces a working `plexus.exe`