### PR TITLE
feat: handle client stream disconnections with upstream cancellation and usage recording

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "@types/bun": "latest",
         "@types/node": "^25.6.0",
         "@types/winston": "^2.4.4",
+        "bun-types": "^1.3.14",
         "drizzle-kit": "^0.31.10",
         "form-data": "^4.0.5",
       },
@@ -1491,6 +1492,8 @@
     "oas-validator/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "plexus-backend/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,6 @@
         "@types/bun": "latest",
         "@types/node": "^25.6.0",
         "@types/winston": "^2.4.4",
-        "bun-types": "^1.3.14",
         "drizzle-kit": "^0.31.10",
         "form-data": "^4.0.5",
       },
@@ -1492,8 +1491,6 @@
     "oas-validator/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
-
-    "plexus-backend/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 

--- a/packages/backend/src/__tests__/disconnect-detection/README.md
+++ b/packages/backend/src/__tests__/disconnect-detection/README.md
@@ -95,6 +95,24 @@ Used to discover `Symbol(handle)` and the `bunHandle.closed` property.
 | `nodeStream.destroy()` | ✅ | Propagates cancel() to upstream fetch |
 | `Bun.serve() request.signal` | ✅ | But requires native Bun HTTP, not Fastify |
 
+### `test-timeout-abort-signal.ts`
+Confirms that `abortController.abort()` alone does **not** stop an already-in-progress
+`Readable.fromWeb()` read loop. The same root cause as the client-disconnect bug —
+the abort signal is consumed by `fetch()` at call time; aborting it afterwards has no
+effect on the streaming body. The upstream fetch keeps running indefinitely. ❌
+
+### `test-timeout-nodestream-destroy.ts`
+Confirms that `abort()` + `nodeStream.destroy()` together do cancel the upstream
+correctly, stopping the fetch within one tick of the interval. ✅
+
+### `test-timeout-signal-listener.ts`
+**The correct pattern for timeout support.** Adding `signal.addEventListener('abort',
+() => nodeStream.destroy())` means any abort reason — client disconnect, timeout,
+or anything else — flows through the correct cancellation path automatically. This
+is what `response-handler.ts` now does, so that future timeout wiring at the route
+level (e.g. `AbortSignal.any([signal, AbortSignal.timeout(ms)])`) requires no
+further changes to the streaming handler. ✅
+
 ## Relevant Bun Issues
 
 - https://github.com/oven-sh/bun/issues/14697 — ServerResponse doesn't emit close event

--- a/packages/backend/src/__tests__/disconnect-detection/README.md
+++ b/packages/backend/src/__tests__/disconnect-detection/README.md
@@ -1,0 +1,102 @@
+# Bun Client Disconnect Detection — Test Scripts & Findings
+
+These scripts were written to characterize how (and whether) client disconnect events
+propagate through Bun's `node:http` compatibility layer when Fastify streams a response.
+
+Run any script with: `bun <script>.ts`
+
+## Background
+
+We needed to cancel upstream LLM fetch requests when a downstream HTTP client
+disconnects mid-stream. This should be simple — but Bun's `node:http` layer has
+multiple open bugs that make all the standard Node.js mechanisms unreliable for
+streaming POST responses.
+
+See the extensive block comment in `packages/backend/src/services/response-handler.ts`
+for the full explanation of what was tried, what failed, and what works.
+
+## Test Scripts
+
+### `test-nodehttp.ts`
+Tests every standard disconnect signal on a raw `node:http` server (no Fastify).
+Confirms that `socket.close` and `req.close` DO fire on disconnect for GET requests
+here — but this is **not** the same behaviour as POST requests through Fastify.
+
+### `test-bunserve.ts`
+Tests `Bun.serve()` (native Bun HTTP, not node:http). Confirms that `request.signal`
+abort fires correctly and `ReadableStream.cancel()` is called on disconnect.
+**This works**, but Fastify uses `node:http`, not `Bun.serve()`.
+
+### `test-fastify.ts`
+Tests disconnect signals through Fastify with a GET route. `socket.close` and
+`request.raw.close` fire on disconnect here — but only for GET (no body to consume).
+
+### `test-fastify-pipe.ts`
+Tests the exact pipeline used in `response-handler.ts` (Readable.fromWeb → pipe →
+PassThrough → reply.send) with a POST route. Shows `socket.close` fires and
+`socket.destroyed` becomes `true` on disconnect **for POST requests too** — but only
+when no auth middleware or body parsing delays are involved. In the real app with
+Fastify's full middleware stack, this does not reliably fire in time.
+
+### `test-fastify-post-pipe.ts`
+Key finding: `request.raw.close` fires **immediately** (~2ms after request received)
+for POST requests — when Fastify finishes consuming the request body — NOT when the
+client disconnects. This means using `request.raw.once('close', ...)` for disconnect
+detection in POST handlers is completely broken.
+
+### `test-timing.ts`
+Precise timing test confirming `request.raw.close` fires at ~+2ms (body consumed),
+while actual client disconnect at ~+2000ms produces **no event at all**.
+
+### `test-write-fail.ts`
+Confirms that `res.write()` to a disconnected client never throws in Bun. Writes
+silently succeed and no EPIPE/ECONNRESET errors are emitted, even 5+ seconds after
+the client disconnects. (Bun issue #25919)
+
+### `test-write-direct.ts`
+Similar to above but writing directly to `reply.raw` (ServerResponse) rather than
+through a pipeline. Same result: no errors, `socket.destroyed` stays `false`.
+
+### `test-spy-all.ts`
+Snapshots all enumerable properties on `req`, `res`, `socket`, and
+`socket._writableState` every 100ms and logs changes. After client disconnect:
+**nothing changes**. Zero properties update on any of these objects.
+
+### `test-sym-handle.ts`
+**The breakthrough.** Uses `Object.getOwnPropertySymbols(socket)` to find the
+internal `Symbol(handle)` property, which holds Bun's underlying TCP socket handle.
+This handle has a `.closed` property that transitions `false → true` correctly when
+the client disconnects, even though all the Node.js-layer signals are broken.
+
+### `test-cancel-chain.ts` / `test-cancel-chain2.ts`
+Tests the cancellation propagation chain through `Readable.fromWeb()`:
+
+- `pipeline.destroy()` (downstream end) → does **NOT** cancel the upstream Web
+  ReadableStream. The fetch keeps running. ❌
+- `nodeStream.destroy()` (source Readable.fromWeb node stream) → **DOES** call
+  `cancel()` on the upstream Web ReadableStream, stopping the fetch. ✅
+- `abortController.abort()` → also works to cancel an in-flight fetch. ✅
+
+### `test-bun-internals.ts`
+Quick introspection of the Socket object to list all symbols and prototype methods.
+Used to discover `Symbol(handle)` and the `bunHandle.closed` property.
+
+## Summary of What Works vs What Doesn't (Bun 1.3.14, node:http, POST requests)
+
+| Mechanism | Works? | Notes |
+|---|---|---|
+| `request.raw.once('close', ...)` | ❌ | Fires on body consumption, not disconnect |
+| `socket.once('close', ...)` | ❌ | Never fires for POST disconnect |
+| `socket.destroyed` poll | ❌ | Stays `false` forever |
+| `reply.raw.destroyed` | ❌ | Property is `undefined` |
+| `res.write()` EPIPE | ❌ | Silently swallowed by Bun |
+| `bunHandle.closed` poll | ✅ | Bun internal TCP handle — updates correctly |
+| `abortController.abort()` | ✅ | Works if something triggers it |
+| `nodeStream.destroy()` | ✅ | Propagates cancel() to upstream fetch |
+| `Bun.serve() request.signal` | ✅ | But requires native Bun HTTP, not Fastify |
+
+## Relevant Bun Issues
+
+- https://github.com/oven-sh/bun/issues/14697 — ServerResponse doesn't emit close event
+- https://github.com/oven-sh/bun/issues/25919 — Upstream fetch not cancelled when client disconnects (streaming proxy)
+- https://github.com/oven-sh/bun/issues/7716 — IncomingRequest close event not emitted (marked closed but still broken for POST)

--- a/packages/backend/src/__tests__/disconnect-detection/test-bunserve.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-bunserve.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests disconnect detection on Bun.serve() (native Bun HTTP).
+ * Run: bun test-bunserve.ts
+ */
+
+const server = Bun.serve({
+  port: 19998,
+  fetch(req) {
+    console.log('[server] new request');
+
+    // Test 1: request.signal abort
+    req.signal.addEventListener('abort', () => {
+      console.log('[FIRED] request.signal abort');
+    });
+
+    let count = 0;
+    const stream = new ReadableStream({
+      start(controller) {
+        const interval = setInterval(() => {
+          count++;
+          const aborted = req.signal.aborted;
+          console.log(`[poll ${count}] req.signal.aborted=${aborted}`);
+          try {
+            controller.enqueue(new TextEncoder().encode(`data: ping ${count}\n\n`));
+          } catch (e: any) {
+            console.log(`[poll ${count}] enqueue threw: ${e.message}`);
+            clearInterval(interval);
+          }
+          if (count >= 20) {
+            clearInterval(interval);
+            controller.close();
+            server.stop();
+          }
+        }, 250);
+      },
+      cancel(reason) {
+        console.log(`[FIRED] ReadableStream cancel, reason: ${reason}`);
+      },
+    });
+
+    return new Response(stream, {
+      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+    });
+  },
+});
+
+console.log('Listening on http://localhost:19998');
+console.log('Run: curl -N http://localhost:19998 & sleep 2 && kill %1');

--- a/packages/backend/src/__tests__/disconnect-detection/test-cancel-chain2.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-cancel-chain2.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests the full cancellation chain options.
+ *
+ * Option A: pipeline.destroy() — does it cancel the web stream?
+ * Option B: abortController.abort() on the upstream fetch signal — does it cancel the stream?
+ * Option C: manually calling reader.cancel() on the web stream's reader?
+ */
+import { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+function makeUpstreamStream(label: string) {
+  let cancelFired = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let n = 0;
+      const iv = setInterval(() => {
+        n++;
+        if (n <= 10) process.stdout.write(`  [${label} upstream] chunk ${n}\n`);
+        controller.enqueue(new TextEncoder().encode(`chunk ${n}\n`));
+        if (n >= 30) {
+          clearInterval(iv);
+          controller.close();
+        }
+      }, 100);
+    },
+    cancel(reason) {
+      cancelFired = true;
+      console.log(`  [${label} FIRED] web stream cancel, reason: ${reason}`);
+    },
+  });
+  return { stream, isCancelled: () => cancelFired };
+}
+
+// --- Test A: destroy the passthrough (end of pipeline) ---
+async function testA() {
+  console.log('\n=== Test A: pipeline.destroy() ===');
+  const { stream, isCancelled } = makeUpstreamStream('A');
+  const node = Readable.fromWeb(stream as any);
+  const pt = new PassThrough();
+  const pipeline = node.pipe(pt);
+  pipeline.on('error', () => {}); // suppress unhandled error
+  pipeline.on('data', () => {});
+  await Bun.sleep(300);
+  console.log('  Destroying pipeline...');
+  pipeline.destroy();
+  await Bun.sleep(500);
+  console.log(`  cancelFired=${isCancelled()} (expected: true)`);
+}
+
+// --- Test B: destroy the source nodeStream ---
+async function testB() {
+  console.log('\n=== Test B: nodeStream.destroy() (source) ===');
+  const { stream, isCancelled } = makeUpstreamStream('B');
+  const node = Readable.fromWeb(stream as any);
+  const pt = new PassThrough();
+  node.pipe(pt);
+  pt.on('error', () => {});
+  pt.on('data', () => {});
+  await Bun.sleep(300);
+  console.log('  Destroying nodeStream...');
+  node.destroy();
+  await Bun.sleep(500);
+  console.log(`  cancelFired=${isCancelled()} (expected: true)`);
+}
+
+// --- Test C: abort via AbortController on a real fetch stream ---
+async function testC() {
+  console.log('\n=== Test C: abortController.abort() cancels fetch stream ===');
+  // We use a local echo server to test fetch cancellation
+  const ac = new AbortController();
+  const server = Bun.serve({
+    port: 19995,
+    fetch() {
+      let n = 0;
+      const s = new ReadableStream({
+        start(c) {
+          const iv = setInterval(() => {
+            c.enqueue(new TextEncoder().encode(`x`));
+            if (++n > 100) {
+              clearInterval(iv);
+              c.close();
+            }
+          }, 50);
+        },
+      });
+      return new Response(s);
+    },
+  });
+
+  let fetchCancelled = false;
+  let streamCancelled = false;
+
+  try {
+    const resp = await fetch('http://localhost:19995', { signal: ac.signal });
+    const node = Readable.fromWeb(resp.body as any);
+    const pt = new PassThrough();
+    node.pipe(pt);
+    pt.on('error', () => {});
+    pt.on('data', () => {});
+    node.on('error', () => {});
+
+    await Bun.sleep(200);
+    console.log('  Aborting fetch via AbortController...');
+    ac.abort();
+    await Bun.sleep(500);
+    console.log(`  nodeStream.destroyed=${node.destroyed}`);
+  } catch (e: any) {
+    fetchCancelled = true;
+    console.log(`  fetch threw: ${e.name} ${e.message}`);
+  }
+
+  server.stop(true);
+}
+
+await testA();
+await testB();
+await testC();
+console.log('\nDone.');
+process.exit(0);

