### PR TITLE
feat(quota): add wafer.ai quota checker

### DIFF
--- a/packages/backend/drizzle/schema/postgres/enums.ts
+++ b/packages/backend/drizzle/schema/postgres/enums.ts
@@ -33,4 +33,5 @@ export const quotaCheckerTypeEnum = pgEnum('quota_checker_type', [
   'neuralwatt',
   'zenmux',
   'devpass',
+  'wafer',
 ]);

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -191,6 +191,10 @@ const ZenmuxQuotaCheckerOptionsSchema = z.object({
   endpoint: z.string().url().optional(),
 });
 
+const WaferQuotaCheckerOptionsSchema = z.object({
+  endpoint: z.string().url().optional(),
+});
+
 const PoeQuotaCheckerOptionsSchema = z.object({
   endpoint: z.string().url().optional(),
 });
@@ -361,6 +365,13 @@ const ProviderQuotaCheckerSchema = z.discriminatedUnion('type', [
     intervalMinutes: z.number().min(1).default(30),
     id: z.string().trim().min(1).optional(),
     options: DevPassQuotaCheckerOptionsSchema.optional(),
+  }),
+  z.object({
+    type: z.literal('wafer'),
+    enabled: z.boolean().default(true),
+    intervalMinutes: z.number().min(1).default(30),
+    id: z.string().trim().min(1).optional(),
+    options: WaferQuotaCheckerOptionsSchema.optional().default({}),
   }),
 ]);
 
@@ -988,6 +999,7 @@ export const VALID_QUOTA_CHECKER_TYPES = [
   'neuralwatt',
   'zenmux',
   'devpass',
+  'wafer',
 ] as const;
 
 export type QuotaCheckerType = (typeof VALID_QUOTA_CHECKER_TYPES)[number];

--- a/packages/backend/src/services/quota/checker-registry.ts
+++ b/packages/backend/src/services/quota/checker-registry.ts
@@ -197,4 +197,5 @@ export async function loadAllCheckers(): Promise<void> {
   await import('./checkers/neuralwatt-checker');
   await import('./checkers/zenmux-checker');
   await import('./checkers/devpass-checker');
+  await import('./checkers/wafer-checker');
 }

