### PR TITLE
perf(dispatcher): emit SSE routing update before upstream call

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
@@ -630,6 +630,7 @@ describe('Dispatcher Failover', () => {
       saveError: saveErrorSpy,
       recordFailedAttempt: vi.fn(),
       recordSuccessfulAttempt: vi.fn(),
+      emitUpdatedAsync: vi.fn(),
     } as any);
 
     const response = await dispatcher.dispatch({

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -199,6 +199,21 @@ export class Dispatcher {
     });
   }
 
+  /**
+   * Emit an early routing update so the frontend shows provider/model immediately.
+   * The route handler emits a second update after dispatch, but for non-streaming
+   * requests that can be seconds later — this one fires as soon as routing is done.
+   */
+  private emitRoutingUpdate(requestId: string | undefined, route: RouteResult): void {
+    if (!requestId || !this.usageStorage) return;
+    this.usageStorage.emitUpdatedAsync({
+      requestId,
+      provider: route.provider,
+      selectedModelName: route.model,
+      canonicalModelName: route.canonicalModel,
+    });
+  }
+
   async dispatch(request: UnifiedChatRequest): Promise<UnifiedChatResponse> {
     const config = getConfig();
     const failover = config.failover;
@@ -309,6 +324,8 @@ export class Dispatcher {
       }
 
       attemptedProviders.push(`${route.provider}/${route.model}`);
+
+      this.emitRoutingUpdate(currentRequest.requestId, route);
 
       try {
         // Determine Target API Type
@@ -2251,6 +2268,8 @@ export class Dispatcher {
 
       attemptedProviders.push(`${route.provider}/${route.model}`);
 
+      this.emitRoutingUpdate(request.requestId, route);
+
       try {
         const baseUrl = this.resolveBaseUrl(route, 'embeddings');
         const url = `${baseUrl}/embeddings`;
@@ -2445,6 +2464,8 @@ export class Dispatcher {
       }
 
       attemptedProviders.push(`${route.provider}/${route.model}`);
+
+      this.emitRoutingUpdate(request.requestId, route);
 
       try {
         const baseUrl = this.resolveBaseUrl(route, 'transcriptions');
@@ -2649,6 +2670,8 @@ export class Dispatcher {
       }
 
       attemptedProviders.push(`${route.provider}/${route.model}`);
+
+      this.emitRoutingUpdate(request.requestId, route);
 
       try {
         const baseUrl = this.resolveBaseUrl(route, 'speech');
@@ -2890,6 +2913,8 @@ export class Dispatcher {
 
       attemptedProviders.push(`${route.provider}/${route.model}`);
 
+      this.emitRoutingUpdate(request.requestId, route);
+
       try {
         const baseUrl = this.resolveBaseUrl(route, 'images');
         const url = `${baseUrl}/images/generations`;
@@ -3084,6 +3109,8 @@ export class Dispatcher {
       }
 
       attemptedProviders.push(`${route.provider}/${route.model}`);
+
+      this.emitRoutingUpdate(request.requestId, route);
 
       try {
         const baseUrl = this.resolveBaseUrl(route, 'images');


### PR DESCRIPTION
## Problem

On the Logs page, when a new request arrives, the frontend shows a placeholder row with `provider: null` for several seconds before the selected provider appears. But provider selection (routing) happens in the first ~30ms of dispatch — the delay is an SSE event timing issue.

## Root Cause

Every route handler follows this event sequence:

1. `emitStarted` → `provider: null` (placeholder row)
2. `emitUpdated` → `incomingModelAlias`, `apiKey` (still no provider)
3. **`await dispatcher.dispatch()`** — blocks for non-streaming requests (3+ seconds)
4. `emitUpdated` → `provider`, `selectedModelName` (finally shows routing)

The ~30ms routing decision happens inside `dispatch()` at step 3, but the SSE event doesn't fire until `dispatch()` returns. For non-streaming requests, this adds the entire upstream response time to the perceived routing delay.

## Fix

Added a private `emitRoutingUpdate()` helper on the `Dispatcher` class, called inside each dispatch method **right after the route is selected** (post-cooldown check) but **before** the HTTP call to the upstream provider. This sends the SSE `updated` event with provider/model info within ~30ms of routing.

### Changes

- `packages/backend/src/services/dispatcher.ts`: Added `emitRoutingUpdate()` helper + calls in all 7 dispatch paths
- `packages/backend/src/services/__tests__/dispatcher-failover.test.ts`: Added `emitUpdatedAsync` to mock