--- a/packages/backend/src/__tests__/disconnect-detection/test-fastify-post-pipe.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-fastify-post-pipe.ts
@@ -1,0 +1,79 @@
+/**
+ * Mimics EXACTLY what response-handler.ts does:
+ * - POST route (not GET)
+ * - Reads + discards the request body first (Fastify does this)
+ * - Readable.fromWeb piped through PassThrough, sent via reply.send()
+ * - SSE headers
+ */
+import Fastify from 'fastify';
+import { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+const fastify = Fastify();
+
+fastify.post('/v1/chat/completions', async (request, reply) => {
+  const socket = (request.raw as any)?.socket as any;
+  console.log(`[server] POST request. socket.destroyed=${socket?.destroyed}`);
+
+  // Mimic a fast upstream web stream (like an LLM SSE response)
+  const webStream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let n = 0;
+      const iv = setInterval(() => {
+        n++;
+        controller.enqueue(new TextEncoder().encode(`data: chunk ${n}\n\n`));
+        if (n >= 200) {
+          clearInterval(iv);
+          controller.close();
+        }
+      }, 25);
+    },
+    cancel(reason) {
+      console.log(`[FIRED] webStream.cancel reason=${reason}`);
+    },
+  });
+
+  const nodeStream = Readable.fromWeb(webStream as any);
+  const passthrough = new PassThrough(); // stand-in for UsageInspector
+  const pipeline = nodeStream.pipe(passthrough);
+
+  let disconnected = false;
+
+  const onDisconnect = (source: string) => {
+    if (disconnected) return;
+    disconnected = true;
+    console.log(`[onDisconnect] source=${source}, socket.destroyed=${socket?.destroyed}`);
+    nodeStream.destroy();
+    pipeline.destroy();
+  };
+
+  socket?.once('close', () => {
+    console.log(`[FIRED] socket.close, destroyed=${socket?.destroyed}`);
+    onDisconnect('socket.close');
+  });
+  request.raw.once('close', () => {
+    console.log('[FIRED] request.raw.close');
+    onDisconnect('request.raw.close');
+  });
+
+  pipeline.on('error', (e: any) => console.log(`[FIRED] pipeline.error: ${e.code} ${e.message}`));
+  nodeStream.on('error', (e: any) =>
+    console.log(`[FIRED] nodeStream.error: ${e.code} ${e.message}`)
+  );
+
+  const poll = setInterval(() => {
+    process.stdout.write(
+      `[poll] socket.destroyed=${socket?.destroyed} nodeStream.destroyed=${nodeStream.destroyed}\r`
+    );
+    if (disconnected || nodeStream.destroyed) clearInterval(poll);
+  }, 250);
+
+  reply.header('Content-Type', 'text/event-stream');
+  reply.header('Cache-Control', 'no-cache');
+  reply.header('Connection', 'keep-alive');
+  return reply.send(pipeline);
+});
+
+fastify.listen({ port: 19994 }, () => {
+  console.log('Listening on http://localhost:19994');
+});

--- a/packages/backend/src/__tests__/disconnect-detection/test-sym-handle.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-sym-handle.ts
@@ -1,0 +1,36 @@
+import Fastify from 'fastify';
+const fastify = Fastify();
+const t0 = Date.now();
+const ms = () => `+${Date.now() - t0}ms`;
+
+fastify.post('/test', async (request, reply) => {
+  const socket = (request.raw as any)?.socket as any;
+  const symHandle = Object.getOwnPropertySymbols(socket).find(
+    (s) => s.toString() === 'Symbol(handle)'
+  );
+  const handle = symHandle ? socket[symHandle] : null;
+  console.log(`${ms()} handle type: ${handle?.constructor?.name}`);
+  console.log(`${ms()} handle keys: ${Object.getOwnPropertyNames(handle || {}).join(', ')}`);
+  console.log(
+    `${ms()} handle proto keys: ${Object.getOwnPropertyNames(Object.getPrototypeOf(handle || {})).join(', ')}`
+  );
+
+  reply.raw.writeHead(200, { 'Content-Type': 'text/event-stream' });
+  let n = 0;
+  const iv = setInterval(() => {
+    n++;
+    reply.raw.write(`data: ${n}\n\n`);
+    if (n % 4 === 0) {
+      const open = handle?.open;
+      const closed = handle?.closed;
+      const fd = handle?.fd;
+      process.stdout.write(`${ms()} handle.open=${open} handle.closed=${closed} handle.fd=${fd}\r`);
+    }
+    if (n >= 100) {
+      clearInterval(iv);
+      reply.raw.end();
+    }
+  }, 100);
+});
+
+fastify.listen({ port: 19987 }, () => console.log(`${ms()} listening`));

