### PR TITLE
feat: configurable upstream request timeouts (global + per-provider)

### DIFF
--- a/packages/backend/drizzle/migrations/0041_fearless_baron_strucker.sql
+++ b/packages/backend/drizzle/migrations/0041_fearless_baron_strucker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `providers` ADD `timeout_ms` integer;

--- a/packages/backend/drizzle/migrations/meta/0041_snapshot.json
+++ b/packages/backend/drizzle/migrations/meta/0041_snapshot.json
@@ -1,0 +1,2949 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "beb5e5d5-0d78-4ec5-bd9f-f3b4dd009eee",
+  "prevId": "a59e2f5d-9498-4c52-afec-a5439df1f082",
+  "tables": {
+    "alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "columns": [
+            "alias_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "columns": [
+            "secret"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "columns": [
+            "secret_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debug_logs": {
+      "name": "debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inference_errors": {
+      "name": "inference_errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            "server_name"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meter_snapshots": {
+      "name": "meter_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_type": {
+          "name": "checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_state": {
+          "name": "utilization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_value": {
+          "name": "period_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "period_unit": {
+          "name": "period_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "period_cycle": {
+          "name": "period_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_meter_checker_meter_checked": {
+          "name": "idx_meter_checker_meter_checked",
+          "columns": [
+            "checker_id",
+            "meter_key",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_meter_provider_checked": {
+          "name": "idx_meter_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_meter_checked_at": {
+          "name": "idx_meter_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_alias_targets": {
+      "name": "model_alias_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_aliases": {
+      "name": "model_aliases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_architecture": {
+          "name": "model_architecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enforce_limits": {
+          "name": "enforce_limits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sticky_session": {
+          "name": "sticky_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "preferred_api": {
+          "name": "preferred_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pi_model": {
+          "name": "pi_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_groups": {
+          "name": "target_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_credentials": {
+      "name": "oauth_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            "expiry"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "columns": [
+            "provider",
+            "model"
+          ],
+          "name": "provider_cooldowns_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_models": {
+      "name": "provider_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "columns": [
+            "provider_id",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_performance": {
+      "name": "provider_performance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "e2e_tokens_per_sec": {
+          "name": "e2e_tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            "provider",
+            "model",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gemini_thinking_enabled": {
+          "name": "gemini_thinking_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_profile": {
+          "name": "gpu_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_ram_gb": {
+          "name": "gpu_ram_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_bandwidth_tb_s": {
+          "name": "gpu_bandwidth_tb_s",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_flops_tflop": {
+          "name": "gpu_flops_tflop",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_power_draw_watts": {
+          "name": "gpu_power_draw_watts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_snapshots": {
+      "name": "quota_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            "checker_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            "group_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_state": {
+      "name": "quota_state",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_usage": {
+      "name": "request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            "api_key",
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "response_items": {
+      "name": "response_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            "response_id",
+            "item_index"
+          ],
+          "isUnique": false
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "responses": {
+      "name": "responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            "previous_response_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_settings": {
+      "name": "system_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/backend/drizzle/migrations/meta/_journal.json
+++ b/packages/backend/drizzle/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1778735850501,
       "tag": "0040_motionless_baron_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1778905467722,
+      "tag": "0041_fearless_baron_strucker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/migrations_pg/0051_magenta_talon.sql
+++ b/packages/backend/drizzle/migrations_pg/0051_magenta_talon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "providers" ADD COLUMN "timeout_ms" integer;

--- a/packages/backend/drizzle/migrations_pg/meta/0051_snapshot.json
+++ b/packages/backend/drizzle/migrations_pg/meta/0051_snapshot.json
@@ -1,0 +1,3116 @@
+{
+  "id": "e51e864f-1ca5-4267-b01e-d7f640cd6dc3",
+  "prevId": "a81d495c-0df8-4de3-a259-c70a0227167e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_usage": {
+      "name": "request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_models": {
+      "name": "provider_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "model_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_snapshots": {
+      "name": "quota_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_alias_targets": {
+      "name": "model_alias_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret"
+          ]
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            {
+              "expression": "server_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gemini_thinking_enabled": {
+          "name": "gemini_thinking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "quota_checker_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_profile": {
+          "name": "gpu_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_ram_gb": {
+          "name": "gpu_ram_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_bandwidth_tb_s": {
+          "name": "gpu_bandwidth_tb_s",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_flops_tflop": {
+          "name": "gpu_flops_tflop",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_power_draw_watts": {
+          "name": "gpu_power_draw_watts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_errors": {
+      "name": "inference_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "quota_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "limit_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meter_snapshots": {
+      "name": "meter_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_type": {
+          "name": "checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_state": {
+          "name": "utilization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_value": {
+          "name": "period_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_unit": {
+          "name": "period_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_cycle": {
+          "name": "period_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_meter_checker_meter_checked": {
+          "name": "idx_meter_checker_meter_checked",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meter_provider_checked": {
+          "name": "idx_meter_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meter_checked_at": {
+          "name": "idx_meter_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_aliases": {
+      "name": "model_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "selector_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "alias_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "metadata_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_architecture": {
+          "name": "model_architecture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_limits": {
+          "name": "enforce_limits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sticky_session": {
+          "name": "sticky_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferred_api": {
+          "name": "preferred_api",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pi_model": {
+          "name": "pi_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_groups": {
+          "name": "target_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            {
+              "expression": "expiry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "name": "provider_cooldowns_provider_model_pk",
+          "columns": [
+            "provider",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_performance": {
+      "name": "provider_performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "e2e_tokens_per_sec": {
+          "name": "e2e_tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_state": {
+      "name": "quota_state",
+      "schema": "",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_items": {
+      "name": "response_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.responses": {
+      "name": "responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            {
+              "expression": "previous_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.model_type": {
+      "name": "model_type",
+      "schema": "public",
+      "values": [
+        "chat",
+        "embeddings",
+        "transcriptions",
+        "speech",
+        "image",
+        "responses"
+      ]
+    },
+    "public.oauth_provider_type": {
+      "name": "oauth_provider_type",
+      "schema": "public",
+      "values": [
+        "anthropic",
+        "openai-codex",
+        "github-copilot",
+        "google-gemini-cli",
+        "google-antigravity"
+      ]
+    },
+    "public.quota_checker_type": {
+      "name": "quota_checker_type",
+      "schema": "public",
+      "values": [
+        "naga",
+        "synthetic",
+        "nanogpt",
+        "zai",
+        "moonshot",
+        "minimax",
+        "minimax-coding",
+        "openrouter",
+        "kilo",
+        "openai-codex",
+        "claude-code",
+        "kimi-code",
+        "copilot",
+        "wisdomgate",
+        "apertis",
+        "apertis-coding-plan",
+        "poe",
+        "gemini-cli",
+        "antigravity",
+        "novita",
+        "ollama",
+        "neuralwatt",
+        "zenmux",
+        "devpass",
+        "wafer",
+        "opencode-go"
+      ]
+    },
+    "public.limit_type": {
+      "name": "limit_type",
+      "schema": "public",
+      "values": [
+        "requests",
+        "tokens",
+        "cost"
+      ]
+    },
+    "public.quota_type": {
+      "name": "quota_type",
+      "schema": "public",
+      "values": [
+        "rolling",
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.alias_priority": {
+      "name": "alias_priority",
+      "schema": "public",
+      "values": [
+        "selector",
+        "api_match"
+      ]
+    },
+    "public.metadata_source": {
+      "name": "metadata_source",
+      "schema": "public",
+      "values": [
+        "openrouter",
+        "models.dev",
+        "catwalk",
+        "custom"
+      ]
+    },
+    "public.selector_strategy": {
+      "name": "selector_strategy",
+      "schema": "public",
+      "values": [
+        "random",
+        "in_order",
+        "cost",
+        "latency",
+        "usage",
+        "performance"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/migrations_pg/meta/_journal.json
+++ b/packages/backend/drizzle/migrations_pg/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1778735856746,
       "tag": "0050_marvelous_jackal",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1778905467906,
+      "tag": "0051_magenta_talon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/schema/postgres/providers.ts
+++ b/packages/backend/drizzle/schema/postgres/providers.ts
@@ -47,6 +47,7 @@ export const providers = pgTable(
     gpuFlopsTflop: real('gpu_flops_tflop'), // FLOPS in TFLOP
     gpuPowerDrawWatts: integer('gpu_power_draw_watts'), // Power draw in watts
     adapter: jsonb('adapter'), // string[] — provider-level adapter names
+    timeoutMs: integer('timeout_ms'), // Per-provider upstream request timeout in ms (NULL = use global default)
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
   },

--- a/packages/backend/drizzle/schema/sqlite/providers.ts
+++ b/packages/backend/drizzle/schema/sqlite/providers.ts
@@ -34,6 +34,7 @@ export const providers = sqliteTable(
     gpuFlopsTflop: real('gpu_flops_tflop'), // FLOPS in TFLOP
     gpuPowerDrawWatts: integer('gpu_power_draw_watts'), // Power draw in watts
     adapter: text('adapter'), // JSON: string[] — provider-level adapter names
+    timeoutMs: integer('timeout_ms'), // Per-provider upstream request timeout in ms (NULL = use global default)
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -424,6 +424,7 @@ export const ProviderConfigSchema = z
     gpu_power_draw_watts: z.number().positive().optional(),
     geminiThinkingEnabled: z.boolean().optional(),
     adapter: AdapterConfigSchema,
+    timeoutMs: z.number().int().positive().optional(),
   })
   .refine((data) => !!data.api_key || isOAuthProviderConfig(data), {
     message: "'api_key' must be specified for provider",
@@ -692,6 +693,7 @@ const RawPlexusConfigSchema = z
     performanceExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
     latencyExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
     e2ePerformanceExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
+    timeout: z.object({ defaultSeconds: z.number().min(1).max(3600).default(300) }).optional(),
     backgroundExploration: BackgroundExplorationConfigSchema.optional(),
     mcp_servers: z.record(z.string(), McpServerConfigSchema).optional(),
     user_quotas: z.record(z.string(), QuotaDefinitionSchema).optional(),
@@ -701,9 +703,11 @@ const RawPlexusConfigSchema = z
 export type FailoverPolicy = z.infer<typeof FailoverPolicySchema>;
 export type CooldownPolicy = z.infer<typeof CooldownPolicySchema>;
 export type BackgroundExplorationConfig = z.infer<typeof BackgroundExplorationConfigSchema>;
+export type TimeoutConfig = { defaultSeconds: number };
 export type PlexusConfig = z.infer<typeof RawPlexusConfigSchema> & {
   failover: FailoverPolicy;
   cooldown?: CooldownPolicy;
+  timeout?: TimeoutConfig;
   quotas: QuotaConfig[];
   mcpServers?: Record<string, McpServerConfig>;
 };

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -19,6 +19,7 @@ import type {
   FailoverPolicy,
   CooldownPolicy,
   BackgroundExplorationConfig,
+  TimeoutConfig,
   MetadataOverrides,
 } from '../config';
 import { resolveGpuParams } from '@plexus/shared';
@@ -311,6 +312,7 @@ export class ConfigRepository {
         config.adapter && (Array.isArray(config.adapter) ? config.adapter.length > 0 : true)
           ? toJson(Array.isArray(config.adapter) ? config.adapter : [config.adapter])
           : null,
+      timeoutMs: config.timeoutMs ?? null,
       updatedAt: timestamp,
     };
 
@@ -530,6 +532,7 @@ export class ConfigRepository {
           gpu_power_draw_watts: row.gpuPowerDrawWatts!,
         };
       })(),
+      ...(row.timeoutMs != null ? { timeoutMs: row.timeoutMs } : {}),
     };
 
     return result as ProviderConfig;
@@ -1224,6 +1227,11 @@ export class ConfigRepository {
       2
     );
     return { enabled, stalenessThresholdSeconds, workerConcurrency };
+  }
+
+  async getTimeoutConfig(): Promise<TimeoutConfig> {
+    const defaultSeconds = await this.getSetting<number>('timeout.defaultSeconds', 300);
+    return { defaultSeconds };
   }
 
   // ─── OAuth Credentials ──────────────────────────────────────────

--- a/packages/backend/src/routes/inference/chat.ts
+++ b/packages/backend/src/routes/inference/chat.ts
@@ -10,6 +10,7 @@ import { DebugManager } from '../../services/debug-manager';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../../services/quota/quota-middleware';
 import { attachKeyAccessPolicy } from '../../utils/auth';
+import { wireUpstreamTimeout } from '../../utils/timeout';
 
 export async function registerChatRoute(
   fastify: FastifyInstance,
@@ -87,7 +88,12 @@ export async function registerChatRoute(
       }
 
       const abortController = new AbortController();
-      const unifiedResponse = await dispatcher.dispatch(unifiedRequest, abortController.signal);
+      const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      const unifiedResponse = await dispatcher.dispatch(
+        unifiedRequest,
+        dispatchSignal,
+        addTimeoutSource
+      );
 
       // Emit 'updated' event with routing decision details
       usageStorage.emitUpdatedAsync({
@@ -123,8 +129,13 @@ export async function registerChatRoute(
 
       return result;
     } catch (e: any) {
-      if (e?.routingContext?.code === 'client_disconnected' || e?.routingContext?.code === 'upstream_timeout') {
-        logger.info(`Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`);
+      if (
+        e?.routingContext?.code === 'client_disconnected' ||
+        e?.routingContext?.code === 'upstream_timeout'
+      ) {
+        logger.info(
+          `Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`
+        );
         return;
       }
       usageRecord.responseStatus = 'error';

--- a/packages/backend/src/routes/inference/gemini.ts
+++ b/packages/backend/src/routes/inference/gemini.ts
@@ -10,6 +10,7 @@ import { DebugManager } from '../../services/debug-manager';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../../services/quota/quota-middleware';
 import { attachKeyAccessPolicy } from '../../utils/auth';
+import { wireUpstreamTimeout } from '../../utils/timeout';
 
 export async function registerGeminiRoute(
   fastify: FastifyInstance,
@@ -95,7 +96,12 @@ export async function registerGeminiRoute(
       }
 
       const abortController = new AbortController();
-      const unifiedResponse = await dispatcher.dispatch(unifiedRequest, abortController.signal);
+      const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      const unifiedResponse = await dispatcher.dispatch(
+        unifiedRequest,
+        dispatchSignal,
+        addTimeoutSource
+      );
 
       // Emit 'updated' event with routing decision details
       usageStorage.emitUpdatedAsync({
@@ -132,8 +138,13 @@ export async function registerGeminiRoute(
 
       return result;
     } catch (e: any) {
-      if (e?.routingContext?.code === 'client_disconnected' || e?.routingContext?.code === 'upstream_timeout') {
-        logger.info(`Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`);
+      if (
+        e?.routingContext?.code === 'client_disconnected' ||
+        e?.routingContext?.code === 'upstream_timeout'
+      ) {
+        logger.info(
+          `Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`
+        );
         return;
       }
       usageRecord.responseStatus = 'error';

--- a/packages/backend/src/routes/inference/messages.ts
+++ b/packages/backend/src/routes/inference/messages.ts
@@ -10,6 +10,7 @@ import { DebugManager } from '../../services/debug-manager';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../../services/quota/quota-middleware';
 import { attachKeyAccessPolicy } from '../../utils/auth';
+import { wireUpstreamTimeout } from '../../utils/timeout';
 
 export async function registerMessagesRoute(
   fastify: FastifyInstance,
@@ -85,7 +86,12 @@ export async function registerMessagesRoute(
       }
 
       const abortController = new AbortController();
-      const unifiedResponse = await dispatcher.dispatch(unifiedRequest, abortController.signal);
+      const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      const unifiedResponse = await dispatcher.dispatch(
+        unifiedRequest,
+        dispatchSignal,
+        addTimeoutSource
+      );
 
       // Emit 'updated' event with routing decision details
       usageStorage.emitUpdatedAsync({
@@ -122,8 +128,13 @@ export async function registerMessagesRoute(
 
       return result;
     } catch (e: any) {
-      if (e?.routingContext?.code === 'client_disconnected' || e?.routingContext?.code === 'upstream_timeout') {
-        logger.info(`Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`);
+      if (
+        e?.routingContext?.code === 'client_disconnected' ||
+        e?.routingContext?.code === 'upstream_timeout'
+      ) {
+        logger.info(
+          `Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`
+        );
         return;
       }
       usageRecord.responseStatus = 'error';

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -11,6 +11,7 @@ import { DebugManager } from '../../services/debug-manager';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../../services/quota/quota-middleware';
 import { attachKeyAccessPolicy } from '../../utils/auth';
+import { wireUpstreamTimeout } from '../../utils/timeout';
 
 export async function registerResponsesRoute(
   fastify: FastifyInstance,
@@ -168,7 +169,12 @@ export async function registerResponsesRoute(
       }
 
       const abortController = new AbortController();
-      const unifiedResponse = await dispatcher.dispatch(unifiedRequest, abortController.signal);
+      const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      const unifiedResponse = await dispatcher.dispatch(
+        unifiedRequest,
+        dispatchSignal,
+        addTimeoutSource
+      );
 
       // Emit 'updated' event with routing decision details
       usageStorage.emitUpdatedAsync({
@@ -224,8 +230,13 @@ export async function registerResponsesRoute(
 
       return result;
     } catch (e: any) {
-      if (e?.routingContext?.code === 'client_disconnected' || e?.routingContext?.code === 'upstream_timeout') {
-        logger.info(`Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`);
+      if (
+        e?.routingContext?.code === 'client_disconnected' ||
+        e?.routingContext?.code === 'upstream_timeout'
+      ) {
+        logger.info(
+          `Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`
+        );
         return;
       }
       usageRecord.responseStatus = 'error';

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -583,6 +583,43 @@ export async function registerConfigRoutes(
     }
   });
 
+  // ─── Timeout Config ───────────────────────────────────────────────
+
+  fastify.get('/v0/management/config/timeout', async (_request, reply) => {
+    try {
+      const timeout = await configService.getRepository().getTimeoutConfig();
+      return reply.send(timeout);
+    } catch (e: any) {
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  fastify.patch('/v0/management/config/timeout', async (request, reply) => {
+    const body = request.body as Record<string, unknown> | null;
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return reply.code(400).send({ error: 'Object body is required' });
+    }
+
+    try {
+      if (body.defaultSeconds !== undefined) {
+        const val = Number(body.defaultSeconds);
+        if (!Number.isFinite(val) || !Number.isInteger(val) || val < 1 || val > 3600) {
+          return reply
+            .code(400)
+            .send({ error: 'defaultSeconds must be an integer between 1 and 3600' });
+        }
+        await configService.setSetting('timeout.defaultSeconds', val);
+      }
+
+      const updated = await configService.getRepository().getTimeoutConfig();
+      logger.debug('Timeout config updated via API');
+      return reply.send(updated);
+    } catch (e: any) {
+      logger.error('Failed to patch timeout config', e);
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
   // ─── Vision Fallthrough ───────────────────────────────────────────
 
   fastify.get('/v0/management/config/vision-fallthrough', async (_request, reply) => {

--- a/packages/backend/src/services/__tests__/config-service.test.ts
+++ b/packages/backend/src/services/__tests__/config-service.test.ts
@@ -34,6 +34,7 @@ function createMockRepo() {
     getFailoverPolicy: vi.fn(() => Promise.resolve({ enabled: false })),
     getCooldownPolicy: vi.fn(() => Promise.resolve({ enabled: false })),
     getBackgroundExplorationConfig: vi.fn(() => Promise.resolve({ enabled: false })),
+    getTimeoutConfig: vi.fn(() => Promise.resolve({ defaultSeconds: 300 })),
     getAllSettings: vi.fn(() => Promise.resolve({})),
   };
 }

--- a/packages/backend/src/services/__tests__/dispatcher-abort.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-abort.test.ts
@@ -47,6 +47,7 @@ describe('Dispatcher — AbortSignal / cancellation', () => {
       controller.signal
     );
 
+    // When config is not initialized (test env), the signal is passed through as-is
     expect(mockFetch).toHaveBeenCalledWith(
       'https://example.com/v1/test',
       expect.objectContaining({ signal: controller.signal })

--- a/packages/backend/src/services/config-service.ts
+++ b/packages/backend/src/services/config-service.ts
@@ -10,6 +10,7 @@ import type {
   FailoverPolicy,
   CooldownPolicy,
   QuotaConfig,
+  TimeoutConfig,
 } from '../config';
 
 import { QuotaScheduler } from './quota/quota-scheduler';
@@ -375,6 +376,7 @@ export class ConfigService {
     const failover = await this.repo.getFailoverPolicy();
     const cooldown = await this.repo.getCooldownPolicy();
     const backgroundExploration = await this.repo.getBackgroundExplorationConfig();
+    const timeout = await this.repo.getTimeoutConfig();
     const allSettings = await this.repo.getAllSettings();
 
     // Spread all flat settings (non-dotted keys) onto the cache so new settings
@@ -393,6 +395,7 @@ export class ConfigService {
       keys,
       failover,
       cooldown,
+      timeout,
       backgroundExploration,
       quotas,
       mcpServers: Object.keys(mcpServers).length > 0 ? mcpServers : undefined,

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -240,7 +240,11 @@ export class Dispatcher {
     );
   }
 
-  async dispatch(request: UnifiedChatRequest, signal?: AbortSignal): Promise<UnifiedChatResponse> {
+  async dispatch(
+    request: UnifiedChatRequest,
+    signal?: AbortSignal,
+    addTimeoutSource?: (timeoutMs: number) => void
+  ): Promise<UnifiedChatResponse> {
     const config = getConfig();
     const failover = config.failover;
     const failoverEnabled = failover?.enabled !== false;
@@ -455,6 +459,13 @@ export class Dispatcher {
         // 4. Execute Request
         const url = this.buildRequestUrl(route, transformer, requestWithTargetModel, targetApiType);
         const headers = this.setupHeaders(route, targetApiType, requestWithTargetModel);
+
+        // Wire per-provider timeout override if set. This fires sooner than the
+        // global timeout and aborts the upstream fetch + the route's AbortController
+        // (via addTimeoutSource) so response-handler.ts stream monitoring detects it.
+        if (route.config.timeoutMs && addTimeoutSource) {
+          addTimeoutSource(route.config.timeoutMs);
+        }
 
         const incomingApi = currentRequest.incomingApiType || 'unknown';
 

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -229,7 +229,14 @@ export class UsageInspector extends PassThrough {
     }
 
     const isTimeout = err?.name === 'TimeoutError' || err?.message?.includes('timeout');
-    const status = isTimeout ? 'timeout' : 'cancelled';
+    // If onDisconnect() already set the status to 'timeout' (e.g. when the abort
+    // signal carried a TimeoutError), don't overwrite it with 'cancelled'.
+    const status =
+      this.usageRecord.responseStatus === 'timeout' && !isTimeout
+        ? 'timeout'
+        : isTimeout
+          ? 'timeout'
+          : 'cancelled';
 
     logger.info(
       `UsageInspector: stream destroyed for ${this.usageRecord.requestId} ` +
@@ -255,10 +262,7 @@ export class UsageInspector extends PassThrough {
       }
 
       this.usageStorage.saveRequest(this.usageRecord as UsageRecord).catch((saveErr) => {
-        logger.error(
-          `Failed to save ${status} usage for ${this.usageRecord.requestId}:`,
-          saveErr
-        );
+        logger.error(`Failed to save ${status} usage for ${this.usageRecord.requestId}:`, saveErr);
       });
 
       debugManager.flush(this.usageRecord.requestId!);

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -281,21 +281,43 @@ export async function handleResponse(
     const onDisconnect = (source: string) => {
       if (disconnected) return;
       disconnected = true;
+      // Determine if this is a timeout by checking the source string OR the abort
+      // reason. When wireUpstreamTimeout fires, it calls abortController.abort(TimeoutError),
+      // so the signal listener fires with source='signal.abort' but the reason tells us
+      // it was a timeout.
+      const isTimeout =
+        source.includes('timeout') || abortController?.signal?.reason?.name === 'TimeoutError';
       logger.debug(
-        `Client disconnected for request ${usageRecord.requestId} (detected via ${source}), aborting upstream`
+        `${isTimeout ? 'Upstream timeout' : 'Client disconnected'} for request ${usageRecord.requestId} (detected via ${source}), aborting upstream`
       );
-      abortController?.abort();
+      const timeoutErr = isTimeout
+        ? new DOMException('The operation timed out.', 'TimeoutError')
+        : undefined;
+      abortController?.abort(timeoutErr);
+      // Set responseStatus before destroy so UsageInspector._destroy() sees it.
+      // _destroy respects a pre-set 'timeout' status and won't overwrite it.
+      if (isTimeout) {
+        usageRecord.responseStatus = 'timeout';
+      }
+      // Destroy without passing the error — calling .destroy(err) causes Node.js to
+      // emit 'error' on the stream, which becomes an uncaught exception since
+      // these streams don't have error listeners. The cancellation still works:
+      // nodeStream.destroy() triggers Readable.fromWeb → cancel() on the upstream
+      // fetch body, and _destroy reads the status we already set on usageRecord.
       nodeStream.destroy(); // cancels the upstream fetch via Readable.fromWeb → cancel()
       pipeline.destroy();
     };
 
     if (abortController) {
-      // Wire the abort signal so that timeout aborts (e.g. AbortSignal.timeout() or
-      // AbortSignal.any([clientSignal, AbortSignal.timeout(ms)])) also trigger
+      // Wire the abort signal so that timeout aborts also trigger
       // nodeStream.destroy(). abortController.abort() alone does NOT stop an
       // already-in-progress Readable.fromWeb() read loop — the same root cause as
       // the client-disconnect bug. This listener ensures any abort reason goes through
-      // the correct cancellation path. See test-timeout-signal-listener.ts.
+      // the correct cancellation path. The timeout is wired via wireUpstreamTimeout()
+      // in the route handler, which calls abortController.abort() when the timeout
+      // fires so this listener detects it. The pipeline.on('error') handler also
+      // catches TimeoutErrors that propagate through the stream as a belt-and-suspenders.
+      // See test-timeout-signal-listener.ts and utils/timeout.ts.
       abortController.signal.addEventListener('abort', () => onDisconnect('signal.abort'), {
         once: true,
       });
@@ -326,8 +348,18 @@ export async function handleResponse(
       // Belt-and-suspenders: catch any write errors that do surface (e.g. if Bun
       // ever fixes EPIPE propagation, or on non-Bun runtimes).
       const code = err?.code;
-      if (code === 'EPIPE' || code === 'ECONNRESET' || code === 'ERR_STREAM_DESTROYED') {
-        onDisconnect('pipeline.error.' + code);
+      const isTimeout =
+        err?.name === 'TimeoutError' ||
+        err?.name === 'AbortError' ||
+        err?.message?.includes('timeout') ||
+        err?.message?.includes('aborted');
+      if (
+        code === 'EPIPE' ||
+        code === 'ECONNRESET' ||
+        code === 'ERR_STREAM_DESTROYED' ||
+        isTimeout
+      ) {
+        onDisconnect(isTimeout ? 'pipeline.error.timeout' : 'pipeline.error.' + code);
       }
       cleanupDisconnectWiring();
       // Restore debug mode on error

--- a/packages/backend/src/utils/timeout.ts
+++ b/packages/backend/src/utils/timeout.ts
@@ -1,0 +1,92 @@
+/**
+ * Upstream request timeout utilities.
+ *
+ * When AbortSignal.timeout() fires, AbortSignal.any() creates a combined signal
+ * that aborts, but does NOT propagate the abort back to the original source signals.
+ * The response-handler.ts stream-monitoring code listens on the route's
+ * abortController.signal — so if the timeout fires and that signal never aborts,
+ * onDisconnect() is never called, nodeStream.destroy() is never called, and the
+ * upstream fetch keeps running, generating unhandled TimeoutError rejections.
+ *
+ * To fix this, when the timeout fires we must also abort the route's
+ * AbortController so the listener in response-handler.ts detects it.
+ */
+
+import { getConfig } from '../config';
+
+/**
+ * Wire a timeout signal into the route's AbortController.
+ *
+ * Creates `AbortSignal.timeout(effectiveTimeoutMs)`, combines it with the
+ * existing signal via `AbortSignal.any()`, and adds a listener that calls
+ * `abortController.abort()` when the timeout fires. This ensures that
+ * both the upstream fetch AND the response-handler.ts stream-monitoring
+ * code detect the timeout.
+ *
+ * @param abortController The route's AbortController (the one passed to
+ *   handleResponse for stream disconnect detection).
+ * @param defaultTimeoutMs Override for the effective timeout in milliseconds.
+ *   When null/undefined, the global default is used.
+ * @returns An object containing the combined signal and an `addTimeoutSource`
+ *   method for adding per-provider timeout overrides after routing resolves.
+ */
+export function wireUpstreamTimeout(
+  abortController: AbortController,
+  defaultTimeoutMs?: number | null
+): { signal: AbortSignal; addTimeoutSource: (timeoutMs: number) => void } {
+  const config = getConfig();
+  const globalTimeoutSeconds = config.timeout?.defaultSeconds ?? 300;
+  const effectiveTimeoutMs = defaultTimeoutMs ?? globalTimeoutSeconds * 1000;
+
+  const timeoutSignal = AbortSignal.timeout(effectiveTimeoutMs);
+
+  // Create a combined signal that aborts when EITHER the client disconnects
+  // OR the timeout fires.
+  const combinedSignal = AbortSignal.any([abortController.signal, timeoutSignal]);
+
+  // KEY: AbortSignal.any() does NOT propagate abort back to source signals.
+  // When the timeout fires, combinedSignal aborts but abortController.signal
+  // does NOT. The stream-monitoring code in response-handler.ts only listens
+  // on abortController.signal, so it would never detect the timeout. We bridge
+  // the gap by aborting the route's AbortController when the timeout fires.
+  // This triggers onDisconnect() → nodeStream.destroy() → upstream cancellation.
+  timeoutSignal.addEventListener(
+    'abort',
+    () => {
+      if (!abortController.signal.aborted) {
+        abortController.abort(timeoutSignal.reason);
+      }
+    },
+    { once: true }
+  );
+
+  return {
+    signal: combinedSignal,
+    /**
+     * Add a per-provider timeout source.
+     *
+     * After the dispatcher resolves the route and knows which provider
+     * handles the request, it can add a per-provider timeout that may be
+     * shorter than the global default. When this timeout fires:
+     * 1. The upstream fetch is aborted (the signal passed to the fetch aborts).
+     * 2. The route's abortController is aborted (so response-handler.ts detects it).
+     *
+     * @param providerTimeoutMs Per-provider timeout in milliseconds.
+     */
+    addTimeoutSource: (providerTimeoutMs: number) => {
+      const providerTimeoutSignal = AbortSignal.timeout(providerTimeoutMs);
+
+      // Re-wire: when the provider timeout fires, abort the route's
+      // abortController so response-handler.ts stream monitoring detects it.
+      providerTimeoutSignal.addEventListener(
+        'abort',
+        () => {
+          if (!abortController.signal.aborted) {
+            abortController.abort(providerTimeoutSignal.reason);
+          }
+        },
+        { once: true }
+      );
+    },
+  };
+}

--- a/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
@@ -30,7 +30,12 @@ import { useEffect, useMemo, useState } from 'react';
  */
 import { PieChart as PieChartIcon, BarChart3 } from 'lucide-react';
 import { api, UsageData, PieChartDataPoint, type ConcurrencyData } from '../../../lib/api';
-import { formatNumber, formatTokens, formatTimeLabel, formatDateTimeLabel } from '../../../lib/format';
+import {
+  formatNumber,
+  formatTokens,
+  formatTimeLabel,
+  formatDateTimeLabel,
+} from '../../../lib/format';
 import { Card } from '../../ui/Card';
 import { TotalEnergyComparison } from '../../TotalEnergyComparison';
 import { TimeRangeSelector } from '../TimeRangeSelector';
@@ -372,9 +377,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
       return null;
     };
 
-    const sortedData = [...data].sort(
-      (a, b) => (b[dataKey] as number) - (a[dataKey] as number)
-    );
+    const sortedData = [...data].sort((a, b) => (b[dataKey] as number) - (a[dataKey] as number));
 
     const toggleBtnStyle = (active: boolean): React.CSSProperties => ({
       padding: '4px 6px',
@@ -484,7 +487,11 @@ export const UsageTab: React.FC<UsageTabProps> = ({
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={data}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-glass)" />
-                <XAxis dataKey="timestamp" stroke="var(--color-text-secondary)" tickFormatter={(v) => formatTimeLabel(String(v))} />
+                <XAxis
+                  dataKey="timestamp"
+                  stroke="var(--color-text-secondary)"
+                  tickFormatter={(v) => formatTimeLabel(String(v))}
+                />
                 <YAxis stroke="var(--color-text-secondary)" tickFormatter={formatNumber} />
                 <Tooltip
                   contentStyle={{
@@ -629,7 +636,11 @@ export const UsageTab: React.FC<UsageTabProps> = ({
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={data}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-glass)" />
-                <XAxis dataKey="timestamp" stroke="var(--color-text-secondary)" tickFormatter={(v) => formatTimeLabel(String(v))} />
+                <XAxis
+                  dataKey="timestamp"
+                  stroke="var(--color-text-secondary)"
+                  tickFormatter={(v) => formatTimeLabel(String(v))}
+                />
                 <YAxis stroke="var(--color-text-secondary)" tickFormatter={formatTokens} />
                 <Tooltip
                   contentStyle={{
@@ -686,9 +697,17 @@ export const UsageTab: React.FC<UsageTabProps> = ({
           </div>
         </Card>
 
-        <ChartToggleCard title="Usage by Model Alias (Requests)" dataKey="requests" data={modelData} />
+        <ChartToggleCard
+          title="Usage by Model Alias (Requests)"
+          dataKey="requests"
+          data={modelData}
+        />
         <ChartToggleCard title="Usage by Model Alias (Tokens)" dataKey="tokens" data={modelData} />
-        <ChartToggleCard title="Usage by Provider (Requests)" dataKey="requests" data={providerData} />
+        <ChartToggleCard
+          title="Usage by Provider (Requests)"
+          dataKey="requests"
+          data={providerData}
+        />
         <ChartToggleCard title="Usage by Provider (Tokens)" dataKey="tokens" data={providerData} />
         <ChartToggleCard title="Usage by API Key (Requests)" dataKey="requests" data={keyData} />
         <ChartToggleCard title="Usage by API Key (Tokens)" dataKey="tokens" data={keyData} />

--- a/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
@@ -153,6 +153,46 @@ export function ProviderAdvancedEditor({
             </div>
           </div>
 
+          {/* Timeout Override */}
+          <div className="border border-border-glass rounded-md p-3 bg-bg-subtle">
+            <div className="flex flex-col gap-1">
+              <label className="font-body text-[13px] font-medium text-text">
+                Upstream Timeout (seconds)
+              </label>
+              <div
+                className="font-body text-[11px] text-text-secondary"
+                style={{ lineHeight: 1.35, marginBottom: '4px' }}
+              >
+                Override the global default timeout for this provider. Leave empty to use the global
+                default. Must be between 1 and 3600.
+              </div>
+              <input
+                className="w-full max-w-[200px] py-2 pl-3 pr-7 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                type="number"
+                step="1"
+                min="1"
+                max="3600"
+                placeholder="Global default"
+                value={
+                  editingProvider.timeoutMs != null
+                    ? Math.round(editingProvider.timeoutMs / 1000)
+                    : ''
+                }
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  if (raw === '') {
+                    setEditingProvider({ ...editingProvider, timeoutMs: undefined });
+                  } else {
+                    const seconds = Number(raw);
+                    if (Number.isFinite(seconds) && seconds >= 1 && seconds <= 3600) {
+                      setEditingProvider({ ...editingProvider, timeoutMs: seconds * 1000 });
+                    }
+                  }
+                }}
+              />
+            </div>
+          </div>
+
           {/* Custom Headers */}
           <div className="border border-border-glass rounded-md overflow-hidden">
             <div

--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -70,6 +70,7 @@ export const EMPTY_PROVIDER: Provider = {
   extraBody: {},
   models: {},
   adapter: [],
+  timeoutMs: undefined,
 };
 
 export interface FetchedModel {

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -237,6 +237,7 @@ export interface Provider {
   gpu_flops_tflop?: number;
   gpu_power_draw_watts?: number;
   adapter?: string[];
+  timeoutMs?: number;
 }
 
 export interface McpServer {
@@ -1667,6 +1668,7 @@ export const api = {
           models: normalizedModels,
           quotaChecker: normalizeProviderQuotaChecker(val.quota_checker),
           adapter: val.adapter ? (Array.isArray(val.adapter) ? val.adapter : [val.adapter]) : [],
+          timeoutMs: val.timeoutMs ?? undefined,
         };
       });
     } catch (e) {
@@ -1711,6 +1713,7 @@ export const api = {
         ? { gpu_power_draw_watts: provider.gpu_power_draw_watts }
         : {}),
       ...(provider.adapter && provider.adapter.length > 0 ? { adapter: provider.adapter } : {}),
+      ...(provider.timeoutMs != null ? { timeoutMs: provider.timeoutMs } : {}),
     };
 
     const res = await fetchWithAuth(
@@ -3151,6 +3154,28 @@ export const api = {
       body: JSON.stringify(updates),
     });
     if (!res.ok) throw new Error('Failed to update background exploration settings');
+    return res.json();
+  },
+
+  // ─── Timeout Settings ───────────────────────────────────────────
+
+  /** Fetch current timeout settings. */
+  getTimeoutConfig: async (): Promise<{ defaultSeconds: number }> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/timeout`);
+    if (!res.ok) throw new Error('Failed to fetch timeout settings');
+    return res.json();
+  },
+
+  /** Patch timeout settings. */
+  patchTimeoutConfig: async (updates: {
+    defaultSeconds?: number;
+  }): Promise<{ defaultSeconds: number }> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/timeout`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    });
+    if (!res.ok) throw new Error('Failed to update timeout settings');
     return res.json();
   },
 };

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -167,7 +167,11 @@ export function formatTimeLabel(timestamp: string): string {
 export function formatDateTimeLabel(timestamp: string): string {
   const date = parseTimestamp(timestamp);
   if (date) {
-    const dateStr = date.toLocaleDateString([], { year: 'numeric', month: '2-digit', day: '2-digit' });
+    const dateStr = date.toLocaleDateString([], {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
     const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     return `${dateStr} ${timeStr}`;
   }

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -83,6 +83,14 @@ interface BackgroundExplorationConfig {
   workerConcurrency: number;
 }
 
+interface TimeoutConfig {
+  defaultSeconds: number;
+}
+
+const DEFAULT_TIMEOUT_CONFIG: TimeoutConfig = {
+  defaultSeconds: 300,
+};
+
 const DEFAULT_BACKGROUND_EXPLORATION: BackgroundExplorationConfig = {
   enabled: false,
   stalenessThresholdSeconds: 600,
@@ -141,6 +149,35 @@ export const Config = () => {
     }
     return { valid: true, value: num };
   };
+
+  // Timeout settings state
+  const [timeoutConfig, setTimeoutConfig] = useState<TimeoutConfig>(DEFAULT_TIMEOUT_CONFIG);
+  const [timeoutLoaded, setTimeoutLoaded] = useState(false);
+  const [timeoutSaving, setTimeoutSaving] = useState(false);
+  const [timeoutDefaultInput, setTimeoutDefaultInput] = useState('');
+
+  // Validate timeout input
+  const validateTimeoutInput = (
+    raw: string
+  ): { valid: boolean; value?: number; error?: string } => {
+    if (raw === '') {
+      return { valid: false, error: 'Required' };
+    }
+    const num = Number(raw);
+    if (isNaN(num) || !isFinite(num) || !Number.isInteger(num)) {
+      return { valid: false, error: 'Must be an integer' };
+    }
+    if (num < 1) {
+      return { valid: false, error: 'Must be at least 1' };
+    }
+    if (num > 3600) {
+      return { valid: false, error: 'Must be at most 3600' };
+    }
+    return { valid: true, value: num };
+  };
+
+  const timeoutDefaultValidation = validateTimeoutInput(timeoutDefaultInput);
+  const isTimeoutValid = timeoutLoaded && timeoutDefaultValidation.valid;
 
   const initialValidation = validateCooldownInput(cooldownInitialInput);
   const maxValidation = validateCooldownInput(cooldownMaxInput);
@@ -276,6 +313,18 @@ export const Config = () => {
     }
   }, [toast]);
 
+  const loadTimeoutConfig = useCallback(async () => {
+    try {
+      const cfg = await api.getTimeoutConfig();
+      setTimeoutConfig(cfg);
+      setTimeoutDefaultInput(String(cfg.defaultSeconds));
+      setTimeoutLoaded(true);
+    } catch (e) {
+      console.error('Failed to load timeout config:', e);
+      toast.error('Failed to load timeout settings');
+    }
+  }, [toast]);
+
   const handleSaveFailover = async () => {
     setFailoverSaving(true);
     try {
@@ -327,6 +376,24 @@ export const Config = () => {
       toast.error((e as Error).message, 'Failed to save cooldown settings');
     } finally {
       setCooldownSaving(false);
+    }
+  };
+
+  const handleSaveTimeout = async () => {
+    if (!timeoutDefaultValidation.valid) return;
+    setTimeoutSaving(true);
+    try {
+      const updated = await api.patchTimeoutConfig({
+        defaultSeconds: timeoutDefaultValidation.value!,
+      });
+
+      setTimeoutConfig(updated);
+      setTimeoutDefaultInput(String(updated.defaultSeconds));
+      toast.success('Timeout settings saved');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to save timeout settings');
+    } finally {
+      setTimeoutSaving(false);
     }
   };
 
@@ -404,6 +471,7 @@ export const Config = () => {
     loadConfig();
     loadFailoverPolicy();
     loadCooldownPolicy();
+    loadTimeoutConfig();
     loadExplorationRates();
     loadBackgroundExploration();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -830,6 +898,80 @@ export const Config = () => {
                     : cooldownLoaded
                       ? formatMinutesToMinSec(cooldownPolicy.maxMinutes)
                       : '—'}
+                </span>
+              </div>
+            </div>
+          </div>
+        </Disclosure>
+
+        {/* ─── Timeout Settings ───────────────────────────────────── */}
+        <Disclosure
+          title="Timeout Settings"
+          defaultOpen={false}
+          extra={
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleSaveTimeout}
+              isLoading={timeoutSaving}
+              disabled={!isTimeoutValid}
+              leftIcon={<Save size={14} />}
+            >
+              Save
+            </Button>
+          }
+        >
+          <div className="flex flex-col gap-5">
+            {/* Description */}
+            <div className="flex items-start gap-2">
+              <Timer size={16} className="text-primary mt-0.5" />
+              <div>
+                <p className="text-sm font-medium text-text">Upstream Request Timeout</p>
+                <p className="text-xs text-text-muted">
+                  The maximum time Plexus waits for an upstream provider to respond before aborting
+                  the request. Can be overridden per-provider in the provider's advanced settings.
+                </p>
+              </div>
+            </div>
+
+            {/* Default Seconds */}
+            <div>
+              <label
+                htmlFor="timeoutDefaultSeconds"
+                className="block text-sm font-medium text-text mb-1"
+              >
+                Default Timeout (seconds)
+              </label>
+              <p className="text-xs text-text-muted mb-2">
+                The global default for all upstream requests. Must be between 1 and 3600 seconds.
+                When a provider-specific timeout is set, it overrides this value.
+              </p>
+              <div className="flex items-center gap-3">
+                <div className="flex flex-col gap-1">
+                  <input
+                    id="timeoutDefaultSeconds"
+                    type="number"
+                    min={1}
+                    max={3600}
+                    step={1}
+                    value={timeoutDefaultInput}
+                    onChange={(e) => setTimeoutDefaultInput(e.target.value)}
+                    className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                  />
+                  {!timeoutDefaultValidation.valid && timeoutDefaultInput !== '' && (
+                    <span className="text-xs text-warning">{timeoutDefaultValidation.error}</span>
+                  )}
+                </div>
+                <span className="text-xs text-text-muted tabular-nums min-w-[60px]">
+                  {timeoutDefaultValidation.valid && timeoutDefaultValidation.value !== undefined
+                    ? timeoutDefaultValidation.value >= 60
+                      ? `${Math.floor(timeoutDefaultValidation.value / 60)}m ${timeoutDefaultValidation.value % 60}s`
+                      : `${timeoutDefaultValidation.value}s`
+                    : timeoutLoaded
+                      ? timeoutConfig.defaultSeconds >= 60
+                        ? `${Math.floor(timeoutConfig.defaultSeconds / 60)}m ${timeoutConfig.defaultSeconds % 60}s`
+                        : `${timeoutConfig.defaultSeconds}s`
+                      : '\u2014'}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Adds configurable upstream request timeouts at two levels — a global default and an optional per-provider override — so Plexus can abort long-running upstream requests instead of burning provider quota indefinitely.

### Why this matters for cost

Without timeouts, a stalled or slow upstream provider continues consuming tokens and burning API quota until the client eventually disconnects. For providers billed by token usage, this means paying for output that the client never receives. A well-tuned timeout:

- **Caps waste** — stops paying for tokens the client has already given up on.
- **Enables failover** — a timed-out request triggers Plexus's existing failover logic, retrying on a healthier provider instead of waiting on a stuck one.
- **Protects against runaway streams** — a provider that streams infinitely (or very slowly) is cut off at a known boundary, preventing surprise bills.

Even a generous default (300s) is better than infinite; operators who know their providers' latency profiles can tune per-provider timeouts tighter (e.g., 30s for a fast inference endpoint, 120s for a slower one).

---

## Changes

### Backend

- **New `timeout_ms` column** on `providers` table (both SQLite & PostgreSQL schemas, nullable — `NULL` means use global default).
- **Global timeout setting** stored as `timeout.defaultSeconds` in `system_settings` (default: 300).
- **`GET`/`PATCH /v0/management/config/timeout`** — dedicated API endpoints with validation (integer 1–3600).
- **`wireUpstreamTimeout()` utility** (`src/utils/timeout.ts`) — combines `AbortSignal.timeout()` with the route's `AbortController` and bridges the gap where `AbortSignal.any()` does NOT propagate abort back to source signals. Also exposes `addTimeoutSource()` for per-provider overrides after routing resolves.
- **Dispatcher** — calls `addTimeoutSource(route.config.timeoutMs)` when the provider has a per-provider override, which fires a shorter timeout and aborts the route's `AbortController`.
- **`response-handler.ts`** — `onDisconnect()` now detects timeouts (via source string or `signal.reason`), sets `responseStatus = 'timeout'`, and the `pipeline.on(error)` handler catches `TimeoutError`/`AbortError` as a belt-and-suspenders path.
- **`usage-logging.ts`** — `_destroy()` respects a pre-set `timeout` status so it isn't overwritten with `cancelled`.
- **Config types** — `TimeoutConfig` type, `timeout` field on `PlexusConfig`, `timeoutMs` on `ProviderConfigSchema`.

### Frontend

- **Config page** — new "Timeout Settings" Disclosure with a number input for the global default (1–3600 seconds, with human-readable `Xm Ys` display).
- **Provider Advanced editor** — new "Upstream Timeout (seconds)" input field; empty means "use global default". Displays in seconds, stores in milliseconds.
- **API client** — `getTimeoutConfig()` / `patchTimeoutConfig()` methods, `timeoutMs` on `Provider` interface and `saveProvider()` body.

### Tests

- Updated `config-service.test.ts` mock to include `getTimeoutConfig`.
- Updated `dispatcher-abort.test.ts` with comment clarifying signal passthrough in test environments.

---

## Configuration

| Setting | Location | Default | Range |
|---------|----------|---------|-------|
| Global default timeout | Config page → Timeout Settings | 300s | 1–3600s |
| Per-provider timeout | Provider → Advanced → Upstream Timeout | *(use global)* | 1–3600s |

The effective timeout for a request is: `provider.timeoutMs ?? (globalDefaultSeconds × 1000)`.

---

## How it works

1. Route handler calls `wireUpstreamTimeout(abortController)` → creates combined signal with global timeout + client disconnect, wired to abort the controller when timeout fires.
2. Dispatcher resolves the route → if `provider.timeoutMs` is set, calls `addTimeoutSource(timeoutMs)` to also start a shorter per-provider countdown.
3. When either timeout fires → `abortController.abort(TimeoutError)` → combined signal aborts → `fetch()` is cancelled → `response-handler.ts` listener fires → `nodeStream.destroy()` → upstream fetch body is cancelled.
4. Usage logging records `responseStatus = 'timeout', not `'cancelled'.
5. If failover is enabled, the dispatcher retries on the next provider.