### PR TITLE
Refactor: Streamline quota checker registration and API

### DIFF
--- a/.agents/skills/add-quota-checker/SKILL.md
+++ b/.agents/skills/add-quota-checker/SKILL.md
@@ -9,15 +9,47 @@ Every item in this checklist is required. The provider edit modal will not show 
 
 ## Backend
 
-### `packages/backend/src/config.ts`
-- Add the lowercase checker type string to `VALID_QUOTA_CHECKER_TYPES` array — this drives the `/v0/management/quota-checker-types` API endpoint.
+### 1. Create the checker file (`packages/backend/src/services/quota/checkers/{name}-checker.ts`)
 
-### `packages/backend/src/services/quota/checker-registry.ts`
-- Register the checker class in `CHECKER_REGISTRY`.
+Implement the checker using `defineChecker()`. The `type` and `displayName` fields on this object are the **sole source of truth** — they drive the API, the frontend dropdown, and all display labels automatically.
 
-### `packages/backend/drizzle/schema/postgres/enums.ts`
-- Add the type to `quotaCheckerTypeEnum`. (SQLite uses plain `text` and doesn't enforce enum values — Postgres deployments will reject inserts without this.)
-- After your PR merges, CI auto-generates the migration. Do **not** create or edit migration files manually.
+```ts
+import { defineChecker } from '../checker-registry';
+import { z } from 'zod';
+
+export default defineChecker({
+  type: 'my-checker',          // lowercase, kebab-case
+  displayName: 'My Checker',   // human-readable label shown in the UI
+  optionsSchema: z.object({
+    apiKey: z.string().min(1, 'API key is required'),
+    endpoint: z.string().url().optional(),
+  }),
+  async check(ctx) {
+    // ... fetch and return Meter[]
+  },
+});
+```
+
+### 2. Register the import in `packages/backend/src/services/quota/checker-registry.ts`
+
+Add one line to `loadAllCheckers()`:
+
+```ts
+await import('./checkers/my-checker');
+```
+
+### 3. Add the Zod schema to `packages/backend/src/config.ts`
+
+- Add a `{Name}QuotaCheckerOptionsSchema` const with the checker's options.
+- Add a `z.object({ type: z.literal('my-checker'), ... })` entry to `ProviderQuotaCheckerSchema` (the `z.discriminatedUnion`).
+
+### 4. Postgres enum (`packages/backend/drizzle/schema/postgres/enums.ts`)
+
+Add the type string to `quotaCheckerTypeEnum`. SQLite ignores enum enforcement — Postgres deployments will reject inserts without this.
+
+After your PR merges, CI auto-generates the migration. Do **not** create or edit migration files manually.
+
+---
 
 ## Frontend — Config component (`packages/frontend/src/components/quota/`)
 
@@ -26,54 +58,41 @@ Every item in this checklist is required. The provider edit modal will not show 
 - Do **not** add an `apiKey` field — it is auto-inherited from the provider config.
 - Call `onChange` whenever any option changes.
 
-## Frontend — ProviderQuotaEditor (`packages/frontend/src/components/providers/ProviderQuotaEditor.tsx`)
-
-1. Import the config component at the top.
-2. Add an entry to `QUOTA_CONFIG_MAP` mapping the lowercase type string to the component class.
-
-That's it — `ProviderQuotaEditor` handles rendering the config component and wiring up `onChange` generically via the map.
-
-## Frontend — useProviderForm (`packages/frontend/src/hooks/useProviderForm.tsx`)
-
-- Add the lowercase type string to `QUOTA_CHECKER_TYPES_FALLBACK`. This is used as initial state and as a fallback if the API hasn't responded yet.
-- If the checker has required options, add validation logic to `validateQuotaChecker()`.
-
-## Frontend — api.ts (`packages/frontend/src/lib/api.ts`)
-
-- Add the lowercase type string to `FALLBACK_QUOTA_CHECKER_TYPES`. This is returned by `getQuotaCheckerTypes()` when the backend API hasn't been fetched yet or fails to respond.
-
-## Frontend — Display name (`packages/frontend/src/components/quota/checker-presentation.ts`)
-
-- Add the type to `CHECKER_DISPLAY_NAMES` map (e.g. `'checker-name': 'Display Name'`).
-- This is used by `getCheckerDisplayName()` which is called from `Quotas.tsx`, `CompactQuotasCard`, `CombinedBalancesCard`, and the sidebar.
-
-## Frontend — QuotaDisplay component (optional)
-
-### `{Name}QuotaDisplay.tsx`
-- Props: `result: QuotaCheckResult`, `isCollapsed: boolean`
-- Rate-limit checkers → progress bar (`QuotaProgressBar`)
-- Balance checkers → `Wallet` icon + dollar/points display
-- Note: The current UI renders quota data generically via the meter system (`AllowanceMeterRow`, `BalanceMeterRow`). A `QuotaDisplay` component is only needed if the checker requires custom rendering beyond the generic meters. Most checkers do **not** need one.
-
 ### `index.ts`
-- Export the config component. Only export the display component if you created one.
+- Export the config component.
 
 ---
 
-## Hybrid Balance + Rate-Limit Checkers
+## Frontend — ProviderQuotaEditor (`packages/frontend/src/components/providers/ProviderQuotaEditor.tsx`)
 
-Some checkers (e.g. neuralwatt) return **both** a dollar balance and a rate-limit window (e.g. monthly kWh). These require extra steps:
+1. Import the config component at the top.
+2. Add an entry to `QUOTA_CONFIG_MAP` mapping the lowercase type string to the component.
 
-1. **Backend** — set `category: 'balance'` (the dollar balance window drives the category).
-2. **Display component** — render both the `Wallet`/dollar balance and a progress bar for the monthly window. Follow the `ApertisCodingPlanQuotaDisplay` pattern for the rate-limit part.
+---
+
+## Frontend — validation (`packages/frontend/src/hooks/useProviderForm.tsx`)
+
+If the checker has required options, add validation logic to `validateQuotaChecker()`.
+
+No fallback lists to update — the frontend fetches all known types from the backend at runtime.
+
+---
+
+## That's it
+
+The `type` and `displayName` you set in `defineChecker()` are automatically:
+- Returned by `GET /v0/management/quota-checker-types`
+- Returned by `GET /v0/management/quota-checkers` (knownTypes + configured)
+- Used in the provider edit modal dropdown
+- Used in Quotas page headings, sidebar cards, and all display labels
+
+There are **no frontend constant lists to update**.
 
 ---
 
 ## Common Mistakes
 
-- **Missing `VALID_QUOTA_CHECKER_TYPES` in `config.ts`**: The backend API will never return the type to the frontend, even if all frontend registrations are correct.
+- **Missing `loadAllCheckers()` import**: The checker will never be registered — the registry stays empty for that type.
 - **Missing Postgres enum**: SQLite ignores enum enforcement; Postgres deployments will reject inserts.
-- **Missing `QUOTA_CONFIG_MAP` entry**: The provider edit modal will show the dropdown type but no config form for the checker's options.
-- **Missing `CHECKER_DISPLAY_NAMES` entry**: The checker will display as its raw ID instead of a friendly name.
-- **Missing `QUOTA_CHECKER_TYPES_FALLBACK` in `useProviderForm.tsx`**: The type won't appear in the dropdown until the API responds (or at all if the API fails).
-- **Missing `FALLBACK_QUOTA_CHECKER_TYPES` in `api.ts`**: Same issue — `getQuotaCheckerTypes()` returns this set as a fallback when the cache is empty.
+- **Missing `QUOTA_CONFIG_MAP` entry in `ProviderQuotaEditor`**: The provider edit modal will show the dropdown type but no config form for the checker's options.
+- **Missing `ProviderQuotaCheckerSchema` entry in `config.ts`**: The backend Zod validation will reject configs using the new type.

--- a/.agents/skills/add-quota-checker/SKILL.md
+++ b/.agents/skills/add-quota-checker/SKILL.md
@@ -30,13 +30,13 @@ export default defineChecker({
 });
 ```
 
-### 2. Register the import in `packages/backend/src/services/quota/checker-registry.ts`
-
-Add one line to `loadAllCheckers()`:
+### 2. Add the import to `loadAllCheckers()` in `packages/backend/src/services/quota/checker-registry.ts`
 
 ```ts
 await import('./checkers/my-checker');
 ```
+
+> **Note:** this manual step exists because Bun does not yet support `import.meta.glob` (tracked in [oven-sh/bun#21459](https://github.com/oven-sh/bun/pull/21459)). When that ships, `loadAllCheckers()` will auto-discover checkers and this step will be removed.
 
 ### 3. Add the Zod schema to `packages/backend/src/config.ts`
 
@@ -92,7 +92,7 @@ There are **no frontend constant lists to update**.
 
 ## Common Mistakes
 
-- **Missing `loadAllCheckers()` import**: The checker will never be registered — the registry stays empty for that type.
+- **Missing `loadAllCheckers()` import in `checker-registry.ts`**: The checker will never be registered — the registry stays empty for that type, the type won't appear in the dropdown, and the `/v0/management/quota-checker-types` endpoint won't return it.
 - **Missing Postgres enum**: SQLite ignores enum enforcement; Postgres deployments will reject inserts.
 - **Missing `QUOTA_CONFIG_MAP` entry in `ProviderQuotaEditor`**: The provider edit modal will show the dropdown type but no config form for the checker's options.
 - **Missing `ProviderQuotaCheckerSchema` entry in `config.ts`**: The backend Zod validation will reject configs using the new type.

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -986,34 +986,3 @@ export function getDatabaseConfig(): DatabaseConfig | null {
   }
   return { connectionString: databaseUrl };
 }
-
-// Valid quota checker types - single source of truth
-export const VALID_QUOTA_CHECKER_TYPES = [
-  'naga',
-  'synthetic',
-  'nanogpt',
-  'zai',
-  'moonshot',
-  'minimax',
-  'minimax-coding',
-  'openrouter',
-  'kilo',
-  'openai-codex',
-  'claude-code',
-  'kimi-code',
-  'copilot',
-  'wisdomgate',
-  'apertis',
-  'poe',
-  'gemini-cli',
-  'antigravity',
-  'novita',
-  'ollama',
-  'neuralwatt',
-  'zenmux',
-  'devpass',
-  'wafer',
-  'opencode-go',
-] as const;
-
-export type QuotaCheckerType = (typeof VALID_QUOTA_CHECKER_TYPES)[number];

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -1,13 +1,13 @@
 import { FastifyInstance } from 'fastify';
 import { logger } from '../../utils/logger';
 import {
-  VALID_QUOTA_CHECKER_TYPES,
   ProviderConfigSchema,
   ModelConfigSchema,
   KeyConfigSchema,
   McpServerConfigSchema,
 } from '../../config';
 import { ConfigService } from '../../services/config-service';
+import { getCheckerDefinitions } from '../../services/quota/checker-registry';
 import { UsageStorageService } from '../../services/usage-storage';
 import type { GpuParams, ModelArchitecture } from '@plexus/shared';
 import { DEFAULT_GPU_PARAMS } from '@plexus/shared';
@@ -609,9 +609,10 @@ export async function registerConfigRoutes(
   // ─── Quota Checker Types ──────────────────────────────────────────
 
   fastify.get('/v0/management/quota-checker-types', async (_request, reply) => {
+    const defs = getCheckerDefinitions();
     return reply.send({
-      types: VALID_QUOTA_CHECKER_TYPES,
-      count: VALID_QUOTA_CHECKER_TYPES.length,
+      types: defs.map((d) => ({ type: d.type, displayName: d.displayName })),
+      count: defs.length,
     });
   });
 }

--- a/packages/backend/src/routes/management/quotas.ts
+++ b/packages/backend/src/routes/management/quotas.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { QuotaScheduler } from '../../services/quota/quota-scheduler';
 import { getConfig } from '../../config';
 import { logger } from '../../utils/logger';
+import { getCheckerDefinitions } from '../../services/quota/checker-registry';
 import {
   getLegacySnapshotStatus,
   migrateLegacySnapshots,
@@ -31,6 +32,48 @@ export async function registerQuotaRoutes(
   fastify: FastifyInstance,
   quotaScheduler: QuotaScheduler
 ) {
+  fastify.get('/v0/management/quota-checkers', async (_request, reply) => {
+    try {
+      const defs = getCheckerDefinitions();
+      const knownTypes = defs.map((d) => ({ type: d.type, displayName: d.displayName }));
+      const displayNameMap = new Map(defs.map((d) => [d.type, d.displayName]));
+
+      const configured = [];
+      for (const quota of getConfig().quotas ?? []) {
+        const checkerId = quota.id ?? quota.type;
+        try {
+          const latest = await quotaScheduler.getLatestQuota(checkerId);
+          configured.push({
+            ...getOAuthMetadata(checkerId),
+            checkerId,
+            checkerType: quota.type,
+            displayName: displayNameMap.get(quota.type) ?? quota.type,
+            pending: latest === null,
+            meters: latest?.meters ?? [],
+            success: latest?.success ?? false,
+            ...(latest?.error ? { error: latest.error } : {}),
+          });
+        } catch (error) {
+          configured.push({
+            ...getOAuthMetadata(checkerId),
+            checkerId,
+            checkerType: quota.type,
+            displayName: displayNameMap.get(quota.type) ?? quota.type,
+            pending: false,
+            meters: [],
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      }
+
+      return reply.send({ knownTypes, configured });
+    } catch (error) {
+      logger.error(`Failed to get quota checkers: ${error}`);
+      return reply.status(500).send({ error: 'Failed to retrieve quota checkers' });
+    }
+  });
+
   fastify.get('/v0/management/quotas', async (_request, reply) => {
     try {
       const checkerIds = quotaScheduler.getCheckerIds();

--- a/packages/backend/src/services/config-service.ts
+++ b/packages/backend/src/services/config-service.ts
@@ -11,7 +11,7 @@ import type {
   CooldownPolicy,
   QuotaConfig,
 } from '../config';
-import { VALID_QUOTA_CHECKER_TYPES } from '../config';
+
 import { QuotaScheduler } from './quota/quota-scheduler';
 
 /**

--- a/packages/backend/src/services/quota/checker-registry.ts
+++ b/packages/backend/src/services/quota/checker-registry.ts
@@ -45,6 +45,7 @@ interface AllowanceParams {
 
 export interface CheckerDefinition<TOptions extends z.ZodTypeAny = z.ZodTypeAny> {
   type: string;
+  displayName: string;
   optionsSchema: TOptions;
   check(ctx: MeterContext): Promise<Meter[]>;
 }
@@ -62,6 +63,10 @@ export function defineChecker<TOptions extends z.ZodTypeAny>(
 
 export function getCheckerTypes(): string[] {
   return Array.from(REGISTRY.keys());
+}
+
+export function getCheckerDefinitions(): CheckerDefinition[] {
+  return Array.from(REGISTRY.values());
 }
 
 export function getCheckerDefinition(type: string): CheckerDefinition | undefined {

--- a/packages/backend/src/services/quota/checker-registry.ts
+++ b/packages/backend/src/services/quota/checker-registry.ts
@@ -177,6 +177,10 @@ export function createMeterContext(
 // ── Import all checkers to trigger self-registration ─────────────────────────
 // This file must be imported once at startup. Each checker file calls
 // defineChecker() at module load time, which populates REGISTRY.
+//
+// TODO: when Bun ships import.meta.glob (PR #21459), replace the explicit
+// imports below with:
+//   const mods = import.meta.glob('./checkers/*-checker.ts', { eager: true });
 
 export async function loadAllCheckers(): Promise<void> {
   await import('./checkers/naga-checker');

--- a/packages/backend/src/services/quota/checkers/antigravity-checker.ts
+++ b/packages/backend/src/services/quota/checkers/antigravity-checker.ts
@@ -151,6 +151,7 @@ async function fetchModels(
 
 export default defineChecker({
   type: 'antigravity',
+  displayName: 'Antigravity',
   optionsSchema: z.object({
     apiKey: z.string().optional(),
     oauthAccountId: z.string().optional(),

--- a/packages/backend/src/services/quota/checkers/apertis-checker.ts
+++ b/packages/backend/src/services/quota/checkers/apertis-checker.ts
@@ -24,6 +24,7 @@ interface ApertisBillingCreditsResponse {
 
 export default defineChecker({
   type: 'apertis',
+  displayName: 'Apertis',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'Apertis API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/claude-code-checker.ts
+++ b/packages/backend/src/services/quota/checkers/claude-code-checker.ts
@@ -41,6 +41,7 @@ async function resolveApiKey(ctx: {
 
 export default defineChecker({
   type: 'claude-code',
+  displayName: 'Claude Code',
   optionsSchema: z.object({
     apiKey: z.string().optional(),
     oauthAccountId: z.string().optional(),

--- a/packages/backend/src/services/quota/checkers/copilot-checker.ts
+++ b/packages/backend/src/services/quota/checkers/copilot-checker.ts
@@ -55,6 +55,7 @@ async function resolveApiKey(
 
 export default defineChecker({
   type: 'copilot',
+  displayName: 'GitHub Copilot',
   optionsSchema: z.object({
     apiKey: z.string().optional(),
     oauthAccountId: z.string().optional(),

--- a/packages/backend/src/services/quota/checkers/devpass-checker.ts
+++ b/packages/backend/src/services/quota/checkers/devpass-checker.ts
@@ -59,6 +59,7 @@ function addMonths(dateStr: string, months: number): string {
 
 export default defineChecker({
   type: 'devpass',
+  displayName: 'DevPass',
   optionsSchema: z.object({
     session: z.string().trim().min(1, 'DevPass session cookie is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/gemini-cli-checker.ts
+++ b/packages/backend/src/services/quota/checkers/gemini-cli-checker.ts
@@ -72,6 +72,7 @@ function extractBuckets(data: GeminiQuotaResponse): GeminiBucket[] {
 
 export default defineChecker({
   type: 'gemini-cli',
+  displayName: 'Gemini CLI',
   optionsSchema: z.object({
     apiKey: z.string().optional(),
     oauthAccountId: z.string().optional(),

--- a/packages/backend/src/services/quota/checkers/kilo-checker.ts
+++ b/packages/backend/src/services/quota/checkers/kilo-checker.ts
@@ -8,6 +8,7 @@ interface KiloBalanceResponse {
 
 export default defineChecker({
   type: 'kilo',
+  displayName: 'Kilo',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'Kilo API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/kimi-code-checker.ts
+++ b/packages/backend/src/services/quota/checkers/kimi-code-checker.ts
@@ -37,6 +37,7 @@ function resolvePeriod(window: { duration: number; timeUnit: string }): {
 
 export default defineChecker({
   type: 'kimi-code',
+  displayName: 'Kimi Code',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'Kimi Code API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/minimax-checker.ts
+++ b/packages/backend/src/services/quota/checkers/minimax-checker.ts
@@ -9,6 +9,7 @@ interface MiniMaxBalanceResponse {
 
 export default defineChecker({
   type: 'minimax',
+  displayName: 'MiniMax',
   optionsSchema: z.object({
     groupid: z.string().trim().min(1, 'MiniMax groupid is required'),
     hertzSession: z.string().trim().min(1, 'MiniMax HERTZ-SESSION cookie value is required'),

--- a/packages/backend/src/services/quota/checkers/minimax-coding-checker.ts
+++ b/packages/backend/src/services/quota/checkers/minimax-coding-checker.ts
@@ -18,6 +18,7 @@ interface MiniMaxCodingResponse {
 
 export default defineChecker({
   type: 'minimax-coding',
+  displayName: 'MiniMax Coding',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'MiniMax Coding API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/moonshot-checker.ts
+++ b/packages/backend/src/services/quota/checkers/moonshot-checker.ts
@@ -15,6 +15,7 @@ interface MoonshotBalanceResponse {
 
 export default defineChecker({
   type: 'moonshot',
+  displayName: 'Moonshot',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'Moonshot API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/naga-checker.ts
+++ b/packages/backend/src/services/quota/checkers/naga-checker.ts
@@ -7,6 +7,7 @@ interface NagaBalanceResponse {
 
 export default defineChecker({
   type: 'naga',
+  displayName: 'Naga',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'Naga provisioning key is required'),
     max: z.number().positive().optional(),

--- a/packages/backend/src/services/quota/checkers/nanogpt-checker.ts
+++ b/packages/backend/src/services/quota/checkers/nanogpt-checker.ts
@@ -40,6 +40,7 @@ function normalizeApiKey(apiKey: string): string {
 
 export default defineChecker({
   type: 'nanogpt',
+  displayName: 'NanoGPT',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'NanoGPT API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/neuralwatt-checker.ts
+++ b/packages/backend/src/services/quota/checkers/neuralwatt-checker.ts
@@ -31,6 +31,7 @@ interface NeuralwattQuotaResponse {
 
 export default defineChecker({
   type: 'neuralwatt',
+  displayName: 'Neuralwatt',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'Neuralwatt API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/novita-checker.ts
+++ b/packages/backend/src/services/quota/checkers/novita-checker.ts
@@ -8,6 +8,7 @@ interface NovitaBalanceResponse {
 
 export default defineChecker({
   type: 'novita',
+  displayName: 'Novita',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'Novita API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/ollama-checker.ts
+++ b/packages/backend/src/services/quota/checkers/ollama-checker.ts
@@ -26,6 +26,7 @@ function extractUsage(html: string, label: string): { percent: number; resetsAt?
 
 export default defineChecker({
   type: 'ollama',
+  displayName: 'Ollama',
   optionsSchema: z.object({
     sessionCookie: z.string().min(1, 'Ollama session cookie is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/openai-codex-checker.ts
+++ b/packages/backend/src/services/quota/checkers/openai-codex-checker.ts
@@ -90,6 +90,7 @@ function buildMeterFromWindow(
 
 export default defineChecker({
   type: 'openai-codex',
+  displayName: 'OpenAI Codex',
   optionsSchema: z.object({
     apiKey: z.string().optional(),
     oauthAccountId: z.string().optional(),

--- a/packages/backend/src/services/quota/checkers/opencode-go-checker.ts
+++ b/packages/backend/src/services/quota/checkers/opencode-go-checker.ts
@@ -43,6 +43,7 @@ function parseWindowUsage(html: string, field: string): OpenCodeGoWindow | null 
 
 export default defineChecker({
   type: 'opencode-go',
+  displayName: 'OpenCode Go',
   optionsSchema: z.object({
     workspaceId: z.string().min(1, 'OpenCode Go workspace ID is required'),
     authCookie: z.string().min(1, 'OpenCode Go auth cookie is required'),

--- a/packages/backend/src/services/quota/checkers/openrouter-checker.ts
+++ b/packages/backend/src/services/quota/checkers/openrouter-checker.ts
@@ -11,6 +11,7 @@ interface OpenRouterCreditsResponse {
 
 export default defineChecker({
   type: 'openrouter',
+  displayName: 'OpenRouter',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'OpenRouter management key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/poe-checker.ts
+++ b/packages/backend/src/services/quota/checkers/poe-checker.ts
@@ -8,6 +8,7 @@ interface PoeBalanceResponse {
 
 export default defineChecker({
   type: 'poe',
+  displayName: 'POE',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'POE API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/synthetic-checker.ts
+++ b/packages/backend/src/services/quota/checkers/synthetic-checker.ts
@@ -30,6 +30,7 @@ function parseCredits(val?: string): number | undefined {
 
 export default defineChecker({
   type: 'synthetic',
+  displayName: 'Synthetic',
   optionsSchema: z.object({
     apiKey: z.string().optional(),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/wafer-checker.ts
+++ b/packages/backend/src/services/quota/checkers/wafer-checker.ts
@@ -13,6 +13,7 @@ interface WaferQuotaResponse {
 
 export default defineChecker({
   type: 'wafer',
+  displayName: 'Wafer',
   optionsSchema: z.object({
     endpoint: z.string().optional(),
     apiKey: z.string().min(1, 'Wafer API key is required'),

--- a/packages/backend/src/services/quota/checkers/wisdomgate-checker.ts
+++ b/packages/backend/src/services/quota/checkers/wisdomgate-checker.ts
@@ -10,6 +10,7 @@ interface WisdomGateUsageResponse {
 
 export default defineChecker({
   type: 'wisdomgate',
+  displayName: 'Wisdom Gate',
   optionsSchema: z.object({
     session: z.string().trim().min(1, 'Session cookie is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/zai-checker.ts
+++ b/packages/backend/src/services/quota/checkers/zai-checker.ts
@@ -18,6 +18,7 @@ interface ZAIQuotaResponse {
 
 export default defineChecker({
   type: 'zai',
+  displayName: 'ZAI',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'ZAI API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/services/quota/checkers/zenmux-checker.ts
+++ b/packages/backend/src/services/quota/checkers/zenmux-checker.ts
@@ -42,6 +42,7 @@ interface ZenmuxQuotaResponse {
 
 export default defineChecker({
   type: 'zenmux',
+  displayName: 'Zenmux',
   optionsSchema: z.object({
     managementApiKey: z.string().min(1, 'Zenmux management API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -18,7 +18,7 @@ import {
   UserCircle2,
 } from 'lucide-react';
 import { clsx } from 'clsx';
-import { api } from '../../lib/api';
+import { api, fetchQuotaCheckers } from '../../lib/api';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSidebar } from '../../contexts/SidebarContext';
 import { Modal } from '../ui/Modal';
@@ -97,7 +97,8 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
   const [debugMode, setDebugMode] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
-  const [quotas, setQuotas] = useState<QuotaCheckerInfo[]>([]);
+  const [quotas, setQuotas] = useState<(QuotaCheckerInfo & { pending?: boolean })[]>([]);
+  const [displayNameMap, setDisplayNameMap] = useState<Map<string, string>>(new Map());
   const { logout, isAdmin, isLimited, principal } = useAuth();
   const { isCollapsed, toggleSidebar, isMobileOpen, closeMobile } = useSidebar();
   const location = useLocation();
@@ -118,12 +119,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
   }, []);
 
   useEffect(() => {
-    const fetchQuotas = async () => {
-      const data = await api.getQuotas();
-      setQuotas(data);
+    const loadQuotas = async () => {
+      const data = await fetchQuotaCheckers();
+      setDisplayNameMap(new Map(data.knownTypes.map((t) => [t.type, t.displayName])));
+      setQuotas(data.configured);
     };
-    fetchQuotas();
-    const interval = setInterval(fetchQuotas, 60000);
+    loadQuotas();
+    const interval = setInterval(loadQuotas, 60000);
     return () => clearInterval(interval);
   }, []);
 
@@ -290,7 +292,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
                 Balances
               </span>
             </div>
-            <CompactBalancesCard balanceQuotas={balanceQuotas} />
+            <CompactBalancesCard balanceQuotas={balanceQuotas} displayNameMap={displayNameMap} />
           </div>
         )}
 
@@ -302,7 +304,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ mode = 'desktop' }) => {
                 Quotas
               </span>
             </div>
-            <CompactQuotasCard allowanceQuotas={allowanceQuotas} />
+            <CompactQuotasCard allowanceQuotas={allowanceQuotas} displayNameMap={displayNameMap} />
           </div>
         )}
 

--- a/packages/frontend/src/components/quota/CombinedBalancesCard.tsx
+++ b/packages/frontend/src/components/quota/CombinedBalancesCard.tsx
@@ -12,12 +12,14 @@ interface CombinedBalancesCardProps {
   balanceQuotas: QuotaCheckerInfo[];
   onRefresh: (checkerId: string) => void;
   refreshing: Set<string>;
+  displayNameMap?: Map<string, string>;
 }
 
 export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
   balanceQuotas,
   onRefresh,
   refreshing,
+  displayNameMap,
 }) => {
   const [historyTarget, setHistoryTarget] = useState<{
     quota: QuotaCheckerInfo;
@@ -33,7 +35,7 @@ export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
   const rightColumn = shouldSplit ? balanceQuotas.slice(midPoint) : [];
 
   const renderRow = (quota: QuotaCheckerInfo) => {
-    const displayName = getCheckerDisplayName(quota.checkerType, quota.checkerId);
+    const displayName = getCheckerDisplayName(quota.checkerType, quota.checkerId, displayNameMap);
     const balanceMeters = quota.meters.filter((m) => m.kind === 'balance');
 
     return (
@@ -67,7 +69,11 @@ export const CombinedBalancesCard: React.FC<CombinedBalancesCardProps> = ({
                   setHistoryTarget({
                     quota,
                     meter,
-                    displayName: getCheckerDisplayName(quota.checkerType, quota.checkerId),
+                    displayName: getCheckerDisplayName(
+                      quota.checkerType,
+                      quota.checkerId,
+                      displayNameMap
+                    ),
                   })
                 }
               />

--- a/packages/frontend/src/components/quota/CompactBalancesCard.tsx
+++ b/packages/frontend/src/components/quota/CompactBalancesCard.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toTitleCase } from '../../lib/format';
 import type { QuotaCheckerInfo } from '../../types/quota';
 import { formatMeterValue } from './MeterValue';
+import { getCheckerDisplayName } from './checker-presentation';
 
 interface CompactBalancesCardProps {
   balanceQuotas: QuotaCheckerInfo[];
+  displayNameMap?: Map<string, string>;
 }
 
-export const CompactBalancesCard: React.FC<CompactBalancesCardProps> = ({ balanceQuotas }) => {
+export const CompactBalancesCard: React.FC<CompactBalancesCardProps> = ({
+  balanceQuotas,
+  displayNameMap,
+}) => {
   const navigate = useNavigate();
 
   if (balanceQuotas.length === 0) return null;
@@ -27,7 +31,11 @@ export const CompactBalancesCard: React.FC<CompactBalancesCardProps> = ({ balanc
       }}
     >
       {balanceQuotas.map((quota) => {
-        const displayName = toTitleCase(quota.checkerId);
+        const displayName = getCheckerDisplayName(
+          quota.checkerType,
+          quota.checkerId,
+          displayNameMap
+        );
         const balanceMeter = quota.meters.find((m) => m.kind === 'balance');
         const remaining = balanceMeter?.remaining;
         const formattedBalance =

--- a/packages/frontend/src/components/quota/CompactQuotasCard.tsx
+++ b/packages/frontend/src/components/quota/CompactQuotasCard.tsx
@@ -8,13 +8,17 @@ import { AllowanceMeterRow } from './AllowanceMeterRow';
 
 interface CompactQuotasCardProps {
   allowanceQuotas: QuotaCheckerInfo[];
+  displayNameMap?: Map<string, string>;
 }
 
 function getAllowanceMeters(meters: Meter[]): Meter[] {
   return meters.filter((m) => m.kind === 'allowance');
 }
 
-export const CompactQuotasCard: React.FC<CompactQuotasCardProps> = ({ allowanceQuotas }) => {
+export const CompactQuotasCard: React.FC<CompactQuotasCardProps> = ({
+  allowanceQuotas,
+  displayNameMap,
+}) => {
   const navigate = useNavigate();
 
   if (allowanceQuotas.length === 0) return null;
@@ -33,7 +37,11 @@ export const CompactQuotasCard: React.FC<CompactQuotasCardProps> = ({ allowanceQ
       }}
     >
       {allowanceQuotas.map((quota, idx) => {
-        const displayName = getCheckerDisplayName(quota.checkerType, quota.checkerId);
+        const displayName = getCheckerDisplayName(
+          quota.checkerType,
+          quota.checkerId,
+          displayNameMap
+        );
         const allowanceMeters = getAllowanceMeters(quota.meters);
         const isLast = idx === allowanceQuotas.length - 1;
 

--- a/packages/frontend/src/components/quota/checker-presentation.ts
+++ b/packages/frontend/src/components/quota/checker-presentation.ts
@@ -1,31 +1,9 @@
-export const CHECKER_DISPLAY_NAMES: Record<string, string> = {
-  openrouter: 'OpenRouter',
-  minimax: 'MiniMax',
-  'minimax-coding': 'MiniMax Coding',
-  moonshot: 'Moonshot',
-  naga: 'Naga',
-  novita: 'Novita',
-  kilo: 'Kilo',
-  poe: 'POE',
-  'openai-codex': 'OpenAI Codex',
-  'claude-code': 'Claude Code',
-  zai: 'ZAI',
-  synthetic: 'Synthetic',
-  nanogpt: 'NanoGPT',
-  'kimi-code': 'Kimi Code',
-  copilot: 'GitHub Copilot',
-  wisdomgate: 'Wisdom Gate',
-  'gemini-cli': 'Gemini CLI',
-  antigravity: 'Antigravity',
-  apertis: 'Apertis',
-  ollama: 'Ollama',
-  neuralwatt: 'Neuralwatt',
-  zenmux: 'Zenmux',
-  'opencode-go': 'OpenCode Go',
-  devpass: 'DevPass',
-};
-
-export function getCheckerDisplayName(checkerType: string | undefined, checkerId: string): string {
-  if (checkerType && CHECKER_DISPLAY_NAMES[checkerType]) return CHECKER_DISPLAY_NAMES[checkerType];
+export function getCheckerDisplayName(
+  checkerType: string | undefined,
+  checkerId: string,
+  displayNameMap?: Map<string, string>
+): string {
+  if (checkerType && displayNameMap?.has(checkerType)) return displayNameMap.get(checkerType)!;
+  if (checkerType) return checkerType;
   return checkerId;
 }

--- a/packages/frontend/src/components/quota/index.ts
+++ b/packages/frontend/src/components/quota/index.ts
@@ -8,4 +8,4 @@ export { CompactQuotasCard } from './CompactQuotasCard';
 export { BalanceMeterRow } from './BalanceMeterRow';
 export { AllowanceMeterRow } from './AllowanceMeterRow';
 export { MeterValue, formatMeterValue } from './MeterValue';
-export { getCheckerDisplayName, CHECKER_DISPLAY_NAMES } from './checker-presentation';
+export { getCheckerDisplayName } from './checker-presentation';

--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -1,12 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {
-  api,
-  Provider,
-  OAuthSession,
-  initQuotaCheckerTypes,
-  getQuotaCheckerTypes,
-} from '../lib/api';
+import { api, Provider, OAuthSession, fetchQuotaCheckers } from '../lib/api';
 import type { QuotaCheckerInfo } from '../types/quota';
 import { formatMeterValue } from '../components/quota/MeterValue';
 import { Badge } from '../components/ui/Badge';
@@ -31,34 +25,6 @@ export const OAUTH_PROVIDERS = [
   { value: 'google-antigravity', label: 'Antigravity (Gemini 3, Claude, GPT-OSS)' },
   { value: 'openai-codex', label: 'ChatGPT Plus/Pro (Codex Subscription)' },
 ];
-
-const QUOTA_CHECKER_TYPES_FALLBACK = [
-  'synthetic',
-  'naga',
-  'nanogpt',
-  'openai-codex',
-  'claude-code',
-  'kimi-code',
-  'zai',
-  'moonshot',
-  'novita',
-  'minimax',
-  'minimax-coding',
-  'openrouter',
-  'kilo',
-  'wisdomgate',
-  'apertis',
-  'poe',
-  'copilot',
-  'gemini-cli',
-  'antigravity',
-  'ollama',
-  'neuralwatt',
-  'zenmux',
-  'devpass',
-  'wafer',
-  'opencode-go',
-] as const;
 
 const getOAuthCheckerType = (oauthProvider?: string): string | null => {
   if (!oauthProvider) return null;
@@ -125,9 +91,7 @@ export function useProviderForm() {
   const [editingProvider, setEditingProvider] = useState<Provider>(EMPTY_PROVIDER);
   const [originalId, setOriginalId] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
-  const [quotaCheckerTypes, setQuotaCheckerTypes] = useState<string[]>([
-    ...QUOTA_CHECKER_TYPES_FALLBACK,
-  ]);
+  const [quotaCheckerTypes, setQuotaCheckerTypes] = useState<string[]>([]);
   const [quotas, setQuotas] = useState<QuotaCheckerInfo[]>([]);
   const [quotasLoading, setQuotasLoading] = useState(true);
 
@@ -215,9 +179,8 @@ export function useProviderForm() {
 
   // Effects
   useEffect(() => {
-    initQuotaCheckerTypes().then(() => {
-      const types = Array.from(getQuotaCheckerTypes());
-      setQuotaCheckerTypes(types.length > 0 ? types : [...QUOTA_CHECKER_TYPES_FALLBACK]);
+    fetchQuotaCheckers().then((res) => {
+      setQuotaCheckerTypes(res.knownTypes.map((t) => t.type));
     });
   }, []);
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -537,79 +537,30 @@ const summaryRequestCache = new Map<
 const CONFIG_CACHE_TTL_MS = 20000;
 const configRequestCache = new Map<string, { expiresAt: number; promise: Promise<any> }>();
 
-// Cache for quota checker types fetched from backend
-let quotaCheckerTypesCache: Set<string> | null = null;
-let quotaCheckerTypesCacheTime: number = 0;
-const QUOTA_TYPES_CACHE_TTL_MS = 60000; // 1 minute cache
-
-// Fallback types - will be used until fetched from server
-const FALLBACK_QUOTA_CHECKER_TYPES = new Set([
-  'synthetic',
-  'naga',
-  'nanogpt',
-  'openai-codex',
-  'claude-code',
-  'zai',
-  'moonshot',
-  'novita',
-  'minimax',
-  'minimax-coding',
-  'kimi-code',
-  'openrouter',
-  'kilo',
-  'wisdomgate',
-  'apertis',
-  'copilot',
-  'poe',
-  'gemini-cli',
-  'antigravity',
-  'ollama',
-  'neuralwatt',
-  'zenmux',
-  'devpass',
-  'wafer',
-  'opencode-go',
-]);
-
-/**
- * Fetch valid quota checker types from the backend
- */
-async function fetchQuotaCheckerTypes(): Promise<Set<string>> {
-  const now = Date.now();
-  if (quotaCheckerTypesCache && now - quotaCheckerTypesCacheTime < QUOTA_TYPES_CACHE_TTL_MS) {
-    return quotaCheckerTypesCache;
-  }
-
-  try {
-    const response = await fetchWithAuth(`${API_BASE}/v0/management/quota-checker-types`);
-    if (response.ok) {
-      const data = await response.json();
-      if (Array.isArray(data.types)) {
-        quotaCheckerTypesCache = new Set(data.types);
-        quotaCheckerTypesCacheTime = now;
-        return quotaCheckerTypesCache;
-      }
-    }
-  } catch (error) {
-    // Silently fail and use fallback
-  }
-
-  return FALLBACK_QUOTA_CHECKER_TYPES;
+export interface QuotaCheckerType {
+  type: string;
+  displayName: string;
 }
 
-/**
- * Get valid quota checker types (sync version - returns fallback if not fetched)
- * Call fetchQuotaCheckerTypes() early to populate the cache
- */
-export function getQuotaCheckerTypes(): Set<string> {
-  return quotaCheckerTypesCache || FALLBACK_QUOTA_CHECKER_TYPES;
+export interface QuotaCheckersResponse {
+  knownTypes: QuotaCheckerType[];
+  configured: (QuotaCheckerInfo & { displayName: string; pending: boolean })[];
 }
 
-/**
- * Initialize quota checker types cache
- */
-export async function initQuotaCheckerTypes(): Promise<void> {
-  await fetchQuotaCheckerTypes();
+export async function fetchQuotaCheckers(): Promise<QuotaCheckersResponse> {
+  const response = await fetchWithAuth(`${API_BASE}/v0/management/quota-checkers`);
+  if (!response.ok) throw new Error('Failed to fetch quota checkers');
+  const data = await response.json();
+  return {
+    knownTypes: data.knownTypes ?? [],
+    configured: (data.configured ?? []).map(
+      (c: QuotaCheckerInfo & { displayName: string; pending: boolean }) => ({
+        ...normalizeQuotaCheckerInfo(c),
+        displayName: c.displayName,
+        pending: c.pending,
+      })
+    ),
+  };
 }
 
 // Re-export GpuProfileOption from shared package for use by other components
@@ -626,10 +577,9 @@ const normalizeProviderQuotaChecker = (checker?: {
   const type = checker.type?.trim();
   if (!type) return undefined;
 
-  const isValidType = getQuotaCheckerTypes().has(type);
   return {
     type,
-    enabled: isValidType ? checker.enabled !== false : false,
+    enabled: checker.enabled !== false,
     intervalMinutes: Math.max(1, Number(checker.intervalMinutes || 30)),
     options: checker.options,
   };

--- a/packages/frontend/src/pages/Quotas.tsx
+++ b/packages/frontend/src/pages/Quotas.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { RefreshCw, Cpu, Gauge, AlertTriangle, DatabaseZap, Download } from 'lucide-react';
 import { clsx } from 'clsx';
-import { api } from '../lib/api';
+import { api, fetchQuotaCheckers } from '../lib/api';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { EmptyState } from '../components/ui/EmptyState';
@@ -14,7 +14,8 @@ import { MeterHistoryModal } from '../components/quota/MeterHistoryModal';
 import { getCheckerDisplayName } from '../components/quota/checker-presentation';
 
 export const Quotas = () => {
-  const [quotas, setQuotas] = useState<QuotaCheckerInfo[]>([]);
+  const [quotas, setQuotas] = useState<(QuotaCheckerInfo & { pending?: boolean })[]>([]);
+  const [displayNameMap, setDisplayNameMap] = useState<Map<string, string>>(new Map());
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState<Set<string>>(new Set());
   const [legacyRowCount, setLegacyRowCount] = useState<number | null>(null);
@@ -35,9 +36,13 @@ export const Quotas = () => {
 
   const fetchQuotas = async () => {
     setLoading(true);
-    const data = await api.getQuotas();
-    setQuotas(data);
-    setLoading(false);
+    try {
+      const data = await fetchQuotaCheckers();
+      setDisplayNameMap(new Map(data.knownTypes.map((t) => [t.type, t.displayName])));
+      setQuotas(data.configured);
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -96,18 +101,18 @@ export const Quotas = () => {
   };
 
   const balanceQuotas = useMemo(
-    () => quotas.filter((q) => q.meters.some((m) => m.kind === 'balance')),
+    () => quotas.filter((q) => q.pending || q.meters.some((m) => m.kind === 'balance')),
     [quotas]
   );
 
   const allowanceQuotas = useMemo(
-    () => quotas.filter((q) => q.meters.some((m) => m.kind === 'allowance')),
+    () => quotas.filter((q) => q.pending || q.meters.some((m) => m.kind === 'allowance')),
     [quotas]
   );
 
   // Group allowance quotas by checkerType for display
   const allowanceGroups = useMemo(() => {
-    const groups: Record<string, QuotaCheckerInfo[]> = {};
+    const groups: Record<string, (QuotaCheckerInfo & { pending?: boolean })[]> = {};
     for (const quota of allowanceQuotas) {
       const key = quota.checkerType || quota.checkerId;
       if (!groups[key]) groups[key] = [];
@@ -116,7 +121,10 @@ export const Quotas = () => {
     return Object.entries(groups).sort(([a], [b]) => a.localeCompare(b));
   }, [allowanceQuotas]);
 
-  const renderCheckerCard = (quota: QuotaCheckerInfo, _groupDisplayName: string) => {
+  const renderCheckerCard = (
+    quota: QuotaCheckerInfo & { pending?: boolean },
+    _groupDisplayName: string
+  ) => {
     const allowances = quota.meters.filter((m) => m.kind === 'allowance');
 
     return (
@@ -127,18 +135,20 @@ export const Quotas = () => {
         <button
           type="button"
           onClick={() => handleRefresh(quota.checkerId)}
-          disabled={refreshing.has(quota.checkerId)}
+          disabled={refreshing.has(quota.checkerId) || quota.pending}
           aria-label="Refresh"
           className="absolute top-2 right-2 inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted hover:bg-bg-hover hover:text-text transition-colors duration-fast disabled:opacity-50"
         >
           <RefreshCw
             size={14}
-            className={clsx(refreshing.has(quota.checkerId) && 'animate-spin')}
+            className={clsx((refreshing.has(quota.checkerId) || quota.pending) && 'animate-spin')}
           />
         </button>
 
         <div className="pr-8">
-          {!quota.success ? (
+          {quota.pending ? (
+            <span className="text-xs text-text-muted">Pending first check...</span>
+          ) : !quota.success ? (
             <div className="flex items-center gap-2 text-danger">
               <AlertTriangle size={14} />
               <span className="text-xs">Check failed</span>
@@ -308,6 +318,7 @@ export const Quotas = () => {
                   balanceQuotas={balanceQuotas}
                   onRefresh={handleRefresh}
                   refreshing={refreshing}
+                  displayNameMap={displayNameMap}
                 />
               </section>
             )}
@@ -322,7 +333,8 @@ export const Quotas = () => {
                   {allowanceGroups.map(([checkerType, quotasList]) => {
                     const displayName = getCheckerDisplayName(
                       checkerType,
-                      quotasList[0]?.checkerId ?? checkerType
+                      quotasList[0]?.checkerId ?? checkerType,
+                      displayNameMap
                     );
                     return (
                       <div key={checkerType} className="flex flex-col gap-3">


### PR DESCRIPTION
   - Centralizes all quota checker registrations in one registry, making it the definitive source of truth.
   - Removes outdated configuration files and updates services to depend on the new registry.
   - Introduces dedicated management routes for quota operations that expose registry data via the API.
   - Aligns backend services and frontend components (sidebar, quota cards, presentation layer, provider form, API helpers) to consume checker
 information exclusively from the registry.
   - Cleans up imports, eliminates redundant code paths, and improves type safety across the stack.
   - Provides documentation on the current limitation of import.meta.glob and outlines a future migration plan.
   - Closes #385."