--- a/packages/backend/src/services/quota/checkers/__tests__/wafer-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/wafer-checker.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMeterContext, isCheckerRegistered } from '../../checker-registry';
+import checkerDef from '../wafer-checker';
+
+const makeCtx = (options: Record<string, unknown> = {}) =>
+  createMeterContext('wafer-test', 'wafer', { apiKey: 'test-key', ...options });
+
+describe('wafer checker', () => {
+  const setFetchMock = (impl: (...args: unknown[]) => Promise<Response>): void => {
+    global.fetch = vi.fn(impl) as unknown as typeof fetch;
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is registered under wafer', () => {
+    expect(isCheckerRegistered('wafer')).toBe(true);
+  });
+
+  it('queries quota endpoint and returns allowance meter', async () => {
+    let capturedUrl: string | undefined;
+    let capturedHeaders: Headers | undefined;
+
+    setFetchMock(async (input: unknown, init: unknown) => {
+      capturedUrl = String(input as string);
+      capturedHeaders = new Headers((init as RequestInit | undefined)?.headers);
+      return new Response(
+        JSON.stringify({
+          window_start: '2023-01-01T00:00:00Z',
+          window_end: '2023-01-01T05:00:00Z',
+          included_request_limit: 2000,
+          included_request_count: 35,
+          remaining_included_requests: 1965,
+          current_period_used_percent: 1.75,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+
+    const meters = await checkerDef.check(makeCtx());
+
+    expect(capturedUrl).toBe('https://pass.wafer.ai/v1/inference/quota');
+    expect(capturedHeaders!.get('Accept-Encoding')).toBe('identity');
+    expect(capturedHeaders!.get('Accept')).toBe('application/json');
+    expect(meters).toHaveLength(1);
+
+    const m = meters[0]!;
+    expect(m.kind).toBe('allowance');
+    expect(m.unit).toBe('requests');
+    expect(m.limit).toBe(2000);
+    expect(m.used).toBe(35);
+    expect(m.remaining).toBe(1965);
+    expect(m.label).toBe('5-hour request quota');
+    expect(m.periodValue).toBe(5);
+    expect(m.periodUnit).toBe('hour');
+    expect(m.periodCycle).toBe('fixed');
+    expect(m.resetsAt).toBe('2023-01-01T05:00:00.000Z');
+  });
+
+  it('handles non-ok HTTP response', async () => {
+    setFetchMock(
+      async () =>
+        new Response('Internal Server Error', { status: 500, statusText: 'Internal Server Error' })
+    );
+
+    await expect(checkerDef.check(makeCtx())).rejects.toThrow('HTTP 500: Internal Server Error');
+  });
+
+  it('handles invalid included_request_limit', async () => {
+    setFetchMock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            window_start: '2023-01-01T00:00:00Z',
+            window_end: '2023-01-01T05:00:00Z',
+            included_request_limit: 'not-a-number',
+            included_request_count: 0,
+            remaining_included_requests: 2000,
+            current_period_used_percent: 0,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    await expect(checkerDef.check(makeCtx())).rejects.toThrow(
+      'Invalid included_request_limit received: not-a-number'
+    );
+  });
+
+  it('handles negative included_request_count', async () => {
+    setFetchMock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            window_start: '2023-01-01T00:00:00Z',
+            window_end: '2023-01-01T05:00:00Z',
+            included_request_limit: 2000,
+            included_request_count: -5,
+            remaining_included_requests: 2005,
+            current_period_used_percent: 0,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    await expect(checkerDef.check(makeCtx())).rejects.toThrow(
+      'Invalid included_request_count received: -5'
+    );
+  });
+
+  it('handles negative remaining_included_requests', async () => {
+    setFetchMock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            window_start: '2023-01-01T00:00:00Z',
+            window_end: '2023-01-01T05:00:00Z',
+            included_request_limit: 2000,
+            included_request_count: 0,
+            remaining_included_requests: -10,
+            current_period_used_percent: 0,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    await expect(checkerDef.check(makeCtx())).rejects.toThrow(
+      'Invalid remaining_included_requests received: -10'
+    );
+  });
+
+  it('handles invalid window_end', async () => {
+    setFetchMock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            window_start: '2023-01-01T00:00:00Z',
+            window_end: 'invalid-date',
+            included_request_limit: 2000,
+            included_request_count: 0,
+            remaining_included_requests: 2000,
+            current_period_used_percent: 0,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    );
+
+    await expect(checkerDef.check(makeCtx())).rejects.toThrow(
+      'Invalid window_end date received: invalid-date'
+    );
+  });
+
+  it('uses custom endpoint when provided', async () => {
+    let capturedUrl: string | undefined;
+
+    setFetchMock(async (input: unknown) => {
+      capturedUrl = String(input as string);
+      return new Response(
+        JSON.stringify({
+          window_start: '2023-01-01T00:00:00Z',
+          window_end: '2023-01-01T05:00:00Z',
+          included_request_limit: 100,
+          included_request_count: 10,
+          remaining_included_requests: 90,
+          current_period_used_percent: 10,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+    });
+
+    await checkerDef.check(makeCtx({ endpoint: 'https://custom.wafer.example.com/quota' }));
+    expect(capturedUrl).toBe('https://custom.wafer.example.com/quota');
+  });
+});

--- a/packages/backend/src/services/quota/checkers/wafer-checker.ts
+++ b/packages/backend/src/services/quota/checkers/wafer-checker.ts
@@ -1,0 +1,83 @@
+import { defineChecker } from '../checker-registry';
+import { z } from 'zod';
+import { logger } from '../../../utils/logger';
+
+interface WaferQuotaResponse {
+  window_start: string;
+  window_end: string;
+  included_request_limit: number;
+  included_request_count: number;
+  remaining_included_requests: number;
+  current_period_used_percent: number;
+}
+
+export default defineChecker({
+  type: 'wafer',
+  optionsSchema: z.object({
+    endpoint: z.string().optional(),
+    apiKey: z.string().min(1, 'Wafer API key is required'),
+  }),
+  async check(ctx) {
+    const apiKey = ctx.requireOption<string>('apiKey');
+    const endpoint = ctx.getOption<string>('endpoint', 'https://pass.wafer.ai/v1/inference/quota');
+    logger.silly(`[wafer] Calling ${endpoint}`);
+
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+        'Accept-Encoding': 'identity',
+      },
+    });
+
+    if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+
+    const data: WaferQuotaResponse = await response.json();
+
+    const {
+      included_request_limit,
+      included_request_count,
+      remaining_included_requests,
+      window_end,
+    } = data;
+
+    const resetsAt = new Date(window_end);
+    if (isNaN(resetsAt.getTime())) {
+      throw new Error(`Invalid window_end date received: ${window_end}`);
+    }
+
+    const limit = Number(included_request_limit);
+    if (!Number.isFinite(limit) || limit < 0) {
+      throw new Error(`Invalid included_request_limit received: ${String(included_request_limit)}`);
+    }
+    const used = Number(included_request_count);
+    if (!Number.isFinite(used) || used < 0) {
+      throw new Error(`Invalid included_request_count received: ${String(included_request_count)}`);
+    }
+    const remaining = Number(remaining_included_requests);
+    if (!Number.isFinite(remaining) || remaining < 0) {
+      throw new Error(
+        `Invalid remaining_included_requests received: ${String(remaining_included_requests)}`
+      );
+    }
+
+    const meters = [
+      ctx.allowance({
+        key: 'wafer_5h',
+        label: '5-hour request quota',
+        unit: 'requests',
+        limit,
+        used,
+        remaining,
+        periodValue: 5,
+        periodUnit: 'hour',
+        periodCycle: 'fixed',
+        resetsAt: resetsAt.toISOString(),
+      }),
+    ];
+
+    logger.silly(`Returning ${meters.length} meters`);
+    return meters;
+  },
+});

--- a/packages/frontend/src/components/providers/ProviderQuotaEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderQuotaEditor.tsx
@@ -19,6 +19,7 @@ import { OllamaQuotaConfig } from '../quota/OllamaQuotaConfig';
 import { DevPassQuotaConfig } from '../quota/DevPassQuotaConfig';
 import { NeuralwattQuotaConfig } from '../quota/NeuralwattQuotaConfig';
 import { ZenmuxQuotaConfig } from '../quota/ZenmuxQuotaConfig';
+import { WaferQuotaConfig } from '../quota/WaferQuotaConfig';
 
 interface Props {
   editingProvider: Provider;
@@ -57,6 +58,7 @@ const QUOTA_CONFIG_MAP: Record<
   devpass: DevPassQuotaConfig,
   neuralwatt: NeuralwattQuotaConfig,
   zenmux: ZenmuxQuotaConfig,
+  wafer: WaferQuotaConfig,
 };
 
 export function ProviderQuotaEditor({

--- a/packages/frontend/src/components/quota/WaferQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/WaferQuotaConfig.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Input } from '../ui/Input';
+
+export interface WaferQuotaConfigProps {
+  options: Record<string, unknown>;
+  onChange: (options: Record<string, unknown>) => void;
+}
+
+export const WaferQuotaConfig: React.FC<WaferQuotaConfigProps> = ({ options, onChange }) => {
+  const handleChange = (key: string, value: string) => {
+    onChange({ ...options, [key]: value });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1">
+        <label className="font-body text-[13px] font-medium text-text-secondary">
+          Endpoint (optional)
+        </label>
+        <Input
+          value={(options.endpoint as string) ?? ''}
+          onChange={(e) => handleChange('endpoint', e.target.value)}
+          placeholder="https://pass.wafer.ai/v1/inference/quota"
+        />
+        <span className="text-[10px] text-text-muted">
+          Custom endpoint URL. Defaults to Wafer.ai API.
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/quota/WaferQuotaDisplay.tsx
+++ b/packages/frontend/src/components/quota/WaferQuotaDisplay.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { clsx } from 'clsx';
+import { AlertTriangle, CheckCircle2, TrendingUp } from 'lucide-react';
+import type { QuotaCheckResult } from '../../types/quota';
+import { QuotaProgressBar } from './QuotaProgressBar';
+import { formatNumber } from '../../lib/format';
+
+interface WaferQuotaDisplayProps {
+  result: QuotaCheckResult;
+  isCollapsed: boolean;
+}
+
+export const WaferQuotaDisplay: React.FC<WaferQuotaDisplayProps> = ({ result, isCollapsed }) => {
+  if (!result.success) {
+    return (
+      <div className="px-2 py-2">
+        <div
+          className={clsx('flex items-center gap-2 text-danger', isCollapsed && 'justify-center')}
+        >
+          <AlertTriangle size={16} />
+          {!isCollapsed && <span className="text-xs">Error</span>}
+        </div>
+      </div>
+    );
+  }
+
+  const windows = result.windows || [];
+  const primaryWindow = windows[0];
+
+  if (isCollapsed) {
+    const status = primaryWindow?.status || 'ok';
+    return (
+      <div className="px-2 py-2 flex justify-center">
+        {status === 'ok' ? (
+          <CheckCircle2 size={18} className="text-success" />
+        ) : (
+          <AlertTriangle
+            size={18}
+            className={clsx(status === 'warning' ? 'text-warning' : 'text-danger')}
+          />
+        )}
+      </div>
+    );
+  }
+
+  if (windows.length === 0) {
+    return (
+      <div className="px-2 py-2 flex items-center gap-2 text-text-secondary">
+        <TrendingUp size={16} />
+        <span className="text-xs italic">No quota data</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-2 py-1 space-y-3">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-xs font-semibold text-text whitespace-nowrap">Wafer</span>
+      </div>
+      {windows.map((window, index) => (
+        <QuotaProgressBar
+          key={index}
+          label={window.windowLabel || 'Requests'}
+          value={window.used ?? 0}
+          max={window.limit ?? 100}
+          status={window.status}
+          displayValue={
+            window.unit === 'requests'
+              ? `${formatNumber(window.used ?? 0)} / ${formatNumber(window.limit ?? 0)}`
+              : `${Math.round(window.utilizationPercent ?? 0)}%`
+          }
+        />
+      ))}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/quota/index.ts
+++ b/packages/frontend/src/components/quota/index.ts
@@ -1,4 +1,6 @@
 export { QuotaProgressBar } from './QuotaProgressBar';
+export { WaferQuotaDisplay } from './WaferQuotaDisplay';
+export { WaferQuotaConfig } from './WaferQuotaConfig';
 export { CombinedBalancesCard } from './CombinedBalancesCard';
 export { CompactBalancesCard } from './CompactBalancesCard';
 export { CompactQuotasCard } from './CompactQuotasCard';

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -567,6 +567,7 @@ const FALLBACK_QUOTA_CHECKER_TYPES = new Set([
   'neuralwatt',
   'zenmux',
   'devpass',
+  'wafer',
 ]);
 
 /**


### PR DESCRIPTION
Adds a quota checker for Wafer.ai (https://wafer.ai) that tracks their 5-hour fixed-window request limit, displayed as wafer in the providers' quota config UI.

### How it works

Backend:
- Registers as type wafer via `checker-registry.ts`
- Schema: `apiKey` (required, injected from provider config) + endpoint (optional, defaults to Wafer's quota endpoint)
- Calls `GET https://pass.wafer.ai/v1/inference/quota` with Authorization: Bearer <apiKey>
- Maps the response (`window_start`, `window_end`, `included_request_limit`, `included_request_count`, `remaining_included_requests`) to an allowance meter—a 5-hour fixed window (not rolling, since Wafer uses time-block windows)
- Validates all numeric fields and the date before returning

Frontend:

- `WaferQuotaConfig.tsx` — config form with optional endpoint override
- `WaferQuotaDisplay.tsx` — quota display card
- Both registered in `ProviderQuotaEditor.tsx`'s `QUOTA_CONFIG_MAP`
- `api.ts` includes 'wafer' in `QUOTA_CHECKER_TYPES`

### Files changed

| File | Change |
|:-|:-|
| `packages/backend/drizzle/schema/postgres/enums.ts` | Added 'wafer' to quotaCheckerTypeEnum |
| `packages/backend/src/services/quota/checker-registry.ts` | Added wafer-checker import |
| `packages/backend/src/services/quota/checkers/wafer-checker.ts` | New — checker implementation |
| `packages/backend/src/services/quota/checkers/__tests__/wafer-checker.test.ts` | New — unit tests |
| `packages/frontend/src/components/providers/ProviderQuotaEditor.tsx` | Added `WaferQuotaConfig` to config map |
| `packages/frontend/src/components/quota/WaferQuotaConfig.tsx` | New — config form |
| `packages/frontend/src/components/quota/WaferQuotaDisplay.tsx` | New — display card |
| `packages/frontend/src/components/quota/index.ts` | Added Wafer exports |
| `packages/frontend/src/lib/api.ts` | Added 'wafer' to `QUOTA_CHECKER_TYPES` |
