### PR TITLE
Add background exploration: probe-based performance data refresh

### DIFF
--- a/BGEXPLORE.md
+++ b/BGEXPLORE.md
@@ -1,0 +1,407 @@
+# Background Exploration Plan
+
+## Goal
+
+Add an optional background exploration mode that keeps performance data
+(TTFT / TPS / E2E TPS) fresh for the `latency`, `performance`, and
+`e2e_performance` selectors **without** diverting live request traffic to
+slower providers.
+
+When enabled, the existing inline `Math.random() < explorationRate` branches in
+those selectors are suppressed; instead, a separate background worker fires
+representative synthetic probes at stale targets, and their results populate
+the same `providerPerformance` table the selectors already read from.
+
+The manual "test" path triggered from the management UI is folded into the
+same probe machinery so there is exactly one canonical probe shape and code
+path.
+
+---
+
+## Design summary
+
+- **Trigger:** staleness-driven, gated on live requests. Each live request to
+  an alias whose group is using one of the three perf-based selectors causes a
+  check: any target in the active group whose `lastProbedAt` is older than
+  `stalenessThresholdMs` is enqueued for a probe.
+- **Bootstrap:** absent entries are treated as `process_start_time`. First
+  probe fires at normal cadence once the threshold elapses, not eagerly on
+  cold start.
+- **Burst handling:** all stale targets are enqueued together. A bounded
+  worker pool drains the queue. Per-target `inFlight` guard prevents
+  duplicates. Existing `CooldownManager` is respected.
+- **Probe shape:** one canonical, version-stamped synthetic `chat` request —
+  moderate input, two stub tool definitions, `max_tokens: 1000`, streaming.
+- **Probe path:** uses the existing `direct/<provider>/<model>` routing
+  syntax, which pins to one specific target, skips alias resolution, and
+  naturally exercises the same transformer + provider + storage path as live
+  traffic.
+- **Attribution:** `apiKey = 'probe'`, `attribution = 'manual' | 'background'`.
+  Probes appear in user-facing usage records.
+- **Unification with manual test:** the management test endpoint becomes a
+  thin wrapper over the same `ProbeService.runProbe()` used by the background
+  worker.
+
+---
+
+## Components
+
+### 1. Config (`packages/backend/src/config.ts`)
+
+Add a new top-level block to `RawPlexusConfigSchema`:
+
+```ts
+const BackgroundExplorationConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  stalenessThresholdMs: z.number().int().min(1000).default(600_000), // 10 min
+  workerConcurrency: z.number().int().min(1).max(16).default(2),
+});
+
+// inside RawPlexusConfigSchema.object({...})
+backgroundExploration: BackgroundExplorationConfigSchema.optional(),
+```
+
+The three existing inline-exploration fields are **not** removed:
+
+- `performanceExplorationRate`
+- `latencyExplorationRate`
+- `e2ePerformanceExplorationRate`
+
+They continue to drive the existing inline exploration. The new mode merely
+**suppresses** them at runtime when `backgroundExploration.enabled === true`.
+
+### 2. Selectors
+
+Files:
+- `packages/backend/src/services/selectors/performance.ts`
+- `packages/backend/src/services/selectors/e2e-performance.ts`
+- `packages/backend/src/services/selectors/latency.ts`
+
+In each, wrap the existing `Math.random() < explorationRate` block:
+
+```ts
+const bgEnabled = config.backgroundExploration?.enabled === true;
+if (!bgEnabled && explorationRate > 0 && Math.random() < explorationRate && ...) {
+  // existing exploration logic, unchanged
+}
+```
+
+No other logic changes. `pickExplorationTarget` in `base.ts` remains in use
+for the inline (non-background) path.
+
+### 3. Probe shape (`packages/backend/src/services/probe-request.ts`, new)
+
+Exports:
+
+```ts
+export const PROBE_SHAPE_VERSION = 1;
+
+export function buildProbeChatRequest(provider: string, model: string): unknown;
+```
+
+Returned object is the **raw inbound chat payload** (the OpenAI-style body the
+existing `OpenAITransformer.parseRequest` consumes), parameterised with
+`model = direct/${provider}/${model}`.
+
+Shape:
+
+- `model: 'direct/<provider>/<model>'`
+- `stream: true`
+- `max_tokens: 1000`
+- `messages`:
+  - `system` (~200 tokens): instructive persona priming text. Stable, checked
+    in as a constant.
+  - `user` (~150 tokens): asks for a brief reasoned answer and, when
+    appropriate, a tool call decision. Stable.
+- `tools`: two stub function definitions (e.g. `get_weather`, `search_docs`)
+  with realistic JSON-schema parameters. Stable.
+
+The shape constants live alongside `PROBE_SHAPE_VERSION` so any future change
+bumps the version.
+
+> Non-chat API types keep their existing trivial `TEST_TEMPLATES` shapes for
+> manual-test UI debugging. The background explorer only ever uses the
+> `chat` shape.
+
+### 4. ProbeService (`packages/backend/src/services/probe-service.ts`, new)
+
+Single entry point used by both the management test endpoint and the
+background worker.
+
+```ts
+type ProbeSource = 'manual' | 'background';
+type ProbeApiType =
+  | 'chat' | 'messages' | 'gemini' | 'responses'
+  | 'embeddings' | 'images' | 'speech' | 'oauth';
+
+interface RunProbeArgs {
+  provider: string;
+  model: string;
+  apiType: ProbeApiType;
+  source: ProbeSource;
+}
+
+class ProbeService {
+  constructor(dispatcher: Dispatcher, usageStorage: UsageStorageService);
+  async runProbe(args: RunProbeArgs): Promise<{
+    success: boolean;
+    durationMs: number;
+    response?: unknown;
+    error?: { message: string; statusCode?: number };
+  }>;
+}
+```
+
+Responsibilities (mirrors the current `test.ts` flow):
+
+1. Generate `requestId`. Construct initial `UsageRecord`:
+   - `apiKey = 'probe'`
+   - `attribution = source`             // 'manual' | 'background'
+   - `incomingModelAlias = 'direct/<provider>/<model>'`
+   - `incomingApiType = apiType`
+   - `sourceIp = null` (no client IP for probes)
+   - emits `started` event via `usageStorage.emitStartedAsync(...)`
+2. Build the request body:
+   - For `apiType === 'chat'`: `buildProbeChatRequest(provider, model)`.
+   - For other types: use the existing per-type templates lifted from
+     `routes/management/test.ts` (same shapes, unchanged).
+3. Run it through the appropriate transformer / dispatcher path, exactly
+   matching the current `test.ts` logic:
+   - chat / messages / gemini / responses → corresponding transformer →
+     `dispatcher.dispatch`
+   - embeddings → `dispatcher.dispatchEmbeddings`
+   - images → `dispatcher.dispatchImageGenerations`
+   - speech → `SpeechTransformer.parseRequest` → `dispatcher.dispatchSpeech`
+   - oauth → hand-built unified request → `dispatcher.dispatch`
+   - transcriptions → unsupported (matches current behavior)
+4. Finalise `UsageRecord` from the dispatch response (provider, model,
+   tokens, cost, ttft, attempt count, retry history, etc.) — same projection
+   the current `test.ts` does.
+5. Persist usage record via the normal usage storage path. Performance
+   metrics (`providerPerformance`) are recorded by the dispatcher itself, so
+   no extra plumbing is required for that.
+6. Return `{ success, durationMs, response | error }` to the caller.
+
+The service is constructed once at startup (alongside other singletons) and
+shared between the management route and the background explorer.
+
+### 5. Management test route (`packages/backend/src/routes/management/test.ts`)
+
+Refactor to a thin wrapper:
+
+- Parse + validate body (`provider`, `model`, `apiType`).
+- Call `probeService.runProbe({ provider, model, apiType, source: 'manual' })`.
+- Map the result to the HTTP response shape the UI already expects.
+- Remove the inlined request building / transformer dispatch / usage record
+  construction (now lives in `ProbeService`).
+
+Behaviour change: the resulting usage record's `apiKey` is `'probe'` instead
+of the caller's key. Documented.
+
+### 6. Background explorer (`packages/backend/src/services/background-explorer.ts`, new)
+
+Singleton.
+
+State:
+
+```ts
+type TargetKey = `${string}:${string}`; // `${provider}:${model}`
+
+interface TargetState {
+  lastProbedAt: number;   // ms epoch; initialised to processStartTime on first sight
+  inFlight: boolean;
+}
+
+private state: Map<TargetKey, TargetState>;
+private queue: Array<{ provider: string; model: string }>;
+private processStartTime: number;
+private activeWorkers: number;
+```
+
+Public API:
+
+```ts
+class BackgroundExplorer {
+  static getInstance(): BackgroundExplorer;
+  static initialize(probeService: ProbeService): void;
+  static resetForTesting(): void;
+
+  /**
+   * Non-blocking. Inspects each target in the group, enqueues any that are
+   * stale, healthy, and not currently in flight. Returns immediately.
+   */
+  maybeTrigger(group: ModelTargetGroup): void;
+}
+```
+
+Behaviour:
+
+- `maybeTrigger` short-circuits if `config.backgroundExploration?.enabled !== true`.
+- For each `target` in `group.targets` (only enabled, non-disabled-provider
+  targets, matching the filtering router does):
+  - Look up or initialise `state[provider:model]` with
+    `lastProbedAt = processStartTime`, `inFlight = false`.
+  - Skip if `state.inFlight`.
+  - Skip if `now - state.lastProbedAt < stalenessThresholdMs`.
+  - Skip if `!CooldownManager.getInstance().isProviderHealthy(provider, model)`.
+  - Otherwise enqueue.
+- After enqueueing, calls `pumpWorkers()` which spawns workers up to
+  `workerConcurrency`.
+- A worker:
+  1. Dequeues `{ provider, model }`.
+  2. Sets `state.inFlight = true`.
+  3. Re-checks cooldown (race-safe). If on cooldown, abort, clear `inFlight`.
+  4. `await probeService.runProbe({ provider, model, apiType: 'chat', source: 'background' })`.
+  5. Regardless of success/failure: `state.lastProbedAt = Date.now()`,
+     `state.inFlight = false`.
+  6. Logs result at debug level. Errors are swallowed (probe failures must
+     never affect live traffic).
+  7. Loops to drain queue.
+
+Note: `lastProbedAt` is updated even on probe failure. A failing target will
+back off naturally because `CooldownManager` will mark it unhealthy after
+real-traffic failures; we don't want a hard-failing target re-probed on every
+live request.
+
+### 7. Router trigger wiring (`packages/backend/src/services/router.ts`)
+
+Two call sites where target selection completes against a known
+`ModelTargetGroup`:
+
+1. The `selectOrderedTargets` path inside `Router.resolveCandidates`
+   (both the direct-group branch around line 226 and the normal alias
+   branch around line 274).
+2. The single-selector path inside `Router.resolve` (the direct-group branch
+   around line 328 and the normal alias branch around line 388).
+
+At each site, immediately **after** a successful selection (i.e. we have an
+`alias` + `group` in scope), call:
+
+```ts
+BackgroundExplorer.getInstance().maybeTrigger(group);
+```
+
+Guards:
+
+- The method itself is a no-op when `backgroundExploration.enabled !== true`.
+- The method is a no-op for groups whose `selector` is not one of
+  `'latency' | 'performance' | 'e2e_performance'` (other selectors don't
+  consume performance data, so probes would be pointless cost).
+- Recursion: probe requests use `model: 'direct/<provider>/<model>'` which
+  bypasses alias resolution entirely. `findAlias` returns no alias, so the
+  alias-and-group branches are not entered; `maybeTrigger` is therefore not
+  called for probe requests. An explicit guard is not required but a
+  defensive check on `incomingModelAlias?.startsWith('direct/')` will be
+  added for clarity.
+
+### 8. Usage storage
+
+No schema change in v1.
+
+- `apiKey = 'probe'` and `attribution = 'manual' | 'background'` are stored
+  on existing columns.
+- `providerPerformance` rows are written by the existing dispatcher path with
+  no changes; probe results pool with live-traffic results.
+
+A future schema change to add an explicit `isProbe` boolean (so dashboards
+can filter cleanly without string matching) is noted as **out of scope for
+v1** but easy to add.
+
+### 9. Startup wiring (`packages/backend/src/index.ts` or equivalent)
+
+After `Dispatcher` and `UsageStorageService` are constructed:
+
+```ts
+const probeService = new ProbeService(dispatcher, usageStorage);
+BackgroundExplorer.initialize(probeService);
+```
+
+Replace the existing direct construction of `ProbeService` consumers
+(management test route) so they receive the shared instance via DI.
+
+---
+
+## Files touched
+
+**New:**
+- `packages/backend/src/services/probe-request.ts`
+- `packages/backend/src/services/probe-service.ts`
+- `packages/backend/src/services/background-explorer.ts`
+
+**Modified:**
+- `packages/backend/src/config.ts` — add `backgroundExploration` schema.
+- `packages/backend/src/services/selectors/performance.ts` — gate inline
+  exploration on `!backgroundExploration.enabled`.
+- `packages/backend/src/services/selectors/e2e-performance.ts` — same.
+- `packages/backend/src/services/selectors/latency.ts` — same.
+- `packages/backend/src/services/router.ts` — add `maybeTrigger` calls at
+  four post-selection sites.
+- `packages/backend/src/routes/management/test.ts` — collapse to thin
+  wrapper over `ProbeService.runProbe`.
+- `packages/backend/src/index.ts` (or wherever the dispatcher singleton is
+  wired today) — construct `ProbeService` and initialise
+  `BackgroundExplorer`.
+
+---
+
+## Tests
+
+Following the project's `__tests__/` convention and `vitest` skill rules.
+
+### Unit tests
+
+- `services/selectors/__tests__/performance.test.ts`,
+  `e2e-performance.test.ts`,
+  `latency.test.ts` — add cases asserting that when
+  `config.backgroundExploration.enabled === true`, inline exploration does
+  **not** occur (deterministic "always pick best"), and when it is `false`
+  the existing behaviour is preserved.
+- `services/__tests__/background-explorer.test.ts` (new):
+  - `maybeTrigger` is a no-op when disabled in config.
+  - `maybeTrigger` is a no-op for non-perf selector groups.
+  - Stale + healthy targets get enqueued; non-stale targets do not.
+  - Targets on cooldown are skipped.
+  - `inFlight` prevents duplicate enqueue while a probe is running.
+  - `workerConcurrency` cap is honoured.
+  - `lastProbedAt` is updated on both success and failure of the probe.
+  - Probe failures are swallowed and do not throw out of `maybeTrigger`.
+- `services/__tests__/probe-service.test.ts` (new):
+  - Builds the correct `direct/<provider>/<model>` request.
+  - Sets `apiKey = 'probe'` and `attribution` from `source`.
+  - Returns success/failure shape correctly.
+  - Dispatches via the correct method per `apiType`.
+
+### Integration test (lightweight)
+
+- `test/integration/background-exploration.test.ts` (new):
+  - With a mocked dispatcher and one alias using `performance` selector,
+    a live request triggers a probe for a stale target; that probe's
+    completion writes a `providerPerformance` row attributable to the
+    probe target.
+  - Live request itself is unaffected.
+
+`registerSpy` from `test/test-utils.ts` is used in lieu of raw `vi.spyOn`.
+Singletons (`BackgroundExplorer`) expose `resetForTesting()` and are reset
+in `beforeEach`.
+
+---
+
+## Rollout / defaults
+
+- `backgroundExploration.enabled` defaults to `false`. Existing deployments
+  see zero behaviour change until they opt in.
+- Defaults when enabled: `stalenessThresholdMs = 600_000` (10 min),
+  `workerConcurrency = 2`.
+
+---
+
+## Out of scope (future)
+
+- Per-alias `backgroundExploration` overrides.
+- Budget-bounded exploration (cost / count caps per hour or day).
+- `isProbe` boolean column on `requestUsage` / `providerPerformance` for
+  cleaner dashboard filtering.
+- Versioned probe-shape invalidation in `providerPerformance` (only matters
+  when `PROBE_SHAPE_VERSION` increments).
+- Per-target probe-shape variants (e.g. larger context for long-context
+  models).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -232,7 +232,34 @@ If no groups are explicitly configured, all targets live in a single `default` g
 | `usage` | Routes to provider with least recent usage (last 24 hours) |
 | `e2e_performance` | Routes to highest end-to-end throughput (output tokens / total request time) |
 
