### PR TITLE
A small opencode plugin to add plexus as a provider

### DIFF
--- a/packages/backend/src/routes/inference/models.ts
+++ b/packages/backend/src/routes/inference/models.ts
@@ -21,6 +21,7 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
     const metadataManager = ModelMetadataManager.getInstance();
 
     const created = Math.floor(Date.now() / 1000);
+    const hasVisionFallthrough = !!config.vision_fallthrough;
 
     const models = Object.entries(config.models).map(([aliasId, modelConfig]) => {
       const metaConfig = modelConfig?.metadata;
@@ -33,6 +34,17 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
       };
 
       if (!metaConfig) {
+        // When vision fallthrough is enabled for this alias, advertise image
+        // input capability even without explicit metadata.
+        if (hasVisionFallthrough && modelConfig.use_image_fallthrough) {
+          return {
+            ...base,
+            architecture: {
+              input_modalities: ['text', 'image'],
+              output_modalities: ['text'],
+            },
+          };
+        }
         return base;
       }
 
@@ -54,7 +66,7 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
         return base;
       }
 
-      return {
+      const result: Record<string, unknown> = {
         ...base,
         name: enriched.name,
         ...(enriched.description !== undefined && { description: enriched.description }),
@@ -66,6 +78,27 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
         }),
         ...(enriched.top_provider !== undefined && { top_provider: enriched.top_provider }),
       };
+
+      // When vision fallthrough is enabled, ensure image is listed in
+      // input_modalities so downstream clients know this alias accepts images.
+      if (hasVisionFallthrough && modelConfig.use_image_fallthrough) {
+        const arch = (result.architecture ?? {}) as Record<string, unknown>;
+        const inputModalities = (arch.input_modalities as string[] | undefined) ?? [];
+        if (!inputModalities.includes('image')) {
+          result.architecture = {
+            ...arch,
+            input_modalities: [...inputModalities, 'image'],
+          };
+        }
+        if (!arch.output_modalities) {
+          result.architecture = {
+            ...result.architecture,
+            output_modalities: ['text'],
+          };
+        }
+      }
+
+      return result;
     });
 
     return reply.send({

--- a/packages/backend/src/routes/management.ts
+++ b/packages/backend/src/routes/management.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { UsageStorageService } from '../services/usage-storage';
-import { registerConfigRoutes } from './management/config';
+import { registerConfigRoutes, registerReadOnlyConfigRoutes } from './management/config';
 import { registerUsageRoutes } from './management/usage';
 import { registerCooldownRoutes } from './management/cooldowns';
 import { registerPerformanceRoutes } from './management/performance';
@@ -85,6 +85,10 @@ export async function registerManagementRoutes(
       await registerUsageRoutes(scoped, usageStorage);
       await registerDebugRoutes(scoped, usageStorage);
       await registerErrorRoutes(scoped, usageStorage);
+
+      // Read-only config routes: any authenticated user can inspect aliases,
+      // providers, etc. without needing the full admin key.
+      await registerReadOnlyConfigRoutes(scoped);
     });
 
     // Admin-only routes: mutating config, system-level controls, etc.

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -64,6 +64,29 @@ async function recalculateEnergyIfChanged(
   }
 }
 
