### PR TITLE
fix(frontend): invoke Tailwind with current Bun executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,17 @@ ADMIN_KEY="your-admin-password" ./plexus
 curl -L https://github.com/mcowger/plexus/releases/latest/download/plexus-linux -o plexus
 chmod +x plexus
 ADMIN_KEY="your-admin-password" ./plexus
-
-# Windows (x64) — download plexus.exe from the releases page, then:
-# set ADMIN_KEY=your-admin-password && plexus.exe
 ```
+
+```powershell
+# Windows (x64, PowerShell)
+Invoke-WebRequest -Uri "https://github.com/mcowger/plexus/releases/latest/download/plexus.exe" -OutFile "plexus.exe"
+$env:ADMIN_KEY = "your-admin-password"
+$env:DATABASE_URL = "sqlite://./data/plexus.db"
+.\plexus.exe
+```
+
+For Windows troubleshooting and Command Prompt usage, see [Running the Windows Standalone Binary](docs/INSTALLATION.md#running-the-windows-standalone-binary).
 
 The binary is self-contained — no runtime or external dependencies required. Database migration files and the web dashboard are embedded inside the binary.
 

--- a/packages/frontend/build.ts
+++ b/packages/frontend/build.ts
@@ -7,7 +7,7 @@ import { spawn } from 'child_process';
 const buildCSS = async () => {
   console.log('Building CSS...');
   const proc = spawn(
-    'bun',
+    process.execPath,
     ['x', '@tailwindcss/cli', '-i', './src/globals.css', '-o', './dist/main.css'],
     {
       stdio: 'inherit',
@@ -16,6 +16,11 @@ const buildCSS = async () => {
   );
 
   return new Promise<void>((resolve, reject) => {
+    proc.on('error', (error) => {
+      console.error('CSS Build failed.');
+      reject(error);
+    });
+
     proc.on('close', (code) => {
       if (code === 0) {
         console.log('CSS Build complete.');


### PR DESCRIPTION
Fixes Windows compilation by invoking Tailwind through the currently running Bun executable (process.execPath) instead of relying on bun being discoverable via   
 PATH.                                                                                                                                                             
This bug appear with the command `bun run compile:windows`              
                                                                                                                                                     
 This avoids ENOENT failures from Windows shell/PATH shims while remaining cross-platform. Verified locally for Windows, and GitHub Actions successfully built     
 Linux and macOS binaries.   
 
 I do not have linux/macos to test the compiler commands so i rely on GH actions for it