+#### Inline Exploration (default)
+
 Use `performanceExplorationRate` (default 0.05) to occasionally explore other targets and prevent locking onto one provider. Applies to `performance`, `latency`, and `e2e_performance` selectors. `latencyExplorationRate` and `e2ePerformanceExplorationRate` can be set separately for their respective selectors (each defaults to `performanceExplorationRate` if not specified). Unlike `performance`, the `e2e_performance` selector explores across all candidates including the current best, ensuring end-to-end metrics stay fresh for every provider.
+
+Inline exploration occurs on the live request path: a small fraction of incoming requests are intentionally routed to non-optimal targets so their performance data stays fresh. The trade-off is that those specific requests may be slower than necessary.
+
+#### Background Exploration
+
+To keep performance data fresh **without** ever diverting live requests, enable `backgroundExploration` instead. When enabled, the inline exploration above is suppressed for the three perf-based selectors, and Plexus instead fires small representative probe requests in the background against stale targets.
+
+```yaml
+backgroundExploration:
+  enabled: true                  # default: false
+  stalenessThresholdSeconds: 600 # default: 600 (10 minutes), minimum: 1
+  workerConcurrency: 2           # default: 2, range: 1–16
+```
+
+How it works:
+
+- Each live request to an alias whose selector is `latency`, `performance`, or `e2e_performance` checks the targets in its active group. Any target whose last probe is older than `stalenessThresholdSeconds` is enqueued for a background probe.
+- The live request itself is **never** redirected or delayed — it is served by the selector's best choice.
+- A worker pool (`workerConcurrency`) drains the queue. Per-target in-flight guards and the global cooldown manager prevent duplicate or unhealthy probes.
+- Each probe is a single canonical chat request (moderate input, two tool definitions, `max_tokens: 1000`, streaming). It exercises the same transformer + provider path as live traffic, so TTFT / TPS / E2E TPS are measured identically.
+- Probes route via `direct/<provider>/<target_model>` so they bypass alias resolution and failover, hitting exactly one target.
+- Probes appear in usage records with `apiKey = "probe"` and `attribution = "background"` (or `"manual"` for probes triggered from the management test endpoint). They are real requests and do consume provider quota / cost; budgets and rate caps are out of scope in v1.
+- On cold start, each target's `lastProbedAt` is initialised to the process start time — the first probe for a target fires at normal cadence once `stalenessThresholdSeconds` elapses, not eagerly on the first request.
+
+The inline `performanceExplorationRate` / `latencyExplorationRate` / `e2ePerformanceExplorationRate` settings are preserved and continue to take effect when `backgroundExploration.enabled` is `false` (the default). All four settings can be edited from the **Config** page in the admin UI.
 
 ### Priority Modes
 

--- a/docs/openapi/paths/v0_management_test.yaml
+++ b/docs/openapi/paths/v0_management_test.yaml
@@ -3,14 +3,15 @@ post:
     - Management — Test
   summary: Synthetic test inference (admin only)
   description: |
-    Runs a short inference request directly against a (provider, model)
+    Runs a canonical probe request directly against a (provider, model)
     pair, bypassing alias resolution.
 
     ## Use case
 
     Used by the admin UI's "test" button next to each alias target. Allows
     testing a specific provider/model combination without going through
-    the normal routing pipeline.
+    the normal routing pipeline. Internally shares the same probe machinery
+    as background exploration.
 
     ## Direct bypass
 
@@ -20,18 +21,28 @@ post:
     - No retries, cooldowns, or quota checks applied
     - Short timeout (typically 30s)
 
+    ## Usage record attribution
+
+    Test requests appear in usage records with `apiKey = "probe"` and
+    `attribution = "manual"` (background exploration probes use
+    `attribution = "background"`). They are real requests that count
+    against provider quota.
+
     ## Response
 
-    Returns 200 even on failure (`success: false`). This is intentional —
-    the UI needs to render error messages from failed tests, not treat them
-    as HTTP errors.
+    Returns 200 with `success: false` for runtime errors (failed dispatch,
+    upstream errors). The UI needs to render error messages without
+    treating them as HTTP errors. Validation errors (missing fields,
+    unknown `apiType`, unsupported `transcriptions`) return 400.
 
     ## Request fields
 
     - `provider` — Provider slug (e.g. `openai`, `anthropic`)
     - `model` — Model name (e.g. `gpt-4o`, `claude-3-opus`)
     - `apiType` — API type (default: `chat`). Options: `chat`, `messages`,
-      `gemini`, `responses`, `embeddings`, `images`, `speech`, `oauth`
+      `gemini`, `responses`, `embeddings`, `images`, `speech`, `oauth`.
+      The `transcriptions` API requires a file upload and is not supported
+      by this endpoint.
 
     **Admin only** — limited principals receive 403.
   security:
@@ -103,6 +114,9 @@ post:
                 durationMs: 567
                 apiType: chat
                 error: "401 Unauthorized - invalid API key"
+    '400':
+      description: Validation error — missing required fields, unknown
+        `apiType`, or unsupported `transcriptions` apiType.
     '401':
       description: Authentication required or invalid credentials.
   operationId: postV0ManagementTest

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -658,6 +658,12 @@ const VisionFallthroughConfigSchema = z.object({
   default_prompt: z.string().default(DEFAULT_VISION_DESCRIPTION_PROMPT),
 });
 
+const BackgroundExplorationConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  stalenessThresholdSeconds: z.number().int().min(1).default(600),
+  workerConcurrency: z.number().int().min(1).max(16).default(2),
+});
+
 const RawPlexusConfigSchema = z
   .object({
     providers: z.record(z.string(), ProviderConfigSchema),
@@ -669,6 +675,7 @@ const RawPlexusConfigSchema = z
     performanceExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
     latencyExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
     e2ePerformanceExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
+    backgroundExploration: BackgroundExplorationConfigSchema.optional(),
     mcp_servers: z.record(z.string(), McpServerConfigSchema).optional(),
     user_quotas: z.record(z.string(), QuotaDefinitionSchema).optional(),
   })
@@ -676,6 +683,7 @@ const RawPlexusConfigSchema = z
 
 export type FailoverPolicy = z.infer<typeof FailoverPolicySchema>;
 export type CooldownPolicy = z.infer<typeof CooldownPolicySchema>;
+export type BackgroundExplorationConfig = z.infer<typeof BackgroundExplorationConfigSchema>;
 export type PlexusConfig = z.infer<typeof RawPlexusConfigSchema> & {
   failover: FailoverPolicy;
   cooldown?: CooldownPolicy;

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -18,6 +18,7 @@ import type {
   McpServerConfig,
   FailoverPolicy,
   CooldownPolicy,
+  BackgroundExplorationConfig,
   MetadataOverrides,
 } from '../config';
 import { resolveGpuParams } from '@plexus/shared';
@@ -1204,6 +1205,19 @@ export class ConfigRepository {
     const initialMinutes = await this.getSetting<number>('cooldown.initialMinutes', 2);
     const maxMinutes = await this.getSetting<number>('cooldown.maxMinutes', 300);
     return { initialMinutes, maxMinutes };
+  }
+
+  async getBackgroundExplorationConfig(): Promise<BackgroundExplorationConfig> {
+    const enabled = await this.getSetting<boolean>('backgroundExploration.enabled', false);
+    const stalenessThresholdSeconds = await this.getSetting<number>(
+      'backgroundExploration.stalenessThresholdSeconds',
+      600
+    );
+    const workerConcurrency = await this.getSetting<number>(
+      'backgroundExploration.workerConcurrency',
+      2
+    );
+    return { enabled, stalenessThresholdSeconds, workerConcurrency };
   }
 
   // ─── OAuth Credentials ──────────────────────────────────────────

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -49,6 +49,8 @@ import { getConfig } from './config';
 import { ConfigService } from './services/config-service';
 import { Dispatcher } from './services/dispatcher';
 import { UsageStorageService } from './services/usage-storage';
+import { ProbeService } from './services/probe-service';
+import { BackgroundExplorer } from './services/background-explorer';
 import { CooldownManager } from './services/cooldown-manager';
 import { DebugManager } from './services/debug-manager';
 import { PricingManager } from './services/pricing-manager';
@@ -128,6 +130,13 @@ const quotaScheduler = QuotaScheduler.getInstance();
 dispatcher.setUsageStorage(usageStorage);
 DebugManager.getInstance().setStorage(usageStorage);
 SelectorFactory.setUsageStorage(usageStorage);
+
+// ProbeService is shared between the management test endpoint and the
+// background explorer. BackgroundExplorer is created here so router
+// triggers can pick it up via getInstance() once routes start handling
+// traffic.
+const probeService = new ProbeService(dispatcher, usageStorage);
+BackgroundExplorer.initialize(probeService);
 
 // Enable debug mode if DEBUG=true environment variable is set
 if (process.env.DEBUG === 'true') {
@@ -272,6 +281,7 @@ await registerManagementRoutes(
   fastify,
   usageStorage,
   dispatcher,
+  probeService,
   quotaScheduler,
   mcpUsageStorage,
   quotaEnforcer

--- a/packages/backend/src/routes/management.ts
+++ b/packages/backend/src/routes/management.ts
@@ -22,6 +22,7 @@ import { authenticate, requireAdmin, ManagementAuthError } from './management/_p
 import { registerModelRoutes } from './management/models';
 import { registerBackupRoutes } from './management/backup';
 import { Dispatcher } from '../services/dispatcher';
+import { ProbeService } from '../services/probe-service';
 import { QuotaScheduler } from '../services/quota/quota-scheduler';
 import { QuotaEnforcer } from '../services/quota/quota-enforcer';
 import { McpUsageStorageService } from '../services/mcp-proxy/mcp-usage-storage';
@@ -30,6 +31,7 @@ export async function registerManagementRoutes(
   fastify: FastifyInstance,
   usageStorage: UsageStorageService,
   dispatcher: Dispatcher,
+  probeService: ProbeService,
   quotaScheduler?: QuotaScheduler,
   mcpUsageStorage?: McpUsageStorageService,
   quotaEnforcer?: QuotaEnforcer
@@ -94,7 +96,7 @@ export async function registerManagementRoutes(
 
       await registerConfigRoutes(adminOnly, usageStorage);
       await registerSystemLogRoutes(adminOnly);
-      await registerTestRoutes(adminOnly, dispatcher, usageStorage);
+      await registerTestRoutes(adminOnly, probeService);
       await registerOAuthRoutes(adminOnly);
       await registerLoggingRoutes(adminOnly);
       await registerRestartRoutes(adminOnly);

--- a/packages/backend/src/routes/management/__tests__/admin-auth.test.ts
+++ b/packages/backend/src/routes/management/__tests__/admin-auth.test.ts
@@ -5,6 +5,7 @@ import { registerManagementRoutes } from '../../management';
 import { registerInferenceRoutes } from '../../inference';
 import { Dispatcher } from '../../../services/dispatcher';
 import { UsageStorageService } from '../../../services/usage-storage';
+import { ProbeService } from '../../../services/probe-service';
 import { DebugManager } from '../../../services/debug-manager';
 import { SelectorFactory } from '../../../services/selectors/factory';
 
@@ -71,7 +72,16 @@ function makeMockDeps() {
     })),
   } as unknown as Dispatcher;
 
-  return { mockUsageStorage, mockDispatcher };
+  const mockProbeService = {
+    runProbe: vi.fn(async () => ({
+      success: true,
+      durationMs: 0,
+      apiType: 'chat' as const,
+      response: 'ok',
+    })),
+  } as unknown as ProbeService;
+
+  return { mockUsageStorage, mockDispatcher, mockProbeService };
 }
 
 // ---------------------------------------------------------------------------
@@ -85,8 +95,8 @@ describe('GET /v0/management/auth/verify', () => {
     process.env.ADMIN_KEY = 'correct-admin-key';
     setConfigForTesting(BASE_CONFIG);
     fastify = Fastify();
-    const { mockUsageStorage, mockDispatcher } = makeMockDeps();
-    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher);
+    const { mockUsageStorage, mockDispatcher, mockProbeService } = makeMockDeps();
+    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher, mockProbeService);
     await fastify.ready();
   });
 
@@ -182,8 +192,8 @@ describe('Management route protection', () => {
     process.env.ADMIN_KEY = 'correct-admin-key';
     setConfigForTesting(BASE_CONFIG);
     fastify = Fastify();
-    const { mockUsageStorage, mockDispatcher } = makeMockDeps();
-    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher);
+    const { mockUsageStorage, mockDispatcher, mockProbeService } = makeMockDeps();
+    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher, mockProbeService);
     await fastify.ready();
   });
 
@@ -251,8 +261,8 @@ describe('Admin key env var change', () => {
     process.env.ADMIN_KEY = 'original-key';
     setConfigForTesting(BASE_CONFIG);
     fastify = Fastify();
-    const { mockUsageStorage, mockDispatcher } = makeMockDeps();
-    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher);
+    const { mockUsageStorage, mockDispatcher, mockProbeService } = makeMockDeps();
+    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher, mockProbeService);
     await fastify.ready();
   });
 
@@ -299,13 +309,13 @@ describe('v1 inference routes are unaffected by admin key auth', () => {
     process.env.ADMIN_KEY = 'correct-admin-key';
     setConfigForTesting(BASE_CONFIG);
     fastify = Fastify();
-    const { mockUsageStorage, mockDispatcher } = makeMockDeps();
+    const { mockUsageStorage, mockDispatcher, mockProbeService } = makeMockDeps();
 
     DebugManager.getInstance().setStorage(mockUsageStorage);
     SelectorFactory.setUsageStorage(mockUsageStorage);
 
     await registerInferenceRoutes(fastify, mockDispatcher, mockUsageStorage);
-    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher);
+    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher, mockProbeService);
     await fastify.ready();
   });
 

--- a/packages/backend/src/routes/management/__tests__/test-route.test.ts
+++ b/packages/backend/src/routes/management/__tests__/test-route.test.ts
@@ -4,6 +4,7 @@ import { setConfigForTesting } from '../../../config';
 import { registerManagementRoutes } from '../../management';
 import { Dispatcher } from '../../../services/dispatcher';
 import { UsageStorageService } from '../../../services/usage-storage';
