### PR TITLE
fix the build step

### DIFF
--- a/packages/frontend/build.ts
+++ b/packages/frontend/build.ts
@@ -8,7 +8,16 @@ const buildCSS = async () => {
   console.log('Building CSS...');
   const proc = spawn(
     process.execPath,
-    ['x', '@tailwindcss/cli', '-i', './src/globals.css', '-o', './dist/main.css'],
+    [
+      'x',
+      '-p',
+      '@tailwindcss/cli',
+      'tailwindcss',
+      '-i',
+      './src/globals.css',
+      '-o',
+      './dist/main.css',
+    ],
     {
       stdio: 'inherit',
       cwd: '.',


### PR DESCRIPTION
if `cli` is already in path (from mono) then bunx kinda breaks