+/**
+ * Read-only config routes — any authenticated principal (admin or limited)
+ * can call these. Separated from registerConfigRoutes so they can be mounted
+ * under a less-restrictive hook chain.
+ */
+export async function registerReadOnlyConfigRoutes(fastify: FastifyInstance) {
+  const configService = ConfigService.getInstance();
+
+  // GET /v0/management/aliases
+  // Returns all model aliases. Previously admin-only; now available to any
+  // authenticated caller so external tools (e.g. opencode plugins) can inspect
+  // alias configuration including use_image_fallthrough without needing the
+  // full admin key.
+  fastify.get('/v0/management/aliases', async (_request, reply) => {
+    try {
+      const aliases = await configService.getRepository().getAllAliases();
+      return reply.send(aliases);
+    } catch (e: any) {
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+}
+
 export async function registerConfigRoutes(
   fastify: FastifyInstance,
   usageStorage?: UsageStorageService
@@ -188,15 +211,8 @@ export async function registerConfigRoutes(
   });
 
   // ─── Model Aliases ────────────────────────────────────────────────
-
-  fastify.get('/v0/management/aliases', async (_request, reply) => {
-    try {
-      const aliases = await configService.getRepository().getAllAliases();
-      return reply.send(aliases);
-    } catch (e: any) {
-      return reply.code(500).send({ error: 'Internal server error' });
-    }
-  });
+  // NOTE: GET /v0/management/aliases is registered in registerReadOnlyConfigRoutes
+  // so any authenticated user (not just admin) can read aliases.
 
   // PUT — full create-or-replace with Zod validation
   // Using wildcard to support slugs containing '/' (e.g. "provider/model")

--- a/scripts/opencode-plugin.ts
+++ b/scripts/opencode-plugin.ts
@@ -23,6 +23,46 @@ interface PlexusModel {
   }
 }
 
+interface PlexusAlias {
+  targets?: Array<{ provider: string; model: string; enabled?: boolean }>
+  selector?: string
+  priority?: string
+  use_image_fallthrough?: boolean
+  additional_aliases?: string[]
+  metadata?: {
+    source?: string
+    source_path?: string
+    overrides?: {
+      name?: string
+      description?: string
+      context_length?: number
+      pricing?: {
+        prompt?: string
+        completion?: string
+        input_cache_read?: string
+        input_cache_write?: string
+      }
+      architecture?: {
+        input_modalities?: string[]
+        output_modalities?: string[]
+        tokenizer?: string
+      }
+      supported_parameters?: string[]
+    }
+  }
+  type?: string
+  model_architecture?: {
+    total_params?: number
+    active_params?: number
+    layers?: number
+    heads?: number
+    kv_lora_rank?: number
+    qk_rope_head_dim?: number
+    context_length?: number
+    dtype?: string
+  }
+}
+
 interface PlexusModelsResponse {
   object: string
   data: PlexusModel[]
@@ -43,19 +83,34 @@ function findPlexusProvider(config: Record<string, unknown>): { name: string; cf
   return null
 }
 
+function resolveApiKey(cfg: ProviderConfig): string | undefined {
+  // Check options.apiKey first
+  const optionsKey = (cfg.options as Record<string, unknown> | undefined)?.apiKey
+  if (typeof optionsKey === "string" && optionsKey) return optionsKey
+
+  // Fall back to env vars listed in the provider config
+  if (cfg.env) {
+    for (const envVar of cfg.env) {
+      const val = process.env[envVar]
+      if (val) return val
+    }
+  }
+
+  return undefined
+}
+
 function parsePrice(value: string | undefined): number | undefined {
   if (!value) return undefined
   const n = parseFloat(value)
   return Number.isNaN(n) ? undefined : n
 }
 
-function mapModel(model: PlexusModel): Record<string, unknown> {
+function mapFromPublicModel(model: PlexusModel): Record<string, unknown> {
   const entry: Record<string, unknown> = {
     id: model.id,
     name: model.name ?? model.id,
   }
 
-  // Context and output limits
   const contextLength = model.context_length ?? model.top_provider?.context_length
   const maxOutput = model.top_provider?.max_completion_tokens ?? contextLength
   if (contextLength || maxOutput) {
@@ -65,7 +120,6 @@ function mapModel(model: PlexusModel): Record<string, unknown> {
     }
   }
 
-  // Input/output modalities
   const inputModalities = model.architecture?.input_modalities
   const outputModalities = model.architecture?.output_modalities
   if (inputModalities || outputModalities) {
@@ -75,12 +129,10 @@ function mapModel(model: PlexusModel): Record<string, unknown> {
     entry.modalities = modalities
   }
 
-  // Attachment support from multimodal input
   if (inputModalities?.some((m) => m === "image" || m === "pdf")) {
     entry.attachment = true
   }
 
-  // Pricing
   if (model.pricing) {
     const cost: Record<string, unknown> = {}
     const inputCost = parsePrice(model.pricing.prompt)
@@ -100,14 +152,81 @@ function mapModel(model: PlexusModel): Record<string, unknown> {
     if (Object.keys(cost).length > 0) entry.cost = cost
   }
 
-  // Capabilities derived from supported_parameters
   const params = model.supported_parameters ?? []
   if (params.includes("temperature")) entry.temperature = true
   if (params.includes("tools") || params.includes("tool_choice") || params.includes("function_calling")) {
     entry.tool_call = true
   }
 
-  // Thinking variants for models that support reasoning
+  const supportsThinking = params.some((p) => p === "thinking" || p === "reasoning" || p === "reasoning_effort")
+  if (supportsThinking) {
+    entry.variants = {
+      default: {},
+      thinking: { reasoning: true },
+    }
+  }
+
+  return entry
+}
+
+function mapFromAlias(aliasId: string, alias: PlexusAlias): Record<string, unknown> {
+  const meta = alias.metadata?.overrides
+  const entry: Record<string, unknown> = {
+    id: aliasId,
+    name: meta?.name ?? aliasId,
+  }
+
+  const contextLength = meta?.context_length ?? alias.model_architecture?.context_length
+  if (contextLength) {
+    entry.limit = { context: contextLength, output: contextLength }
+  }
+
+  const inputModalities = meta?.architecture?.input_modalities
+  const outputModalities = meta?.architecture?.output_modalities
+  if (inputModalities || outputModalities) {
+    const modalities: Record<string, string[]> = {}
+    if (inputModalities) modalities.input = inputModalities
+    if (outputModalities) modalities.output = outputModalities
+    entry.modalities = modalities
+  }
+
+  // Vision fallthrough means this alias effectively supports image input
+  if (alias.use_image_fallthrough) {
+    entry.attachment = true
+    if (inputModalities && !inputModalities.includes("image")) {
+      const modalities = (entry.modalities as Record<string, string[]> | undefined) ?? {}
+      modalities.input = [...(modalities.input ?? []), "image"]
+      entry.modalities = modalities
+    }
+  } else if (inputModalities?.some((m) => m === "image" || m === "pdf")) {
+    entry.attachment = true
+  }
+
+  if (meta?.pricing) {
+    const cost: Record<string, unknown> = {}
+    const inputCost = parsePrice(meta.pricing.prompt)
+    const outputCost = parsePrice(meta.pricing.completion)
+    if (inputCost !== undefined) cost.input = inputCost
+    if (outputCost !== undefined) cost.output = outputCost
+
+    const cacheRead = parsePrice(meta.pricing.input_cache_read)
+    const cacheWrite = parsePrice(meta.pricing.input_cache_write)
+    if (cacheRead !== undefined || cacheWrite !== undefined) {
+      cost.cache = {
+        ...(cacheRead !== undefined && { read: cacheRead }),
+        ...(cacheWrite !== undefined && { write: cacheWrite }),
+      }
+    }
+
+    if (Object.keys(cost).length > 0) entry.cost = cost
+  }
+
+  const params = meta?.supported_parameters ?? []
+  if (params.includes("temperature")) entry.temperature = true
+  if (params.includes("tools") || params.includes("tool_choice") || params.includes("function_calling")) {
+    entry.tool_call = true
+  }
+
   const supportsThinking = params.some((p) => p === "thinking" || p === "reasoning" || p === "reasoning_effort")
   if (supportsThinking) {
     entry.variants = {
@@ -153,38 +272,61 @@ export const PlexusPlugin: Plugin = async () => {
       }
 
       const { name: providerName, cfg, baseUrl } = provider
-      const modelsUrl = `${baseUrl}/models`
 
-      let res: Response
+      // Resolve an API key for management endpoints (x-admin-key header).
+      // The provider env vars or options.apiKey are checked; inference auth
+      // from auth.json is handled separately by the opencode runtime.
+      const apiKey = resolveApiKey(cfg)
+      const authHeaders: Record<string, string> = apiKey ? { "x-admin-key": apiKey } : {}
+
+      // ── Try the read-only management aliases endpoint first ────────────
+      // This endpoint (in the user's fork) only requires authenticate, not
+      // admin, and returns the full alias config including use_image_fallthrough.
+      let aliases: Record<string, PlexusAlias> | null = null
       try {
-        res = await fetch(modelsUrl)
-      } catch (err) {
-        console.warn(`${LOG} Could not reach ${modelsUrl} — skipping model sync (${(err as Error).message})`)
-        return
-      }
-
-      if (!res.ok) {
-        console.warn(`${LOG} GET ${modelsUrl} returned ${res.status} — skipping model sync`)
-        return
-      }
-
-      let body: PlexusModelsResponse
-      try {
-        body = (await res.json()) as PlexusModelsResponse
+        const res = await fetch(`${baseUrl.replace(/\/v1$/, "")}/v0/management/aliases`, {
+          headers: authHeaders,
+        })
+        if (res.ok) {
+          aliases = (await res.json()) as Record<string, PlexusAlias>
+        }
       } catch {
-        console.warn(`${LOG} Invalid JSON from ${modelsUrl} — skipping model sync`)
-        return
+        // fall through to public endpoint
       }
 
-      const models = body?.data ?? []
-      if (!models.length) {
-        console.warn(`${LOG} No models returned from ${modelsUrl} — skipping`)
-        return
-      }
+      let modelsConfig: Record<string, unknown>
 
-      const modelsConfig: Record<string, unknown> = {}
-      for (const m of models) {
-        modelsConfig[m.id] = mapModel(m)
+      if (aliases && Object.keys(aliases).length > 0) {
+        modelsConfig = {}
+        for (const [aliasId, alias] of Object.entries(aliases)) {
+          modelsConfig[aliasId] = mapFromAlias(aliasId, alias)
+        }
+      } else {
+        // ── Fall back to the public /v1/models endpoint ─────────────────
+        const res = await fetch(`${baseUrl}/models`).catch(() => null)
+        if (!res?.ok) {
+          console.warn(`${LOG} Could not reach ${baseUrl}/models — skipping model sync`)
+          return
+        }
+
+        let body: PlexusModelsResponse
+        try {
+          body = (await res.json()) as PlexusModelsResponse
+        } catch {
+          console.warn(`${LOG} Invalid JSON from ${baseUrl}/models — skipping model sync`)
+          return
+        }
+
+        const models = body?.data ?? []
+        if (!models.length) {
+          console.warn(`${LOG} No models returned from ${baseUrl}/models — skipping`)
+          return
+        }
+
+        modelsConfig = {}
+        for (const m of models) {
+          modelsConfig[m.id] = mapFromPublicModel(m)
+        }
       }
 
       const providers = (config.provider ?? {}) as Record<string, unknown>

--- a/scripts/opencode-plugin.ts
+++ b/scripts/opencode-plugin.ts
@@ -1,0 +1,203 @@
+import type { Plugin, ProviderConfig } from "@opencode-ai/plugin"
+
+interface PlexusModel {
+  id: string
+  name?: string
+  description?: string
+  context_length?: number
+  architecture?: {
+    input_modalities?: string[]
+    output_modalities?: string[]
+    tokenizer?: string
+  }
+  pricing?: {
+    prompt?: string
+    completion?: string
+    input_cache_read?: string
+    input_cache_write?: string
+  }
+  supported_parameters?: string[]
+  top_provider?: {
+    context_length?: number
+    max_completion_tokens?: number
+  }
+}
+
+interface PlexusModelsResponse {
+  object: string
+  data: PlexusModel[]
+}
+
+function findPlexusProvider(config: Record<string, unknown>): { name: string; cfg: ProviderConfig; baseUrl: string } | null {
+  const providers = config.provider as Record<string, unknown> | undefined
+  if (!providers) return null
+
+  for (const [name, p] of Object.entries(providers)) {
+    const cfg = p as ProviderConfig
+    if (!cfg.api || typeof cfg.api !== "string") continue
+
+    if (name === "plexus" || cfg.api.toLowerCase().includes("plexus") || cfg.name?.toLowerCase() === "plexus") {
+      return { name, cfg, baseUrl: cfg.api.replace(/\/+$/, "") }
+    }
+  }
+  return null
+}
+
+function parsePrice(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const n = parseFloat(value)
+  return Number.isNaN(n) ? undefined : n
+}
+
+function mapModel(model: PlexusModel): Record<string, unknown> {
+  const entry: Record<string, unknown> = {
+    id: model.id,
+    name: model.name ?? model.id,
+  }
+
+  // Context and output limits
+  const contextLength = model.context_length ?? model.top_provider?.context_length
+  const maxOutput = model.top_provider?.max_completion_tokens ?? contextLength
+  if (contextLength || maxOutput) {
+    entry.limit = {
+      context: contextLength ?? maxOutput ?? 0,
+      output: maxOutput ?? contextLength ?? 0,
+    }
+  }
+
+  // Input/output modalities
+  const inputModalities = model.architecture?.input_modalities
+  const outputModalities = model.architecture?.output_modalities
+  if (inputModalities || outputModalities) {
+    const modalities: Record<string, string[]> = {}
+    if (inputModalities) modalities.input = inputModalities
+    if (outputModalities) modalities.output = outputModalities
+    entry.modalities = modalities
+  }
+
+  // Attachment support from multimodal input
+  if (inputModalities?.some((m) => m === "image" || m === "pdf")) {
+    entry.attachment = true
+  }
+
+  // Pricing
+  if (model.pricing) {
+    const cost: Record<string, unknown> = {}
+    const inputCost = parsePrice(model.pricing.prompt)
+    const outputCost = parsePrice(model.pricing.completion)
+    if (inputCost !== undefined) cost.input = inputCost
+    if (outputCost !== undefined) cost.output = outputCost
+
+    const cacheRead = parsePrice(model.pricing.input_cache_read)
+    const cacheWrite = parsePrice(model.pricing.input_cache_write)
+    if (cacheRead !== undefined || cacheWrite !== undefined) {
+      cost.cache = {
+        ...(cacheRead !== undefined && { read: cacheRead }),
+        ...(cacheWrite !== undefined && { write: cacheWrite }),
+      }
+    }
+
+    if (Object.keys(cost).length > 0) entry.cost = cost
+  }
+
+  // Capabilities derived from supported_parameters
+  const params = model.supported_parameters ?? []
+  if (params.includes("temperature")) entry.temperature = true
+  if (params.includes("tools") || params.includes("tool_choice") || params.includes("function_calling")) {
+    entry.tool_call = true
+  }
+
+  // Thinking variants for models that support reasoning
+  const supportsThinking = params.some((p) => p === "thinking" || p === "reasoning" || p === "reasoning_effort")
+  if (supportsThinking) {
+    entry.variants = {
+      default: {},
+      thinking: { reasoning: true },
+    }
+  }
+
+  return entry
+}
+
+export const PlexusPlugin: Plugin = async () => {
+  const LOG = "[plexus-plugin]"
+
+  return {
+    auth: {
+      provider: "plexus",
+      methods: [
+        {
+          type: "api",
+          label: "API Key",
+          prompts: [
+            {
+              type: "text",
+              key: "apiKey",
+              message: "Enter your Plexus API key",
+              placeholder: "sk-...",
+            },
+          ],
+          authorize: async (inputs) => {
+            if (!inputs?.apiKey) return { type: "failed" }
+            return { type: "success", key: inputs.apiKey, provider: "plexus" }
+          },
+        },
+      ],
+    },
+
+    config: async (config) => {
+      const provider = findPlexusProvider(config as unknown as Record<string, unknown>)
+      if (!provider) {
+        console.warn(`${LOG} No plexus provider found in config — skipping model sync`)
+        return
+      }
+
+      const { name: providerName, cfg, baseUrl } = provider
+      const modelsUrl = `${baseUrl}/models`
+
+      let res: Response
+      try {
+        res = await fetch(modelsUrl)
+      } catch (err) {
+        console.warn(`${LOG} Could not reach ${modelsUrl} — skipping model sync (${(err as Error).message})`)
+        return
+      }
+
+      if (!res.ok) {
+        console.warn(`${LOG} GET ${modelsUrl} returned ${res.status} — skipping model sync`)
+        return
+      }
+
+      let body: PlexusModelsResponse
+      try {
+        body = (await res.json()) as PlexusModelsResponse
+      } catch {
+        console.warn(`${LOG} Invalid JSON from ${modelsUrl} — skipping model sync`)
+        return
+      }
+
+      const models = body?.data ?? []
+      if (!models.length) {
+        console.warn(`${LOG} No models returned from ${modelsUrl} — skipping`)
+        return
+      }
+
+      const modelsConfig: Record<string, unknown> = {}
+      for (const m of models) {
+        modelsConfig[m.id] = mapModel(m)
+      }
+
+      const providers = (config.provider ?? {}) as Record<string, unknown>
+      const existing = (providers[providerName] as Record<string, unknown> | undefined) ?? {}
+      const existingModels = (existing.models as Record<string, unknown> | undefined) ?? {}
+
+      providers[providerName] = {
+        ...existing,
+        models: { ...existingModels, ...modelsConfig },
+      }
+
+      if (!config.provider) config.provider = {} as Record<string, ProviderConfig>
+      Object.assign(config.provider, providers)
+    },
+  }
+}


### PR DESCRIPTION
1. adds plexus to the auth hook so you can do `/connect` or `opencode auth login`
you have to add the provider manually in opencode.jsonc, doesn't seem to be a way around that, but also the api base url has to be specified anyway
```
    "plexus": {
      "api": "http://localhost:4000/v1",
      "name": "Plexus",
    },
```
2. fetches and adds all the models from plexus the selector
3. a second commit, which is optional, does a few tweaks to the `v1/models/` endpoint to add image modalities for alias that has use_image_fallthrough
4. another optional commit, I wonder if it is an okay idea to expose the management/alias endpoint without the admin_key (just normal auth), this would allow getting richer information for things like this plugin, and in case (2) is undesired.