+import { ProbeService } from '../../../services/probe-service';
 
 const TEST_CONFIG = {
   providers: {},
@@ -93,6 +94,7 @@ describe('POST /v0/management/test', () => {
   let fastify: FastifyInstance;
   let mockUsageStorage: UsageStorageService;
   let mockDispatcher: Dispatcher;
+  let probeService: ProbeService;
 
   beforeEach(async () => {
     process.env.ADMIN_KEY = 'test-admin-key';
@@ -101,7 +103,8 @@ describe('POST /v0/management/test', () => {
     const deps = makeMockDeps();
     mockUsageStorage = deps.mockUsageStorage;
     mockDispatcher = deps.mockDispatcher;
-    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher);
+    probeService = new ProbeService(mockDispatcher, mockUsageStorage);
+    await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher, probeService);
     await fastify.ready();
   });
 
@@ -172,7 +175,7 @@ describe('POST /v0/management/test', () => {
     expect(body.error).toContain('Invalid API type');
   });
 
-  it('returns error for transcriptions apiType (not supported in test endpoint)', async () => {
+  it('returns 400 for transcriptions apiType (not supported in test endpoint)', async () => {
     const res = await fastify.inject({
       method: 'POST',
       url: '/v0/management/test',
@@ -180,11 +183,10 @@ describe('POST /v0/management/test', () => {
       payload: { provider: 'openai', model: 'whisper-1', apiType: 'transcriptions' },
     });
 
-    // transcriptions is not in TEST_TEMPLATES, so the request fails
+    expect(res.statusCode).toBe(400);
     const body = res.json();
     expect(body.success).toBe(false);
-    // The route returns 200 even on error
-    expect(res.statusCode).toBe(200);
+    expect(body.error).toMatch(/transcriptions/i);
   });
 
   it('emits started event when a test request begins', async () => {

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -530,6 +530,59 @@ export async function registerConfigRoutes(
     }
   });
 
+  // ─── Background Exploration ──────────────────────────────────────
+
+  fastify.get('/v0/management/config/background-exploration', async (_request, reply) => {
+    try {
+      const cfg = await configService.getRepository().getBackgroundExplorationConfig();
+      return reply.send(cfg);
+    } catch (e: any) {
+      logger.error('Failed to read background-exploration config', e);
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  fastify.patch('/v0/management/config/background-exploration', async (request, reply) => {
+    const body = request.body as Record<string, unknown> | null;
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return reply.code(400).send({ error: 'Object body is required' });
+    }
+
+    try {
+      if (body.enabled !== undefined) {
+        if (typeof body.enabled !== 'boolean') {
+          return reply.code(400).send({ error: 'enabled must be a boolean' });
+        }
+        await configService.setSetting('backgroundExploration.enabled', body.enabled);
+      }
+      if (body.stalenessThresholdSeconds !== undefined) {
+        const val = Number(body.stalenessThresholdSeconds);
+        if (!Number.isFinite(val) || !Number.isInteger(val) || val < 1) {
+          return reply
+            .code(400)
+            .send({ error: 'stalenessThresholdSeconds must be an integer >= 1' });
+        }
+        await configService.setSetting('backgroundExploration.stalenessThresholdSeconds', val);
+      }
+      if (body.workerConcurrency !== undefined) {
+        const val = Number(body.workerConcurrency);
+        if (!Number.isFinite(val) || !Number.isInteger(val) || val < 1 || val > 16) {
+          return reply
+            .code(400)
+            .send({ error: 'workerConcurrency must be an integer between 1 and 16' });
+        }
+        await configService.setSetting('backgroundExploration.workerConcurrency', val);
+      }
+
+      const updated = await configService.getRepository().getBackgroundExplorationConfig();
+      logger.debug('Background exploration config updated via API');
+      return reply.send(updated);
+    } catch (e: any) {
+      logger.error('Failed to patch background-exploration config', e);
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
   // ─── Vision Fallthrough ───────────────────────────────────────────
 
   fastify.get('/v0/management/config/vision-fallthrough', async (_request, reply) => {

--- a/packages/backend/src/routes/management/test.ts
+++ b/packages/backend/src/routes/management/test.ts
@@ -1,410 +1,76 @@
 import { FastifyInstance } from 'fastify';
 import { logger } from '../../utils/logger';
-import { Dispatcher } from '../../services/dispatcher';
-import { UsageStorageService } from '../../services/usage-storage';
-import { UsageRecord } from '../../types/usage';
+import { ProbeService, ProbeApiType } from '../../services/probe-service';
 import { getClientIp } from '../../utils/ip';
-import { calculateCosts } from '../../utils/calculate-costs';
-import { DebugManager } from '../../services/debug-manager';
-import {
-  OpenAITransformer,
-  AnthropicTransformer,
-  GeminiTransformer,
-  ResponsesTransformer,
-  EmbeddingsTransformer,
-  ImageTransformer,
-  SpeechTransformer,
-} from '../../transformers';
 
-/**
- * Test request templates for each API type
- */
-const TEST_SYSTEM_PROMPT = 'You are a helpful assistant.';
-const TEST_USER_PROMPT = 'Just respond with the word acknowledged';
+const VALID_API_TYPES: ProbeApiType[] = [
+  'chat',
+  'messages',
+  'gemini',
+  'responses',
+  'embeddings',
+  'images',
+  'speech',
+  'oauth',
+];
 
-const TEST_TEMPLATES = {
-  chat: (modelPath: string) => ({
-    model: modelPath,
-    stream: false,
-    messages: [
-      {
-        role: 'system',
-        content: TEST_SYSTEM_PROMPT,
-      },
-      {
-        role: 'user',
-        content: TEST_USER_PROMPT,
-      },
-    ],
-  }),
-
-  messages: (modelPath: string) => ({
-    model: modelPath,
-    stream: false,
-    max_tokens: 100,
-    system: TEST_SYSTEM_PROMPT,
-    messages: [{ role: 'user', content: TEST_USER_PROMPT }],
-  }),
-
-  gemini: (modelPath: string) => ({
-    model: modelPath,
-    contents: [
-      {
-        role: 'user',
-        parts: [{ text: TEST_USER_PROMPT }],
-      },
-    ],
-    system_instruction: {
-      parts: [{ text: TEST_SYSTEM_PROMPT }],
-    },
-    generationConfig: {
-      maxOutputTokens: 100,
-    },
-  }),
-
-  responses: (modelPath: string) => ({
-    model: modelPath,
-    input: TEST_USER_PROMPT,
-    instructions: TEST_SYSTEM_PROMPT,
-  }),
-
-  embeddings: (modelPath: string) => ({
-    model: modelPath,
-    input: ['Hello world'],
-  }),
-
-  images: (modelPath: string) => ({
-    model: modelPath,
-    prompt: 'A tiny 256x256 red square',
-    n: 1,
-    size: '256x256',
-  }),
-
-  speech: (modelPath: string) => ({
-    model: modelPath,
-    input: 'Hello world',
-  }),
-
-  oauth: (_modelPath: string) => ({
-    context: {
-      systemPrompt: TEST_SYSTEM_PROMPT,
-      messages: [
-        {
-          role: 'user',
-          content: TEST_USER_PROMPT,
-          timestamp: Date.now(),
-        },
-      ],
-    },
-    options: {
-      maxTokens: 100,
-    },
-  }),
-};
-
-export async function registerTestRoutes(
-  fastify: FastifyInstance,
-  dispatcher: Dispatcher,
-  usageStorage: UsageStorageService
-) {
+export async function registerTestRoutes(fastify: FastifyInstance, probeService: ProbeService) {
   /**
    * POST /v0/management/test
-   * Test a specific provider/model combination with a simple request
+   * Test a specific provider/model combination with a canonical probe
+   * request. Delegates to ProbeService.runProbe with source='manual'.
    */
   fastify.post('/v0/management/test', async (request, reply) => {
-    const requestId = crypto.randomUUID();
-    const startTime = Date.now();
+    const body = request.body as { provider: string; model: string; apiType?: string };
 
-    let usageRecord: Partial<UsageRecord> = {
-      requestId,
-      date: new Date().toISOString(),
-      sourceIp: getClientIp(request),
-      incomingApiType: 'chat',
-      startTime,
-      isStreamed: false,
-      responseStatus: 'pending',
-      incomingModelAlias: 'test-request',
-    };
-
-    // Emit 'started' event immediately
-    usageStorage.emitStartedAsync(usageRecord);
-
-    try {
-      const body = request.body as { provider: string; model: string; apiType?: string };
-
-      logger.debug('Test endpoint called with body:', body);
-
-      if (!body.provider || !body.model) {
-        return reply.code(400).send({
-          success: false,
-          error: 'Both provider and model are required',
-        });
-      }
-
-      // Default to 'chat' if no apiType specified
-      const apiType = body.apiType || 'chat';
-
-      usageRecord.incomingApiType = apiType;
-      usageRecord.incomingModelAlias = `direct/${body.provider}/${body.model}`;
-      usageRecord.apiKey = (request as any).keyName;
-
-      logger.debug(`Testing model: ${body.provider}/${body.model} via ${apiType} API`);
-
-      // Validate API type
-      if (
-        ![
-          'chat',
-          'messages',
-          'gemini',
-          'responses',
-          'embeddings',
-          'images',
-          'transcriptions',
-          'speech',
-          'oauth',
-        ].includes(apiType)
-      ) {
-        return reply.code(400).send({
-          success: false,
-          error: `Invalid API type: ${apiType}. Must be one of: chat, messages, gemini, responses, embeddings, images, transcriptions, speech, oauth`,
-        });
-      }
-
-      // Create a simple test request using the appropriate format
-      // Use direct/provider/model format for direct routing (bypasses alias resolution)
-      const directModelPath = `direct/${body.provider}/${body.model}`;
-      logger.debug(`Direct model path: ${directModelPath}`);
-
-      const testRequest = TEST_TEMPLATES[apiType as keyof typeof TEST_TEMPLATES](directModelPath);
-
-      logger.debug('Creating transformer...');
-      let dispatchMethod: 'dispatch' | 'dispatchEmbeddings' | 'dispatchImageGenerations' =
-        'dispatch';
-      let imageRequestData: {
-        model: string;
-        prompt: string;
-        n?: number;
-        size?: string;
-        response_format?: 'url' | 'b64_json';
-        quality?: string;
-        style?: string;
-        user?: string;
-      } | null = null;
-      switch (apiType) {
-        case 'chat':
-        case 'messages':
-        case 'gemini':
-        case 'responses':
-        case 'speech':
-          // These use the standard dispatch path with transformers
-          break;
-        case 'embeddings':
-          dispatchMethod = 'dispatchEmbeddings';
-          break;
-        case 'images':
-          dispatchMethod = 'dispatchImageGenerations';
-          const imgReq = testRequest as {
-            model: string;
-            prompt: string;
-            n?: number;
-            size?: string;
-            quality?: string;
-            style?: string;
-            user?: string;
-          };
-          imageRequestData = {
-            model: imgReq.model,
-            prompt: imgReq.prompt,
-            n: imgReq.n,
-            size: imgReq.size,
-            response_format: 'url' as const,
-            quality: imgReq.quality,
-            style: imgReq.style,
-            user: imgReq.user,
-          };
-          break;
-        default:
-          break;
-      }
-
-      logger.debug('Dispatching request...');
-      let response;
-
-      if (apiType === 'transcriptions') {
-        return reply.code(400).send({
-          success: false,
-          error:
-            'Cannot test transcriptions API via test endpoint - requires file upload. Use the actual /v1/audio/transcriptions endpoint to test.',
-        });
-      }
-
-      if (apiType === 'oauth') {
-        const { context, options } = testRequest as {
-          context: { systemPrompt?: string; messages: Array<{ role: string; content: any }> };
-          options?: Record<string, any>;
-        };
-
-        const unifiedRequest = {
-          model: directModelPath,
-          messages: [
-            ...(context.systemPrompt ? [{ role: 'system', content: context.systemPrompt }] : []),
-            ...context.messages.map((message) => ({
-              role: message.role as any,
-              content: message.content,
-            })),
-          ],
-          incomingApiType: 'oauth',
-          originalBody: { context, options },
-        };
-
-        response = await dispatcher.dispatch(unifiedRequest);
-      } else if (dispatchMethod === 'dispatchEmbeddings') {
-        response = await dispatcher.dispatchEmbeddings({
-          model: directModelPath,
-          originalBody: testRequest,
-          requestId,
-          incomingApiType: 'embeddings',
-        });
-      } else if (dispatchMethod === 'dispatchImageGenerations' && imageRequestData) {
-        response = await dispatcher.dispatchImageGenerations({
-          ...imageRequestData,
-          originalBody: testRequest,
-          requestId,
-          incomingApiType: 'images',
-        });
-      } else if (apiType === 'speech') {
-        const { SpeechTransformer } = await import('../../transformers/speech');
-        const transformer = new SpeechTransformer();
-        const unifiedRequest = await transformer.parseRequest(testRequest);
-        unifiedRequest.incomingApiType = 'speech';
-        unifiedRequest.originalBody = testRequest;
-        unifiedRequest.requestId = requestId;
-        response = await dispatcher.dispatchSpeech(unifiedRequest);
-      } else {
-        // chat, messages, gemini, responses all use transformers with parseRequest
-        let transformer;
-        switch (apiType) {
-          case 'chat':
-            transformer = new OpenAITransformer();
-            break;
-          case 'messages':
-            transformer = new AnthropicTransformer();
-            break;
-          case 'gemini':
-            transformer = new GeminiTransformer();
-            break;
-          case 'responses':
-            transformer = new ResponsesTransformer();
-            break;
-          default:
-            transformer = new OpenAITransformer();
-        }
-        const unifiedRequest = await transformer.parseRequest(testRequest);
-        unifiedRequest.incomingApiType = apiType;
-        unifiedRequest.originalBody = testRequest;
-        unifiedRequest.requestId = requestId;
-        response = await dispatcher.dispatch(unifiedRequest);
-      }
-
-      const durationMs = Date.now() - startTime;
-
-      // Update usage record with routing details from response
-      usageRecord.provider = response.plexus?.provider;
-      usageRecord.selectedModelName = response.plexus?.model;
-      usageRecord.canonicalModelName = response.plexus?.canonicalModel;
-      usageRecord.outgoingApiType = response.plexus?.apiType;
-      usageRecord.durationMs = durationMs;
-      usageRecord.responseStatus = 'success';
-      usageRecord.isPassthrough =
-        apiType !== 'chat' &&
-        apiType !== 'messages' &&
-        apiType !== 'gemini' &&
-        apiType !== 'responses';
-      usageRecord.attemptCount = response.plexus?.attemptCount || 1;
-      usageRecord.retryHistory = response.plexus?.retryHistory || null;
-      usageRecord.finalAttemptProvider =
-        response.plexus?.finalAttemptProvider || usageRecord.provider || null;
-      usageRecord.finalAttemptModel =
-        response.plexus?.finalAttemptModel || usageRecord.selectedModelName || null;
-      usageRecord.allAttemptedProviders = response.plexus?.allAttemptedProviders || null;
-
-      // Capture token usage if available
-      if (response.usage) {
-        usageRecord.tokensInput = response.usage.input_tokens;
-        usageRecord.tokensOutput = response.usage.output_tokens;
-        usageRecord.tokensCached = response.usage.cached_tokens;
-        usageRecord.tokensCacheWrite = response.usage.cache_creation_tokens;
-        usageRecord.tokensReasoning = response.usage.reasoning_tokens;
-      }
-
-      const pricing = response.plexus?.pricing;
-      const providerDiscount = response.plexus?.providerDiscount;
-      calculateCosts(usageRecord, pricing, providerDiscount);
-
-      // Emit 'updated' event with routing details
-      usageStorage.emitUpdatedAsync({
-        requestId,
-        provider: usageRecord.provider,
-        selectedModelName: usageRecord.selectedModelName,
-        canonicalModelName: usageRecord.canonicalModelName,
-      });
-
-      // Save usage record
-      usageStorage.saveRequest(usageRecord as UsageRecord);
-
-      logger.debug(`Test completed in ${durationMs}ms`);
-
-      // Extract response text based on API type
-      let responseText: string;
-      if (apiType === 'images') {
-        responseText =
-          response.data && Array.isArray(response.data)
-            ? `Success (${response.data.length} image${response.data.length > 1 ? 's' : ''} created)`
-            : 'Success';
-      } else if (apiType === 'embeddings') {
-        responseText =
-          response.data && Array.isArray(response.data)
-            ? `Success (${response.data.length} embedding${response.data.length > 1 ? 's' : ''})`
-            : 'Success';
-      } else {
-        responseText = response.content
-          ? typeof response.content === 'string'
-            ? response.content.substring(0, 100)
-            : 'Success'
-          : 'Success';
-      }
-
-      return reply.code(200).send({
-        success: true,
-        durationMs,
-        apiType,
-        response: responseText,
-      });
-    } catch (e: any) {
-      const durationMs = Date.now() - startTime;
-      logger.error('Error testing model:', e);
-      logger.error('Error stack:', e.stack);
-
-      usageRecord.responseStatus = 'error';
-      usageRecord.durationMs = durationMs;
-      usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
-      usageRecord.retryHistory = e.routingContext?.retryHistory || usageRecord.retryHistory || null;
-      usageStorage.saveRequest(usageRecord as UsageRecord);
-
-      const errorDetails = {
-        apiType: (request.body as any)?.apiType || 'chat',
-        ...(e.routingContext || {}),
-      };
-      usageStorage.saveError(requestId, e, errorDetails);
-
-      DebugManager.getInstance().flush(requestId);
-
-      return reply.code(200).send({
+    if (!body.provider || !body.model) {
+      return reply.code(400).send({
         success: false,
-        error: e.message || 'Unknown error',
-        durationMs,
-        apiType: (request.body as any)?.apiType || 'chat',
+        error: 'Both provider and model are required',
       });
     }
+
+    const apiType = (body.apiType || 'chat') as ProbeApiType;
+
+    if (apiType === ('transcriptions' as ProbeApiType)) {
+      return reply.code(400).send({
+        success: false,
+        error:
+          'Cannot test transcriptions API via test endpoint - requires file upload. Use the actual /v1/audio/transcriptions endpoint to test.',
+      });
+    }
+
+    if (!VALID_API_TYPES.includes(apiType)) {
+      return reply.code(400).send({
+        success: false,
+        error: `Invalid API type: ${apiType}. Must be one of: ${VALID_API_TYPES.join(', ')}`,
+      });
+    }
+
+    logger.debug(`Test endpoint: probing ${body.provider}/${body.model} via ${apiType}`);
+
+    const result = await probeService.runProbe({
+      provider: body.provider,
+      model: body.model,
+      apiType,
+      source: 'manual',
+      sourceIp: getClientIp(request),
+    });
+
+    if (result.success) {
+      return reply.code(200).send({
+        success: true,
+        durationMs: result.durationMs,
+        apiType: result.apiType,
+        response: result.response,
+      });
+    }
+
+    return reply.code(200).send({
+      success: false,
+      error: result.error || 'Unknown error',
+      durationMs: result.durationMs,
+      apiType: result.apiType,
+    });
   });
 }

--- a/packages/backend/src/services/__tests__/background-explorer.test.ts
+++ b/packages/backend/src/services/__tests__/background-explorer.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { BackgroundExplorer } from '../background-explorer';
+import { ProbeService } from '../probe-service';
+import { CooldownManager } from '../cooldown-manager';
+import { setConfigForTesting, ModelTargetGroup } from '../../config';
+
+function makeGroup(
+  selector: ModelTargetGroup['selector'],
+  targets: Array<{ provider: string; model: string; enabled?: boolean }>
+): ModelTargetGroup {
+  return {
+    name: 'g',
+    selector,
+    targets,
+  } as ModelTargetGroup;
+}
+
+function makeProbeService() {
+  return {
+    runProbe: vi.fn(async () => ({
+      success: true,
+      durationMs: 5,
+      apiType: 'chat' as const,
+      response: 'ok',
+    })),
+  } as unknown as ProbeService;
+}
+
+function setBaseConfig(opts: {
+  enabled: boolean;
+  stalenessThresholdSeconds?: number;
+  workerConcurrency?: number;
+  providers?: Record<string, { enabled?: boolean }>;
+}) {
+  setConfigForTesting({
+    providers: (opts.providers ?? {
+      p1: { enabled: true },
+      p2: { enabled: true },
+    }) as any,
+    models: {},
+    keys: {},
+    failover: {
+      enabled: false,
+      retryableStatusCodes: [],
+      retryableErrors: [],
+    },
+    quotas: [],
+    backgroundExploration: {
+      enabled: opts.enabled,
+      stalenessThresholdSeconds: opts.stalenessThresholdSeconds ?? 1,
+      workerConcurrency: opts.workerConcurrency ?? 2,
+    },
+  } as any);
+}
+
+async function flushPromises(): Promise<void> {
+  // Drain microtasks several times to allow chained .then() handlers (cooldown
+  // check → enqueue → worker pump → probe → state update) to all run.
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('BackgroundExplorer', () => {
+  beforeEach(async () => {
+    BackgroundExplorer.resetForTesting();
+    CooldownManager.resetInstance();
+    await CooldownManager.getInstance().clearCooldown();
+  });
+
+  afterEach(async () => {
+    BackgroundExplorer.resetForTesting();
+    await CooldownManager.getInstance().clearCooldown();
+    CooldownManager.resetInstance();
+  });
+
+  test('maybeTrigger is a no-op when config is disabled', async () => {
+    setBaseConfig({ enabled: false });
+    const probe = makeProbeService();
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    explorer.maybeTrigger(makeGroup('latency', [{ provider: 'p1', model: 'm1' }]));
+    await flushPromises();
+
+    expect(probe.runProbe).not.toHaveBeenCalled();
+  });
+
+  test('maybeTrigger is a no-op for non-performance selectors', async () => {
+    setBaseConfig({ enabled: true });
+    const probe = makeProbeService();
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    explorer.maybeTrigger(makeGroup('random', [{ provider: 'p1', model: 'm1' }]));
+    explorer.maybeTrigger(makeGroup('cost', [{ provider: 'p1', model: 'm1' }]));
+    explorer.maybeTrigger(makeGroup('in_order', [{ provider: 'p1', model: 'm1' }]));
+    await flushPromises();
+
+    expect(probe.runProbe).not.toHaveBeenCalled();
+  });
+
+  test('does not probe within the staleness window after process start', async () => {
+    setBaseConfig({ enabled: true, stalenessThresholdSeconds: 1000 });
+    const probe = makeProbeService();
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    explorer.maybeTrigger(makeGroup('latency', [{ provider: 'p1', model: 'm1' }]));
+    await flushPromises();
+
+    expect(probe.runProbe).not.toHaveBeenCalled();
+  });
+
+  test('probes stale healthy targets', async () => {
+    setBaseConfig({ enabled: true, stalenessThresholdSeconds: 0 });
+    const probe = makeProbeService();
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    explorer.maybeTrigger(
+      makeGroup('performance', [
+        { provider: 'p1', model: 'm1' },
+        { provider: 'p2', model: 'm2' },
+      ])
+    );
+    await flushPromises();
+
+    expect(probe.runProbe).toHaveBeenCalledTimes(2);
+    const calls = (probe.runProbe as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: 'p1',
+          model: 'm1',
+          apiType: 'chat',
+          source: 'background',
+        }),
+        expect.objectContaining({
+          provider: 'p2',
+          model: 'm2',
+          apiType: 'chat',
+          source: 'background',
+        }),
+      ])
+    );
+  });
+
+  test('skips targets that are on cooldown', async () => {
+    setBaseConfig({ enabled: true, stalenessThresholdSeconds: 0 });
+    const probe = makeProbeService();
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    // Put p1 on cooldown
+    await CooldownManager.getInstance().markProviderFailure('p1', 'm1');
+
+    explorer.maybeTrigger(
+      makeGroup('latency', [
+        { provider: 'p1', model: 'm1' },
+        { provider: 'p2', model: 'm2' },
+      ])
+    );
+    await flushPromises();
+
+    const calls = (probe.runProbe as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ provider: 'p2', model: 'm2' });
+  });
+
+  test('skips disabled targets and disabled providers', async () => {
+    setBaseConfig({
+      enabled: true,
+      stalenessThresholdSeconds: 0,
+      providers: {
+        p1: { enabled: true },
+        p2: { enabled: false },
+      },
+    });
+    const probe = makeProbeService();
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    explorer.maybeTrigger(
+      makeGroup('latency', [
+        { provider: 'p1', model: 'm1', enabled: false },
+        { provider: 'p2', model: 'm2' },
+      ])
+    );
+    await flushPromises();
+
+    expect(probe.runProbe).not.toHaveBeenCalled();
+  });
+
+  test('does not re-probe a target whose probe is still in flight', async () => {
+    setBaseConfig({ enabled: true, stalenessThresholdSeconds: 0 });
+
+    let resolveProbe: () => void = () => {};
+    const probe = {
+      runProbe: vi.fn(
+        () =>
+          new Promise<any>((resolve) => {
+            resolveProbe = () =>
+              resolve({
+                success: true,
+                durationMs: 5,
+                apiType: 'chat',
+                response: 'ok',
+              });
+          })
+      ),
+    } as unknown as ProbeService;
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    const group = makeGroup('latency', [{ provider: 'p1', model: 'm1' }]);
+
+    explorer.maybeTrigger(group);
+    await flushPromises();
+    // Probe is in flight, second trigger must not enqueue another.
+    explorer.maybeTrigger(group);
+    await flushPromises();
+
+    expect(probe.runProbe).toHaveBeenCalledTimes(1);
+
+    resolveProbe();
+    await flushPromises();
+  });
+
+  test('updates lastProbedAt on both success and failure', async () => {
+    setBaseConfig({ enabled: true, stalenessThresholdSeconds: 1 });
+
+    const probe = {
+      runProbe: vi
+        .fn()
+        .mockResolvedValueOnce({
+          success: false,
+          durationMs: 5,
+          apiType: 'chat',
+          error: 'fail',
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          durationMs: 5,
+          apiType: 'chat',
+          response: 'ok',
+        }),
+    } as unknown as ProbeService;
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    const group = makeGroup('latency', [{ provider: 'p1', model: 'm1' }]);
+
+    // First trigger after staleness threshold elapses.
+    await new Promise((r) => setTimeout(r, 1100));
+    explorer.maybeTrigger(group);
+    await flushPromises();
+    expect(probe.runProbe).toHaveBeenCalledTimes(1);
+
+    // Immediately re-triggering should be skipped (lastProbedAt was just updated).
+    explorer.maybeTrigger(group);
+    await flushPromises();
+    expect(probe.runProbe).toHaveBeenCalledTimes(1);
+
+    // Wait past the staleness window again; next trigger should fire.
+    await new Promise((r) => setTimeout(r, 1100));
+    explorer.maybeTrigger(group);
+    await flushPromises();
+    expect(probe.runProbe).toHaveBeenCalledTimes(2);
+  }, 10_000);
+
+  test('thrown probe errors are swallowed and do not break the worker', async () => {
+    setBaseConfig({ enabled: true, stalenessThresholdSeconds: 0 });
+
+    const probe = {
+      runProbe: vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({
+        success: true,
+        durationMs: 5,
+        apiType: 'chat',
+        response: 'ok',
+      }),
+    } as unknown as ProbeService;
+    const explorer = BackgroundExplorer.initialize(probe);
+
+    explorer.maybeTrigger(
+      makeGroup('latency', [
+        { provider: 'p1', model: 'm1' },
+        { provider: 'p2', model: 'm2' },
+      ])
+    );
+    await flushPromises();
+
+    expect(probe.runProbe).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/services/__tests__/probe-service.test.ts
+++ b/packages/backend/src/services/__tests__/probe-service.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { ProbeService } from '../probe-service';
+import { Dispatcher } from '../dispatcher';
+import { UsageStorageService } from '../usage-storage';
+import { setConfigForTesting } from '../../config';
+
+function makeMocks() {
+  const usageStorage = {
+    saveRequest: vi.fn(async () => {}),
+    saveError: vi.fn(),
+    emitStartedAsync: vi.fn(),
+    emitUpdatedAsync: vi.fn(),
+  } as unknown as UsageStorageService;
+
+  const dispatcher = {
+    dispatch: vi.fn(async () => ({
+      id: 'r',
+      model: 'test-model',
+      created: Date.now(),
+      content: 'ok',
+      usage: { input_tokens: 12, output_tokens: 34, total_tokens: 46 },
+      plexus: {
+        provider: 'p1',
+        model: 'm1',
+        apiType: 'chat',
+        canonicalModel: 'm1',
+        attemptCount: 1,
+      },
+    })),
+    dispatchEmbeddings: vi.fn(),
+    dispatchImageGenerations: vi.fn(),
+    dispatchSpeech: vi.fn(),
+  } as unknown as Dispatcher;
+
+  return { usageStorage, dispatcher };
+}
+
+describe('ProbeService', () => {
+  beforeEach(() => {
+    setConfigForTesting({
+      providers: {},
+      models: {},
+      keys: {},
+      failover: {
+        enabled: false,
+        retryableStatusCodes: [],
+        retryableErrors: [],
+      },
+      quotas: [],
+    } as any);
+  });
+
+  test('runProbe builds direct/<provider>/<model> model string for chat', async () => {
+    const { usageStorage, dispatcher } = makeMocks();
+    const svc = new ProbeService(dispatcher, usageStorage);
+
+    await svc.runProbe({
+      provider: 'p1',
+      model: 'm1',
+      apiType: 'chat',
+      source: 'background',
+    });
+
+    expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
+    const unified = (dispatcher.dispatch as any).mock.calls[0][0];
+    expect(unified.model).toBe('direct/p1/m1');
+    expect(unified.incomingApiType).toBe('chat');
+  });
+
+  test('runProbe records apiKey="probe" and attribution from source', async () => {
+    const { usageStorage, dispatcher } = makeMocks();
+    const svc = new ProbeService(dispatcher, usageStorage);
+
+    await svc.runProbe({
+      provider: 'p1',
+      model: 'm1',
+      apiType: 'chat',
+      source: 'manual',
+    });
+
+    expect(usageStorage.emitStartedAsync).toHaveBeenCalled();
+    const started = (usageStorage.emitStartedAsync as any).mock.calls[0][0];
+    expect(started.apiKey).toBe('probe');
+    expect(started.attribution).toBe('manual');
+    expect(started.incomingModelAlias).toBe('direct/p1/m1');
+
+    const saved = (usageStorage.saveRequest as any).mock.calls[0][0];
+    expect(saved.apiKey).toBe('probe');
+    expect(saved.attribution).toBe('manual');
+  });
+
+  test('runProbe records attribution="background" for background source', async () => {
+    const { usageStorage, dispatcher } = makeMocks();
+    const svc = new ProbeService(dispatcher, usageStorage);
+
+    await svc.runProbe({
+      provider: 'p1',
+      model: 'm1',
+      apiType: 'chat',
+      source: 'background',
+    });
+
+    const saved = (usageStorage.saveRequest as any).mock.calls[0][0];
+    expect(saved.attribution).toBe('background');
+  });
+
+  test('runProbe returns success result on dispatch success', async () => {
+    const { usageStorage, dispatcher } = makeMocks();
+    const svc = new ProbeService(dispatcher, usageStorage);
+
+    const result = await svc.runProbe({
+      provider: 'p1',
+      model: 'm1',
+      apiType: 'chat',
+      source: 'background',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.apiType).toBe('chat');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('runProbe returns failure result and saves error on dispatch failure', async () => {
+    const { usageStorage, dispatcher } = makeMocks();
+    (dispatcher.dispatch as any).mockRejectedValueOnce(new Error('boom'));
+    const svc = new ProbeService(dispatcher, usageStorage);
+
+    const result = await svc.runProbe({
+      provider: 'p1',
+      model: 'm1',
+      apiType: 'chat',
+      source: 'background',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('boom');
+    expect(usageStorage.saveError).toHaveBeenCalled();
+    const saved = (usageStorage.saveRequest as any).mock.calls[0][0];
+    expect(saved.responseStatus).toBe('error');
+  });
+
+  test('runProbe rejects transcriptions apiType', async () => {
+    const { usageStorage, dispatcher } = makeMocks();
+    const svc = new ProbeService(dispatcher, usageStorage);
+
+    const result = await svc.runProbe({
+      provider: 'p1',
+      model: 'm1',
+      apiType: 'transcriptions' as any,
+      source: 'manual',
+    });
+
+    expect(result.success).toBe(false);
+    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/services/background-explorer.ts
+++ b/packages/backend/src/services/background-explorer.ts
@@ -1,0 +1,178 @@
+import { logger } from '../utils/logger';
+import { getConfig, ModelTargetGroup, SelectorType } from '../config';
+import { CooldownManager } from './cooldown-manager';
+import { ProbeService } from './probe-service';
+
+type TargetKey = `${string}:${string}`;
+
+interface TargetState {
+  lastProbedAt: number;
+  inFlight: boolean;
+}
+
+const PERFORMANCE_SELECTORS: SelectorType[] = ['latency', 'performance', 'e2e_performance'];
+
+/**
+ * BackgroundExplorer keeps performance data (TTFT / TPS / E2E TPS) fresh by
+ * firing representative synthetic probes at stale targets in the background,
+ * independently of live request routing.
+ *
+ * Triggered by maybeTrigger(group), which is called from the router after a
+ * target has been selected for a live request. The live request itself is
+ * never affected by exploration — probes run after the trigger returns.
+ */
+export class BackgroundExplorer {
+  private static instance: BackgroundExplorer | null = null;
+
+  private probeService: ProbeService;
+  private state = new Map<TargetKey, TargetState>();
+  private queue: Array<{ provider: string; model: string }> = [];
+  private activeWorkers = 0;
+  private readonly processStartTime = Date.now();
+
+  private constructor(probeService: ProbeService) {
+    this.probeService = probeService;
+  }
+
+  static initialize(probeService: ProbeService): BackgroundExplorer {
+    if (!BackgroundExplorer.instance) {
+      BackgroundExplorer.instance = new BackgroundExplorer(probeService);
+    }
+    return BackgroundExplorer.instance;
+  }
+
+  static getInstance(): BackgroundExplorer | null {
+    return BackgroundExplorer.instance;
+  }
+
+  static resetForTesting(): void {
+    BackgroundExplorer.instance = null;
+  }
+
+  /**
+   * Inspect a target group selected by the router. For each target whose
+   * `lastProbedAt` is older than the staleness threshold, that is healthy
+   * (not on cooldown), and that is not already in flight, enqueue a probe.
+   *
+   * Non-blocking. Returns immediately. Safe to call on every live request.
+   */
+  maybeTrigger(group: ModelTargetGroup): void {
+    const config = getConfig();
+    const bg = config.backgroundExploration;
+    if (!bg || bg.enabled !== true) {
+      return;
+    }
+
+    if (!PERFORMANCE_SELECTORS.includes(group.selector)) {
+      return;
+    }
+
+    const now = Date.now();
+    const thresholdMs = bg.stalenessThresholdSeconds * 1000;
+    const cooldownMgr = CooldownManager.getInstance();
+
+    // Snapshot of provider config so we can skip disabled providers/targets.
+    const providers = config.providers;
+
+    for (const target of group.targets) {
+      if (target.enabled === false) continue;
+      const providerCfg = providers[target.provider];
+      if (!providerCfg || providerCfg.enabled === false) continue;
+
+      const key = this.keyFor(target.provider, target.model);
+      let st = this.state.get(key);
+      if (!st) {
+        st = { lastProbedAt: this.processStartTime, inFlight: false };
+        this.state.set(key, st);
+      }
+
+      if (st.inFlight) continue;
+      if (now - st.lastProbedAt < thresholdMs) continue;
+
+      // Fire-and-forget cooldown check + enqueue. Cooldown lookup is async;
+      // we don't want to block the live-request path waiting on it. The
+      // worker re-checks cooldown right before probing as well.
+      const captured = st;
+      cooldownMgr
+        .isProviderHealthy(target.provider, target.model)
+        .then((healthy) => {
+          if (!healthy) return;
+          if (captured.inFlight) return;
+          // Re-check staleness in case another trigger raced us.
+          if (Date.now() - captured.lastProbedAt < thresholdMs) return;
+
+          this.queue.push({ provider: target.provider, model: target.model });
+          this.pumpWorkers();
+        })
+        .catch((err) => {
+          logger.debug(
+            `BackgroundExplorer: cooldown check failed for ${target.provider}/${target.model}: ${err?.message ?? err}`
+          );
+        });
+    }
+  }
+
+  private keyFor(provider: string, model: string): TargetKey {
+    return `${provider}:${model}` as TargetKey;
+  }
+
+  private pumpWorkers(): void {
+    const config = getConfig();
+    const bg = config.backgroundExploration;
+    if (!bg || bg.enabled !== true) return;
+    const concurrency = bg.workerConcurrency;
+
+    while (this.activeWorkers < concurrency && this.queue.length > 0) {
+      this.activeWorkers++;
+      // Fire and forget; the worker manages its own lifecycle.
+      void this.worker();
+    }
+  }
+
+  private async worker(): Promise<void> {
+    try {
+      while (this.queue.length > 0) {
+        const next = this.queue.shift();
+        if (!next) break;
+
+        const key = this.keyFor(next.provider, next.model);
+        const st = this.state.get(key);
+        if (!st) continue;
+
+        if (st.inFlight) continue;
+
+        // Final cooldown re-check immediately before dispatching the probe.
+        const healthy = await CooldownManager.getInstance()
+          .isProviderHealthy(next.provider, next.model)
+          .catch(() => false);
+        if (!healthy) {
+          logger.debug(
+            `BackgroundExplorer: skipping probe for ${next.provider}/${next.model} — on cooldown`
+          );
+          continue;
+        }
+
+        st.inFlight = true;
+        try {
+          logger.debug(`BackgroundExplorer: probing ${next.provider}/${next.model}`);
+          await this.probeService.runProbe({
+            provider: next.provider,
+            model: next.model,
+            apiType: 'chat',
+            source: 'background',
+          });
+        } catch (err: any) {
+          // ProbeService.runProbe should never throw, but defend in depth.
+          logger.debug(
+            `BackgroundExplorer: probe threw for ${next.provider}/${next.model}: ${err?.message ?? err}`
+          );
+        } finally {
+          st.lastProbedAt = Date.now();
+          st.inFlight = false;
+        }
+      }
+    } finally {
+      this.activeWorkers--;
+    }
+  }
+}

--- a/packages/backend/src/services/config-service.ts
+++ b/packages/backend/src/services/config-service.ts
@@ -281,6 +281,7 @@ export class ConfigService {
     const mcpServers = await this.repo.getAllMcpServers();
     const failover = await this.repo.getFailoverPolicy();
     const cooldown = await this.repo.getCooldownPolicy();
+    const backgroundExploration = await this.repo.getBackgroundExplorationConfig();
     const allSettings = await this.repo.getAllSettings();
 
     // Spread all flat settings (non-dotted keys) onto the cache so new settings
@@ -299,6 +300,7 @@ export class ConfigService {
       keys,
       failover,
       cooldown,
+      backgroundExploration,
       quotas,
       mcpServers: Object.keys(mcpServers).length > 0 ? mcpServers : undefined,
       mcp_servers: Object.keys(mcpServers).length > 0 ? mcpServers : undefined,

--- a/packages/backend/src/services/probe-request.ts
+++ b/packages/backend/src/services/probe-request.ts
@@ -1,0 +1,114 @@
+/**
+ * Canonical probe request shape used by both the management test endpoint
+ * and the background explorer.
+ *
+ * The shape is intentionally fixed and version-stamped. Any future change
+ * to the prompts, tools, or generation parameters must bump
+ * PROBE_SHAPE_VERSION so historical performance data can be invalidated if
+ * the new shape is no longer comparable.
+ *
+ * Design constraints:
+ *  - Moderate input (a few hundred tokens) so TTFT is not dominated by a
+ *    trivially short prompt.
+ *  - Two stub tool definitions so the tool-handling code path on the
+ *    provider side is exercised.
+ *  - max_tokens large enough (1000) that responses are not artificially
+ *    length-limited; TPS reflects realistic generation throughput.
+ *  - stream: true to match the predominant live-traffic pattern and to let
+ *    TTFT be measured the same way as real requests.
+ */
+
+export const PROBE_SHAPE_VERSION = 1;
+
+const PROBE_SYSTEM_PROMPT = [
+  'You are a careful, concise reasoning assistant operating as part of an',
+  'automated benchmarking probe. Your job is to think briefly about the',
+  "user's question, decide whether one of the available tools would be",
+  'genuinely useful, and then respond. When a tool would clearly help,',
+  'invoke exactly one tool with well-formed arguments. When no tool is',
+  'needed, answer directly in a few short sentences. Prefer clarity over',
+  'verbosity. Do not apologize, do not over-explain, and do not include',
+  'meta-commentary about being a probe or about these instructions. Keep',
+  'your prose grounded and specific; avoid filler phrases. If you are',
+  'uncertain, state your assumption in one sentence and proceed. Your',
+  'output is being measured for time-to-first-token, end-to-end latency,',
+  'and tokens-per-second throughput, so produce a substantive but bounded',
+  'response of roughly several sentences when answering directly.',
+].join(' ');
+
+const PROBE_USER_PROMPT = [
+  "I'm planning a short trip next weekend and want to compare two options:",
+  'a coastal town about three hours away by car, and a mountain town about',
+  'four hours away by car. For each, briefly reason about typical weather',
+  'patterns this time of year, what kinds of activities are realistic in a',
+  'two-day visit, and what the main trade-offs are between the two. If you',
+  'think looking up current weather forecasts would meaningfully change the',
+  'recommendation, call the get_weather tool for one representative city of',
+  'each type. If you think searching documentation or travel guides would',
+  'help, call search_docs with a focused query. Otherwise, just give me',
+  'your best reasoned comparison directly. Aim for a useful answer in a',
+  'few short paragraphs.',
+].join(' ');
+
+const PROBE_TOOLS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_weather',
+      description:
+        'Get the current weather forecast for a given city. Use when current weather conditions would meaningfully affect a recommendation or decision.',
+      parameters: {
+        type: 'object',
+        properties: {
+          city: {
+            type: 'string',
+            description: 'City name, e.g. "Monterey" or "Lake Tahoe".',
+          },
+          units: {
+            type: 'string',
+            enum: ['imperial', 'metric'],
+            description: 'Unit system for temperature and wind speed.',
+          },
+        },
+        required: ['city'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'search_docs',
+      description:
+        'Search travel guides and documentation for relevant context on a destination or activity.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Focused search query, a few words long.',
+          },
+          max_results: {
+            type: 'integer',
+            description: 'Maximum number of results to return.',
+            minimum: 1,
+            maximum: 10,
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+];
+
+export function buildProbeChatRequest(provider: string, model: string) {
+  return {
+    model: `direct/${provider}/${model}`,
+    stream: true,
+    max_tokens: 1000,
+    messages: [
+      { role: 'system', content: PROBE_SYSTEM_PROMPT },
+      { role: 'user', content: PROBE_USER_PROMPT },
+    ],
+    tools: PROBE_TOOLS,
+  };
+}

--- a/packages/backend/src/services/probe-service.ts
+++ b/packages/backend/src/services/probe-service.ts
@@ -1,0 +1,327 @@
+import { logger } from '../utils/logger';
+import { Dispatcher } from './dispatcher';
+import { UsageStorageService } from './usage-storage';
+import { UsageRecord } from '../types/usage';
+import { DebugManager } from './debug-manager';
+import { calculateCosts } from '../utils/calculate-costs';
+import { buildProbeChatRequest } from './probe-request';
+import {
+  OpenAITransformer,
+  AnthropicTransformer,
+  GeminiTransformer,
+  ResponsesTransformer,
+} from '../transformers';
+
+export type ProbeSource = 'manual' | 'background';
+
+export type ProbeApiType =
+  | 'chat'
+  | 'messages'
+  | 'gemini'
+  | 'responses'
+  | 'embeddings'
+  | 'images'
+  | 'speech'
+  | 'oauth';
+
+export interface RunProbeArgs {
+  provider: string;
+  model: string;
+  apiType: ProbeApiType;
+  source: ProbeSource;
+  sourceIp?: string | null;
+}
+
+export interface ProbeResult {
+  success: boolean;
+  durationMs: number;
+  apiType: ProbeApiType;
+  response?: string;
+  error?: string;
+}
+
+/**
+ * Non-chat probe templates. Kept for manual-test UI debugging only — the
+ * background explorer always uses the chat shape from probe-request.ts.
+ *
+ * Shapes mirror the historical TEST_TEMPLATES in routes/management/test.ts.
+ */
+const SECONDARY_SYSTEM_PROMPT = 'You are a helpful assistant.';
+const SECONDARY_USER_PROMPT = 'Just respond with the word acknowledged';
+
+function buildSecondaryRequest(apiType: ProbeApiType, modelPath: string): any {
+  switch (apiType) {
+    case 'messages':
+      return {
+        model: modelPath,
+        stream: false,
+        max_tokens: 100,
+        system: SECONDARY_SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: SECONDARY_USER_PROMPT }],
+      };
+    case 'gemini':
+      return {
+        model: modelPath,
+        contents: [{ role: 'user', parts: [{ text: SECONDARY_USER_PROMPT }] }],
+        system_instruction: { parts: [{ text: SECONDARY_SYSTEM_PROMPT }] },
+        generationConfig: { maxOutputTokens: 100 },
+      };
+    case 'responses':
+      return {
+        model: modelPath,
+        input: SECONDARY_USER_PROMPT,
+        instructions: SECONDARY_SYSTEM_PROMPT,
+      };
+    case 'embeddings':
+      return { model: modelPath, input: ['Hello world'] };
+    case 'images':
+      return {
+        model: modelPath,
+        prompt: 'A tiny 256x256 red square',
+        n: 1,
+        size: '256x256',
+      };
+    case 'speech':
+      return { model: modelPath, input: 'Hello world' };
+    case 'oauth':
+      return {
+        context: {
+          systemPrompt: SECONDARY_SYSTEM_PROMPT,
+          messages: [{ role: 'user', content: SECONDARY_USER_PROMPT, timestamp: Date.now() }],
+        },
+        options: { maxTokens: 100 },
+      };
+    default:
+      throw new Error(`No secondary probe template for apiType '${apiType}'`);
+  }
+}
+
+export class ProbeService {
+  constructor(
+    private dispatcher: Dispatcher,
+    private usageStorage: UsageStorageService
+  ) {}
+
+  async runProbe(args: RunProbeArgs): Promise<ProbeResult> {
+    const { provider, model, apiType, source } = args;
+    const requestId = crypto.randomUUID();
+    const startTime = Date.now();
+    const directModelPath = `direct/${provider}/${model}`;
+
+    const usageRecord: Partial<UsageRecord> = {
+      requestId,
+      date: new Date().toISOString(),
+      sourceIp: args.sourceIp ?? null,
+      apiKey: 'probe',
+      attribution: source,
+      incomingApiType: apiType,
+      startTime,
+      isStreamed: false,
+      responseStatus: 'pending',
+      incomingModelAlias: directModelPath,
+    };
+
+    this.usageStorage.emitStartedAsync(usageRecord);
+
+    if (apiType === ('transcriptions' as ProbeApiType)) {
+      // Historic test.ts rejected transcriptions; preserve that.
+      const error = 'Cannot probe transcriptions API — requires file upload.';
+      usageRecord.responseStatus = 'error';
+      usageRecord.durationMs = Date.now() - startTime;
+      await this.usageStorage.saveRequest(usageRecord as UsageRecord);
+      return {
+        success: false,
+        durationMs: usageRecord.durationMs,
+        apiType,
+        error,
+      };
+    }
+
+    try {
+      const testRequest =
+        apiType === 'chat'
+          ? buildProbeChatRequest(provider, model)
+          : buildSecondaryRequest(apiType, directModelPath);
+
+      let response: any;
+
+      if (apiType === 'oauth') {
+        const { context, options } = testRequest as {
+          context: {
+            systemPrompt?: string;
+            messages: Array<{ role: string; content: any }>;
+          };
+          options?: Record<string, any>;
+        };
+
+        const unifiedRequest = {
+          model: directModelPath,
+          messages: [
+            ...(context.systemPrompt ? [{ role: 'system', content: context.systemPrompt }] : []),
+            ...context.messages.map((m) => ({
+              role: m.role as any,
+              content: m.content,
+            })),
+          ],
+          incomingApiType: 'oauth',
+          originalBody: { context, options },
+          requestId,
+        };
+
+        response = await this.dispatcher.dispatch(unifiedRequest as any);
+      } else if (apiType === 'embeddings') {
+        response = await this.dispatcher.dispatchEmbeddings({
+          model: directModelPath,
+          originalBody: testRequest,
+          requestId,
+          incomingApiType: 'embeddings',
+        });
+      } else if (apiType === 'images') {
+        const imgReq = testRequest as {
+          model: string;
+          prompt: string;
+          n?: number;
+          size?: string;
+          quality?: string;
+          style?: string;
+          user?: string;
+        };
+        response = await this.dispatcher.dispatchImageGenerations({
+          model: imgReq.model,
+          prompt: imgReq.prompt,
+          n: imgReq.n,
+          size: imgReq.size,
+          response_format: 'url' as const,
+          quality: imgReq.quality,
+          style: imgReq.style,
+          user: imgReq.user,
+          originalBody: testRequest,
+          requestId,
+          incomingApiType: 'images',
+        } as any);
+      } else if (apiType === 'speech') {
+        const { SpeechTransformer } = await import('../transformers/speech');
+        const transformer = new SpeechTransformer();
+        const unifiedRequest = await transformer.parseRequest(testRequest);
+        unifiedRequest.incomingApiType = 'speech';
+        unifiedRequest.originalBody = testRequest;
+        unifiedRequest.requestId = requestId;
+        response = await this.dispatcher.dispatchSpeech(unifiedRequest);
+      } else {
+        let transformer;
+        switch (apiType) {
+          case 'chat':
+            transformer = new OpenAITransformer();
+            break;
+          case 'messages':
+            transformer = new AnthropicTransformer();
+            break;
+          case 'gemini':
+            transformer = new GeminiTransformer();
+            break;
+          case 'responses':
+            transformer = new ResponsesTransformer();
+            break;
+          default:
+            transformer = new OpenAITransformer();
+        }
+        const unifiedRequest = await transformer.parseRequest(testRequest);
+        unifiedRequest.incomingApiType = apiType;
+        unifiedRequest.originalBody = testRequest;
+        unifiedRequest.requestId = requestId;
+        response = await this.dispatcher.dispatch(unifiedRequest);
+      }
+
+      const durationMs = Date.now() - startTime;
+
+      usageRecord.provider = response.plexus?.provider;
+      usageRecord.selectedModelName = response.plexus?.model;
+      usageRecord.canonicalModelName = response.plexus?.canonicalModel;
+      usageRecord.outgoingApiType = response.plexus?.apiType;
+      usageRecord.durationMs = durationMs;
+      usageRecord.responseStatus = 'success';
+      usageRecord.isPassthrough =
+        apiType !== 'chat' &&
+        apiType !== 'messages' &&
+        apiType !== 'gemini' &&
+        apiType !== 'responses';
+      usageRecord.attemptCount = response.plexus?.attemptCount || 1;
+      usageRecord.retryHistory = response.plexus?.retryHistory || null;
+      usageRecord.finalAttemptProvider =
+        response.plexus?.finalAttemptProvider || usageRecord.provider || null;
+      usageRecord.finalAttemptModel =
+        response.plexus?.finalAttemptModel || usageRecord.selectedModelName || null;
+      usageRecord.allAttemptedProviders = response.plexus?.allAttemptedProviders || null;
+
+      if (response.usage) {
+        usageRecord.tokensInput = response.usage.input_tokens;
+        usageRecord.tokensOutput = response.usage.output_tokens;
+        usageRecord.tokensCached = response.usage.cached_tokens;
+        usageRecord.tokensCacheWrite = response.usage.cache_creation_tokens;
+        usageRecord.tokensReasoning = response.usage.reasoning_tokens;
+      }
+
+      const pricing = response.plexus?.pricing;
+      const providerDiscount = response.plexus?.providerDiscount;
+      calculateCosts(usageRecord, pricing, providerDiscount);
+
+      this.usageStorage.emitUpdatedAsync({
+        requestId,
+        provider: usageRecord.provider,
+        selectedModelName: usageRecord.selectedModelName,
+        canonicalModelName: usageRecord.canonicalModelName,
+      });
+
+      await this.usageStorage.saveRequest(usageRecord as UsageRecord);
+
+      let responseText: string;
+      if (apiType === 'images') {
+        responseText =
+          response.data && Array.isArray(response.data)
+            ? `Success (${response.data.length} image${response.data.length > 1 ? 's' : ''} created)`
+            : 'Success';
+      } else if (apiType === 'embeddings') {
+        responseText =
+          response.data && Array.isArray(response.data)
+            ? `Success (${response.data.length} embedding${response.data.length > 1 ? 's' : ''})`
+            : 'Success';
+      } else {
+        responseText = response.content
+          ? typeof response.content === 'string'
+            ? response.content.substring(0, 100)
+            : 'Success'
+          : 'Success';
+      }
+
+      return {
+        success: true,
+        durationMs,
+        apiType,
+        response: responseText,
+      };
+    } catch (e: any) {
+      const durationMs = Date.now() - startTime;
+      logger.error(`Probe failed for ${provider}/${model} (${apiType}, ${source}):`, e);
+
+      usageRecord.responseStatus = 'error';
+      usageRecord.durationMs = durationMs;
+      usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
+      usageRecord.retryHistory = e.routingContext?.retryHistory || usageRecord.retryHistory || null;
+      await this.usageStorage.saveRequest(usageRecord as UsageRecord);
+
+      const errorDetails = {
+        apiType,
+        ...(e.routingContext || {}),
+      };
+      this.usageStorage.saveError(requestId, e, errorDetails);
+      DebugManager.getInstance().flush(requestId);
+
+      return {
+        success: false,
+        durationMs,
+        apiType,
+        error: e.message || 'Unknown error',
+      };
+    }
+  }
+}

--- a/packages/backend/src/services/router.ts
+++ b/packages/backend/src/services/router.ts
@@ -8,6 +8,7 @@ import {
   type ModelConfig,
   type ModelTargetGroup,
 } from '../config';
+import { BackgroundExplorer } from './background-explorer';
 import { CooldownManager } from './cooldown-manager';
 import { SelectorFactory } from './selectors/factory';
 import { EnrichedModelTarget } from './selectors/base';
@@ -225,6 +226,8 @@ export class Router {
 
           const ordered = await selectOrderedTargets(group.selector, enriched);
 
+          BackgroundExplorer.getInstance()?.maybeTrigger(group);
+
           const results: RouteResult[] = [];
           for (const target of ordered) {
             const providerConfig = config.providers[target.provider];
@@ -273,6 +276,8 @@ export class Router {
       if (enriched.length === 0) continue;
 
       const ordered = await selectOrderedTargets(group.selector, enriched);
+
+      BackgroundExplorer.getInstance()?.maybeTrigger(group);
 
       for (const target of ordered) {
         const providerConfig = config.providers[target.provider];
@@ -334,6 +339,8 @@ export class Router {
               );
             }
 
+            BackgroundExplorer.getInstance()?.maybeTrigger(group);
+
             const providerConfig = config.providers[target.provider];
             if (!providerConfig) {
               throw new Error(`Provider '${target.provider}' not found`);
@@ -384,6 +391,8 @@ export class Router {
         const target = await selector.select(enriched);
 
         if (!target) continue;
+
+        BackgroundExplorer.getInstance()?.maybeTrigger(group);
 
         const providerConfig = config.providers[target.provider];
         if (!providerConfig) {

--- a/packages/backend/src/services/selectors/__tests__/e2e-performance.test.ts
+++ b/packages/backend/src/services/selectors/__tests__/e2e-performance.test.ts
@@ -212,5 +212,48 @@ describe('E2EPerformanceSelector', () => {
         Math.random = originalRandom;
       }
     });
+
+    it('suppresses inline exploration when backgroundExploration.enabled is true', async () => {
+      setConfigForTesting({
+        ...makeConfig(1, 1),
+        backgroundExploration: {
+          enabled: true,
+          stalenessThresholdSeconds: 600,
+          workerConcurrency: 2,
+        },
+      } as PlexusConfig);
+
+      mockGetProviderPerformance.mockImplementation((provider) => {
+        if (provider === 'p1')
+          return Promise.resolve([
+            {
+              target_model: 'm1',
+              avg_e2e_tokens_per_sec: 100,
+              sample_count: 10,
+              last_updated: 1000,
+            },
+          ]);
+        if (provider === 'p2')
+          return Promise.resolve([
+            {
+              target_model: 'm2',
+              avg_e2e_tokens_per_sec: 50,
+              sample_count: 10,
+              last_updated: 2000,
+            },
+          ]);
+        return Promise.resolve([]);
+      });
+
+      const targets: ModelTarget[] = [
+        { provider: 'p1', model: 'm1' },
+        { provider: 'p2', model: 'm2' },
+      ];
+
+      for (let i = 0; i < 10; i++) {
+        const selected = await selector.select(targets);
+        expect(selected).toEqual(targets[0]!);
+      }
+    });
   });
 });

--- a/packages/backend/src/services/selectors/__tests__/latency.test.ts
+++ b/packages/backend/src/services/selectors/__tests__/latency.test.ts
@@ -187,4 +187,37 @@ describe('LatencySelector', () => {
       expect(selected?.provider).toBe('p1');
     }
   });
+
+  it('suppresses inline exploration when backgroundExploration.enabled is true', async () => {
+    setConfigForTesting({
+      ...makeConfig({ latencyExplorationRate: 1 }),
+      backgroundExploration: {
+        enabled: true,
+        stalenessThresholdSeconds: 600,
+        workerConcurrency: 2,
+      },
+    } as PlexusConfig);
+
+    mockGetProviderPerformance.mockImplementation((provider) => {
+      if (provider === 'p1')
+        return Promise.resolve([
+          { target_model: 'm1', avg_ttft_ms: 100, sample_count: 5, last_updated: 1000 },
+        ]);
+      if (provider === 'p2')
+        return Promise.resolve([
+          { target_model: 'm2', avg_ttft_ms: 500, sample_count: 5, last_updated: 2000 },
+        ]);
+      return Promise.resolve([]);
+    });
+
+    const targets: ModelTarget[] = [
+      { provider: 'p1', model: 'm1' },
+      { provider: 'p2', model: 'm2' },
+    ];
+
+    for (let i = 0; i < 10; i++) {
+      const selected = await selector.select(targets);
+      expect(selected).toEqual(targets[0]!);
+    }
+  });
 });

--- a/packages/backend/src/services/selectors/__tests__/performance.test.ts
+++ b/packages/backend/src/services/selectors/__tests__/performance.test.ts
@@ -191,5 +191,40 @@ describe('PerformanceSelector', () => {
         Math.random = originalRandom;
       }
     });
+
+    it('suppresses inline exploration when backgroundExploration.enabled is true', async () => {
+      // Even with a guaranteed-to-fire explorationRate, background mode must
+      // make the selector deterministically pick the best target.
+      setConfigForTesting({
+        ...makeConfig(1),
+        backgroundExploration: {
+          enabled: true,
+          stalenessThresholdSeconds: 600,
+          workerConcurrency: 2,
+        },
+      } as PlexusConfig);
+
+      mockGetProviderPerformance.mockImplementation((provider) => {
+        if (provider === 'p1')
+          return Promise.resolve([
+            { target_model: 'm1', avg_tokens_per_sec: 100, sample_count: 10, last_updated: 1000 },
+          ]);
+        if (provider === 'p2')
+          return Promise.resolve([
+            { target_model: 'm2', avg_tokens_per_sec: 50, sample_count: 10, last_updated: 2000 },
+          ]);
+        return Promise.resolve([]);
+      });
+
+      const targets: ModelTarget[] = [
+        { provider: 'p1', model: 'm1' },
+        { provider: 'p2', model: 'm2' },
+      ];
+
+      for (let i = 0; i < 10; i++) {
+        const selected = await selector.select(targets);
+        expect(selected).toEqual(targets[0]!);
+      }
+    });
   });
 });

--- a/packages/backend/src/services/selectors/e2e-performance.ts
+++ b/packages/backend/src/services/selectors/e2e-performance.ts
@@ -21,8 +21,10 @@ export class E2EPerformanceSelector extends Selector {
     }
 
     const config = getConfig();
-    const explorationRate =
-      config.e2ePerformanceExplorationRate ?? config.performanceExplorationRate ?? 0.05;
+    const bgEnabled = config.backgroundExploration?.enabled === true;
+    const explorationRate = bgEnabled
+      ? 0
+      : (config.e2ePerformanceExplorationRate ?? config.performanceExplorationRate ?? 0.05);
 
     const candidates: { target: ModelTarget; e2eTps: number }[] = [];
     const explorationStats: CandidateStats[] = [];

--- a/packages/backend/src/services/selectors/latency.ts
+++ b/packages/backend/src/services/selectors/latency.ts
@@ -55,8 +55,10 @@ export class LatencySelector extends Selector {
       validCandidates.sort((a, b) => a.avgTtft - b.avgTtft);
 
       const config = getConfig();
-      const explorationRate =
-        config.latencyExplorationRate ?? config.performanceExplorationRate ?? 0;
+      const bgEnabled = config.backgroundExploration?.enabled === true;
+      const explorationRate = bgEnabled
+        ? 0
+        : (config.latencyExplorationRate ?? config.performanceExplorationRate ?? 0);
 
       // If exploration rate is set and we have multiple candidates, occasionally explore
       if (explorationRate > 0 && validCandidates.length > 1 && Math.random() < explorationRate) {

--- a/packages/backend/src/services/selectors/performance.ts
+++ b/packages/backend/src/services/selectors/performance.ts
@@ -22,7 +22,8 @@ export class PerformanceSelector extends Selector {
 
     // Get exploration rate from config (default 5%)
     const config = getConfig();
-    const explorationRate = config.performanceExplorationRate ?? 0.05;
+    const bgEnabled = config.backgroundExploration?.enabled === true;
+    const explorationRate = bgEnabled ? 0 : (config.performanceExplorationRate ?? 0.05);
 
     // If no performance data exists, we might want to fall back to random or first.
     // For now, let's assume we want to pick the one with highest known performance.

--- a/packages/backend/test/integration/background-exploration.test.ts
+++ b/packages/backend/test/integration/background-exploration.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { Router } from '../../src/services/router';
+import { BackgroundExplorer } from '../../src/services/background-explorer';
+import { ProbeService } from '../../src/services/probe-service';
+import { CooldownManager } from '../../src/services/cooldown-manager';
+import { SelectorFactory } from '../../src/services/selectors/factory';
+import { UsageStorageService } from '../../src/services/usage-storage';
+import { Dispatcher } from '../../src/services/dispatcher';
+import { setConfigForTesting, PlexusConfig } from '../../src/config';
+
+/**
+ * Integration: live request → Router → BackgroundExplorer.maybeTrigger →
+ * ProbeService.runProbe → Dispatcher.dispatch (mocked).
+ *
+ * Verifies that a live request flowing through the Router under
+ * backgroundExploration.enabled=true causes background probes to fire for
+ * stale targets in the resolved group, without affecting the live request's
+ * own selection.
+ */
+describe('Background exploration integration', () => {
+  const baseConfig: PlexusConfig = {
+    providers: {
+      p1: { enabled: true } as any,
+      p2: { enabled: true } as any,
+    } as any,
+    models: {
+      myalias: {
+        target_groups: [
+          {
+            name: 'g1',
+            selector: 'performance',
+            targets: [
+              { provider: 'p1', model: 'm1' },
+              { provider: 'p2', model: 'm2' },
+            ],
+          },
+        ],
+      } as any,
+    } as any,
+    keys: {},
+    failover: {
+      enabled: false,
+      retryableStatusCodes: [],
+      retryableErrors: [],
+    },
+    quotas: [],
+    backgroundExploration: {
+      enabled: true,
+      stalenessThresholdSeconds: 0,
+      workerConcurrency: 2,
+    },
+  } as PlexusConfig;
+
+  beforeEach(async () => {
+    BackgroundExplorer.resetForTesting();
+    CooldownManager.resetInstance();
+    await CooldownManager.getInstance().clearCooldown();
+    setConfigForTesting(baseConfig);
+
+    // Make the performance selector deterministic: pick p1 (higher TPS).
+    const mockUsageStorage = {
+      getProviderPerformance: vi.fn(async (provider?: string) => {
+        if (provider === 'p1')
+          return [
+            { target_model: 'm1', avg_tokens_per_sec: 100, sample_count: 10, last_updated: 1000 },
+          ];
+        if (provider === 'p2')
+          return [
+            { target_model: 'm2', avg_tokens_per_sec: 50, sample_count: 10, last_updated: 1000 },
+          ];
+        return [];
+      }),
+    } as unknown as UsageStorageService;
+    SelectorFactory.setUsageStorage(mockUsageStorage);
+  });
+
+  afterEach(async () => {
+    BackgroundExplorer.resetForTesting();
+    await CooldownManager.getInstance().clearCooldown();
+    CooldownManager.resetInstance();
+  });
+
+  test('live request triggers background probes for stale targets in the resolved group', async () => {
+    const probeService = {
+      runProbe: vi.fn(async () => ({
+        success: true,
+        durationMs: 5,
+        apiType: 'chat' as const,
+        response: 'ok',
+      })),
+    } as unknown as ProbeService;
+
+    BackgroundExplorer.initialize(probeService);
+
+    // Live request resolution — Router should pick p1 (best TPS) and also
+    // fire maybeTrigger for the group.
+    const candidates = await Router.resolveCandidates('myalias');
+
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0]!.provider).toBe('p1');
+    expect(candidates[0]!.model).toBe('m1');
+
+    // Allow background pump → cooldown checks → probe dispatch to complete.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+
+    expect(probeService.runProbe).toHaveBeenCalledTimes(2);
+    const calls = (probeService.runProbe as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: 'p1',
+          model: 'm1',
+          source: 'background',
+          apiType: 'chat',
+        }),
+        expect.objectContaining({
+          provider: 'p2',
+          model: 'm2',
+          source: 'background',
+          apiType: 'chat',
+        }),
+      ])
+    );
+  });
+
+  test('background exploration disabled → no probes fired', async () => {
+    setConfigForTesting({
+      ...baseConfig,
+      backgroundExploration: {
+        enabled: false,
+        stalenessThresholdSeconds: 0,
+        workerConcurrency: 2,
+      },
+    } as PlexusConfig);
+
+    const probeService = {
+      runProbe: vi.fn(async () => ({
+        success: true,
+        durationMs: 5,
+        apiType: 'chat' as const,
+      })),
+    } as unknown as ProbeService;
+    BackgroundExplorer.initialize(probeService);
+
+    await Router.resolveCandidates('myalias');
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+
+    expect(probeService.runProbe).not.toHaveBeenCalled();
+  });
+
+  test('targets on cooldown are skipped by background probes', async () => {
+    const probeService = {
+      runProbe: vi.fn(async () => ({
+        success: true,
+        durationMs: 5,
+        apiType: 'chat' as const,
+      })),
+    } as unknown as ProbeService;
+    BackgroundExplorer.initialize(probeService);
+
+    await CooldownManager.getInstance().markProviderFailure('p2', 'm2');
+
+    await Router.resolveCandidates('myalias');
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+
+    const probedTargets = (probeService.runProbe as any).mock.calls.map(
+      (c: any[]) => `${c[0].provider}/${c[0].model}`
+    );
+    expect(probedTargets).toContain('p1/m1');
+    expect(probedTargets).not.toContain('p2/m2');
+  });
+
+  // Reference to Dispatcher kept so the test file documents the full
+  // composition surface even though we mock ProbeService for isolation.
+  test('ProbeService is constructible from Dispatcher + UsageStorageService', () => {
+    const dispatcher = {} as unknown as Dispatcher;
+    const usageStorage = {} as unknown as UsageStorageService;
+    const svc = new ProbeService(dispatcher, usageStorage);
+    expect(svc).toBeInstanceOf(ProbeService);
+  });
+});

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -3088,4 +3088,36 @@ export const api = {
     if (!res.ok) throw new Error('Failed to update exploration rate settings');
     return res.json();
   },
+
+  // ─── Background Exploration Settings ──────────────────────────
+
+  /** Fetch current background exploration settings. */
+  getBackgroundExploration: async (): Promise<{
+    enabled: boolean;
+    stalenessThresholdSeconds: number;
+    workerConcurrency: number;
+  }> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/background-exploration`);
+    if (!res.ok) throw new Error('Failed to fetch background exploration settings');
+    return res.json();
+  },
+
+  /** Patch background exploration settings. */
+  patchBackgroundExploration: async (updates: {
+    enabled?: boolean;
+    stalenessThresholdSeconds?: number;
+    workerConcurrency?: number;
+  }): Promise<{
+    enabled: boolean;
+    stalenessThresholdSeconds: number;
+    workerConcurrency: number;
+  }> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/background-exploration`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    });
+    if (!res.ok) throw new Error('Failed to update background exploration settings');
+    return res.json();
+  },
 };

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -13,6 +13,7 @@ import {
   Save,
   Timer,
   Compass,
+  Radar,
 } from 'lucide-react';
 import { api } from '../lib/api';
 import { formatMinutesToMinSec } from '@plexus/shared';
@@ -74,6 +75,18 @@ const DEFAULT_EXPLORATION_RATES: ExplorationRates = {
   performanceExplorationRate: 0.05,
   latencyExplorationRate: 0.05,
   e2ePerformanceExplorationRate: 0.05,
+};
+
+interface BackgroundExplorationConfig {
+  enabled: boolean;
+  stalenessThresholdSeconds: number;
+  workerConcurrency: number;
+}
+
+const DEFAULT_BACKGROUND_EXPLORATION: BackgroundExplorationConfig = {
+  enabled: false,
+  stalenessThresholdSeconds: 600,
+  workerConcurrency: 2,
 };
 
 const DEFAULT_FAILOVER_POLICY: FailoverPolicy = {
@@ -162,8 +175,53 @@ export const Config = () => {
   const perfValidation = validateExplorationInput(explorationPerformanceInput);
   const latValidation = validateExplorationInput(explorationLatencyInput);
   const e2eValidation = validateExplorationInput(explorationE2EInput);
-  const isExplorationValid =
+  const inlineRatesValid =
     explorationLoaded && perfValidation.valid && latValidation.valid && e2eValidation.valid;
+
+  // Background exploration settings state
+  const [bgExploration, setBgExploration] = useState<BackgroundExplorationConfig>(
+    DEFAULT_BACKGROUND_EXPLORATION
+  );
+  const [bgExplorationLoaded, setBgExplorationLoaded] = useState(false);
+  const [bgExplorationSaving, setBgExplorationSaving] = useState(false);
+  const [bgStalenessInput, setBgStalenessInput] = useState('');
+  const [bgConcurrencyInput, setBgConcurrencyInput] = useState('');
+
+  const validateStalenessInput = (
+    raw: string
+  ): { valid: boolean; value?: number; error?: string } => {
+    if (raw === '') return { valid: false, error: 'Required' };
+    const num = Number(raw);
+    if (!Number.isFinite(num) || !Number.isInteger(num)) {
+      return { valid: false, error: 'Must be an integer (seconds)' };
+    }
+    if (num < 1) return { valid: false, error: 'Must be at least 1 second' };
+    return { valid: true, value: num };
+  };
+
+  const validateConcurrencyInput = (
+    raw: string
+  ): { valid: boolean; value?: number; error?: string } => {
+    if (raw === '') return { valid: false, error: 'Required' };
+    const num = Number(raw);
+    if (!Number.isFinite(num) || !Number.isInteger(num)) {
+      return { valid: false, error: 'Must be an integer' };
+    }
+    if (num < 1 || num > 16) return { valid: false, error: 'Must be between 1 and 16' };
+    return { valid: true, value: num };
+  };
+
+  const stalenessValidation = validateStalenessInput(bgStalenessInput);
+  const concurrencyValidation = validateConcurrencyInput(bgConcurrencyInput);
+  const bgFieldsValid =
+    bgExplorationLoaded && stalenessValidation.valid && concurrencyValidation.valid;
+
+  // When background exploration is enabled, inline rate inputs are ignored at
+  // runtime, so we don't gate Save on their validation. When disabled, the
+  // background tunables still need to be valid (they're just dormant).
+  const isExplorationValid = bgExploration.enabled
+    ? bgFieldsValid
+    : inlineRatesValid && bgFieldsValid;
 
   const loadFailoverPolicy = useCallback(async () => {
     try {
@@ -202,6 +260,19 @@ export const Config = () => {
     } catch (e) {
       console.error('Failed to load exploration rates:', e);
       toast.error('Failed to load exploration rate settings');
+    }
+  }, [toast]);
+
+  const loadBackgroundExploration = useCallback(async () => {
+    try {
+      const cfg = await api.getBackgroundExploration();
+      setBgExploration(cfg);
+      setBgStalenessInput(String(cfg.stalenessThresholdSeconds));
+      setBgConcurrencyInput(String(cfg.workerConcurrency));
+      setBgExplorationLoaded(true);
+    } catch (e) {
+      console.error('Failed to load background exploration settings:', e);
+      toast.error('Failed to load background exploration settings');
     }
   }, [toast]);
 
@@ -259,25 +330,61 @@ export const Config = () => {
     }
   };
 
-  const handleSaveExplorationRates = async () => {
-    if (!perfValidation.valid || !latValidation.valid || !e2eValidation.valid) return;
+  const handleSaveExploration = async () => {
+    if (!stalenessValidation.valid || !concurrencyValidation.valid) return;
+    // Inline rates only need to validate when background mode is off; when it
+    // is on, the rates aren't consulted at runtime.
+    if (
+      !bgExploration.enabled &&
+      (!perfValidation.valid || !latValidation.valid || !e2eValidation.valid)
+    ) {
+      return;
+    }
     setExplorationSaving(true);
+    setBgExplorationSaving(true);
     try {
-      const updated = await api.patchExplorationRates({
-        performanceExplorationRate: perfValidation.value!,
-        latencyExplorationRate: latValidation.value!,
-        e2ePerformanceExplorationRate: e2eValidation.value!,
-      });
+      const tasks: Promise<unknown>[] = [
+        api.patchBackgroundExploration({
+          enabled: bgExploration.enabled,
+          stalenessThresholdSeconds: stalenessValidation.value!,
+          workerConcurrency: concurrencyValidation.value!,
+        }),
+      ];
+      // Only persist inline rates when their inputs are valid. Skipping when
+      // background mode is on (and rates may be untouched) avoids overwriting
+      // stored values with stale strings.
+      if (perfValidation.valid && latValidation.valid && e2eValidation.valid) {
+        tasks.push(
+          api.patchExplorationRates({
+            performanceExplorationRate: perfValidation.value!,
+            latencyExplorationRate: latValidation.value!,
+            e2ePerformanceExplorationRate: e2eValidation.value!,
+          })
+        );
+      }
+      const results = await Promise.all(tasks);
+      const updatedBg = results[0] as Awaited<ReturnType<typeof api.patchBackgroundExploration>>;
+      const updatedRates = results[1] as
+        | Awaited<ReturnType<typeof api.patchExplorationRates>>
+        | undefined;
 
-      setExplorationRates(updated);
-      setExplorationPerformanceInput(String(updated.performanceExplorationRate));
-      setExplorationLatencyInput(String(updated.latencyExplorationRate));
-      setExplorationE2EInput(String(updated.e2ePerformanceExplorationRate));
-      toast.success('Exploration rate settings saved');
+      setBgExploration(updatedBg);
+      setBgStalenessInput(String(updatedBg.stalenessThresholdSeconds));
+      setBgConcurrencyInput(String(updatedBg.workerConcurrency));
+
+      if (updatedRates) {
+        setExplorationRates(updatedRates);
+        setExplorationPerformanceInput(String(updatedRates.performanceExplorationRate));
+        setExplorationLatencyInput(String(updatedRates.latencyExplorationRate));
+        setExplorationE2EInput(String(updatedRates.e2ePerformanceExplorationRate));
+      }
+
+      toast.success('Exploration settings saved');
     } catch (e) {
-      toast.error((e as Error).message, 'Failed to save exploration rate settings');
+      toast.error((e as Error).message, 'Failed to save exploration settings');
     } finally {
       setExplorationSaving(false);
+      setBgExplorationSaving(false);
     }
   };
 
@@ -298,6 +405,7 @@ export const Config = () => {
     loadFailoverPolicy();
     loadCooldownPolicy();
     loadExplorationRates();
+    loadBackgroundExploration();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -728,16 +836,16 @@ export const Config = () => {
           </div>
         </Disclosure>
 
-        {/* ─── Exploration Rate Settings ────────────────────────────── */}
+        {/* ─── Exploration Settings (inline rates + background mode) ───── */}
         <Disclosure
-          title="Exploration Rate Settings"
+          title="Exploration Settings"
           defaultOpen={false}
           extra={
             <Button
               variant="primary"
               size="sm"
-              onClick={handleSaveExplorationRates}
-              isLoading={explorationSaving}
+              onClick={handleSaveExploration}
+              isLoading={explorationSaving || bgExplorationSaving}
               disabled={!isExplorationValid}
               leftIcon={<Save size={14} />}
             >
@@ -746,108 +854,192 @@ export const Config = () => {
           }
         >
           <div className="flex flex-col gap-5">
-            {/* Exploration Rate description */}
-            <div className="flex items-center gap-2">
-              <Compass size={16} className="text-primary" />
+            {/* Description */}
+            <div className="flex items-start gap-2">
+              <Compass size={16} className="text-primary mt-0.5" />
               <div>
                 <p className="text-sm font-medium text-text">Provider Exploration</p>
                 <p className="text-xs text-text-muted">
-                  Exploration rate controls how often the selector picks a non-optimal provider to
-                  discover better options. A value of 0 always selects the best-known provider; a
-                  value of 1 picks randomly. Applies to performance, latency, and e2e_performance
-                  selectors.
+                  Exploration keeps performance, latency, and end-to-end TPS data fresh across
+                  targets. By default, inline exploration occasionally diverts a small fraction of
+                  live requests to non-optimal providers. Enable background exploration to suppress
+                  inline exploration and instead fire representative probe requests in the
+                  background — live traffic is never redirected. Both modes apply to the
+                  performance, latency, and e2e_performance selectors.
                 </p>
               </div>
             </div>
 
-            {/* Performance Exploration Rate */}
-            <div>
-              <label
-                htmlFor="performanceExplorationRate"
-                className="block text-sm font-medium text-text mb-1"
-              >
-                Performance Exploration Rate
-              </label>
-              <p className="text-xs text-text-muted mb-2">
-                The probability of exploring a non-optimal provider when using the performance
-                selector. Default: 0.05 (5%).
-              </p>
-              <div className="flex flex-col gap-1">
-                <input
-                  id="performanceExplorationRate"
-                  type="number"
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={explorationPerformanceInput}
-                  onChange={(e) => setExplorationPerformanceInput(e.target.value)}
-                  className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-                />
-                {!perfValidation.valid && explorationPerformanceInput !== '' && (
-                  <span className="text-xs text-warning">{perfValidation.error}</span>
-                )}
+            {/* Background exploration: master toggle */}
+            <div className="flex items-center justify-between gap-4 rounded-md border border-border bg-bg-glass/40 p-3">
+              <div className="flex items-start gap-2">
+                <Radar size={16} className="text-primary mt-0.5" />
+                <div>
+                  <p className="text-sm font-medium text-text">Background Exploration</p>
+                  <p className="text-xs text-text-muted">
+                    When enabled, inline exploration is suppressed and Plexus fires small
+                    representative probe requests in the background. Probes appear in usage records
+                    with apiKey="probe" and attribution="background".
+                  </p>
+                </div>
               </div>
+              <Switch
+                checked={bgExploration.enabled}
+                onChange={(checked) => setBgExploration((prev) => ({ ...prev, enabled: checked }))}
+                aria-label="Toggle background exploration on/off"
+              />
             </div>
 
-            {/* Latency Exploration Rate */}
-            <div>
-              <label
-                htmlFor="latencyExplorationRate"
-                className="block text-sm font-medium text-text mb-1"
-              >
-                Latency Exploration Rate
-              </label>
-              <p className="text-xs text-text-muted mb-2">
-                The probability of exploring a non-optimal provider when using the latency selector.
-                Defaults to the Performance Exploration Rate if not explicitly set.
-              </p>
-              <div className="flex flex-col gap-1">
-                <input
-                  id="latencyExplorationRate"
-                  type="number"
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={explorationLatencyInput}
-                  onChange={(e) => setExplorationLatencyInput(e.target.value)}
-                  className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-                />
-                {!latValidation.valid && explorationLatencyInput !== '' && (
-                  <span className="text-xs text-warning">{latValidation.error}</span>
-                )}
-              </div>
-            </div>
+            {/* Background tunables — only rendered when background mode is on */}
+            {bgExploration.enabled && (
+              <div className="flex flex-col gap-5">
+                <div>
+                  <label
+                    htmlFor="bgExplorationStaleness"
+                    className="block text-sm font-medium text-text mb-1"
+                  >
+                    Staleness Threshold (seconds)
+                  </label>
+                  <p className="text-xs text-text-muted mb-2">
+                    A target is re-probed only after this many seconds have elapsed since its last
+                    probe. Default: 600 (10 minutes). Minimum: 1.
+                  </p>
+                  <div className="flex flex-col gap-1">
+                    <input
+                      id="bgExplorationStaleness"
+                      type="number"
+                      min={1}
+                      step={1}
+                      value={bgStalenessInput}
+                      onChange={(e) => setBgStalenessInput(e.target.value)}
+                      className="w-full max-w-[240px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                    />
+                    {!stalenessValidation.valid && bgStalenessInput !== '' && (
+                      <span className="text-xs text-warning">{stalenessValidation.error}</span>
+                    )}
+                  </div>
+                </div>
 
-            {/* E2E Performance Exploration Rate */}
-            <div>
-              <label
-                htmlFor="e2ePerformanceExplorationRate"
-                className="block text-sm font-medium text-text mb-1"
-              >
-                E2E Performance Exploration Rate
-              </label>
-              <p className="text-xs text-text-muted mb-2">
-                The probability of exploring any provider when using the e2e_performance selector.
-                Unlike the performance selector, exploration includes all candidates (including the
-                current best) to keep end-to-end metrics fresh. Defaults to the Performance
-                Exploration Rate if not explicitly set.
-              </p>
-              <div className="flex flex-col gap-1">
-                <input
-                  id="e2ePerformanceExplorationRate"
-                  type="number"
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={explorationE2EInput}
-                  onChange={(e) => setExplorationE2EInput(e.target.value)}
-                  className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-                />
-                {!e2eValidation.valid && explorationE2EInput !== '' && (
-                  <span className="text-xs text-warning">{e2eValidation.error}</span>
-                )}
+                <div>
+                  <label
+                    htmlFor="bgExplorationConcurrency"
+                    className="block text-sm font-medium text-text mb-1"
+                  >
+                    Worker Concurrency
+                  </label>
+                  <p className="text-xs text-text-muted mb-2">
+                    Maximum number of background probes Plexus runs in parallel. Per-target probes
+                    are deduplicated separately. Default: 2. Range: 1–16.
+                  </p>
+                  <div className="flex flex-col gap-1">
+                    <input
+                      id="bgExplorationConcurrency"
+                      type="number"
+                      min={1}
+                      max={16}
+                      step={1}
+                      value={bgConcurrencyInput}
+                      onChange={(e) => setBgConcurrencyInput(e.target.value)}
+                      className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                    />
+                    {!concurrencyValidation.valid && bgConcurrencyInput !== '' && (
+                      <span className="text-xs text-warning">{concurrencyValidation.error}</span>
+                    )}
+                  </div>
+                </div>
               </div>
-            </div>
+            )}
+
+            {/* Inline rate tunables — only rendered when background mode is off */}
+            {!bgExploration.enabled && (
+              <div className="flex flex-col gap-5">
+                <div>
+                  <label
+                    htmlFor="performanceExplorationRate"
+                    className="block text-sm font-medium text-text mb-1"
+                  >
+                    Performance Exploration Rate
+                  </label>
+                  <p className="text-xs text-text-muted mb-2">
+                    The probability of exploring a non-optimal provider when using the performance
+                    selector. Default: 0.05 (5%).
+                  </p>
+                  <div className="flex flex-col gap-1">
+                    <input
+                      id="performanceExplorationRate"
+                      type="number"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      value={explorationPerformanceInput}
+                      onChange={(e) => setExplorationPerformanceInput(e.target.value)}
+                      className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                    />
+                    {!perfValidation.valid && explorationPerformanceInput !== '' && (
+                      <span className="text-xs text-warning">{perfValidation.error}</span>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="latencyExplorationRate"
+                    className="block text-sm font-medium text-text mb-1"
+                  >
+                    Latency Exploration Rate
+                  </label>
+                  <p className="text-xs text-text-muted mb-2">
+                    The probability of exploring a non-optimal provider when using the latency
+                    selector. Defaults to the Performance Exploration Rate if not explicitly set.
+                  </p>
+                  <div className="flex flex-col gap-1">
+                    <input
+                      id="latencyExplorationRate"
+                      type="number"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      value={explorationLatencyInput}
+                      onChange={(e) => setExplorationLatencyInput(e.target.value)}
+                      className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                    />
+                    {!latValidation.valid && explorationLatencyInput !== '' && (
+                      <span className="text-xs text-warning">{latValidation.error}</span>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="e2ePerformanceExplorationRate"
+                    className="block text-sm font-medium text-text mb-1"
+                  >
+                    E2E Performance Exploration Rate
+                  </label>
+                  <p className="text-xs text-text-muted mb-2">
+                    The probability of exploring any provider when using the e2e_performance
+                    selector. Unlike the performance selector, exploration includes all candidates
+                    (including the current best) to keep end-to-end metrics fresh. Defaults to the
+                    Performance Exploration Rate if not explicitly set.
+                  </p>
+                  <div className="flex flex-col gap-1">
+                    <input
+                      id="e2ePerformanceExplorationRate"
+                      type="number"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      value={explorationE2EInput}
+                      onChange={(e) => setExplorationE2EInput(e.target.value)}
+                      className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                    />
+                    {!e2eValidation.valid && explorationE2EInput !== '' && (
+                      <span className="text-xs text-warning">{e2eValidation.error}</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         </Disclosure>
 


### PR DESCRIPTION
## Summary

Introduces an **optional background exploration mode** that keeps performance data (TTFT / TPS / E2E TPS) fresh for the `latency`, `performance`, and `e2e_performance` selectors **without ever diverting live requests** to slower providers.

When enabled, the existing inline `*ExplorationRate` branches in those selectors are suppressed; instead, a separate background worker fires representative synthetic probes at stale targets, and their results populate the same `providerPerformance` table the selectors already read from.

The manual "test" path triggered from the management UI is folded into the same probe machinery so there is exactly one canonical probe shape and code path.

## Design

- **Trigger**: staleness-driven, gated on live requests. Each live request to an alias whose group uses one of the three perf-based selectors checks targets; any target whose `lastProbedAt` is older than `stalenessThresholdSeconds` is enqueued for a background probe.
- **Live request unaffected**: the live request is served by the selector's best choice; the probe trigger is fire-and-forget.
- **Probe shape**: one canonical, version-stamped synthetic `chat` request — ~200-token system prompt, ~150-token user prompt, two stub tool definitions, `max_tokens: 1000`, streaming.
- **Routing**: probes use `direct/<provider>/<model>`, bypassing alias resolution and failover, hitting exactly one target. The probe exercises the same transformer + provider + storage path as live traffic, so TTFT / TPS / E2E TPS are measured identically.
- **Attribution**: probes appear in usage records with `apiKey = "probe"` and `attribution = "manual" | "background"`. They are real requests and do consume provider quota / cost.
- **Bootstrap**: each target's `lastProbedAt` is initialised to the process start time. The first probe fires at normal cadence once `stalenessThresholdSeconds` elapses — not eagerly on the first request.
- **Concurrency**: small worker pool (`workerConcurrency`, default 2) drains the queue. Per-target `inFlight=1` guard and the global cooldown manager prevent duplicate or unhealthy probes.

## What changed

### New
- `services/probe-request.ts` — canonical chat probe shape + `PROBE_SHAPE_VERSION`.
- `services/probe-service.ts` — unified `ProbeService.runProbe({ source: 'manual' | 'background' })` used by both the management test endpoint and the background worker.
- `services/background-explorer.ts` — singleton with staleness map, bounded worker pool, per-target `inFlight` guard, cooldown re-check.

### Modified
- `config.ts` — added `backgroundExploration: { enabled, stalenessThresholdSeconds, workerConcurrency }` schema.
- `db/config-repository.ts` + `services/config-service.ts` — persistence and cache wiring for the new config.
- `routes/management/config.ts` — `GET/PATCH /v0/management/config/background-exploration`.
- `routes/management/test.ts` — collapsed to a thin wrapper over `ProbeService.runProbe({ source: 'manual' })`. Behavior change: `apiKey` is now `"probe"` (previously the caller's key); `transcriptions` returns 400 with a clear error.
- `services/router.ts` — `BackgroundExplorer.getInstance()?.maybeTrigger(group)` at 4 post-selection sites.
- `selectors/{performance, e2e-performance, latency}.ts` — inline exploration gated on `!backgroundExploration.enabled`.
- `frontend/src/lib/api.ts` — new client methods for the background exploration endpoints.
- `frontend/src/pages/Config.tsx` — single consolidated **Exploration Settings** card replacing the previous two cards (background mode + inline rates). Master Switch toggles background mode; inactive controls are hidden from the DOM; one Save button persists both groups in parallel.

## Tests

- **9** unit tests for `BackgroundExplorer` covering trigger gating, staleness, cooldown skipping, `inFlight` guard, `lastProbedAt` updates on success/failure, and swallowed probe errors.
- **6** unit tests for `ProbeService` (request shape, attribution, success/failure result shapes, `transcriptions` rejection).
- **3** new gating tests added to the perf-selector test files asserting inline exploration is suppressed when `backgroundExploration.enabled === true`.
- **4** integration tests for the end-to-end Router → BackgroundExplorer → ProbeService flow.
- Existing `test-route.test.ts` and `admin-auth.test.ts` updated for the new `registerManagementRoutes` signature.

All 586 tests pass; typecheck and lint clean.

## Docs

- `docs/CONFIGURATION.md` — split exploration section into **Inline Exploration** and **Background Exploration** subsections with YAML example, full description of trigger, probe shape, attribution, bootstrap behavior, and a note that inline rates remain in effect when background mode is off.
- `docs/openapi/paths/v0_management_test.yaml` — reframed test endpoint as a canonical probe; added usage record attribution details and 400 response for validation errors.
- `BGEXPLORE.md` — design document covering the decisions, components, and integration plan.

## Rollout / defaults

- `backgroundExploration.enabled` defaults to **false**. Existing deployments see **zero behavior change** until they opt in.
- When enabled, defaults: `stalenessThresholdSeconds = 600` (10 minutes), `workerConcurrency = 2`.

## Out of scope (future)

- Per-alias `backgroundExploration` overrides.
- Budget-bounded exploration (cost / count caps per hour or day).
- Explicit `isProbe` column on `requestUsage` for cleaner dashboard filtering.
- Versioned probe-shape invalidation in `providerPerformance` (only matters when `PROBE_SHAPE_VERSION` increments).
- Per-target probe-shape variants (e.g. larger context for long-context models).
