### PR TITLE
feat(frontend): add Import button for orphaned provider models

### DIFF
--- a/packages/frontend/src/hooks/useModels.ts
+++ b/packages/frontend/src/hooks/useModels.ts
@@ -2,6 +2,12 @@ import { useState, useEffect, useCallback } from 'react';
 import { api, Alias, Provider, Model, Cooldown } from '../lib/api';
 import { useToast } from '../contexts/ToastContext';
 
+export interface OrphanGroup {
+  modelId: string;
+  existingAlias?: Alias;
+  candidates: Array<{ provider: Provider; model: Model }>;
+}
+
 const EMPTY_ALIAS: Alias = {
   id: '',
   aliases: [],
@@ -32,6 +38,12 @@ export const useModels = () => {
       { loading: boolean; result?: 'success' | 'error'; message?: string; showResult: boolean }
     >
   >({});
+
+  // Import Orphaned Models State
+  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
+  const [orphanGroups, setOrphanGroups] = useState<OrphanGroup[]>([]);
+  const [selectedImports, setSelectedImports] = useState<Map<string, Set<string>>>(new Map());
+  const [isImporting, setIsImporting] = useState(false);
 
   const loadData = useCallback(async () => {
     try {
@@ -175,6 +187,106 @@ export const useModels = () => {
 
   const filteredAliases = aliases.filter((a) => a.id.toLowerCase().includes(search.toLowerCase()));
 
+  const handleOpenImport = useCallback(() => {
+    // Build set of covered (provider, model) pairs from all alias targets
+    const covered = new Set<string>();
+    aliases.forEach((alias) => {
+      alias.targets.forEach((t) => {
+        covered.add(`${t.provider}|${t.model}`);
+      });
+    });
+
+    // Find orphaned models and group by model.id
+    const orphanMap = new Map<string, Array<{ provider: Provider; model: Model }>>();
+    availableModels.forEach((model) => {
+      const key = `${model.providerId}|${model.id}`;
+      if (covered.has(key)) return;
+
+      if (!orphanMap.has(model.id)) {
+        orphanMap.set(model.id, []);
+      }
+      const provider = providers.find((p) => p.id === model.providerId);
+      if (provider) {
+        orphanMap.get(model.id)!.push({ provider, model });
+      }
+    });
+
+    const groups: OrphanGroup[] = [];
+    orphanMap.forEach((candidates, modelId) => {
+      const existingAlias = aliases.find((a) => a.id === modelId);
+      groups.push({ modelId, existingAlias, candidates });
+    });
+    groups.sort((a, b) => a.modelId.localeCompare(b.modelId));
+
+    // Default: select all candidates
+    const selections = new Map<string, Set<string>>();
+    groups.forEach((group) => {
+      selections.set(group.modelId, new Set(group.candidates.map((c) => c.provider.id)));
+    });
+
+    setOrphanGroups(groups);
+    setSelectedImports(selections);
+    setIsImportModalOpen(true);
+  }, [aliases, availableModels, providers]);
+
+  const handleSaveImports = useCallback(async () => {
+    setIsImporting(true);
+    try {
+      for (const [modelId, providerIds] of selectedImports.entries()) {
+        if (providerIds.size === 0) continue;
+
+        const group = orphanGroups.find((g) => g.modelId === modelId);
+        if (!group) continue;
+
+        const selectedCandidates = group.candidates.filter((c) => providerIds.has(c.provider.id));
+
+        if (group.existingAlias) {
+          // Merge into existing alias
+          const updatedAlias = JSON.parse(JSON.stringify(group.existingAlias));
+          selectedCandidates.forEach((c) => {
+            const alreadyExists = updatedAlias.targets.some(
+              (t: { provider: string; model: string }) =>
+                t.provider === c.provider.id && t.model === c.model.id
+            );
+            if (!alreadyExists) {
+              updatedAlias.targets.push({
+                provider: c.provider.id,
+                model: c.model.id,
+                enabled: true,
+              });
+            }
+          });
+          await api.saveAlias(updatedAlias, group.existingAlias.id);
+        } else {
+          // Create new alias
+          const newAlias: Alias = {
+            ...EMPTY_ALIAS,
+            id: modelId,
+            targets: selectedCandidates.map((c) => ({
+              provider: c.provider.id,
+              model: c.model.id,
+              enabled: true,
+            })),
+          };
+          await api.saveAlias(newAlias, undefined);
+        }
+      }
+
+      await loadData();
+      toast.success('Imports saved successfully');
+      setIsImportModalOpen(false);
+      setSelectedImports(new Map());
+      setOrphanGroups([]);
+      return true;
+    } catch (e) {
+      console.error('Failed to save imports', e);
+      toast.error('Failed to save imports');
+      return false;
+    } finally {
+      setIsImporting(false);
+    }
+  }, [selectedImports, orphanGroups, loadData, toast]);
+
   return {
     aliases: filteredAliases,
     allAliases: aliases,
@@ -199,5 +311,14 @@ export const useModels = () => {
     handleToggleTarget,
     handleTestTarget,
     loadData,
+    isImportModalOpen,
+    setIsImportModalOpen,
+    orphanGroups,
+    setOrphanGroups,
+    selectedImports,
+    setSelectedImports,
+    isImporting,
+    handleOpenImport,
+    handleSaveImports,
   };
 };

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -41,6 +41,7 @@ import {
   AlertTriangle,
   Cpu,
   Play,
+  Download,
 } from 'lucide-react';
 
 export const Models = () => {
@@ -66,6 +67,14 @@ export const Models = () => {
     handleDeleteAll: hookDeleteAll,
     handleToggleTarget,
     handleTestTarget,
+    isImportModalOpen,
+    setIsImportModalOpen,
+    orphanGroups,
+    selectedImports,
+    setSelectedImports,
+    isImporting,
+    handleOpenImport,
+    handleSaveImports,
   } = useModels();
 
   // Modal State
@@ -915,6 +924,14 @@ export const Models = () => {
               disabled={aliases.length === 0}
             >
               Delete All
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              leftIcon={<Download size={14} />}
+              onClick={handleOpenImport}
+            >
+              Import
             </Button>
             <Button leftIcon={<Plus size={14} />} onClick={handleAddNew} size="sm">
               Add model
@@ -2439,6 +2456,149 @@ export const Models = () => {
             ) : (
               <div className="text-text-muted italic text-center text-sm py-8">
                 Enter a search term to find models
+              </div>
+            )}
+          </div>
+        </Modal>
+
+        {/* Import Modal */}
+        <Modal
+          isOpen={isImportModalOpen}
+          onClose={() => setIsImportModalOpen(false)}
+          title="Import Orphaned Models"
+          size="lg"
+          footer={
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>
+              <Button variant="ghost" onClick={() => setIsImportModalOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSaveImports}
+                isLoading={isImporting}
+                disabled={
+                  Array.from(selectedImports.values()).every(
+                    (providerIds) => providerIds.size === 0
+                  ) || orphanGroups.length === 0
+                }
+              >
+                Import Selected
+              </Button>
+            </div>
+          }
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            {orphanGroups.length === 0 ? (
+              <div className="text-text-muted italic text-center text-sm py-8">
+                No orphaned models found — all provider models are covered by aliases.
+              </div>
+            ) : (
+              <div
+                style={{
+                  maxHeight: '500px',
+                  overflowY: 'auto',
+                  overflowX: 'auto',
+                  border: '1px solid var(--color-border-glass)',
+                  borderRadius: 'var(--radius-sm)',
+                }}
+              >
+                <table className="w-full border-collapse font-body text-[13px]">
+                  <thead
+                    style={{
+                      position: 'sticky',
+                      top: 0,
+                      backgroundColor: 'var(--color-bg-hover)',
+                      zIndex: 10,
+                    }}
+                  >
+                    <tr>
+                      <th
+                        className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                        style={{ width: '40px' }}
+                      >
+                        {' '}
+                      </th>
+                      <th className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                        Model / Alias
+                      </th>
+                      <th className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                        Providers
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {orphanGroups.map((group) => {
+                      const selected = selectedImports.get(group.modelId) || new Set<string>();
+                      const allChecked =
+                        group.candidates.length > 0 &&
+                        group.candidates.every((c) => selected.has(c.provider.id));
+
+                      return (
+                        <tr key={group.modelId} className="hover:bg-bg-hover">
+                          <td className="px-4 py-3 text-left text-text">
+                            <input
+                              type="checkbox"
+                              checked={allChecked}
+                              onChange={(e) => {
+                                const next = new Map(selectedImports);
+                                if (e.target.checked) {
+                                  next.set(
+                                    group.modelId,
+                                    new Set(group.candidates.map((c) => c.provider.id))
+                                  );
+                                } else {
+                                  next.set(group.modelId, new Set<string>());
+                                }
+                                setSelectedImports(next);
+                              }}
+                            />
+                          </td>
+                          <td className="px-4 py-3 text-left text-text">
+                            <div className="font-medium">{group.modelId}</div>
+                            {group.existingAlias ? (
+                              <span className="inline-flex rounded border border-border-glass px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary">
+                                Existing Alias
+                              </span>
+                            ) : (
+                              <span className="inline-flex rounded border border-border-glass px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-text-muted">
+                                New Alias
+                              </span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-left">
+                            <div className="flex flex-col gap-1">
+                              {group.candidates.map((c) => {
+                                const isChecked = selected.has(c.provider.id);
+                                return (
+                                  <label
+                                    key={c.provider.id}
+                                    className="flex items-center gap-2 cursor-pointer"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={isChecked}
+                                      onChange={() => {
+                                        const next = new Map(selectedImports);
+                                        const current = new Set(next.get(group.modelId) || []);
+                                        if (current.has(c.provider.id)) {
+                                          current.delete(c.provider.id);
+                                        } else {
+                                          current.add(c.provider.id);
+                                        }
+                                        next.set(group.modelId, current);
+                                        setSelectedImports(next);
+                                      }}
+                                    />
+                                    <span className="text-text text-[13px]">{c.provider.name}</span>
+                                  </label>
+                                );
+                              })}
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Adds an **Import** button on the Models page that discovers provider models not currently referenced by any existing alias target, and offers to create or extend aliases for them.

## How it works

1. Click **Import** on the Models page
2. The system scans all provider models and finds "orphans" — models not used by any alias target
3. Orphans are grouped by model name. For each group:
   - If an alias with that name already exists, it shows **"Existing Alias"** — checking providers merges them into that alias
   - If no alias exists, it shows **"New Alias"** — checking providers creates a new alias
4. All candidate providers are pre-checked by default
5. Click **Import Selected** to save

## Changes

- **`useModels.ts`**: Added `OrphanGroup` type, `handleOpenImport` (compute orphans), `handleSaveImports` (merge into existing or create new)
- **`Models.tsx`**: Added Import button in page header and full Import modal with per-provider checkboxes

## Testing

- TypeScript type-check passes
- Frontend build passes
- Lint/format passes