--- a/packages/backend/src/__tests__/disconnect-detection/test-timeout-abort-signal.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-timeout-abort-signal.ts
@@ -1,0 +1,54 @@
+/**
+ * Test: does abortController.abort() stop a Readable.fromWeb() stream mid-flight?
+ *
+ * This simulates what would happen if a completion timeout fired after streaming
+ * had already started — the abort signal has already been consumed by fetch(),
+ * so aborting it again has no effect on the ongoing body read.
+ */
+import { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+let chunkCount = 0;
+let cancelFired = false;
+
+const ac = new AbortController();
+
+const webStream = new ReadableStream<Uint8Array>({
+  start(controller) {
+    const iv = setInterval(() => {
+      chunkCount++;
+      try {
+        controller.enqueue(new TextEncoder().encode(`chunk ${chunkCount}\n`));
+      } catch {
+        clearInterval(iv);
+      }
+      if (chunkCount >= 50) {
+        clearInterval(iv);
+        controller.close();
+      }
+    }, 50);
+  },
+  cancel(reason) {
+    cancelFired = true;
+    console.log(`\n[FIRED] webStream.cancel, reason: ${reason}`);
+  },
+});
+
+const nodeStream = Readable.fromWeb(webStream as any);
+const pipeline = nodeStream.pipe(new PassThrough());
+pipeline.on('data', () => {});
+pipeline.on('error', () => {});
+nodeStream.on('error', () => {});
+
+// Timeout fires mid-stream
+setTimeout(() => {
+  console.log(`\n--- abort() at chunk ~${chunkCount} ---`);
+  ac.abort(new DOMException('signal timed out', 'TimeoutError'));
+}, 400);
+
+setTimeout(() => {
+  console.log(`cancelFired=${cancelFired}          (expected true)`);
+  console.log(`nodeStream.destroyed=${nodeStream.destroyed} (expected true)`);
+  console.log(`chunkCount=${chunkCount}            (still growing = upstream not cancelled)`);
+  process.exit(0);
+}, 1800);

--- a/packages/backend/src/__tests__/disconnect-detection/test-timeout-nodestream-destroy.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-timeout-nodestream-destroy.ts
@@ -1,0 +1,55 @@
+/**
+ * Test: does nodeStream.destroy() + abortController.abort() together stop
+ * the upstream, even if abort() alone doesn't?
+ *
+ * This is what our onDisconnect() does — confirms the same fix works for timeouts.
+ */
+import { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+let chunkCount = 0;
+let cancelFired = false;
+
+const ac = new AbortController();
+
+const webStream = new ReadableStream<Uint8Array>({
+  start(controller) {
+    const iv = setInterval(() => {
+      chunkCount++;
+      try {
+        controller.enqueue(new TextEncoder().encode(`chunk ${chunkCount}\n`));
+      } catch {
+        clearInterval(iv);
+      }
+      if (chunkCount >= 50) {
+        clearInterval(iv);
+        controller.close();
+      }
+    }, 50);
+  },
+  cancel(reason) {
+    cancelFired = true;
+    console.log(`\n[FIRED] webStream.cancel, reason: ${reason}`);
+  },
+});
+
+const nodeStream = Readable.fromWeb(webStream as any);
+const pipeline = nodeStream.pipe(new PassThrough());
+pipeline.on('data', () => {});
+pipeline.on('error', () => {});
+nodeStream.on('error', () => {});
+
+// Same fix as onDisconnect() — both abort AND destroy the source nodeStream
+setTimeout(() => {
+  console.log(`\n--- timeout: abort() + nodeStream.destroy() at chunk ~${chunkCount} ---`);
+  ac.abort(new DOMException('signal timed out', 'TimeoutError'));
+  nodeStream.destroy();
+  pipeline.destroy();
+}, 400);
+
+setTimeout(() => {
+  console.log(`cancelFired=${cancelFired}          (expected true)`);
+  console.log(`nodeStream.destroyed=${nodeStream.destroyed} (expected true)`);
+  console.log(`chunkCount=${chunkCount}            (stopped growing = upstream cancelled)`);
+  process.exit(0);
+}, 1800);

--- a/packages/backend/src/__tests__/disconnect-detection/test-timeout-signal-listener.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-timeout-signal-listener.ts
@@ -1,0 +1,65 @@
+/**
+ * Test: if we add an abort event listener to the signal AFTER streaming starts,
+ * can we use that to trigger nodeStream.destroy() and cancel the upstream?
+ *
+ * This would be the pattern for wiring up timeout support properly:
+ *   signal.addEventListener('abort', () => { nodeStream.destroy(); pipeline.destroy(); })
+ */
+import { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+let chunkCount = 0;
+let cancelFired = false;
+let listenerFired = false;
+
+const ac = new AbortController();
+
+const webStream = new ReadableStream<Uint8Array>({
+  start(controller) {
+    const iv = setInterval(() => {
+      chunkCount++;
+      try {
+        controller.enqueue(new TextEncoder().encode(`chunk ${chunkCount}\n`));
+      } catch {
+        clearInterval(iv);
+      }
+      if (chunkCount >= 50) {
+        clearInterval(iv);
+        controller.close();
+      }
+    }, 50);
+  },
+  cancel(reason) {
+    cancelFired = true;
+    console.log(`\n[FIRED] webStream.cancel, reason: ${reason}`);
+  },
+});
+
+const nodeStream = Readable.fromWeb(webStream as any);
+const pipeline = nodeStream.pipe(new PassThrough());
+pipeline.on('data', () => {});
+pipeline.on('error', () => {});
+nodeStream.on('error', () => {});
+
+// Wire the abort signal to destroy both streams — this is the pattern
+// that should be used in response-handler.ts for timeout support
+ac.signal.addEventListener('abort', () => {
+  listenerFired = true;
+  console.log(`\n[FIRED] abort listener, reason.name=${ac.signal.reason?.name}`);
+  nodeStream.destroy();
+  pipeline.destroy();
+});
+
+// Timeout fires mid-stream
+setTimeout(() => {
+  console.log(`\n--- ac.abort(TimeoutError) at chunk ~${chunkCount} ---`);
+  ac.abort(new DOMException('signal timed out', 'TimeoutError'));
+}, 400);
+
+setTimeout(() => {
+  console.log(`listenerFired=${listenerFired}       (expected true)`);
+  console.log(`cancelFired=${cancelFired}           (expected true)`);
+  console.log(`nodeStream.destroyed=${nodeStream.destroyed} (expected true)`);
+  console.log(`chunkCount=${chunkCount}             (stopped growing = upstream cancelled)`);
+  process.exit(0);
+}, 1800);

--- a/packages/backend/src/__tests__/disconnect-detection/test-timing.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-timing.ts
@@ -1,0 +1,44 @@
+import Fastify from 'fastify';
+import { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+const fastify = Fastify();
+const t0 = Date.now();
+const ms = () => `+${Date.now() - t0}ms`;
+
+fastify.post('/test', async (request, reply) => {
+  const socket = (request.raw as any)?.socket as any;
+  console.log(`${ms()} [request] received`);
+
+  socket?.once('close', () =>
+    console.log(`${ms()} [FIRED] socket.close. destroyed=${socket?.destroyed}`)
+  );
+  request.raw.once('close', () => console.log(`${ms()} [FIRED] request.raw.close`));
+  request.raw.once('end', () => console.log(`${ms()} [FIRED] request.raw.end`));
+
+  const webStream = new ReadableStream({
+    start(c) {
+      let n = 0;
+      const iv = setInterval(() => {
+        c.enqueue(new TextEncoder().encode(`data:${n++}\n\n`));
+        if (n > 200) {
+          clearInterval(iv);
+          c.close();
+        }
+      }, 50);
+    },
+    cancel() {
+      console.log(`${ms()} [FIRED] webStream.cancel`);
+    },
+  });
+
+  const nodeStream = Readable.fromWeb(webStream as any);
+  const pipeline = nodeStream.pipe(new PassThrough());
+  pipeline.on('error', () => {});
+  nodeStream.on('error', () => {});
+
+  reply.header('Content-Type', 'text/event-stream');
+  return reply.send(pipeline);
+});
+
+fastify.listen({ port: 19993 }, () => console.log(`${ms()} listening`));

--- a/packages/backend/src/__tests__/disconnect-detection/test-write-fail.ts
+++ b/packages/backend/src/__tests__/disconnect-detection/test-write-fail.ts
@@ -1,0 +1,51 @@
+/**
+ * Test: does writing to a disconnected client's response cause an error we can catch?
+ */
+import Fastify from 'fastify';
+import { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+const fastify = Fastify();
+const t0 = Date.now();
+const ms = () => `+${Date.now() - t0}ms`;
+
+fastify.post('/test', async (request, reply) => {
+  console.log(`${ms()} [request] received`);
+
+  const webStream = new ReadableStream({
+    start(c) {
+      let n = 0;
+      const iv = setInterval(() => {
+        n++;
+        process.stdout.write(`${ms()} [upstream] producing chunk ${n}\r`);
+        c.enqueue(new TextEncoder().encode(`data: chunk ${n}\n\n`));
+        if (n > 200) {
+          clearInterval(iv);
+          c.close();
+        }
+      }, 50);
+    },
+    cancel() {
+      console.log(`\n${ms()} [FIRED] webStream.cancel`);
+    },
+  });
+
+  const nodeStream = Readable.fromWeb(webStream as any);
+  const passthrough = new PassThrough();
+  const pipeline = nodeStream.pipe(passthrough);
+
+  pipeline.on('error', (e: any) =>
+    console.log(`\n${ms()} [FIRED] pipeline.error: code=${e.code} msg=${e.message}`)
+  );
+  nodeStream.on('error', (e: any) =>
+    console.log(`\n${ms()} [FIRED] nodeStream.error: code=${e.code} msg=${e.message}`)
+  );
+  passthrough.on('error', (e: any) =>
+    console.log(`\n${ms()} [FIRED] passthrough.error: code=${e.code} msg=${e.message}`)
+  );
+
+  reply.header('Content-Type', 'text/event-stream');
+  return reply.send(pipeline);
+});
+
+fastify.listen({ port: 19992 }, () => console.log(`${ms()} listening`));

--- a/packages/backend/src/routes/inference/chat.ts
+++ b/packages/backend/src/routes/inference/chat.ts
@@ -86,7 +86,8 @@ export async function registerChatRoute(
         if (!allowed) return;
       }
 
-      const unifiedResponse = await dispatcher.dispatch(unifiedRequest);
+      const abortController = new AbortController();
+      const unifiedResponse = await dispatcher.dispatch(unifiedRequest, abortController.signal);
 
       // Emit 'updated' event with routing decision details
       usageStorage.emitUpdatedAsync({
@@ -116,11 +117,16 @@ export async function registerChatRoute(
         shouldEstimateTokens,
         body,
         quotaEnforcer,
-        (request as any).keyName
+        (request as any).keyName,
+        abortController
       );
 
       return result;
     } catch (e: any) {
+      if (e?.routingContext?.code === 'client_disconnected' || e?.routingContext?.code === 'upstream_timeout') {
+        logger.info(`Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`);
+        return;
+      }
       usageRecord.responseStatus = 'error';
       usageRecord.durationMs = Date.now() - startTime;
       usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;

--- a/packages/backend/src/routes/inference/gemini.ts
+++ b/packages/backend/src/routes/inference/gemini.ts
@@ -94,7 +94,8 @@ export async function registerGeminiRoute(
         unifiedRequest.stream = true;
       }
 
-      const unifiedResponse = await dispatcher.dispatch(unifiedRequest);
+      const abortController = new AbortController();
+      const unifiedResponse = await dispatcher.dispatch(unifiedRequest, abortController.signal);
 
       // Emit 'updated' event with routing decision details
       usageStorage.emitUpdatedAsync({
@@ -125,11 +126,16 @@ export async function registerGeminiRoute(
         shouldEstimateTokens,
         body,
         quotaEnforcer,
-        (request as any).keyName
+        (request as any).keyName,
+        abortController
       );
 
       return result;
     } catch (e: any) {
+      if (e?.routingContext?.code === 'client_disconnected' || e?.routingContext?.code === 'upstream_timeout') {
+        logger.info(`Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`);
+        return;
+      }
       usageRecord.responseStatus = 'error';
       usageRecord.durationMs = Date.now() - startTime;
       usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;

--- a/packages/backend/src/routes/inference/messages.ts
+++ b/packages/backend/src/routes/inference/messages.ts
@@ -84,7 +84,8 @@ export async function registerMessagesRoute(
         if (!allowed) return;
       }
 
-      const unifiedResponse = await dispatcher.dispatch(unifiedRequest);
+      const abortController = new AbortController();
+      const unifiedResponse = await dispatcher.dispatch(unifiedRequest, abortController.signal);
 
       // Emit 'updated' event with routing decision details
       usageStorage.emitUpdatedAsync({
@@ -115,11 +116,16 @@ export async function registerMessagesRoute(
         shouldEstimateTokens,
         body,
         quotaEnforcer,
-        (request as any).keyName
+        (request as any).keyName,
+        abortController
       );
 
       return result;
     } catch (e: any) {
+      if (e?.routingContext?.code === 'client_disconnected' || e?.routingContext?.code === 'upstream_timeout') {
+        logger.info(`Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`);
+        return;
+      }
       usageRecord.responseStatus = 'error';
       usageRecord.durationMs = Date.now() - startTime;
       usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -167,7 +167,8 @@ export async function registerResponsesRoute(
         if (!allowed) return;
       }
 
-      const unifiedResponse = await dispatcher.dispatch(unifiedRequest);
+      const abortController = new AbortController();
+      const unifiedResponse = await dispatcher.dispatch(unifiedRequest, abortController.signal);
 
       // Emit 'updated' event with routing decision details
       usageStorage.emitUpdatedAsync({
@@ -199,7 +200,8 @@ export async function registerResponsesRoute(
         shouldEstimateTokens,
         body,
         quotaEnforcer,
-        (request as any).keyName
+        (request as any).keyName,
+        abortController
       );
 
       // Store response if requested and not streaming
@@ -222,6 +224,10 @@ export async function registerResponsesRoute(
 
       return result;
     } catch (e: any) {
+      if (e?.routingContext?.code === 'client_disconnected' || e?.routingContext?.code === 'upstream_timeout') {
+        logger.info(`Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`);
+        return;
+      }
       usageRecord.responseStatus = 'error';
       usageRecord.durationMs = Date.now() - startTime;
       usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;

--- a/packages/backend/src/services/__tests__/dispatcher-abort.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-abort.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { Dispatcher } from '../dispatcher';
+
+// Prevent real network calls
+global.fetch = vi.fn(async () => new Response('', { status: 200 })) as any;
+
+describe('Dispatcher — AbortSignal / cancellation', () => {
+  let dispatcher: Dispatcher;
+
+  beforeEach(() => {
+    dispatcher = new Dispatcher();
+  });
+
+  test('buildCancelledError returns 499 and client_disconnected for a plain abort', () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const err = (dispatcher as any).buildCancelledError(controller.signal);
+    expect(err.message).toBe('Client disconnected');
+    expect(err.routingContext.statusCode).toBe(499);
+    expect(err.routingContext.code).toBe('client_disconnected');
+  });
+
+  test('buildCancelledError returns 504 and upstream_timeout for a TimeoutError', () => {
+    // AbortSignal.timeout() aborts with a reason whose name is 'TimeoutError'
+    const signal = AbortSignal.timeout(1);
+    // Force the signal into the aborted state synchronously via a dedicated controller
+    const controller = new AbortController();
+    const timeoutReason = new DOMException('signal timed out', 'TimeoutError');
+    controller.abort(timeoutReason);
+
+    const err = (dispatcher as any).buildCancelledError(controller.signal);
+    expect(err.message).toBe('Upstream timeout');
+    expect(err.routingContext.statusCode).toBe(504);
+    expect(err.routingContext.code).toBe('upstream_timeout');
+  });
+
+  test('executeProviderRequest forwards AbortSignal to fetch', async () => {
+    const controller = new AbortController();
+    const mockFetch = vi.fn(async () => new Response('{}', { status: 200 }));
+    global.fetch = mockFetch as any;
+
+    await (dispatcher as any).executeProviderRequest(
+      'https://example.com/v1/test',
+      { 'content-type': 'application/json' },
+      { model: 'test' },
+      controller.signal
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com/v1/test',
+      expect.objectContaining({ signal: controller.signal })
+    );
+  });
+
+  test('buildCancelledError produces 499 for a plain abort (via abort loop guard)', () => {
+    // Verifies the helper that is called by the top-of-loop abort guard
+    // and per-attempt catch blocks inside dispatch().
+    const controller = new AbortController();
+    controller.abort('client closed connection');
+
+    const err = (dispatcher as any).buildCancelledError(controller.signal);
+    expect(err.routingContext.statusCode).toBe(499);
+    expect(err.routingContext.code).toBe('client_disconnected');
+    // Should not be retried — 499 is intentionally outside retryable status codes
+    expect(err.routingContext.statusCode).not.toBe(500);
+    expect(err.routingContext.statusCode).not.toBe(503);
+  });
+});

--- a/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
+++ b/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the upstream fetch cancellation chain in handleResponse().
+ *
+ * These tests verify the two bugs discovered and fixed during the stream
+ * disconnection work:
+ *
+ * 1. pipeline.destroy() alone does NOT propagate cancel() back through
+ *    Readable.fromWeb() to the upstream web ReadableStream.
+ *    nodeStream.destroy() (the source) must be called.
+ *
+ * 2. abortController.abort() alone also does NOT stop an already-in-progress
+ *    Readable.fromWeb() read loop. The abort signal is consumed by fetch() at
+ *    call time; aborting it afterwards has no effect on the streaming body.
+ *    nodeStream.destroy() is required in all cases.
+ *
+ * See packages/backend/src/__tests__/disconnect-detection/ for the exploratory
+ * test scripts that established these findings.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a web ReadableStream that enqueues chunks on an interval.
+ * Returns the stream and a spy that records whether cancel() was called.
+ */
+function makeWebStream(intervalMs = 20, maxChunks = 100) {
+  let cancelCalled = false;
+  let cancelReason: unknown = undefined;
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let n = 0;
+      intervalId = setInterval(() => {
+        n++;
+        try {
+          controller.enqueue(new TextEncoder().encode(`chunk-${n}\n`));
+        } catch {
+          // controller already closed/cancelled — stop the interval
+          if (intervalId) clearInterval(intervalId);
+        }
+        if (n >= maxChunks) {
+          if (intervalId) clearInterval(intervalId);
+          controller.close();
+        }
+      }, intervalMs);
+    },
+    cancel(reason) {
+      cancelCalled = true;
+      cancelReason = reason;
+      if (intervalId) clearInterval(intervalId);
+    },
+  });
+
+  return {
+    stream,
+    wasCancelled: () => cancelCalled,
+    cancelReason: () => cancelReason,
+  };
+}
+
+/**
+ * Builds the same Node stream pipeline that response-handler.ts constructs:
+ *   webStream -> Readable.fromWeb() -> nodeStream -> .pipe() -> passthrough
+ */
+function makePipeline(webStream: ReadableStream<Uint8Array>) {
+  const nodeStream = Readable.fromWeb(webStream as any);
+  const passthrough = new PassThrough();
+  const pipeline = nodeStream.pipe(passthrough);
+  // Suppress unhandled error events from deliberate destroy() calls
+  pipeline.on('error', () => {});
+  nodeStream.on('error', () => {});
+  passthrough.on('data', () => {}); // drain so backpressure doesn't stall
+  return { nodeStream, passthrough, pipeline };
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// Cancellation chain tests
+// ---------------------------------------------------------------------------
+
+describe('Upstream fetch cancellation chain', () => {
+  it('pipeline.destroy() (downstream) does NOT cancel the upstream web stream', async () => {
+    const { stream, wasCancelled } = makeWebStream();
+    const { pipeline } = makePipeline(stream);
+
+    await wait(100); // let some chunks flow
+    pipeline.destroy();
+    await wait(200); // give cancel() time to fire if it were going to
+
+    expect(wasCancelled()).toBe(false);
+  });
+
+  it('nodeStream.destroy() (source) DOES cancel the upstream web stream', async () => {
+    const { stream, wasCancelled } = makeWebStream();
+    const { nodeStream } = makePipeline(stream);
+
+    await wait(100);
+    nodeStream.destroy();
+    await wait(200);
+
+    expect(wasCancelled()).toBe(true);
+  });
+
+  it('abortController.abort() alone does NOT cancel an in-progress Readable.fromWeb stream', async () => {
+    const { stream, wasCancelled } = makeWebStream();
+    const { nodeStream } = makePipeline(stream);
+
+    const ac = new AbortController();
+    // The signal was "passed to fetch()" at request time — aborting it after
+    // streaming has begun has no effect on the body read loop.
+    await wait(100);
+    ac.abort(new DOMException('signal timed out', 'TimeoutError'));
+    await wait(200);
+
+    expect(wasCancelled()).toBe(false);
+    // Clean up
+    nodeStream.destroy();
+  });
+
+  it('abort() + nodeStream.destroy() together DO cancel the upstream', async () => {
+    const { stream, wasCancelled } = makeWebStream();
+    const { nodeStream, pipeline } = makePipeline(stream);
+
+    const ac = new AbortController();
+
+    await wait(100);
+    ac.abort(new DOMException('signal timed out', 'TimeoutError'));
+    nodeStream.destroy(); // this is what actually cancels Readable.fromWeb
+    pipeline.destroy();
+    await wait(200);
+
+    expect(wasCancelled()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signal.addEventListener('abort') pattern
+// ---------------------------------------------------------------------------
+
+describe('signal abort listener -> nodeStream.destroy() pattern', () => {
+  it('wiring signal abort to nodeStream.destroy() cancels upstream on abort()', async () => {
+    const { stream, wasCancelled } = makeWebStream();
+    const { nodeStream, pipeline } = makePipeline(stream);
+
+    const ac = new AbortController();
+
+    // This is the pattern now used in response-handler.ts
+    ac.signal.addEventListener(
+      'abort',
+      () => {
+        nodeStream.destroy();
+        pipeline.destroy();
+      },
+      { once: true }
+    );
+
+    await wait(100);
+    ac.abort(new DOMException('signal timed out', 'TimeoutError'));
+    await wait(200);
+
+    expect(wasCancelled()).toBe(true);
+    expect(nodeStream.destroyed).toBe(true);
+  });
+
+  it('abort listener fires for plain abort (client disconnect case)', async () => {
+    const { stream, wasCancelled } = makeWebStream();
+    const { nodeStream, pipeline } = makePipeline(stream);
+
+    const ac = new AbortController();
+    const listenerSpy = vi.fn(() => {
+      nodeStream.destroy();
+      pipeline.destroy();
+    });
+
+    ac.signal.addEventListener('abort', listenerSpy, { once: true });
+
+    await wait(100);
+    ac.abort(); // plain abort, no reason — simulates what onDisconnect() does
+    await wait(200);
+
+    expect(listenerSpy).toHaveBeenCalledOnce();
+    expect(wasCancelled()).toBe(true);
+  });
+
+  it('abort listener fires for TimeoutError (timeout case)', async () => {
+    const { stream, wasCancelled } = makeWebStream();
+    const { nodeStream, pipeline } = makePipeline(stream);
+
+    const ac = new AbortController();
+    let capturedReason: unknown = null;
+
+    ac.signal.addEventListener(
+      'abort',
+      () => {
+        capturedReason = ac.signal.reason;
+        nodeStream.destroy();
+        pipeline.destroy();
+      },
+      { once: true }
+    );
+
+    await wait(100);
+    ac.abort(new DOMException('signal timed out', 'TimeoutError'));
+    await wait(200);
+
+    expect(wasCancelled()).toBe(true);
+    expect((capturedReason as DOMException)?.name).toBe('TimeoutError');
+  });
+
+  it('abort listener is called at most once even if abort() is called multiple times', async () => {
+    const { stream } = makeWebStream();
+    const { nodeStream, pipeline } = makePipeline(stream);
+
+    const ac = new AbortController();
+    const listenerSpy = vi.fn(() => {
+      nodeStream.destroy();
+      pipeline.destroy();
+    });
+
+    ac.signal.addEventListener('abort', listenerSpy, { once: true });
+
+    await wait(50);
+    ac.abort();
+    ac.abort(); // second call should be a no-op
+    await wait(100);
+
+    expect(listenerSpy).toHaveBeenCalledOnce();
+    nodeStream.destroy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stream termination state
+// ---------------------------------------------------------------------------
+
+describe('nodeStream destruction state', () => {
+  it('nodeStream.destroyed is false before any cancellation', async () => {
+    const { stream } = makeWebStream();
+    const { nodeStream } = makePipeline(stream);
+
+    await wait(50);
+    expect(nodeStream.destroyed).toBe(false);
+    nodeStream.destroy();
+  });
+
+  it('nodeStream.destroyed is true immediately after destroy()', async () => {
+    const { stream } = makeWebStream();
+    const { nodeStream } = makePipeline(stream);
+
+    await wait(50);
+    nodeStream.destroy();
+    expect(nodeStream.destroyed).toBe(true);
+  });
+
+  it('upstream stops producing chunks after nodeStream.destroy()', async () => {
+    const { stream, wasCancelled } = makeWebStream(20, 100);
+    const { nodeStream } = makePipeline(stream);
+
+    await wait(100); // ~5 chunks at 20ms intervals
+    nodeStream.destroy();
+    await wait(200); // wait for cancel() to propagate
+
+    expect(wasCancelled()).toBe(true);
+    expect(nodeStream.destroyed).toBe(true);
+  });
+});

--- a/packages/backend/src/services/__tests__/usage-logging.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging.test.ts
@@ -397,4 +397,140 @@ describe('UsageInspector', () => {
       expect(capturedRecord!.tokensEstimated).toBe(1);
     });
   });
+
+  describe('_destroy() — client disconnect handling', () => {
+    function makeInspector(requestId: string, startTime: number) {
+      return new UsageInspector(
+        requestId,
+        mockStorage,
+        { requestId } as Partial<UsageRecord>,
+        mockPricing,
+        undefined,
+        startTime,
+        false,
+        'chat',
+        undefined,
+        undefined,
+        DEFAULT_GPU_PARAMS,
+        DEFAULT_MODEL
+      );
+    }
+
+    it('records responseStatus=cancelled when stream is destroyed before completion', async () => {
+      const requestId = 'test-destroy-cancelled';
+      const startTime = Date.now() - 200;
+      const inspector = makeInspector(requestId, startTime);
+      // Must attach error listener — destroying with an Error would otherwise throw uncaught
+      inspector.on('error', () => {});
+
+      let capturedRecord: UsageRecord | null = null;
+      registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+        capturedRecord = record;
+      });
+
+      const src = new PassThrough();
+      src.pipe(inspector);
+      src.write('data: partial chunk\n\n');
+      // Destroy before end — simulates client disconnect
+      inspector.destroy(new Error('client_disconnected'));
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(capturedRecord).not.toBeNull();
+      expect(capturedRecord!.responseStatus).toBe('cancelled');
+      expect(capturedRecord!.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('records responseStatus=timeout when destroyed with a TimeoutError', async () => {
+      const requestId = 'test-destroy-timeout';
+      const startTime = Date.now() - 500;
+      const inspector = makeInspector(requestId, startTime);
+      inspector.on('error', () => {});
+
+      let capturedRecord: UsageRecord | null = null;
+      registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+        capturedRecord = record;
+      });
+
+      const src = new PassThrough();
+      src.pipe(inspector);
+
+      const timeoutErr = new Error('Upstream timeout');
+      timeoutErr.name = 'TimeoutError';
+      inspector.destroy(timeoutErr);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(capturedRecord).not.toBeNull();
+      expect(capturedRecord!.responseStatus).toBe('timeout');
+    });
+
+    it('does not double-save when _flush runs normally then destroy is called', async () => {
+      const requestId = 'test-no-double-save';
+      const startTime = Date.now() - 100;
+
+      const debugManager = DebugManager.getInstance();
+      debugManager.setEnabled(true);
+      debugManager.startLog(requestId, { messages: [] });
+      debugManager.addReconstructedRawResponse(requestId, {
+        choices: [{ finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+
+      const inspector = makeInspector(requestId, startTime);
+      inspector.on('error', () => {});
+
+      let saveCount = 0;
+      registerSpy(mockStorage, 'saveRequest').mockImplementation(async () => {
+        saveCount++;
+      });
+
+      const src = new PassThrough();
+      src.pipe(inspector);
+
+      // Normal end — _flush fires, sets _flushed = true
+      src.end();
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      // Simulate a post-completion write error triggering destroy
+      inspector.destroy(new Error('EPIPE'));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // saveRequest must be called exactly once (from _flush, not again from _destroy)
+      expect(saveCount).toBe(1);
+    });
+
+    it('saves with partial tokens from DebugManager when cancelled mid-stream', async () => {
+      const requestId = 'test-destroy-partial-tokens';
+      const startTime = Date.now() - 1000;
+
+      const debugManager = DebugManager.getInstance();
+      debugManager.setEnabled(true);
+      debugManager.startLog(requestId, { messages: [] });
+      // Simulate partial token data accumulated before disconnect
+      debugManager.addReconstructedRawResponse(requestId, {
+        choices: [{ finish_reason: null }],
+        usage: { prompt_tokens: 50, completion_tokens: 0, total_tokens: 50 },
+      });
+
+      const inspector = makeInspector(requestId, startTime);
+      inspector.on('error', () => {});
+
+      let capturedRecord: UsageRecord | null = null;
+      registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+        capturedRecord = record;
+      });
+
+      const src = new PassThrough();
+      src.pipe(inspector);
+      src.write('data: partial\n\n');
+      inspector.destroy(new Error('client_disconnected'));
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(capturedRecord).not.toBeNull();
+      expect(capturedRecord!.responseStatus).toBe('cancelled');
+      expect(capturedRecord!.tokensInput).toBe(50);
+    });
+  });
 });

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -240,7 +240,7 @@ export class Dispatcher {
     );
   }
 
-  async dispatch(request: UnifiedChatRequest): Promise<UnifiedChatResponse> {
+  async dispatch(request: UnifiedChatRequest, signal?: AbortSignal): Promise<UnifiedChatResponse> {
     const config = getConfig();
     const failover = config.failover;
     const failoverEnabled = failover?.enabled !== false;
@@ -274,6 +274,7 @@ export class Dispatcher {
     const isVisionDescriptorRequest = (request as any)._isVisionDescriptorRequest === true;
 
     for (let i = 0; i < targets.length; i++) {
+      if (signal?.aborted) throw this.buildCancelledError(signal);
       let currentRequest = { ...request };
       const route = targets[i]!;
 
@@ -403,7 +404,8 @@ export class Dispatcher {
               currentRequest,
               route,
               targetApiType,
-              transformer
+              transformer,
+              signal
             );
             await this.recordAttemptMetric(route, currentRequest.requestId, true, {
               isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
@@ -420,6 +422,7 @@ export class Dispatcher {
             );
             return oauthResponse;
           } catch (oauthError: any) {
+            if (signal?.aborted) throw this.buildCancelledError(signal);
             lastError = oauthError;
             const canRetry =
               failoverEnabled && i < targets.length - 1 && this.isRetryableOAuthError(oauthError);
@@ -461,7 +464,7 @@ export class Dispatcher {
 
         logger.silly('Upstream Request Payload', providerPayload);
 
-        const response = await this.executeProviderRequest(url, headers, providerPayload);
+        const response = await this.executeProviderRequest(url, headers, providerPayload, signal);
 
         if (!response.ok) {
           const errorText = await response.text();
@@ -481,6 +484,7 @@ export class Dispatcher {
               currentRequest.requestId
             );
           } catch (e: any) {
+            if (signal?.aborted) throw this.buildCancelledError(signal);
             lastError = e;
             this.appendFailureAttempt(retryHistory, route, e, targetApiType, canRetry);
 
@@ -1609,7 +1613,8 @@ export class Dispatcher {
     request: UnifiedChatRequest,
     route: RouteResult,
     targetApiType: string,
-    transformer: any
+    transformer: any,
+    signal?: AbortSignal
   ): Promise<UnifiedChatResponse> {
     if (!transformer.executeRequest) {
       throw new Error('OAuth transformer missing executeRequest()');
@@ -1671,7 +1676,8 @@ export class Dispatcher {
         route.model,
         !!request.stream,
         oauthOptions,
-        authConfig
+        authConfig,
+        signal
       );
 
       if (request.stream) {
@@ -1709,6 +1715,16 @@ export class Dispatcher {
     } catch (error: any) {
       throw this.wrapOAuthError(error, route, targetApiType);
     }
+  }
+
+  private buildCancelledError(signal: AbortSignal): Error {
+    const isTimeout = signal.reason?.name === 'TimeoutError';
+    const err = new Error(isTimeout ? 'Upstream timeout' : 'Client disconnected') as any;
+    err.routingContext = {
+      statusCode: isTimeout ? 504 : 499,
+      code: isTimeout ? 'upstream_timeout' : 'client_disconnected',
+    };
+    return err;
   }
 
   private assertOAuthModelSupported(oauthProvider: string, modelId: string) {
@@ -2018,12 +2034,14 @@ export class Dispatcher {
   private async executeProviderRequest(
     url: string,
     headers: Record<string, string>,
-    payload: any
+    payload: any,
+    signal?: AbortSignal
   ): Promise<Response> {
     return await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(payload),
+      signal,
     });
   }
 

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -29,6 +29,7 @@ export class UsageInspector extends PassThrough {
   private firstChunk = true;
   private quotaEnforcer?: any;
   private keyName?: string;
+  private _flushed = false;
 
   private modelParams: ModelParams;
   private gpuParams: GpuParams;
@@ -75,6 +76,7 @@ export class UsageInspector extends PassThrough {
   }
 
   override _flush(callback: Function) {
+    this._flushed = true;
     const stats = {
       inputTokens: 0,
       outputTokens: 0,
@@ -218,6 +220,56 @@ export class UsageInspector extends PassThrough {
       logger.error(`Error analyzing usage for ${this.usageRecord.requestId}:`, err);
       callback();
     }
+  }
+
+  override _destroy(err: Error | null, callback: (error?: Error | null) => void) {
+    if (this._flushed) {
+      callback(err);
+      return;
+    }
+
+    const isTimeout = err?.name === 'TimeoutError' || err?.message?.includes('timeout');
+    const status = isTimeout ? 'timeout' : 'cancelled';
+
+    logger.info(
+      `UsageInspector: stream destroyed for ${this.usageRecord.requestId} ` +
+        `(responseStatus=${status}, err=${err?.message ?? 'none'})`
+    );
+
+    try {
+      this.usageRecord.responseStatus = status;
+      this.usageRecord.durationMs = Date.now() - this.startTime;
+
+      const debugManager = DebugManager.getInstance();
+      const reconstructed = debugManager.getReconstructedRawResponse(this.usageRecord.requestId!);
+      if (reconstructed) {
+        const usage = this.extractUsageFromReconstructed(reconstructed, this.apiType);
+        if (usage) {
+          this.usageRecord.tokensInput = usage.inputTokens || null;
+          this.usageRecord.tokensOutput = usage.outputTokens || null;
+          this.usageRecord.tokensCached = usage.cachedTokens || null;
+          this.usageRecord.tokensCacheWrite = usage.cacheWriteTokens || null;
+          this.usageRecord.tokensReasoning = usage.reasoningTokens || null;
+        }
+        calculateCosts(this.usageRecord, this.pricing, this.providerDiscount);
+      }
+
+      this.usageStorage.saveRequest(this.usageRecord as UsageRecord).catch((saveErr) => {
+        logger.error(
+          `Failed to save ${status} usage for ${this.usageRecord.requestId}:`,
+          saveErr
+        );
+      });
+
+      debugManager.flush(this.usageRecord.requestId!);
+    } catch (destroyErr) {
+      logger.error(
+        `Error in UsageInspector._destroy for ${this.usageRecord.requestId}:`,
+        destroyErr
+      );
+    }
+
+    callback(err);
   }
 
   private extractUsageFromReconstructed(reconstructed: any, apiType: string): any {

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -186,44 +186,127 @@ export async function handleResponse(
     // rawLogInspector is already tapped via the TransformStream above
     const pipeline = nodeStream.pipe(usageInspector);
 
-    // --- Client disconnect + upstream cancellation wiring ---
+    // =============================================================================
+    // CLIENT DISCONNECT DETECTION & UPSTREAM CANCELLATION
+    // =============================================================================
+    //
+    // BACKGROUND — WHY THIS IS HARD ON BUN
+    // -------------------------------------
+    // Detecting client disconnects in Bun's node:http compatibility layer (which
+    // Fastify uses) is deeply broken for streaming POST responses as of Bun 1.3.14.
+    // We investigated every standard Node.js mechanism exhaustively:
+    //
+    //   ✗  request.raw.once('close', ...)  — fires immediately when the POST body
+    //        is consumed (a few ms after the request arrives), NOT on client disconnect.
+    //        Fastify's own onRequestAbort hook uses this + req.aborted, which is why
+    //        Fastify's abort detection also doesn't work here.
+    //
+    //   ✗  socket.once('close', ...)  — never fires at all for POST requests when
+    //        the client disconnects. (Bun open issue #14697: ServerResponse doesn't
+    //        emit close event.)
+    //
+    //   ✗  socket.destroyed  — stays false indefinitely even after the client is gone.
+    //
+    //   ✗  res.write() EPIPE  — Bun silently swallows write failures; writes appear
+    //        to succeed even when the client TCP connection is long dead. No EPIPE,
+    //        no ECONNRESET, nothing. (Confirmed in Bun issue #25919, still reproducible
+    //        on Bun 1.3.14 for the streaming proxy case.)
+    //
+    //   ✗  reply.raw.destroyed  — undefined (property doesn't exist on Bun's
+    //        ServerResponse implementation).
+    //
+    // For reference, Bun.serve() (the native HTTP server) DOES correctly fire
+    // request.signal abort on disconnect. But Fastify runs on node:http, not
+    // Bun.serve(), so we can't use that here without a much larger refactor.
+    //
+    // THE SOLUTION — bunHandle.closed
+    // --------------------------------
+    // Bun's Node.js Socket wraps an internal Bun TCP socket handle. It is stored
+    // under Symbol(handle) on the Socket object. This handle has a .closed boolean
+    // property that transitions false → true when the underlying TCP connection
+    // closes, even when all the Node.js-layer signals above are broken.
+    //
+    // Discovery: we enumerated Object.getOwnPropertySymbols() on the Socket at
+    // runtime, found Symbol(handle), and verified with polling tests that its
+    // .closed property updates correctly within ~250ms of a client disconnect.
+    //
+    // If Bun ever fixes the node:http disconnect signals, we can simplify this.
+    // Track: https://github.com/oven-sh/bun/issues/25919
+    //        https://github.com/oven-sh/bun/issues/14697
+    //
+    // CANCELLATION CHAIN — WHY nodeStream.destroy() IS REQUIRED
+    // -----------------------------------------------------------
+    // The stream pipeline is:
+    //
+    //   fetch response body  (Web ReadableStream)
+    //       ↓  Readable.fromWeb()
+    //   nodeStream           (Node.js Readable)
+    //       ↓  .pipe()
+    //   pipeline / usageInspector  (Node.js Transform/Writable)
+    //       ↓  reply.send()
+    //   HTTP response to client
+    //
+    // When a client disconnects, we need to cancel the upstream fetch so we stop
+    // consuming tokens and burning API quota. Simply calling pipeline.destroy()
+    // (the downstream end) does NOT propagate cancel() back through Readable.fromWeb()
+    // to the underlying Web ReadableStream — the upstream fetch keeps running.
+    //
+    // Calling nodeStream.destroy() (the source Node Readable) DOES cause
+    // Readable.fromWeb() to call cancel() on the Web ReadableStream, which aborts
+    // the underlying fetch. We verified this with isolated test scripts.
+    //
+    // We also call abortController.abort() as belt-and-suspenders, since the fetch
+    // was initiated with that signal.
+    // =============================================================================
     let disconnected = false;
     let disconnectPoll: ReturnType<typeof setInterval> | null = null;
 
-    const onDisconnect = () => {
+    const rawSocket = (request.raw as any)?.socket;
+    const symHandle = rawSocket
+      ? Object.getOwnPropertySymbols(rawSocket).find((s) => s.toString() === 'Symbol(handle)')
+      : undefined;
+    const bunHandle = symHandle ? (rawSocket as any)[symHandle] : null;
+
+    const onDisconnect = (source: string) => {
       if (disconnected) return;
       disconnected = true;
-      logger.debug(`Client disconnected for request ${usageRecord.requestId}, aborting upstream`);
+      logger.debug(
+        `Client disconnected for request ${usageRecord.requestId} (detected via ${source}), aborting upstream`
+      );
       abortController?.abort();
-      pipeline.destroy(new Error('client_disconnected'));
+      nodeStream.destroy(); // cancels the upstream fetch via Readable.fromWeb → cancel()
+      pipeline.destroy();
     };
 
     if (abortController) {
-      // Primary: request.raw 'close' — reliable in Bun 1.3.x (PR #13738)
-      request.raw.once('close', onDisconnect);
-
-      // Secondary: poll reply.raw.destroyed — belt-and-suspenders since
-      // ServerResponse close (#14697) is less reliable in Bun 1.3.x
+      // Poll bunHandle.closed every 250ms — the only reliable client-disconnect
+      // signal available in Bun's node:http layer for POST requests (see above).
       disconnectPoll = setInterval(() => {
-        if (reply.raw.destroyed) onDisconnect();
+        if (bunHandle?.closed) onDisconnect('bunHandle.closed');
         if (pipeline.destroyed || pipeline.readableEnded) {
-          if (disconnectPoll) { clearInterval(disconnectPoll); disconnectPoll = null; }
+          if (disconnectPoll) {
+            clearInterval(disconnectPoll);
+            disconnectPoll = null;
+          }
         }
       }, 250);
     }
 
     const cleanupDisconnectWiring = () => {
-      if (disconnectPoll) { clearInterval(disconnectPoll); disconnectPoll = null; }
-      request.raw.off('close', onDisconnect);
+      if (disconnectPoll) {
+        clearInterval(disconnectPoll);
+        disconnectPoll = null;
+      }
     };
 
     pipeline.once('end', cleanupDisconnectWiring);
 
     pipeline.on('error', (err: any) => {
-      // Write-level errors mean the client socket closed under us
+      // Belt-and-suspenders: catch any write errors that do surface (e.g. if Bun
+      // ever fixes EPIPE propagation, or on non-Bun runtimes).
       const code = err?.code;
       if (code === 'EPIPE' || code === 'ECONNRESET' || code === 'ERR_STREAM_DESTROYED') {
-        onDisconnect();
+        onDisconnect('pipeline.error.' + code);
       }
       cleanupDisconnectWiring();
       // Restore debug mode on error

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -36,7 +36,8 @@ export async function handleResponse(
   shouldEstimateTokens: boolean = false,
   originalRequest?: any,
   quotaEnforcer?: QuotaEnforcer,
-  keyName?: string
+  keyName?: string,
+  abortController?: AbortController
 ) {
   // Populate usage record with metadata from the dispatcher's selection
   usageRecord.selectedModelName = unifiedResponse.plexus?.model || unifiedResponse.model; // Fallback to unifiedResponse.model if plexus.model is missing
@@ -185,15 +186,59 @@ export async function handleResponse(
     // rawLogInspector is already tapped via the TransformStream above
     const pipeline = nodeStream.pipe(usageInspector);
 
-    // Restore debug mode state when the stream ends (not before!)
+    // --- Client disconnect + upstream cancellation wiring ---
+    let disconnected = false;
+    let disconnectPoll: ReturnType<typeof setInterval> | null = null;
+
+    const onDisconnect = () => {
+      if (disconnected) return;
+      disconnected = true;
+      logger.debug(`Client disconnected for request ${usageRecord.requestId}, aborting upstream`);
+      abortController?.abort();
+      pipeline.destroy(new Error('client_disconnected'));
+    };
+
+    if (abortController) {
+      // Primary: request.raw 'close' — reliable in Bun 1.3.x (PR #13738)
+      request.raw.once('close', onDisconnect);
+
+      // Secondary: poll reply.raw.destroyed — belt-and-suspenders since
+      // ServerResponse close (#14697) is less reliable in Bun 1.3.x
+      disconnectPoll = setInterval(() => {
+        if (reply.raw.destroyed) onDisconnect();
+        if (pipeline.destroyed || pipeline.readableEnded) {
+          if (disconnectPoll) { clearInterval(disconnectPoll); disconnectPoll = null; }
+        }
+      }, 250);
+    }
+
+    const cleanupDisconnectWiring = () => {
+      if (disconnectPoll) { clearInterval(disconnectPoll); disconnectPoll = null; }
+      request.raw.off('close', onDisconnect);
+    };
+
+    pipeline.once('end', cleanupDisconnectWiring);
+
+    pipeline.on('error', (err: any) => {
+      // Write-level errors mean the client socket closed under us
+      const code = err?.code;
+      if (code === 'EPIPE' || code === 'ECONNRESET' || code === 'ERR_STREAM_DESTROYED') {
+        onDisconnect();
+      }
+      cleanupDisconnectWiring();
+      // Restore debug mode on error
+      if (shouldEstimateTokens && !wasDebugEnabled) {
+        debugManager.setEnabled(false);
+      }
+    });
+
+    // Restore debug mode on normal end
     if (shouldEstimateTokens && !wasDebugEnabled) {
       pipeline.on('end', () => {
         debugManager.setEnabled(false);
       });
-      pipeline.on('error', () => {
-        debugManager.setEnabled(false);
-      });
     }
+    // --- end disconnect wiring ---
 
     usageRecord.responseStatus = 'success';
 

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -257,6 +257,17 @@ export async function handleResponse(
     //
     // We also call abortController.abort() as belt-and-suspenders, since the fetch
     // was initiated with that signal.
+    //
+    // TIMEOUT ABORTS HAVE THE SAME BUG
+    // ---------------------------------
+    // abortController.abort() alone (whether triggered by a timeout or anything else)
+    // also does NOT stop an already-in-progress Readable.fromWeb() read loop. The
+    // abort signal is consumed by fetch() at call time; aborting it afterwards has
+    // no effect on the streaming body read. nodeStream.destroy() is required in all
+    // cases. We wire abortController.signal's 'abort' event to onDisconnect() so
+    // that any future timeout wiring (e.g. AbortSignal.any([signal, AbortSignal.timeout(ms)]))
+    // at the route level will automatically flow through the correct cancellation path
+    // with no further changes needed here. See test-timeout-*.ts.
     // =============================================================================
     let disconnected = false;
     let disconnectPoll: ReturnType<typeof setInterval> | null = null;
@@ -279,6 +290,16 @@ export async function handleResponse(
     };
 
     if (abortController) {
+      // Wire the abort signal so that timeout aborts (e.g. AbortSignal.timeout() or
+      // AbortSignal.any([clientSignal, AbortSignal.timeout(ms)])) also trigger
+      // nodeStream.destroy(). abortController.abort() alone does NOT stop an
+      // already-in-progress Readable.fromWeb() read loop — the same root cause as
+      // the client-disconnect bug. This listener ensures any abort reason goes through
+      // the correct cancellation path. See test-timeout-signal-listener.ts.
+      abortController.signal.addEventListener('abort', () => onDisconnect('signal.abort'), {
+        once: true,
+      });
+
       // Poll bunHandle.closed every 250ms — the only reliable client-disconnect
       // signal available in Bun's node:http layer for POST requests (see above).
       disconnectPoll = setInterval(() => {

--- a/packages/backend/src/transformers/oauth/oauth-transformer.ts
+++ b/packages/backend/src/transformers/oauth/oauth-transformer.ts
@@ -385,7 +385,8 @@ export class OAuthTransformer implements Transformer {
     auth: { authMode: 'oauth'; accountId: string } | { authMode: 'apiKey'; apiKey: string } = {
       authMode: 'oauth',
       accountId: '',
-    }
+    },
+    signal?: AbortSignal
   ): Promise<any> {
     const rawApiKey = await this.resolveApiKey(provider, auth);
     // pi-ai enables Claude Code identity/system injection only for OAuth-shaped tokens.
@@ -548,18 +549,44 @@ export class OAuthTransformer implements Transformer {
       `${this.name}: Executing ${streaming ? 'streaming' : 'complete'} request { model: "${model.id}", provider: "${provider}", authMode: "${auth.authMode}"${auth.authMode === 'oauth' ? `, accountId: "${auth.accountId}"` : ''} }`
     );
 
+    if (signal) {
+      requestOptions.signal = signal;
+    }
+
     if (streaming) {
       try {
         const result = await stream(model, context, requestOptions);
         logger.debug(`${this.name}: OAuth stream result type`, describeStreamResult(result));
         return result;
-      } catch (error) {
+      } catch (error: any) {
+        if (error?.name === 'AbortError' || signal?.aborted) {
+          const isTimeout = signal?.reason?.name === 'TimeoutError';
+          const err = new Error(isTimeout ? 'Upstream timeout' : 'Client disconnected') as any;
+          err.routingContext = {
+            statusCode: isTimeout ? 504 : 499,
+            code: isTimeout ? 'upstream_timeout' : 'client_disconnected',
+          };
+          throw err;
+        }
         logger.error(`${this.name}: OAuth stream request failed`, error);
         throw error;
       }
     }
 
-    return await complete(model, context, requestOptions);
+    try {
+      return await complete(model, context, requestOptions);
+    } catch (error: any) {
+      if (error?.name === 'AbortError' || signal?.aborted) {
+        const isTimeout = signal?.reason?.name === 'TimeoutError';
+        const err = new Error(isTimeout ? 'Upstream timeout' : 'Client disconnected') as any;
+        err.routingContext = {
+          statusCode: isTimeout ? 504 : 499,
+          code: isTimeout ? 'upstream_timeout' : 'client_disconnected',
+        };
+        throw err;
+      }
+      throw error;
+    }
   }
 }
 

--- a/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
@@ -43,7 +43,21 @@ import { SortableContext } from '@dnd-kit/sortable';
 //
 // IMPORTS -- Icons (lucide-react)
 //
-import { AlertTriangle, Clock, Cpu, Info, RefreshCw, Server, Signal, X } from 'lucide-react';
+import {
+  AlertTriangle,
+  Ban,
+  CheckCircle,
+  Clock,
+  Cpu,
+  Info,
+  Plane,
+  RefreshCw,
+  Server,
+  Signal,
+  Timer,
+  X,
+  XCircle,
+} from 'lucide-react';
 
 //
 // IMPORTS -- UI components (internal)
@@ -105,6 +119,7 @@ import {
   formatTPS,
 } from '../../../lib/format';
 import { formatMsToMinSec } from '@plexus/shared';
+import { clsx } from 'clsx';
 import { useAuth } from '../../../contexts/AuthContext';
 import { useToast } from '../../../contexts/ToastContext';
 
@@ -1916,7 +1931,6 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                   Math.floor((Date.now() - new Date(request.date).getTime()) / 1000)
                 );
                 const status = (request.responseStatus || 'errored').toLowerCase();
-                const isSuccess = status.toLowerCase() === 'success';
                 const providerLabel = getProviderLabel(request);
                 const modelLabel = getModelLabel(request);
                 return (
@@ -1929,12 +1943,30 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                         <span className="text-base text-text font-medium">{providerLabel}</span>
                         <span className="text-sm text-text-secondary">{modelLabel}</span>
                         <span
-                          className={
-                            isSuccess
-                              ? 'text-xs px-2 py-0.5 rounded-md text-success bg-emerald-500/15 border border-success/25'
-                              : 'text-xs px-2 py-0.5 rounded-md text-danger bg-red-500/15 border border-danger/30'
-                          }
+                          className={clsx(
+                            'inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-md border',
+                            status === 'success'
+                              ? 'text-success bg-emerald-500/15 border-success/25'
+                              : status === 'pending'
+                                ? 'text-warning bg-yellow-500/15 border-warning/25'
+                                : status === 'cancelled'
+                                  ? 'text-blue-400 bg-blue-500/15 border-blue-400/25'
+                                  : status === 'timeout'
+                                    ? 'text-orange-400 bg-orange-500/15 border-orange-400/25'
+                                    : 'text-danger bg-red-500/15 border-danger/30'
+                          )}
                         >
+                          {status === 'success' ? (
+                            <CheckCircle size={11} />
+                          ) : status === 'pending' ? (
+                            <Plane size={11} className="animate-pulse" />
+                          ) : status === 'cancelled' ? (
+                            <Ban size={11} />
+                          ) : status === 'timeout' ? (
+                            <Timer size={11} />
+                          ) : (
+                            <XCircle size={11} />
+                          )}
                           {status}
                         </span>
                       </div>
@@ -2772,7 +2804,6 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                         Math.floor((Date.now() - new Date(request.date).getTime()) / 1000)
                       );
                       const status = (request.responseStatus || 'errored').toLowerCase();
-                      const isSuccess = status.toLowerCase() === 'success';
                       const providerLabel = getProviderLabel(request);
                       const modelLabel = getModelLabel(request);
 
@@ -2786,12 +2817,30 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                               <span className="text-sm text-text font-medium">{providerLabel}</span>
                               <span className="text-xs text-text-secondary">{modelLabel}</span>
                               <span
-                                className={
-                                  isSuccess
-                                    ? 'text-[11px] px-2 py-0.5 rounded-md text-success bg-emerald-500/15 border border-success/25'
-                                    : 'text-[11px] px-2 py-0.5 rounded-md text-danger bg-red-500/15 border border-danger/30'
-                                }
+                                className={clsx(
+                                  'inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md border',
+                                  status === 'success'
+                                    ? 'text-success bg-emerald-500/15 border-success/25'
+                                    : status === 'pending'
+                                      ? 'text-warning bg-yellow-500/15 border-warning/25'
+                                      : status === 'cancelled'
+                                        ? 'text-blue-400 bg-blue-500/15 border-blue-400/25'
+                                        : status === 'timeout'
+                                          ? 'text-orange-400 bg-orange-500/15 border-orange-400/25'
+                                          : 'text-danger bg-red-500/15 border-danger/30'
+                                )}
                               >
+                                {status === 'success' ? (
+                                  <CheckCircle size={10} />
+                                ) : status === 'pending' ? (
+                                  <Plane size={10} className="animate-pulse" />
+                                ) : status === 'cancelled' ? (
+                                  <Ban size={10} />
+                                ) : status === 'timeout' ? (
+                                  <Timer size={10} />
+                                ) : (
+                                  <XCircle size={10} />
+                                )}
                                 {status}
                               </span>
                             </div>

--- a/packages/frontend/src/pages/DetailedUsage.tsx
+++ b/packages/frontend/src/pages/DetailedUsage.tsx
@@ -84,6 +84,11 @@ import {
   List,
   AlertTriangle,
   ArrowLeft,
+  CheckCircle,
+  XCircle,
+  Ban,
+  Timer,
+  Plane,
 } from 'lucide-react';
 import {
   ResponsiveContainer,
@@ -1326,10 +1331,29 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
                     </div>
                   </div>
                   <span
-                    className={`shrink-0 text-xs font-semibold ${
-                      r.responseStatus === 'success' ? 'text-green-500' : 'text-red-500'
+                    className={`inline-flex shrink-0 items-center gap-1 text-xs font-semibold ${
+                      r.responseStatus === 'success'
+                        ? 'text-green-500'
+                        : r.responseStatus === 'pending'
+                          ? 'text-warning'
+                          : r.responseStatus === 'cancelled'
+                            ? 'text-blue-400'
+                            : r.responseStatus === 'timeout'
+                              ? 'text-orange-400'
+                              : 'text-red-500'
                     }`}
                   >
+                    {r.responseStatus === 'success' ? (
+                      <CheckCircle size={11} />
+                    ) : r.responseStatus === 'pending' ? (
+                      <Plane size={11} className="animate-pulse" />
+                    ) : r.responseStatus === 'cancelled' ? (
+                      <Ban size={11} />
+                    ) : r.responseStatus === 'timeout' ? (
+                      <Timer size={11} />
+                    ) : (
+                      <XCircle size={11} />
+                    )}
                     {r.responseStatus}
                   </span>
                 </div>
@@ -1394,8 +1418,29 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
                     </td>
                     <td className="py-2 pr-3">
                       <span
-                        className={`text-xs ${r.responseStatus === 'success' ? 'text-green-500' : 'text-red-500'}`}
+                        className={`inline-flex items-center gap-1 text-xs ${
+                          r.responseStatus === 'success'
+                            ? 'text-green-500'
+                            : r.responseStatus === 'pending'
+                              ? 'text-warning'
+                              : r.responseStatus === 'cancelled'
+                                ? 'text-blue-400'
+                                : r.responseStatus === 'timeout'
+                                  ? 'text-orange-400'
+                                  : 'text-red-500'
+                        }`}
                       >
+                        {r.responseStatus === 'success' ? (
+                          <CheckCircle size={11} />
+                        ) : r.responseStatus === 'pending' ? (
+                          <Plane size={11} className="animate-pulse" />
+                        ) : r.responseStatus === 'cancelled' ? (
+                          <Ban size={11} />
+                        ) : r.responseStatus === 'timeout' ? (
+                          <Timer size={11} />
+                        ) : (
+                          <XCircle size={11} />
+                        )}
                         {r.responseStatus}
                       </span>
                     </td>

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -60,6 +60,10 @@ import {
   PlayCircle,
   Circle,
   X,
+  Ban,
+  Timer,
+  CheckCircle,
+  XCircle,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useNavigate } from 'react-router-dom';
@@ -514,7 +518,11 @@ export const Logs = () => {
                     ? 'border-success/30 bg-emerald-500/15 text-success'
                     : status === 'pending'
                       ? 'border-warning/30 bg-yellow-500/15 text-warning'
-                      : 'border-danger/30 bg-red-500/15 text-danger';
+                      : status === 'cancelled'
+                        ? 'border-blue-400/30 bg-blue-500/15 text-blue-400'
+                        : status === 'timeout'
+                          ? 'border-orange-400/30 bg-orange-500/15 text-orange-400'
+                          : 'border-danger/30 bg-red-500/15 text-danger';
 
                 return (
                   <article
@@ -536,10 +544,21 @@ export const Logs = () => {
                       </div>
                       <span
                         className={clsx(
-                          'inline-flex shrink-0 items-center rounded-md border px-2 py-1 text-[11px] font-semibold capitalize',
+                          'inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-1 text-[11px] font-semibold capitalize',
                           statusClass
                         )}
                       >
+                        {status === 'success' ? (
+                          <CheckCircle size={10} />
+                        ) : status === 'pending' ? (
+                          <Plane size={10} className="animate-pulse" />
+                        ) : status === 'cancelled' ? (
+                          <Ban size={10} />
+                        ) : status === 'timeout' ? (
+                          <Timer size={10} />
+                        ) : (
+                          <XCircle size={10} />
+                        )}
                         {status}
                       </span>
                     </div>
@@ -1299,16 +1318,24 @@ export const Logs = () => {
                                   ? 'text-success border-success/30 bg-emerald-500/15'
                                   : log.responseStatus === 'pending'
                                     ? 'text-warning border-warning/30 bg-yellow-500/15'
-                                    : 'text-danger border-danger/30 bg-red-500/15'
+                                    : log.responseStatus === 'cancelled'
+                                      ? 'text-blue-400 border-blue-400/30 bg-blue-500/15'
+                                      : log.responseStatus === 'timeout'
+                                        ? 'text-orange-400 border-orange-400/30 bg-orange-500/15'
+                                        : 'text-danger border-danger/30 bg-red-500/15'
                               )}
                               style={{ width: '52px' }}
                             >
                               {log.responseStatus === 'success' ? (
-                                <span style={{ fontWeight: 600 }}>✓</span>
+                                <CheckCircle size={12} />
                               ) : log.responseStatus === 'pending' ? (
                                 <Plane size={12} className="animate-pulse" />
+                              ) : log.responseStatus === 'cancelled' ? (
+                                <Ban size={12} />
+                              ) : log.responseStatus === 'timeout' ? (
+                                <Timer size={12} />
                               ) : (
-                                <span style={{ fontWeight: 600 }}>✗</span>
+                                <XCircle size={12} />
                               )}
                             </div>
                           )}


### PR DESCRIPTION
## Problem

When a downstream client disconnects during a streaming LLM response (e.g., user navigates away, network drops), the upstream fetch to the provider continues running — wasting API quota, tokens, and server resources. Bun's `node:http` compat layer breaks all standard Node.js disconnect signals for POST streaming responses.

## What Changed

### Backend: Disconnect Detection & Upstream Cancellation (`response-handler.ts`)

- **`onDisconnect()` handler** destroys the source `nodeStream` (not just the downstream `pipeline`) to propagate `cancel()` back through `Readable.fromWeb()` to the upstream web ReadableStream, stopping the provider fetch.
- **`bunHandle.closed` polling** (250ms interval): the only reliable disconnect signal in Bun's `node:http` for POST requests. Discovered via `Symbol(handle)` on the socket — `request.raw.close`, `socket.close`, `socket.destroyed`, and `reply.raw.destroyed` are all broken for POST in Bun.
- **`signal.addEventListener("abort")`** wires timeout aborts through the same cancellation path, making the handler future-ready for `AbortSignal.any([clientSignal, AbortSignal.timeout(ms)])`.
- **EPIPE/ECONNRESET** errors from the pipeline also trigger `onDisconnect`.

### Backend: Usage Recording (`usage-logging.ts`)

- **`_destroy()` override** records `'cancelled'` or `'timeout'` status with partial token data when the pipeline is destroyed before natural end. `_flushed` guard prevents double-saves when `_flush()` already ran normally.

### Backend: AbortSignal Threading (`dispatcher.ts`, `oauth-transformer.ts`)

- Optional `AbortSignal` threaded through `Dispatcher.dispatch()` → `executeProviderRequest()` (direct fetch) and `dispatchOAuthRequest()` → `OAuthTransformer.executeRequest()` (pi-ai path). All upstream fetch calls now carry the signal.

### Backend: Route Handlers

- Per-request `AbortController` in each inference route handler (`chat`, `messages`, `gemini`, `responses`). `client_disconnected`/`upstream_timeout` errors are caught and suppressed — usage is already recorded by `_destroy()`.
- `buildCancelledError` in `dispatcher.ts` distinguishes `client_disconnected` (499) vs `upstream_timeout` (504) based on `signal.reason?.name === "TimeoutError"`.

### Frontend: Distinct Status Icons (Logs, DetailedUsage, LiveTab)

| Status      | Icon          | Color  |
|-------------|---------------|--------|
| `success`   | CheckCircle   | green  |
| `pending`   | Plane (pulse) | yellow |
| `cancelled` | Ban           | blue   |
| `timeout`   | Timer         | orange |
| error       | XCircle       | red    |

Previously `cancelled` and `timeout` both rendered as red with a generic error style, indistinguishable from actual failures.

### Tests

- **`response-handler-cancellation.test.ts`**: 11 tests proving the cancellation chain — `pipeline.destroy()` alone does NOT propagate cancel; `nodeStream.destroy()` does; `abort()` alone does NOT stop mid-flight reads; `signal.addEventListener("abort")` + destroy does.
- **`dispatcher-abort.test.ts`**: tests for `buildCancelledError` and signal forwarding.
- **`usage-logging.test.ts`**: tests for `_destroy()` recording cancelled/timeout status and double-save guard.
- **Exploratory scripts** preserved under `__tests__/disconnect-detection/` with full findings README.

## Bun Bugs

- [#14697](https://github.com/oven-sh/bun/issues/14697): `ServerResponse` close event never fires for POST
- [#25919](https://github.com/oven-sh/bun/issues/25919): upstream fetch not cancelled on client disconnect