### PR TITLE
feat: stream stall detection with automatic failover

### DIFF
--- a/packages/backend/drizzle/migrations/0042_careless_shotgun.sql
+++ b/packages/backend/drizzle/migrations/0042_careless_shotgun.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `providers` ADD `stall_ttfb_ms` integer;--> statement-breakpoint
+ALTER TABLE `providers` ADD `stall_ttfb_bytes` integer;--> statement-breakpoint
+ALTER TABLE `providers` ADD `stall_min_bps` integer;--> statement-breakpoint
+ALTER TABLE `providers` ADD `stall_window_ms` integer;--> statement-breakpoint
+ALTER TABLE `providers` ADD `stall_grace_period_ms` integer;

--- a/packages/backend/drizzle/migrations/meta/0042_snapshot.json
+++ b/packages/backend/drizzle/migrations/meta/0042_snapshot.json
@@ -1,0 +1,2984 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f9f3dc57-e1fe-4f15-92c9-945b3ce4d8d2",
+  "prevId": "beb5e5d5-0d78-4ec5-bd9f-f3b4dd009eee",
+  "tables": {
+    "alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "columns": [
+            "alias_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "columns": [
+            "secret"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "columns": [
+            "secret_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debug_logs": {
+      "name": "debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inference_errors": {
+      "name": "inference_errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            "server_name"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meter_snapshots": {
+      "name": "meter_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_type": {
+          "name": "checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_state": {
+          "name": "utilization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_value": {
+          "name": "period_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "period_unit": {
+          "name": "period_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "period_cycle": {
+          "name": "period_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_meter_checker_meter_checked": {
+          "name": "idx_meter_checker_meter_checked",
+          "columns": [
+            "checker_id",
+            "meter_key",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_meter_provider_checked": {
+          "name": "idx_meter_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_meter_checked_at": {
+          "name": "idx_meter_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_alias_targets": {
+      "name": "model_alias_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_aliases": {
+      "name": "model_aliases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_architecture": {
+          "name": "model_architecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enforce_limits": {
+          "name": "enforce_limits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sticky_session": {
+          "name": "sticky_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "preferred_api": {
+          "name": "preferred_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pi_model": {
+          "name": "pi_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_groups": {
+          "name": "target_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_credentials": {
+      "name": "oauth_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            "expiry"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "columns": [
+            "provider",
+            "model"
+          ],
+          "name": "provider_cooldowns_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_models": {
+      "name": "provider_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "columns": [
+            "provider_id",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_performance": {
+      "name": "provider_performance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "e2e_tokens_per_sec": {
+          "name": "e2e_tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            "provider",
+            "model",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gemini_thinking_enabled": {
+          "name": "gemini_thinking_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_profile": {
+          "name": "gpu_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_ram_gb": {
+          "name": "gpu_ram_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_bandwidth_tb_s": {
+          "name": "gpu_bandwidth_tb_s",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_flops_tflop": {
+          "name": "gpu_flops_tflop",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_power_draw_watts": {
+          "name": "gpu_power_draw_watts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_ttfb_ms": {
+          "name": "stall_ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_ttfb_bytes": {
+          "name": "stall_ttfb_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_min_bps": {
+          "name": "stall_min_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_window_ms": {
+          "name": "stall_window_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_grace_period_ms": {
+          "name": "stall_grace_period_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_snapshots": {
+      "name": "quota_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            "checker_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            "group_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_state": {
+      "name": "quota_state",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_usage": {
+      "name": "request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            "api_key",
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "response_items": {
+      "name": "response_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            "response_id",
+            "item_index"
+          ],
+          "isUnique": false
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "responses": {
+      "name": "responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            "previous_response_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_settings": {
+      "name": "system_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/backend/drizzle/migrations/meta/_journal.json
+++ b/packages/backend/drizzle/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1778905467722,
       "tag": "0041_fearless_baron_strucker",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "6",
+      "when": 1778908618664,
+      "tag": "0042_careless_shotgun",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/migrations_pg/0052_chilly_living_mummy.sql
+++ b/packages/backend/drizzle/migrations_pg/0052_chilly_living_mummy.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "providers" ADD COLUMN "stall_ttfb_ms" integer;--> statement-breakpoint
+ALTER TABLE "providers" ADD COLUMN "stall_ttfb_bytes" integer;--> statement-breakpoint
+ALTER TABLE "providers" ADD COLUMN "stall_min_bps" integer;--> statement-breakpoint
+ALTER TABLE "providers" ADD COLUMN "stall_window_ms" integer;--> statement-breakpoint
+ALTER TABLE "providers" ADD COLUMN "stall_grace_period_ms" integer;

--- a/packages/backend/drizzle/migrations_pg/meta/0052_snapshot.json
+++ b/packages/backend/drizzle/migrations_pg/meta/0052_snapshot.json
@@ -1,0 +1,3146 @@
+{
+  "id": "e6edeb89-f9ca-4f7b-93e4-1f2a08ac5c2d",
+  "prevId": "e51e864f-1ca5-4267-b01e-d7f640cd6dc3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_usage": {
+      "name": "request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_models": {
+      "name": "provider_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "model_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_snapshots": {
+      "name": "quota_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_alias_targets": {
+      "name": "model_alias_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret"
+          ]
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            {
+              "expression": "server_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gemini_thinking_enabled": {
+          "name": "gemini_thinking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "quota_checker_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_profile": {
+          "name": "gpu_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_ram_gb": {
+          "name": "gpu_ram_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_bandwidth_tb_s": {
+          "name": "gpu_bandwidth_tb_s",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_flops_tflop": {
+          "name": "gpu_flops_tflop",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_power_draw_watts": {
+          "name": "gpu_power_draw_watts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_ttfb_ms": {
+          "name": "stall_ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_ttfb_bytes": {
+          "name": "stall_ttfb_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_min_bps": {
+          "name": "stall_min_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_window_ms": {
+          "name": "stall_window_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_grace_period_ms": {
+          "name": "stall_grace_period_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_errors": {
+      "name": "inference_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "quota_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "limit_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meter_snapshots": {
+      "name": "meter_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_type": {
+          "name": "checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_state": {
+          "name": "utilization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_value": {
+          "name": "period_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_unit": {
+          "name": "period_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_cycle": {
+          "name": "period_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_meter_checker_meter_checked": {
+          "name": "idx_meter_checker_meter_checked",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meter_provider_checked": {
+          "name": "idx_meter_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meter_checked_at": {
+          "name": "idx_meter_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_aliases": {
+      "name": "model_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "selector_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "alias_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "metadata_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_architecture": {
+          "name": "model_architecture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_limits": {
+          "name": "enforce_limits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sticky_session": {
+          "name": "sticky_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferred_api": {
+          "name": "preferred_api",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pi_model": {
+          "name": "pi_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_groups": {
+          "name": "target_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            {
+              "expression": "expiry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "name": "provider_cooldowns_provider_model_pk",
+          "columns": [
+            "provider",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_performance": {
+      "name": "provider_performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "e2e_tokens_per_sec": {
+          "name": "e2e_tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_state": {
+      "name": "quota_state",
+      "schema": "",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_items": {
+      "name": "response_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.responses": {
+      "name": "responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            {
+              "expression": "previous_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.model_type": {
+      "name": "model_type",
+      "schema": "public",
+      "values": [
+        "chat",
+        "embeddings",
+        "transcriptions",
+        "speech",
+        "image",
+        "responses"
+      ]
+    },
+    "public.oauth_provider_type": {
+      "name": "oauth_provider_type",
+      "schema": "public",
+      "values": [
+        "anthropic",
+        "openai-codex",
+        "github-copilot",
+        "google-gemini-cli",
+        "google-antigravity"
+      ]
+    },
+    "public.quota_checker_type": {
+      "name": "quota_checker_type",
+      "schema": "public",
+      "values": [
+        "naga",
+        "synthetic",
+        "nanogpt",
+        "zai",
+        "moonshot",
+        "minimax",
+        "minimax-coding",
+        "openrouter",
+        "kilo",
+        "openai-codex",
+        "claude-code",
+        "kimi-code",
+        "copilot",
+        "wisdomgate",
+        "apertis",
+        "apertis-coding-plan",
+        "poe",
+        "gemini-cli",
+        "antigravity",
+        "novita",
+        "ollama",
+        "neuralwatt",
+        "zenmux",
+        "devpass",
+        "wafer",
+        "opencode-go"
+      ]
+    },
+    "public.limit_type": {
+      "name": "limit_type",
+      "schema": "public",
+      "values": [
+        "requests",
+        "tokens",
+        "cost"
+      ]
+    },
+    "public.quota_type": {
+      "name": "quota_type",
+      "schema": "public",
+      "values": [
+        "rolling",
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.alias_priority": {
+      "name": "alias_priority",
+      "schema": "public",
+      "values": [
+        "selector",
+        "api_match"
+      ]
+    },
+    "public.metadata_source": {
+      "name": "metadata_source",
+      "schema": "public",
+      "values": [
+        "openrouter",
+        "models.dev",
+        "catwalk",
+        "custom"
+      ]
+    },
+    "public.selector_strategy": {
+      "name": "selector_strategy",
+      "schema": "public",
+      "values": [
+        "random",
+        "in_order",
+        "cost",
+        "latency",
+        "usage",
+        "performance"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/migrations_pg/meta/_journal.json
+++ b/packages/backend/drizzle/migrations_pg/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1778905467906,
       "tag": "0051_magenta_talon",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1778908618834,
+      "tag": "0052_chilly_living_mummy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/schema/postgres/providers.ts
+++ b/packages/backend/drizzle/schema/postgres/providers.ts
@@ -48,6 +48,12 @@ export const providers = pgTable(
     gpuPowerDrawWatts: integer('gpu_power_draw_watts'), // Power draw in watts
     adapter: jsonb('adapter'), // string[] — provider-level adapter names
     timeoutMs: integer('timeout_ms'), // Per-provider upstream request timeout in ms (NULL = use global default)
+    // Per-provider stall detection overrides (NULL = use global setting)
+    stallTtfbMs: integer('stall_ttfb_ms'), // TTFB timeout in ms
+    stallTtfbBytes: integer('stall_ttfb_bytes'), // TTFB byte threshold
+    stallMinBps: integer('stall_min_bps'), // Minimum bytes per second for throughput stall
+    stallWindowMs: integer('stall_window_ms'), // Sliding window width in ms for throughput calculation
+    stallGracePeriodMs: integer('stall_grace_period_ms'), // Grace period in ms before throughput enforcement
     createdAt: bigint('created_at', { mode: 'number' }).notNull(),
     updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
   },

--- a/packages/backend/drizzle/schema/sqlite/providers.ts
+++ b/packages/backend/drizzle/schema/sqlite/providers.ts
@@ -35,6 +35,12 @@ export const providers = sqliteTable(
     gpuPowerDrawWatts: integer('gpu_power_draw_watts'), // Power draw in watts
     adapter: text('adapter'), // JSON: string[] — provider-level adapter names
     timeoutMs: integer('timeout_ms'), // Per-provider upstream request timeout in ms (NULL = use global default)
+    // Per-provider stall detection overrides (NULL = use global setting)
+    stallTtfbMs: integer('stall_ttfb_ms'), // TTFB timeout in ms
+    stallTtfbBytes: integer('stall_ttfb_bytes'), // TTFB byte threshold
+    stallMinBps: integer('stall_min_bps'), // Minimum bytes per second for throughput stall
+    stallWindowMs: integer('stall_window_ms'), // Sliding window width in ms for throughput calculation
+    stallGracePeriodMs: integer('stall_grace_period_ms'), // Grace period in ms before throughput enforcement
     createdAt: integer('created_at').notNull(),
     updatedAt: integer('updated_at').notNull(),
   },

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -425,6 +425,12 @@ export const ProviderConfigSchema = z
     geminiThinkingEnabled: z.boolean().optional(),
     adapter: AdapterConfigSchema,
     timeoutMs: z.number().int().positive().optional(),
+    // Per-provider stall detection overrides (null = use global setting)
+    stallTtfbMs: z.number().int().min(5000).max(120000).nullable().optional(),
+    stallTtfbBytes: z.number().int().min(50).max(10000).nullable().optional(),
+    stallMinBps: z.number().int().min(50).max(5000).nullable().optional(),
+    stallWindowMs: z.number().int().min(3000).max(30000).nullable().optional(),
+    stallGracePeriodMs: z.number().int().min(0).max(120000).nullable().optional(),
   })
   .refine((data) => !!data.api_key || isOAuthProviderConfig(data), {
     message: "'api_key' must be specified for provider",
@@ -682,6 +688,14 @@ const BackgroundExplorationConfigSchema = z.object({
   workerConcurrency: z.number().int().min(1).max(16).default(2),
 });
 
+const StallConfigSchema = z.object({
+  ttfbSeconds: z.number().min(5).max(120).nullable().optional(),
+  ttfbBytes: z.number().int().min(50).max(10000).default(100).optional(),
+  minBytesPerSecond: z.number().int().min(50).max(5000).nullable().optional(),
+  windowSeconds: z.number().int().min(3).max(30).default(10).optional(),
+  gracePeriodSeconds: z.number().int().min(0).max(120).default(30).optional(),
+});
+
 const RawPlexusConfigSchema = z
   .object({
     providers: z.record(z.string(), ProviderConfigSchema),
@@ -694,6 +708,7 @@ const RawPlexusConfigSchema = z
     latencyExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
     e2ePerformanceExplorationRate: z.number().min(0).max(1).default(0.05).optional(),
     timeout: z.object({ defaultSeconds: z.number().min(1).max(3600).default(300) }).optional(),
+    stall: StallConfigSchema.optional(),
     backgroundExploration: BackgroundExplorationConfigSchema.optional(),
     mcp_servers: z.record(z.string(), McpServerConfigSchema).optional(),
     user_quotas: z.record(z.string(), QuotaDefinitionSchema).optional(),
@@ -704,10 +719,18 @@ export type FailoverPolicy = z.infer<typeof FailoverPolicySchema>;
 export type CooldownPolicy = z.infer<typeof CooldownPolicySchema>;
 export type BackgroundExplorationConfig = z.infer<typeof BackgroundExplorationConfigSchema>;
 export type TimeoutConfig = { defaultSeconds: number };
+export type StallConfigType = {
+  ttfbSeconds?: number | null;
+  ttfbBytes?: number;
+  minBytesPerSecond?: number | null;
+  windowSeconds?: number;
+  gracePeriodSeconds?: number;
+};
 export type PlexusConfig = z.infer<typeof RawPlexusConfigSchema> & {
   failover: FailoverPolicy;
   cooldown?: CooldownPolicy;
   timeout?: TimeoutConfig;
+  stall?: StallConfigType;
   quotas: QuotaConfig[];
   mcpServers?: Record<string, McpServerConfig>;
 };

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -20,6 +20,7 @@ import type {
   CooldownPolicy,
   BackgroundExplorationConfig,
   TimeoutConfig,
+  StallConfigType,
   MetadataOverrides,
 } from '../config';
 import { resolveGpuParams } from '@plexus/shared';
@@ -313,6 +314,12 @@ export class ConfigRepository {
           ? toJson(Array.isArray(config.adapter) ? config.adapter : [config.adapter])
           : null,
       timeoutMs: config.timeoutMs ?? null,
+      // Per-provider stall detection overrides
+      stallTtfbMs: config.stallTtfbMs ?? null,
+      stallTtfbBytes: config.stallTtfbBytes ?? null,
+      stallMinBps: config.stallMinBps ?? null,
+      stallWindowMs: config.stallWindowMs ?? null,
+      stallGracePeriodMs: config.stallGracePeriodMs ?? null,
       updatedAt: timestamp,
     };
 
@@ -533,6 +540,11 @@ export class ConfigRepository {
         };
       })(),
       ...(row.timeoutMs != null ? { timeoutMs: row.timeoutMs } : {}),
+      ...(row.stallTtfbMs != null ? { stallTtfbMs: row.stallTtfbMs } : {}),
+      ...(row.stallTtfbBytes != null ? { stallTtfbBytes: row.stallTtfbBytes } : {}),
+      ...(row.stallMinBps != null ? { stallMinBps: row.stallMinBps } : {}),
+      ...(row.stallWindowMs != null ? { stallWindowMs: row.stallWindowMs } : {}),
+      ...(row.stallGracePeriodMs != null ? { stallGracePeriodMs: row.stallGracePeriodMs } : {}),
     };
 
     return result as ProviderConfig;
@@ -1232,6 +1244,15 @@ export class ConfigRepository {
   async getTimeoutConfig(): Promise<TimeoutConfig> {
     const defaultSeconds = await this.getSetting<number>('timeout.defaultSeconds', 300);
     return { defaultSeconds };
+  }
+
+  async getStallConfig(): Promise<import('../config').StallConfigType> {
+    const ttfbSeconds = await this.getSetting<number | null>('stall.ttfbSeconds', null);
+    const ttfbBytes = await this.getSetting<number>('stall.ttfbBytes', 100);
+    const minBytesPerSecond = await this.getSetting<number | null>('stall.minBytesPerSecond', null);
+    const windowSeconds = await this.getSetting<number>('stall.windowSeconds', 10);
+    const gracePeriodSeconds = await this.getSetting<number>('stall.gracePeriodSeconds', 30);
+    return { ttfbSeconds, ttfbBytes, minBytesPerSecond, windowSeconds, gracePeriodSeconds };
   }
 
   // ─── OAuth Credentials ──────────────────────────────────────────

--- a/packages/backend/src/routes/inference/chat.ts
+++ b/packages/backend/src/routes/inference/chat.ts
@@ -10,7 +10,8 @@ import { DebugManager } from '../../services/debug-manager';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../../services/quota/quota-middleware';
 import { attachKeyAccessPolicy } from '../../utils/auth';
-import { wireUpstreamTimeout } from '../../utils/timeout';
+import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/timeout';
+import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 
 export async function registerChatRoute(
   fastify: FastifyInstance,
@@ -41,6 +42,7 @@ export async function registerChatRoute(
     // Emit 'started' event immediately - this allows frontend to show in-flight requests
     usageStorage.emitStartedAsync(usageRecord);
 
+    let earlyDisconnect: ReturnType<typeof wireEarlyDisconnectDetection> | undefined;
     try {
       const body = request.body as any;
       usageRecord.incomingModelAlias = body.model;
@@ -89,10 +91,13 @@ export async function registerChatRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,
         dispatchSignal,
-        addTimeoutSource
+        addTimeoutSource,
+        stallDetectionResult?.addStallConfig
       );
 
       // Emit 'updated' event with routing decision details
@@ -124,15 +129,25 @@ export async function registerChatRoute(
         body,
         quotaEnforcer,
         (request as any).keyName,
-        abortController
+        abortController,
+        stallDetectionResult
       );
 
+      earlyDisconnect?.cleanup();
       return result;
     } catch (e: any) {
+      earlyDisconnect?.cleanup();
       if (
         e?.routingContext?.code === 'client_disconnected' ||
         e?.routingContext?.code === 'upstream_timeout'
       ) {
+        usageRecord.responseStatus =
+          e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled';
+        usageRecord.durationMs = Date.now() - startTime;
+        usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
+        usageRecord.retryHistory =
+          e.routingContext?.retryHistory || usageRecord.retryHistory || null;
+        usageStorage.saveRequest(usageRecord as UsageRecord);
         logger.info(
           `Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`
         );

--- a/packages/backend/src/routes/inference/gemini.ts
+++ b/packages/backend/src/routes/inference/gemini.ts
@@ -10,7 +10,8 @@ import { DebugManager } from '../../services/debug-manager';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../../services/quota/quota-middleware';
 import { attachKeyAccessPolicy } from '../../utils/auth';
-import { wireUpstreamTimeout } from '../../utils/timeout';
+import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/timeout';
+import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 
 export async function registerGeminiRoute(
   fastify: FastifyInstance,
@@ -40,6 +41,7 @@ export async function registerGeminiRoute(
     // Emit 'started' event immediately - this allows frontend to show in-flight requests
     usageStorage.emitStartedAsync(usageRecord);
 
+    let earlyDisconnect: ReturnType<typeof wireEarlyDisconnectDetection> | undefined;
     try {
       const body = request.body as any;
       const params = request.params as any;
@@ -97,10 +99,13 @@ export async function registerGeminiRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,
         dispatchSignal,
-        addTimeoutSource
+        addTimeoutSource,
+        stallDetectionResult?.addStallConfig
       );
 
       // Emit 'updated' event with routing decision details
@@ -133,15 +138,25 @@ export async function registerGeminiRoute(
         body,
         quotaEnforcer,
         (request as any).keyName,
-        abortController
+        abortController,
+        stallDetectionResult
       );
 
+      earlyDisconnect?.cleanup();
       return result;
     } catch (e: any) {
+      earlyDisconnect?.cleanup();
       if (
         e?.routingContext?.code === 'client_disconnected' ||
         e?.routingContext?.code === 'upstream_timeout'
       ) {
+        usageRecord.responseStatus =
+          e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled';
+        usageRecord.durationMs = Date.now() - startTime;
+        usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
+        usageRecord.retryHistory =
+          e.routingContext?.retryHistory || usageRecord.retryHistory || null;
+        usageStorage.saveRequest(usageRecord as UsageRecord);
         logger.info(
           `Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`
         );

--- a/packages/backend/src/routes/inference/messages.ts
+++ b/packages/backend/src/routes/inference/messages.ts
@@ -10,7 +10,8 @@ import { DebugManager } from '../../services/debug-manager';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../../services/quota/quota-middleware';
 import { attachKeyAccessPolicy } from '../../utils/auth';
-import { wireUpstreamTimeout } from '../../utils/timeout';
+import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/timeout';
+import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 
 export async function registerMessagesRoute(
   fastify: FastifyInstance,
@@ -39,6 +40,7 @@ export async function registerMessagesRoute(
     // Emit 'started' event immediately - this allows frontend to show in-flight requests
     usageStorage.emitStartedAsync(usageRecord);
 
+    let earlyDisconnect: ReturnType<typeof wireEarlyDisconnectDetection> | undefined;
     try {
       const body = request.body as any;
       usageRecord.incomingModelAlias = body.model;
@@ -87,10 +89,13 @@ export async function registerMessagesRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,
         dispatchSignal,
-        addTimeoutSource
+        addTimeoutSource,
+        stallDetectionResult?.addStallConfig
       );
 
       // Emit 'updated' event with routing decision details
@@ -123,15 +128,25 @@ export async function registerMessagesRoute(
         body,
         quotaEnforcer,
         (request as any).keyName,
-        abortController
+        abortController,
+        stallDetectionResult
       );
 
+      earlyDisconnect?.cleanup();
       return result;
     } catch (e: any) {
+      earlyDisconnect?.cleanup();
       if (
         e?.routingContext?.code === 'client_disconnected' ||
         e?.routingContext?.code === 'upstream_timeout'
       ) {
+        usageRecord.responseStatus =
+          e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled';
+        usageRecord.durationMs = Date.now() - startTime;
+        usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
+        usageRecord.retryHistory =
+          e.routingContext?.retryHistory || usageRecord.retryHistory || null;
+        usageStorage.saveRequest(usageRecord as UsageRecord);
         logger.info(
           `Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`
         );

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -11,7 +11,8 @@ import { DebugManager } from '../../services/debug-manager';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../../services/quota/quota-middleware';
 import { attachKeyAccessPolicy } from '../../utils/auth';
-import { wireUpstreamTimeout } from '../../utils/timeout';
+import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/timeout';
+import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 
 export async function registerResponsesRoute(
   fastify: FastifyInstance,
@@ -50,6 +51,7 @@ export async function registerResponsesRoute(
     // Emit 'started' event immediately - this allows frontend to show in-flight requests
     usageStorage.emitStartedAsync(usageRecord);
 
+    let earlyDisconnect: ReturnType<typeof wireEarlyDisconnectDetection> | undefined;
     try {
       const body = request.body as any;
       usageRecord.incomingModelAlias = body.model;
@@ -170,10 +172,13 @@ export async function registerResponsesRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,
         dispatchSignal,
-        addTimeoutSource
+        addTimeoutSource,
+        stallDetectionResult?.addStallConfig
       );
 
       // Emit 'updated' event with routing decision details
@@ -207,7 +212,8 @@ export async function registerResponsesRoute(
         body,
         quotaEnforcer,
         (request as any).keyName,
-        abortController
+        abortController,
+        stallDetectionResult
       );
 
       // Store response if requested and not streaming
@@ -228,12 +234,21 @@ export async function registerResponsesRoute(
         }
       }
 
+      earlyDisconnect?.cleanup();
       return result;
     } catch (e: any) {
+      earlyDisconnect?.cleanup();
       if (
         e?.routingContext?.code === 'client_disconnected' ||
         e?.routingContext?.code === 'upstream_timeout'
       ) {
+        usageRecord.responseStatus =
+          e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled';
+        usageRecord.durationMs = Date.now() - startTime;
+        usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
+        usageRecord.retryHistory =
+          e.routingContext?.retryHistory || usageRecord.retryHistory || null;
+        usageStorage.saveRequest(usageRecord as UsageRecord);
         logger.info(
           `Request ${requestId}: ${e.message}, usage recorded as ${e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled'}`
         );

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -620,6 +620,88 @@ export async function registerConfigRoutes(
     }
   });
 
+  // ─── Stall Config ──────────────────────────────────────────────────
+
+  fastify.get('/v0/management/config/stall', async (_request, reply) => {
+    try {
+      const stall = await configService.getRepository().getStallConfig();
+      return reply.send(stall);
+    } catch (e: any) {
+      logger.error('Failed to read stall config', e);
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  fastify.patch('/v0/management/config/stall', async (request, reply) => {
+    const body = request.body as Record<string, unknown> | null;
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return reply.code(400).send({ error: 'Object body is required' });
+    }
+
+    try {
+      if (body.ttfbSeconds !== undefined) {
+        if (body.ttfbSeconds === null) {
+          await configService.setSetting('stall.ttfbSeconds', null);
+        } else {
+          const val = Number(body.ttfbSeconds);
+          if (!Number.isFinite(val) || val < 5 || val > 120) {
+            return reply
+              .code(400)
+              .send({ error: 'ttfbSeconds must be null or a number between 5 and 120' });
+          }
+          await configService.setSetting('stall.ttfbSeconds', val);
+        }
+      }
+      if (body.ttfbBytes !== undefined) {
+        const val = Number(body.ttfbBytes);
+        if (!Number.isFinite(val) || !Number.isInteger(val) || val < 50 || val > 10000) {
+          return reply
+            .code(400)
+            .send({ error: 'ttfbBytes must be an integer between 50 and 10000' });
+        }
+        await configService.setSetting('stall.ttfbBytes', val);
+      }
+      if (body.minBytesPerSecond !== undefined) {
+        if (body.minBytesPerSecond === null) {
+          await configService.setSetting('stall.minBytesPerSecond', null);
+        } else {
+          const val = Number(body.minBytesPerSecond);
+          if (!Number.isFinite(val) || !Number.isInteger(val) || val < 50 || val > 5000) {
+            return reply
+              .code(400)
+              .send({ error: 'minBytesPerSecond must be null or an integer between 50 and 5000' });
+          }
+          await configService.setSetting('stall.minBytesPerSecond', val);
+        }
+      }
+      if (body.windowSeconds !== undefined) {
+        const val = Number(body.windowSeconds);
+        if (!Number.isFinite(val) || !Number.isInteger(val) || val < 3 || val > 30) {
+          return reply
+            .code(400)
+            .send({ error: 'windowSeconds must be an integer between 3 and 30' });
+        }
+        await configService.setSetting('stall.windowSeconds', val);
+      }
+      if (body.gracePeriodSeconds !== undefined) {
+        const val = Number(body.gracePeriodSeconds);
+        if (!Number.isFinite(val) || !Number.isInteger(val) || val < 0 || val > 120) {
+          return reply
+            .code(400)
+            .send({ error: 'gracePeriodSeconds must be an integer between 0 and 120' });
+        }
+        await configService.setSetting('stall.gracePeriodSeconds', val);
+      }
+
+      const updated = await configService.getRepository().getStallConfig();
+      logger.debug('Stall config updated via API');
+      return reply.send(updated);
+    } catch (e: any) {
+      logger.error('Failed to patch stall config', e);
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
   // ─── Vision Fallthrough ───────────────────────────────────────────
 
   fastify.get('/v0/management/config/vision-fallthrough', async (_request, reply) => {

--- a/packages/backend/src/services/__tests__/config-service.test.ts
+++ b/packages/backend/src/services/__tests__/config-service.test.ts
@@ -35,6 +35,15 @@ function createMockRepo() {
     getCooldownPolicy: vi.fn(() => Promise.resolve({ enabled: false })),
     getBackgroundExplorationConfig: vi.fn(() => Promise.resolve({ enabled: false })),
     getTimeoutConfig: vi.fn(() => Promise.resolve({ defaultSeconds: 300 })),
+    getStallConfig: vi.fn(() =>
+      Promise.resolve({
+        ttfbSeconds: null,
+        ttfbBytes: 100,
+        minBytesPerSecond: null,
+        windowSeconds: 10,
+        gracePeriodSeconds: 30,
+      })
+    ),
     getAllSettings: vi.fn(() => Promise.resolve({})),
   };
 }

--- a/packages/backend/src/services/config-service.ts
+++ b/packages/backend/src/services/config-service.ts
@@ -11,6 +11,7 @@ import type {
   CooldownPolicy,
   QuotaConfig,
   TimeoutConfig,
+  StallConfigType,
 } from '../config';
 
 import { QuotaScheduler } from './quota/quota-scheduler';
@@ -377,6 +378,7 @@ export class ConfigService {
     const cooldown = await this.repo.getCooldownPolicy();
     const backgroundExploration = await this.repo.getBackgroundExplorationConfig();
     const timeout = await this.repo.getTimeoutConfig();
+    const stall = await this.repo.getStallConfig();
     const allSettings = await this.repo.getAllSettings();
 
     // Spread all flat settings (non-dotted keys) onto the cache so new settings
@@ -396,6 +398,7 @@ export class ConfigService {
       failover,
       cooldown,
       timeout,
+      stall: Object.values(stall).some((v) => v !== null && v !== undefined) ? stall : undefined,
       backgroundExploration,
       quotas,
       mcpServers: Object.keys(mcpServers).length > 0 ? mcpServers : undefined,

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -26,6 +26,7 @@ import { applyModelBehaviors } from './model-behaviors';
 import { resolveAdapters } from './adapter-resolver';
 import type { ProviderAdapter } from '../types/provider-adapter';
 import { getModels } from '@earendil-works/pi-ai';
+import type { StallConfig } from './inspectors/stall-inspector';
 import { VisionDescriptorService } from './vision-descriptor-service';
 import { ModelMetadataManager } from './model-metadata-manager';
 import { enforceContextLimit } from './enforce-limits';
@@ -243,7 +244,14 @@ export class Dispatcher {
   async dispatch(
     request: UnifiedChatRequest,
     signal?: AbortSignal,
-    addTimeoutSource?: (timeoutMs: number) => void
+    addTimeoutSource?: (timeoutMs: number) => void,
+    addStallConfig?: (providerOverrides: {
+      stallTtfbMs?: number | null;
+      stallTtfbBytes?: number | null;
+      stallMinBps?: number | null;
+      stallWindowMs?: number | null;
+      stallGracePeriodMs?: number | null;
+    }) => void
   ): Promise<UnifiedChatResponse> {
     const config = getConfig();
     const failover = config.failover;
@@ -467,7 +475,57 @@ export class Dispatcher {
           addTimeoutSource(route.config.timeoutMs);
         }
 
+        // Wire per-provider stall detection overrides if set.
+        if (addStallConfig) {
+          const providerStallOverrides: Parameters<typeof addStallConfig>[0] = {};
+          if (route.config.stallTtfbMs !== undefined)
+            providerStallOverrides.stallTtfbMs = route.config.stallTtfbMs;
+          if (route.config.stallTtfbBytes !== undefined)
+            providerStallOverrides.stallTtfbBytes = route.config.stallTtfbBytes;
+          if (route.config.stallMinBps !== undefined)
+            providerStallOverrides.stallMinBps = route.config.stallMinBps;
+          if (route.config.stallWindowMs !== undefined)
+            providerStallOverrides.stallWindowMs = route.config.stallWindowMs;
+          if (route.config.stallGracePeriodMs !== undefined)
+            providerStallOverrides.stallGracePeriodMs = route.config.stallGracePeriodMs;
+          logger.debug(
+            `Dispatcher: provider stall overrides for ${route.provider}: ${JSON.stringify(providerStallOverrides)}, ` +
+              `route.config stall fields: stallTtfbMs=${route.config.stallTtfbMs}, stallMinBps=${route.config.stallMinBps}`
+          );
+          if (Object.keys(providerStallOverrides).length > 0) {
+            addStallConfig(providerStallOverrides);
+          }
+        }
+
         const incomingApi = currentRequest.incomingApiType || 'unknown';
+
+        // Resolve stall config BEFORE the fetch so we can wrap fetch+probe
+        // in a TTFB timeout. This is critical because fetch() itself may block
+        // for a long time waiting for HTTP response headers — the TTFB timeout
+        // must cover this "headers phase" too, not just the body reading.
+        const globalStall = (getConfig() as any).stall;
+        const stallTtfbMs =
+          route.config.stallTtfbMs ??
+          (globalStall?.ttfbSeconds != null ? globalStall.ttfbSeconds * 1000 : null);
+        let effectiveStallConfig: StallConfig | null =
+          stallTtfbMs != null ||
+          route.config.stallMinBps != null ||
+          globalStall?.minBytesPerSecond != null
+            ? {
+                ttfbMs: stallTtfbMs,
+                ttfbBytes: route.config.stallTtfbBytes ?? globalStall?.ttfbBytes ?? 100,
+                minBytesPerSecond:
+                  route.config.stallMinBps ?? globalStall?.minBytesPerSecond ?? null,
+                windowMs: route.config.stallWindowMs ?? (globalStall?.windowSeconds ?? 10) * 1000,
+                gracePeriodMs:
+                  route.config.stallGracePeriodMs ?? (globalStall?.gracePeriodSeconds ?? 30) * 1000,
+              }
+            : null;
+
+        logger.debug(
+          `Dispatcher: effectiveStallConfig for ${route.provider}: ${JSON.stringify(effectiveStallConfig)}, ` +
+            `route.config.stallTtfbMs=${route.config.stallTtfbMs}, route.config.stallMinBps=${route.config.stallMinBps}`
+        );
 
         logger.info(
           `Dispatching ${currentRequest.model} to ${route.provider}:${route.model} ${incomingApi} <-> ${transformer.name}`
@@ -475,7 +533,115 @@ export class Dispatcher {
 
         logger.silly('Upstream Request Payload', providerPayload);
 
-        const response = await this.executeProviderRequest(url, headers, providerPayload, signal);
+        // When TTFB stall detection is configured for streaming requests, wrap
+        // the fetch + probe in a single timeout that covers the entire TTFB
+        // window (from request dispatch to receiving ttfbBytes of body data).
+        // This handles the case where fetch() itself blocks for a long time
+        // waiting for HTTP response headers from a slow provider.
+        let response: Response;
+        let stallAbortController: AbortController | undefined;
+        let ttfbTimerId: ReturnType<typeof setTimeout> | undefined;
+        const dispatchStartTime = Date.now();
+
+        if (currentRequest.stream && effectiveStallConfig?.ttfbMs != null) {
+          // Create a separate AbortController for the TTFB stall timeout.
+          // We don't use the route's abortController because an abort there
+          // means the client disconnected — we need a distinct signal for
+          // "provider is too slow to start responding".
+          stallAbortController = new AbortController();
+          const combinedSignal = signal
+            ? AbortSignal.any([signal, stallAbortController.signal])
+            : stallAbortController.signal;
+
+          const ttfbMs = effectiveStallConfig.ttfbMs!;
+          ttfbTimerId = setTimeout(() => {
+            stallAbortController!.abort(
+              new DOMException(
+                `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`,
+                'TimeoutError'
+              )
+            );
+          }, ttfbMs);
+          ttfbTimerId.unref?.();
+
+          try {
+            response = await this.executeProviderRequest(
+              url,
+              headers,
+              providerPayload,
+              combinedSignal
+            );
+          } catch (fetchError: any) {
+            // Client disconnected takes priority over stall detection —
+            // if the client is gone, no point retrying.
+            if (signal?.aborted) {
+              clearTimeout(ttfbTimerId);
+              throw this.buildCancelledError(signal);
+            }
+
+            // If the error was caused by our TTFB stall timeout, synthesize
+            // a stall result instead of treating it as a generic network error.
+            if (stallAbortController.signal.aborted) {
+              clearTimeout(ttfbTimerId);
+              const stallError = new Error(
+                `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`
+              );
+              lastError = stallError;
+
+              const canRetryStall =
+                failoverEnabled &&
+                i < targets.length - 1 &&
+                (this.isRetryableNetworkError(stallError, failover?.retryableErrors || []) ||
+                  stallError.message?.includes('stalled'));
+
+              if (canRetryStall) {
+                await this.recordAttemptMetric(route, currentRequest.requestId, false, {
+                  isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+                  isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+                  visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
+                });
+                this.appendFailureAttempt(retryHistory, route, stallError, targetApiType, true);
+                CooldownManager.getInstance().markProviderFailure(
+                  route.provider,
+                  route.model,
+                  undefined,
+                  this.formatFailureReason(stallError)
+                );
+                this.saveIntermediateError(
+                  currentRequest.requestId,
+                  targetApiType || 'chat',
+                  stallError
+                );
+                logger.info(
+                  `TTFB stall: fetch timed out after ${ttfbMs}ms for ${route.provider}/${route.model}, retrying with next provider`
+                );
+                continue;
+              }
+
+              throw stallError;
+            }
+            throw fetchError;
+          }
+
+          // Fetch returned — clear the TTFB timer (we beat the timeout)
+          clearTimeout(ttfbTimerId);
+          ttfbTimerId = undefined;
+
+          // Adjust the stall config's ttfbMs for the probe — subtract the time
+          // already spent waiting for fetch() to return. The probe only needs
+          // to cover the remaining time until the byte threshold is met.
+          const fetchElapsed = Date.now() - dispatchStartTime;
+          const remainingTtfbMs = Math.max(0, ttfbMs - fetchElapsed);
+          if (remainingTtfbMs <= 0 && effectiveStallConfig) {
+            // Fetch returned just barely within the TTFB window — no time left
+            // for the probe. Skip the probe and let the pipeline handle it.
+            effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: null };
+          } else if (effectiveStallConfig) {
+            effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: remainingTtfbMs };
+          }
+        } else {
+          response = await this.executeProviderRequest(url, headers, providerPayload, signal);
+        }
 
         if (!response.ok) {
           const errorText = await response.text();
@@ -528,7 +694,10 @@ export class Dispatcher {
 
         // 5. Handle Response
         if (currentRequest.stream) {
-          const streamProbe = await this.probeStreamingStart(response);
+          // effectiveStallConfig was already computed before the fetch above.
+          // If TTFB stall is still active (fetch returned within TTFB but body
+          // hasn't met the byte threshold yet), the probe will continue checking.
+          const streamProbe = await this.probeStreamingStart(response, effectiveStallConfig);
 
           if (!streamProbe.ok) {
             const error = streamProbe.error;
@@ -538,7 +707,8 @@ export class Dispatcher {
               failoverEnabled &&
               i < targets.length - 1 &&
               !streamProbe.streamStarted &&
-              this.isRetryableNetworkError(error, failover?.retryableErrors || []);
+              (this.isRetryableNetworkError(error, failover?.retryableErrors || []) ||
+                error.message?.includes('stalled'));
 
             if (canRetry) {
               await this.recordAttemptMetric(route, currentRequest.requestId, false, {
@@ -623,6 +793,11 @@ export class Dispatcher {
       } catch (error: any) {
         lastError = error;
 
+        // If the client disconnected (abort signal), don't treat this as a
+        // retryable error — throw a proper client_disconnected error so the
+        // route handler records it as cancelled, not as an inference error.
+        if (signal?.aborted) throw this.buildCancelledError(signal);
+
         // If the error came from handleProviderError, it already called markProviderFailure.
         // Only call it here for network/transport errors that have no HTTP status code.
         const isHttpError = error?.routingContext?.statusCode !== undefined;
@@ -645,7 +820,8 @@ export class Dispatcher {
         const canRetryNetwork =
           failoverEnabled &&
           i < targets.length - 1 &&
-          this.isRetryableNetworkError(error, failover?.retryableErrors || []);
+          (this.isRetryableNetworkError(error, failover?.retryableErrors || []) ||
+            error.message?.includes('stalled'));
 
         this.appendFailureAttempt(retryHistory, route, error, undefined, canRetryNetwork);
 
@@ -731,7 +907,8 @@ export class Dispatcher {
   }
 
   private async probeStreamingStart(
-    response: Response
+    response: Response,
+    stallConfig?: StallConfig | null
   ): Promise<
     { ok: true; response: Response } | { ok: false; error: Error; streamStarted: boolean }
   > {
@@ -739,6 +916,19 @@ export class Dispatcher {
       return { ok: true, response };
     }
 
+    // When TTFB stall detection is configured, probe the stream until we've
+    // received ttfbBytes or the TTFB timeout fires. This allows the
+    // failover loop to retry with a different provider when a provider is
+    // slow to start responding.
+    if (stallConfig?.ttfbMs != null) {
+      logger.debug(
+        `probeStreamingStart: using stall-aware probe (ttfbMs=${stallConfig.ttfbMs}, ttfbBytes=${stallConfig.ttfbBytes})`
+      );
+      return this.probeStreamingStartWithStallCheck(response, stallConfig);
+    }
+
+    // Original 100ms probe — if the first byte doesn't arrive within 100ms,
+    // let the stream continue in the background.
     const reader = response.body.getReader();
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -831,6 +1021,118 @@ export class Dispatcher {
       };
     } finally {
       if (timeoutId) clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Stall-aware stream probe: reads from the stream until we've received
+   * `stallConfig.ttfbBytes` bytes or the TTFB timeout fires.
+   *
+   * - If TTFB threshold is met → returns ok:true, stream continues normally.
+   * - If TTFB timeout fires → returns ok:false with a stall error, which the
+   *   failover loop treats as retryable (same as a network error before first byte).
+   */
+  private async probeStreamingStartWithStallCheck(
+    response: Response,
+    stallConfig: StallConfig
+  ): Promise<
+    { ok: true; response: Response } | { ok: false; error: Error; streamStarted: boolean }
+  > {
+    const reader = response.body!.getReader();
+    const ttfbBytes = stallConfig.ttfbBytes;
+    const ttfbMs = stallConfig.ttfbMs!;
+
+    // Collected chunks to replay into the response stream
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    let streamStarted = false;
+
+    // TTFB stall timer
+    let ttfbTimerId: ReturnType<typeof setTimeout> | undefined;
+    const ttfbTimeoutPromise = new Promise<'ttfb_timeout'>((resolve) => {
+      ttfbTimerId = setTimeout(() => resolve('ttfb_timeout'), ttfbMs);
+    });
+
+    try {
+      // Read chunks until we hit the TTFB byte threshold or the timeout
+      while (totalBytes < ttfbBytes) {
+        const readPromise = reader.read();
+        const result = await Promise.race([readPromise, ttfbTimeoutPromise]);
+
+        if (result === 'ttfb_timeout') {
+          // TTFB stall detected — abort the reader
+          reader
+            .cancel(new DOMException('Stream stalled: TTFB timeout', 'TimeoutError'))
+            .catch(() => {});
+          logger.info(
+            `TTFB stall probe: received ${totalBytes} bytes within ${ttfbMs}ms ` +
+              `(threshold: ${ttfbBytes} bytes)`
+          );
+          return {
+            ok: false,
+            error: new Error(
+              `Stream stalled: TTFB timeout — received ${totalBytes} bytes in ${ttfbMs}ms ` +
+                `(threshold: ${ttfbBytes} bytes within ${ttfbMs}ms)`
+            ),
+            streamStarted,
+          };
+        }
+
+        const { done, value } = result as ReadableStreamReadResult<Uint8Array>;
+        if (done) {
+          // Stream ended before we got enough bytes — not a stall, just a short response
+          break;
+        }
+
+        chunks.push(value);
+        totalBytes += value.length;
+        streamStarted = true;
+      }
+
+      // TTFB threshold met (or stream ended naturally) — build replay stream
+      const replayChunks = [...chunks];
+      let chunkIndex = 0;
+      const replay = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // Replay buffered chunks
+          while (chunkIndex < replayChunks.length) {
+            controller.enqueue(replayChunks[chunkIndex]!);
+            chunkIndex++;
+          }
+        },
+        async pull(controller) {
+          try {
+            const next = await reader.read();
+            if (next.done) {
+              controller.close();
+            } else {
+              controller.enqueue(next.value);
+            }
+          } catch (error) {
+            controller.error(error);
+          }
+        },
+        cancel(reason) {
+          return reader.cancel(reason);
+        },
+      });
+
+      return {
+        ok: true,
+        response: new Response(replay, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        }),
+      };
+    } catch (error: any) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+        streamStarted,
+      };
+    } finally {
+      if (ttfbTimerId) clearTimeout(ttfbTimerId);
     }
   }
 
@@ -2906,7 +3208,7 @@ export class Dispatcher {
 
         let responseForProcessing = response;
         if (isStreamed) {
-          const streamProbe = await this.probeStreamingStart(response);
+          const streamProbe = await this.probeStreamingStart(response, null);
 
           if (!streamProbe.ok) {
             const error = streamProbe.error;

--- a/packages/backend/src/services/inspectors/__tests__/stall-inspector.test.ts
+++ b/packages/backend/src/services/inspectors/__tests__/stall-inspector.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { StallInspector, type StallConfig } from '../stall-inspector';
+import { PassThrough } from 'stream';
+
+function createConfig(overrides: Partial<StallConfig> = {}): StallConfig {
+  return {
+    ttfbMs: 5000,
+    ttfbBytes: 100,
+    minBytesPerSecond: 500,
+    windowMs: 10000,
+    gracePeriodMs: 3000,
+    ...overrides,
+  };
+}
+
+function createChunk(size: number): Buffer {
+  return Buffer.alloc(size, 'a');
+}
+
+describe('StallInspector', () => {
+  let abortController: AbortController;
+  let abortReason: DOMException | null = null;
+
+  beforeEach(() => {
+    abortController = new AbortController();
+    abortReason = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('TTFB is handled at dispatcher level', () => {
+    it("does NOT start a TTFB timer — that is the dispatcher probe's job", () => {
+      vi.useFakeTimers();
+
+      const config = createConfig({ ttfbMs: 5000, ttfbBytes: 100, minBytesPerSecond: null });
+      const inspector = new StallInspector('req-1', config, abortController);
+
+      // Write only 50 bytes (below the 100-byte threshold)
+      inspector.write(createChunk(50));
+
+      // Advance past TTFB timeout — the StallInspector should NOT abort
+      // because TTFB detection is handled by the dispatcher's probe
+      vi.advanceTimersByTime(5001);
+
+      expect(abortController.signal.aborted).toBe(false);
+
+      inspector.destroy();
+    });
+
+    it('does not abort even when ttfbMs expires with no bytes', () => {
+      vi.useFakeTimers();
+
+      const config = createConfig({ ttfbMs: 5000, ttfbBytes: 100, minBytesPerSecond: null });
+      const inspector = new StallInspector('req-2', config, abortController);
+
+      // Advance past TTFB timeout without any bytes
+      vi.advanceTimersByTime(6000);
+
+      expect(abortController.signal.aborted).toBe(false);
+
+      inspector.destroy();
+    });
+  });
+
+  describe('Throughput stall detection', () => {
+    it('detects throughput stall after grace period when stream is too slow', () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const config = createConfig({
+        ttfbMs: null,
+        minBytesPerSecond: 500,
+        windowMs: 3000,
+        gracePeriodMs: 1000,
+      });
+      const inspector = new StallInspector('req-5', config, abortController);
+
+      abortController.signal.addEventListener('abort', () => {
+        abortReason = abortController.signal.reason;
+      });
+
+      // Write initial bytes to transition past DISPATCHED state
+      inspector.write(createChunk(100));
+
+      // Advance through grace period
+      vi.advanceTimersByTime(1100);
+
+      // Write a very small amount (10 bytes)
+      inspector.write(createChunk(10));
+
+      // Advance past the window so throughput is clearly below 500 B/s
+      vi.advanceTimersByTime(3100);
+
+      expect(abortController.signal.aborted).toBe(true);
+      expect(abortReason?.name).toBe('TimeoutError');
+      expect(abortReason?.message).toContain('throughput');
+
+      inspector.destroy();
+    });
+
+    it('does not abort when throughput is above threshold', () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const config = createConfig({
+        ttfbMs: null,
+        minBytesPerSecond: 100,
+        windowMs: 2000,
+        gracePeriodMs: 500,
+      });
+      const inspector = new StallInspector('req-6', config, abortController);
+
+      // Write initial bytes to trigger monitoring
+      inspector.write(createChunk(100));
+
+      // Advance through grace period
+      vi.advanceTimersByTime(600);
+
+      // Write enough bytes to stay above 100 B/s
+      // 100 bytes over 2 seconds = 50 B/s, so we need more
+      inspector.write(createChunk(500));
+
+      // Not enough time for a stall yet
+      expect(abortController.signal.aborted).toBe(false);
+
+      // Continue writing enough data
+      vi.advanceTimersByTime(1000);
+      inspector.write(createChunk(500));
+
+      expect(abortController.signal.aborted).toBe(false);
+
+      inspector.destroy();
+    });
+
+    it('catches fully stalled stream via periodic check (no chunks arriving)', () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const config = createConfig({
+        ttfbMs: 5000,
+        ttfbBytes: 100,
+        minBytesPerSecond: 500,
+        windowMs: 3000,
+        gracePeriodMs: 1000,
+      });
+      const inspector = new StallInspector('req-7', config, abortController);
+
+      abortController.signal.addEventListener('abort', () => {
+        abortReason = abortController.signal.reason;
+      });
+
+      // Write enough bytes to transition out of DISPATCHED state
+      inspector.write(createChunk(200));
+
+      // Advance through grace period + some monitoring time
+      // The periodic check fires every windowMs/2 = 1500ms
+      vi.advanceTimersByTime(2000); // Past grace period (1000ms) + into monitoring
+
+      // Write a tiny chunk to create a second data point
+      inspector.write(createChunk(5));
+
+      // Now advance far enough that throughput over the window is below threshold.
+      // With 205 total bytes over 5+ seconds, throughput is ~40 B/s, well below 500.
+      vi.advanceTimersByTime(4000);
+
+      expect(abortController.signal.aborted).toBe(true);
+      expect(abortReason?.message).toContain('throughput');
+
+      inspector.destroy();
+    });
+  });
+
+  describe('State machine', () => {
+    it('transitions from DISPATCHED to GRACE_PERIOD on first chunk when throughput monitoring is active', () => {
+      vi.useFakeTimers();
+
+      const config = createConfig({
+        ttfbMs: 10000,
+        ttfbBytes: 50,
+        minBytesPerSecond: 100,
+        gracePeriodMs: 5000,
+      });
+      const inspector = new StallInspector('req-8', config, abortController);
+
+      // Write first chunk — should transition to GRACE_PERIOD
+      inspector.write(createChunk(60));
+
+      // TTFB timer no longer exists — should not abort
+      vi.advanceTimersByTime(11000);
+      expect(abortController.signal.aborted).toBe(false);
+
+      inspector.destroy();
+    });
+
+    it('transitions from GRACE_PERIOD to MONITORING after grace period', () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const config = createConfig({
+        ttfbMs: 5000,
+        ttfbBytes: 50,
+        minBytesPerSecond: 100,
+        windowMs: 3000,
+        gracePeriodMs: 2000,
+      });
+      const inspector = new StallInspector('req-9', config, abortController);
+
+      // First chunk triggers transition to GRACE_PERIOD
+      inspector.write(createChunk(60));
+
+      // During grace period — no abort even if throughput is low
+      vi.advanceTimersByTime(1000);
+      expect(abortController.signal.aborted).toBe(false);
+
+      // Advance past grace period but keep sending data
+      vi.advanceTimersByTime(1500);
+      inspector.write(createChunk(1000)); // Plenty of throughput
+      expect(abortController.signal.aborted).toBe(false);
+
+      inspector.destroy();
+    });
+
+    it('stays in DISPATCHED if no throughput monitoring is configured', () => {
+      vi.useFakeTimers();
+
+      const config = createConfig({ ttfbMs: 5000, minBytesPerSecond: null });
+      const inspector = new StallInspector('req-dispatched', config, abortController);
+
+      // Write bytes — but no throughput monitoring, so should stay in DISPATCHED
+      inspector.write(createChunk(100));
+
+      // Advance time — should not abort (no TTFB timer, no throughput check)
+      vi.advanceTimersByTime(10000);
+      expect(abortController.signal.aborted).toBe(false);
+
+      inspector.destroy();
+    });
+  });
+
+  describe('updateConfig', () => {
+    it('updates config but does not start TTFB timer (dispatcher handles TTFB)', () => {
+      vi.useFakeTimers();
+
+      const config = createConfig({ ttfbMs: 10000, ttfbBytes: 100, minBytesPerSecond: null });
+      const inspector = new StallInspector('req-10', config, abortController);
+
+      // Per-provider override with shorter TTFB — but the inspector should NOT
+      // start a TTFB timer because TTFB detection is handled by the dispatcher probe
+      inspector.updateConfig({
+        ...config,
+        ttfbMs: 5000,
+      });
+
+      // Advance well past the 5000ms TTFB — should NOT abort
+      vi.advanceTimersByTime(6000);
+
+      expect(abortController.signal.aborted).toBe(false);
+
+      inspector.destroy();
+    });
+
+    it('enables throughput monitoring when updateConfig adds minBytesPerSecond', () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const config = createConfig({ ttfbMs: 5000, minBytesPerSecond: null });
+      const inspector = new StallInspector('req-10b', config, abortController);
+
+      abortController.signal.addEventListener('abort', () => {
+        abortReason = abortController.signal.reason;
+      });
+
+      // Write initial data while no throughput monitoring
+      inspector.write(createChunk(50));
+
+      // Update config to enable throughput monitoring
+      inspector.updateConfig({
+        ...config,
+        minBytesPerSecond: 1000,
+        gracePeriodMs: 500,
+        windowMs: 2000,
+      });
+
+      // Write a chunk to trigger state transition (DISPATCHED → GRACE_PERIOD)
+      inspector.write(createChunk(5));
+
+      // Advance through grace period + monitoring window + periodic check
+      vi.advanceTimersByTime(5000);
+
+      expect(abortController.signal.aborted).toBe(true);
+      expect(abortReason?.message).toContain('throughput');
+
+      inspector.destroy();
+    });
+  });
+
+  describe('Cleanup', () => {
+    it('cleans up timers on destroy', () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const config = createConfig({ minBytesPerSecond: 500, gracePeriodMs: 1000 });
+      const inspector = new StallInspector('req-11', config, abortController);
+
+      // Start monitoring
+      inspector.write(createChunk(100));
+
+      inspector.destroy();
+
+      // Timer should be cleared — no abort after the timeout
+      vi.advanceTimersByTime(6000);
+      expect(abortController.signal.aborted).toBe(false);
+    });
+
+    it('cleans up timers on flush (normal stream end)', () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const config = createConfig({ minBytesPerSecond: 500, gracePeriodMs: 1000 });
+      const inspector = new StallInspector('req-12', config, abortController);
+
+      // Start monitoring
+      inspector.write(createChunk(100));
+
+      // Simulate a normal stream end
+      inspector.end();
+
+      vi.advanceTimersByTime(6000);
+      expect(abortController.signal.aborted).toBe(false);
+    });
+  });
+
+  describe('Passthrough behavior', () => {
+    it('passes chunks through unchanged', () => {
+      const config = createConfig({ ttfbMs: 5000, minBytesPerSecond: null });
+      const inspector = new StallInspector('req-13', config, abortController);
+
+      const received: Buffer[] = [];
+      inspector.on('data', (chunk: Buffer) => received.push(chunk));
+
+      const chunk1 = createChunk(50);
+      const chunk2 = createChunk(75);
+
+      inspector.write(chunk1);
+      inspector.write(chunk2);
+
+      expect(received.length).toBe(2);
+      expect(received[0]!.length).toBe(50);
+      expect(received[1]!.length).toBe(75);
+
+      inspector.destroy();
+    });
+  });
+});

--- a/packages/backend/src/services/inspectors/index.ts
+++ b/packages/backend/src/services/inspectors/index.ts
@@ -11,3 +11,5 @@
 
 export { DebugLoggingInspector } from './debug-logging';
 export { UsageInspector } from './usage-logging';
+export { StallInspector } from './stall-inspector';
+export type { StallConfig } from './stall-inspector';

--- a/packages/backend/src/services/inspectors/stall-inspector.ts
+++ b/packages/backend/src/services/inspectors/stall-inspector.ts
@@ -1,0 +1,272 @@
+import { PassThrough } from 'stream';
+import { logger } from '../../utils/logger';
+
+/**
+ * Stall detection states.
+ *
+ * State machine (pipeline-level throughput monitoring only):
+ *   DISPATCHED ──[first chunk]──→ GRACE_PERIOD ──[grace timer expires]──→ MONITORING
+ *                                        │
+ *                                        └─[stall detected]──→ THROUGHPUT_STALLED (abort)
+ *
+ * TTFB stall detection is handled at the dispatcher level via probeStreamingStartWithStallCheck,
+ * which runs within the failover loop and can retry with a different provider.
+ */
+enum StallState {
+  /** Waiting for first bytes from upstream. */
+  DISPATCHED = 'DISPATCHED',
+  /** First bytes received; grace period before throughput enforcement. */
+  GRACE_PERIOD = 'GRACE_PERIOD',
+  /** Actively monitoring throughput via sliding window. */
+  MONITORING = 'MONITORING',
+  /** Throughput fell below minBytesPerSecond in the sliding window. */
+  THROUGHPUT_STALLED = 'THROUGHPUT_STALLED',
+}
+
+/** Ring buffer entry for sliding window throughput calculation. */
+interface ByteSample {
+  /** Monotonic timestamp (Date.now()). */
+  timestamp: number;
+  /** Cumulative bytes received at this point. */
+  cumulativeBytes: number;
+}
+
+/**
+ * Resolved stall configuration with all values in milliseconds/bytes.
+ * Null fields mean that dimension of stall detection is disabled.
+ */
+export interface StallConfig {
+  /** Time allowed (ms) to receive ttfbBytes. null = disabled. */
+  ttfbMs: number | null;
+  /** Byte threshold for the TTFB timer. */
+  ttfbBytes: number;
+  /** Throughput floor (bytes/sec) after grace period. null = disabled. */
+  minBytesPerSecond: number | null;
+  /** Sliding window width (ms) for throughput calculation. */
+  windowMs: number;
+  /** Time (ms) after TTFB threshold met before enforcement begins. */
+  gracePeriodMs: number;
+}
+
+/**
+ * StallInspector — a PassThrough stream that monitors upstream response
+ * throughput and aborts the request if a throughput stall is detected.
+ *
+ * TTFB stall detection is handled at the dispatcher level via
+ * probeStreamingStartWithStallCheck(), which runs within the failover loop
+ * and can retry with a different provider. This inspector only handles
+ * throughput stalls (slow streaming after bytes have started flowing),
+ * since those occur after response headers have been sent to the client
+ * and cannot be retried by the dispatcher.
+ *
+ * Inserted into the pipeline: fetch body → nodeStream → StallInspector → UsageInspector → reply
+ */
+export class StallInspector extends PassThrough {
+  private requestId: string;
+  private config: StallConfig;
+  private abortController: AbortController;
+
+  private state: StallState = StallState.DISPATCHED;
+  private totalBytes = 0;
+  private startTime: number;
+
+  // Ring buffer for sliding window: entries of { timestamp, cumulativeBytes }
+  private samples: ByteSample[] = [];
+  private readonly MAX_SAMPLES = 500; // Bound memory usage
+
+  // Timers
+  private graceTimer: ReturnType<typeof setTimeout> | null = null;
+  private periodicCheck: ReturnType<typeof setInterval> | null = null;
+
+  constructor(requestId: string, config: StallConfig, abortController: AbortController) {
+    super();
+    this.requestId = requestId;
+    this.config = config;
+    this.abortController = abortController;
+    this.startTime = Date.now();
+
+    // NOTE: TTFB stall detection is handled at the dispatcher level via
+    // probeStreamingStartWithStallCheck, which runs within the failover loop
+    // and can retry with a different provider. The StallInspector only handles
+    // throughput stalls (slow streaming after bytes have started flowing),
+    // since those occur after response headers have been sent to the client
+    // and cannot be retried by the dispatcher.
+    //
+    // We do NOT start a TTFB timer here. If ttfbMs is set, the dispatcher's
+    // probe will enforce it. The inspector transitions to GRACE_PERIOD on
+    // the first chunk, and then to MONITORING for throughput enforcement.
+  }
+
+  /**
+   * Update the stall configuration (e.g. after per-provider overrides are applied).
+   * Only safe to call before any data has flowed through the inspector.
+   */
+  updateConfig(config: StallConfig): void {
+    this.config = config;
+
+    logger.debug(
+      `StallInspector.updateConfig: ${this.requestId} state=${this.state} ` +
+        `ttfbMs=${config.ttfbMs} minBps=${config.minBytesPerSecond} ` +
+        `totalBytes=${this.totalBytes} elapsed=${Date.now() - this.startTime}ms`
+    );
+
+    // NOTE: We do NOT start/restart the TTFB timer here. TTFB stall detection
+    // is handled by the dispatcher's probeStreamingStartWithStallCheck, which
+    // runs within the failover loop and can retry with a different provider.
+    // The StallInspector only handles throughput stalls.
+  }
+
+  /** Set the request ID (called after pipeline construction). */
+  setRequestId(requestId: string): void {
+    this.requestId = requestId;
+  }
+
+  override _transform(chunk: any, encoding: BufferEncoding, callback: Function) {
+    if (this.state === StallState.THROUGHPUT_STALLED) {
+      // Already stalled — just pass through (abort is already triggered)
+      callback(null, chunk);
+      return;
+    }
+
+    const chunkSize = Buffer.isBuffer(chunk)
+      ? chunk.length
+      : Buffer.byteLength(chunk, encoding as BufferEncoding);
+    this.totalBytes += chunkSize;
+    const now = Date.now();
+
+    // Record sample in ring buffer
+    this.samples.push({ timestamp: now, cumulativeBytes: this.totalBytes });
+    if (this.samples.length > this.MAX_SAMPLES) {
+      this.samples = this.samples.slice(-this.MAX_SAMPLES);
+    }
+
+    // State machine transitions
+    if (this.state === StallState.DISPATCHED) {
+      // TTFB stall is handled at the dispatcher level via probeStreamingStartWithStallCheck.
+      // When data reaches here, the dispatcher probe has already verified TTFB.
+      // Transition to grace period on first chunk for throughput monitoring.
+      if (this.config.minBytesPerSecond != null) {
+        this.transitionToGracePeriod(now);
+      }
+    }
+
+    // Check throughput in MONITORING state (per-chunk check)
+    if (this.state === StallState.MONITORING) {
+      this.checkThroughput(now);
+    }
+
+    // Always pass the chunk through
+    callback(null, chunk);
+  }
+
+  override _destroy(err: Error | null, callback: (error?: Error | null) => void) {
+    this.cleanup();
+    callback(err);
+  }
+
+  override _flush(callback: Function) {
+    this.cleanup();
+    callback();
+  }
+
+  // ─── State transitions ───────────────────────────────────────────
+
+  private transitionToGracePeriod(now: number): void {
+    this.state = StallState.GRACE_PERIOD;
+    logger.debug(
+      `StallInspector: TTFB threshold met for ${this.requestId} ` +
+        `(${this.totalBytes} bytes in ${now - this.startTime}ms), ` +
+        `starting grace period (${this.config.gracePeriodMs}ms)`
+    );
+
+    if (this.config.gracePeriodMs > 0) {
+      this.graceTimer = setTimeout(() => this.onGracePeriodEnd(), this.config.gracePeriodMs);
+      this.graceTimer.unref?.();
+    } else {
+      // Zero grace period — start monitoring immediately
+      this.onGracePeriodEnd();
+    }
+  }
+
+  private onGracePeriodEnd(): void {
+    if (this.state !== StallState.GRACE_PERIOD) return;
+    this.state = StallState.MONITORING;
+    logger.debug(
+      `StallInspector: Grace period ended for ${this.requestId}, ` +
+        `starting throughput monitoring (minBps=${this.config.minBytesPerSecond}, window=${this.config.windowMs}ms)`
+    );
+
+    // Start periodic throughput check. This catches the case where the stream
+    // is truly stalled (no chunks at all), since _transform is never called.
+    if (this.config.minBytesPerSecond != null) {
+      const checkInterval = Math.max(1000, Math.floor(this.config.windowMs / 2));
+      this.periodicCheck = setInterval(() => {
+        if (this.state === StallState.MONITORING) {
+          this.checkThroughput(Date.now());
+        }
+      }, checkInterval);
+      this.periodicCheck.unref?.();
+    }
+  }
+
+  // ─── Throughput checking ─────────────────────────────────────────
+
+  private checkThroughput(now: number): void {
+    if (this.config.minBytesPerSecond == null) return;
+
+    // Prune samples older than the window
+    const windowStart = now - this.config.windowMs;
+    while (this.samples.length > 1 && this.samples[0]!.timestamp < windowStart) {
+      this.samples.shift();
+    }
+
+    if (this.samples.length < 2) {
+      // Not enough samples yet — need at least 2 data points
+      return;
+    }
+
+    // Find the sample closest to (now - windowSeconds)
+    const oldestSample = this.samples[0]!;
+    const bytesInWindow = this.totalBytes - oldestSample.cumulativeBytes;
+    const timeSpanMs = now - oldestSample.timestamp;
+
+    if (timeSpanMs <= 0) {
+      // All samples are at the same timestamp — can't compute throughput
+      return;
+    }
+
+    const throughput = (bytesInWindow / timeSpanMs) * 1000; // bytes/sec
+
+    if (throughput < this.config.minBytesPerSecond) {
+      this.state = StallState.THROUGHPUT_STALLED;
+      this.cleanup();
+
+      logger.info(
+        `StallInspector: Throughput stall detected for ${this.requestId} ` +
+          `(throughput: ${throughput.toFixed(0)} B/s over last ${timeSpanMs}ms, ` +
+          `threshold: ${this.config.minBytesPerSecond} B/s)`
+      );
+
+      this.abortController.abort(
+        new DOMException(
+          `Stream stalled: throughput ${throughput.toFixed(0)} B/s below ` +
+            `threshold ${this.config.minBytesPerSecond} B/s`,
+          'TimeoutError'
+        )
+      );
+    }
+  }
+
+  // ─── Cleanup ──────────────────────────────────────────────────────
+
+  private cleanup(): void {
+    if (this.graceTimer) {
+      clearTimeout(this.graceTimer);
+      this.graceTimer = null;
+    }
+    if (this.periodicCheck) {
+      clearInterval(this.periodicCheck);
+      this.periodicCheck = null;
+    }
+  }
+}

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -229,14 +229,17 @@ export class UsageInspector extends PassThrough {
     }
 
     const isTimeout = err?.name === 'TimeoutError' || err?.message?.includes('timeout');
-    // If onDisconnect() already set the status to 'timeout' (e.g. when the abort
-    // signal carried a TimeoutError), don't overwrite it with 'cancelled'.
+    const isStall = err?.message?.includes('stalled');
+    // If onDisconnect() already set the status to 'stall' or 'timeout' (e.g. when
+    // the abort signal carried a stall/timeout error), don't overwrite it with 'cancelled'.
     const status =
-      this.usageRecord.responseStatus === 'timeout' && !isTimeout
-        ? 'timeout'
-        : isTimeout
-          ? 'timeout'
-          : 'cancelled';
+      this.usageRecord.responseStatus === 'stall' || this.usageRecord.responseStatus === 'timeout'
+        ? this.usageRecord.responseStatus
+        : isStall
+          ? 'stall'
+          : isTimeout
+            ? 'timeout'
+            : 'cancelled';
 
     logger.info(
       `UsageInspector: stream destroyed for ${this.usageRecord.requestId} ` +

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -11,6 +11,7 @@ import { Readable } from 'stream';
 import { DebugManager } from './debug-manager';
 import { estimateKwhUsed } from './inference-energy';
 import { applyProviderReportedCost } from '../utils/provider-cost';
+import { StallInspector, type StallConfig } from './inspectors/stall-inspector';
 import { DEFAULT_GPU_PARAMS, DEFAULT_MODEL } from '@plexus/shared';
 import type { GpuParams } from '@plexus/shared';
 import { QuotaEnforcer } from '../services/quota/quota-enforcer';
@@ -37,7 +38,17 @@ export async function handleResponse(
   originalRequest?: any,
   quotaEnforcer?: QuotaEnforcer,
   keyName?: string,
-  abortController?: AbortController
+  abortController?: AbortController,
+  stallDetectionResult?: {
+    stallInspector: StallInspector;
+    addStallConfig: (providerOverrides: {
+      stallTtfbMs?: number | null;
+      stallTtfbBytes?: number | null;
+      stallMinBps?: number | null;
+      stallWindowMs?: number | null;
+      stallGracePeriodMs?: number | null;
+    }) => void;
+  } | null
 ) {
   // Populate usage record with metadata from the dispatcher's selection
   usageRecord.selectedModelName = unifiedResponse.plexus?.model || unifiedResponse.model; // Fallback to unifiedResponse.model if plexus.model is missing
@@ -182,9 +193,16 @@ export async function handleResponse(
     // Convert Web Stream to Node Stream for piping
     const nodeStream = Readable.fromWeb(finalClientStream as any);
 
-    // Pipeline: Source -> Usage -> Client
-    // rawLogInspector is already tapped via the TransformStream above
-    const pipeline = nodeStream.pipe(usageInspector);
+    // Insert StallInspector into the pipeline if stall detection is active
+    const stallInspector = stallDetectionResult?.stallInspector ?? null;
+    if (stallInspector) {
+      stallInspector.setRequestId(usageRecord.requestId!);
+    }
+
+    // Pipeline: Source -> StallInspector (if active) -> Usage -> Client
+    const pipeline = stallInspector
+      ? nodeStream.pipe(stallInspector).pipe(usageInspector)
+      : nodeStream.pipe(usageInspector);
 
     // =============================================================================
     // CLIENT DISCONNECT DETECTION & UPSTREAM CANCELLATION
@@ -287,16 +305,28 @@ export async function handleResponse(
       // it was a timeout.
       const isTimeout =
         source.includes('timeout') || abortController?.signal?.reason?.name === 'TimeoutError';
+      // Stall detection uses DOMException('TimeoutError') as the abort reason,
+      // but we check the reason message for 'stalled' to distinguish from absolute timeout.
+      const isStall =
+        source === 'stall' ||
+        (abortController?.signal?.reason?.name === 'TimeoutError' &&
+          abortController?.signal?.reason?.message?.includes('stalled'));
       logger.debug(
-        `${isTimeout ? 'Upstream timeout' : 'Client disconnected'} for request ${usageRecord.requestId} (detected via ${source}), aborting upstream`
+        `${isStall ? 'Stream stalled' : isTimeout ? 'Upstream timeout' : 'Client disconnected'} for request ${usageRecord.requestId} (detected via ${source}), aborting upstream`
       );
-      const timeoutErr = isTimeout
-        ? new DOMException('The operation timed out.', 'TimeoutError')
-        : undefined;
+      const timeoutErr = isStall
+        ? new DOMException(
+            abortController?.signal?.reason?.message || 'Stream stalled',
+            'TimeoutError'
+          )
+        : isTimeout
+          ? new DOMException('The operation timed out.', 'TimeoutError')
+          : undefined;
       abortController?.abort(timeoutErr);
       // Set responseStatus before destroy so UsageInspector._destroy() sees it.
-      // _destroy respects a pre-set 'timeout' status and won't overwrite it.
-      if (isTimeout) {
+      if (isStall) {
+        usageRecord.responseStatus = 'stall';
+      } else if (isTimeout) {
         usageRecord.responseStatus = 'timeout';
       }
       // Destroy without passing the error — calling .destroy(err) causes Node.js to

--- a/packages/backend/src/utils/stall.ts
+++ b/packages/backend/src/utils/stall.ts
@@ -1,0 +1,180 @@
+/**
+ * Stall detection wiring utility.
+ *
+ * Analogous to `wireUpstreamTimeout()` — creates a `StallInspector` stream
+ * and wires it into the route's `AbortController` so that when a stall is
+ * detected, the request is aborted with a DOMException('TimeoutError').
+ *
+ * This triggers `onDisconnect('stall')` in `response-handler.ts`, which sets
+ * `usageRecord.responseStatus = 'stall'`.
+ */
+
+import { getConfig } from '../config';
+import { logger } from './logger';
+import { StallInspector, type StallConfig } from '../services/inspectors/stall-inspector';
+
+/**
+ * Resolve the effective stall configuration by merging global settings
+ * with per-provider overrides.
+ */
+export function resolveStallConfig(
+  globalConfig: StallConfig | null,
+  providerOverrides?: {
+    stallTtfbMs?: number | null;
+    stallTtfbBytes?: number | null;
+    stallMinBps?: number | null;
+    stallWindowMs?: number | null;
+    stallGracePeriodMs?: number | null;
+  }
+): StallConfig | null {
+  // Base defaults used when there is no global config
+  const defaults: StallConfig = {
+    ttfbMs: null,
+    ttfbBytes: 100,
+    minBytesPerSecond: null,
+    windowMs: 10000,
+    gracePeriodMs: 30000,
+  };
+
+  const base = globalConfig ?? defaults;
+
+  // If no per-provider overrides, check if base has any active dimension
+  if (!providerOverrides || Object.keys(providerOverrides).length === 0) {
+    if (!globalConfig) return null; // No global config and no overrides = disabled
+    return globalConfig;
+  }
+
+  // Merge: per-provider overrides take precedence when defined (not undefined)
+  // For nullable fields (ttfbMs, minBytesPerSecond), null means "disabled".
+  // For non-nullable fields (ttfbBytes, windowMs, gracePeriodMs), null means "use base".
+  const merged: StallConfig = {
+    ttfbMs:
+      providerOverrides.stallTtfbMs !== undefined ? providerOverrides.stallTtfbMs : base.ttfbMs,
+    ttfbBytes:
+      providerOverrides.stallTtfbBytes != null ? providerOverrides.stallTtfbBytes : base.ttfbBytes,
+    minBytesPerSecond:
+      providerOverrides.stallMinBps !== undefined
+        ? providerOverrides.stallMinBps
+        : base.minBytesPerSecond,
+    windowMs:
+      providerOverrides.stallWindowMs != null ? providerOverrides.stallWindowMs : base.windowMs,
+    gracePeriodMs:
+      providerOverrides.stallGracePeriodMs != null
+        ? providerOverrides.stallGracePeriodMs
+        : base.gracePeriodMs,
+  };
+
+  // If both TTFB and throughput monitoring are null, stall detection is off
+  if (merged.ttfbMs == null && merged.minBytesPerSecond == null) {
+    return null;
+  }
+
+  return merged;
+}
+
+/**
+ * Build the global stall configuration from the PlexusConfig cache.
+ * Returns null if stall detection is globally disabled (all settings null).
+ */
+export function getGlobalStallConfig(): StallConfig | null {
+  const config = getConfig();
+  const stall = (config as any).stall;
+
+  if (!stall) return null;
+
+  const ttfbMs = stall.ttfbSeconds != null ? stall.ttfbSeconds * 1000 : null;
+  const ttfbBytes = stall.ttfbBytes ?? 100;
+  const minBytesPerSecond = stall.minBytesPerSecond ?? null;
+  const windowMs = (stall.windowSeconds ?? 10) * 1000;
+  const gracePeriodMs = (stall.gracePeriodSeconds ?? 30) * 1000;
+
+  // If both TTFB and throughput monitoring are disabled, stall detection is off
+  if (ttfbMs == null && minBytesPerSecond == null) {
+    return null;
+  }
+
+  return {
+    ttfbMs,
+    ttfbBytes,
+    minBytesPerSecond,
+    windowMs,
+    gracePeriodMs,
+  };
+}
+
+/**
+ * Wire stall detection into the route's AbortController.
+ *
+ * Creates a `StallInspector` PassThrough stream that monitors the upstream
+ * response for stalls. When a stall is detected, it aborts the route's
+ * `AbortController`, which triggers `onDisconnect()` in `response-handler.ts`.
+ *
+ * @param abortController The route's AbortController (same one passed to
+ *   `handleResponse` for stream disconnect detection and `wireUpstreamTimeout`).
+ * @param globalStallConfig The resolved global stall config (or null if disabled).
+ * @returns An object with the `stallInspector` stream to insert into the pipeline
+ *   and an `addStallConfig` callback for per-provider overrides, or null if
+ *   stall detection is globally disabled.
+ */
+export function wireStallDetection(
+  abortController: AbortController,
+  globalStallConfig: StallConfig | null
+): {
+  stallInspector: StallInspector;
+  addStallConfig: (providerOverrides: {
+    stallTtfbMs?: number | null;
+    stallTtfbBytes?: number | null;
+    stallMinBps?: number | null;
+    stallWindowMs?: number | null;
+    stallGracePeriodMs?: number | null;
+  }) => void;
+} | null {
+  // When global stall config is null, we still create a StallInspector
+  // with a "disabled" skeleton config so that per-provider overrides can
+  // activate it later via addStallConfig(). This handles the case where
+  // the user only configures stall detection on individual providers
+  // without any global settings.
+  //
+  // If there truly is no stall config at any level, the inspector will
+  // simply pass all data through without monitoring (both ttfbMs and
+  // minBytesPerSecond are null = no timers, no checks). The periodic
+  // check never starts because we never enter MONITORING state.
+  const baseConfig: StallConfig = globalStallConfig ?? {
+    ttfbMs: null,
+    ttfbBytes: 100,
+    minBytesPerSecond: null,
+    windowMs: 10000,
+    gracePeriodMs: 30000,
+  };
+
+  const stallInspector = new StallInspector(
+    crypto.randomUUID(), // Will be overwritten by the request ID in the pipeline
+    baseConfig,
+    abortController
+  );
+
+  const hadGlobalConfig = globalStallConfig !== null;
+
+  logger.debug(
+    `wireStallDetection: creating inspector (hadGlobalConfig=${hadGlobalConfig}, ` +
+      `baseConfig=${JSON.stringify(baseConfig)}, globalStallConfig=${JSON.stringify(globalStallConfig)})`
+  );
+
+  return {
+    stallInspector,
+    addStallConfig: (providerOverrides) => {
+      const merged = resolveStallConfig(
+        // If we started from a skeleton config, resolve against it
+        hadGlobalConfig ? globalStallConfig! : null,
+        providerOverrides
+      );
+      logger.debug(
+        `wireStallDetection.addStallConfig: overrides=${JSON.stringify(providerOverrides)}, ` +
+          `merged=${JSON.stringify(merged)}`
+      );
+      if (!merged) return;
+
+      stallInspector.updateConfig(merged);
+    },
+  };
+}

--- a/packages/backend/src/utils/timeout.ts
+++ b/packages/backend/src/utils/timeout.ts
@@ -13,6 +13,7 @@
  */
 
 import { getConfig } from '../config';
+import { logger } from './logger';
 
 /**
  * Wire a timeout signal into the route's AbortController.
@@ -87,6 +88,68 @@ export function wireUpstreamTimeout(
         },
         { once: true }
       );
+    },
+  };
+}
+
+/**
+ * Start early client-disconnect detection before dispatch.
+ *
+ * Bun's node:http layer does NOT reliably fire close/abort events when a
+ * client disconnects during streaming POST responses. The only working
+ * detection mechanism is polling `bunHandle.closed` on the Socket object.
+ *
+ * The response-handler's polling only starts after the dispatcher returns,
+ * so there's a gap: if the client disconnects while fetch() is still
+ * pending (upstream hasn't responded yet), nothing detects the disconnect.
+ * The fetch keeps running, wasting upstream API quota.
+ *
+ * This function starts the bunHandle.closed polling BEFORE the dispatch,
+ * and aborts the route's AbortController when the client disconnects.
+ * This propagates through the combined signal to fetch(), causing it to
+ * throw AbortError and the dispatcher to stop waiting.
+ *
+ * Callers must call cleanup() after the dispatch completes (whether success
+ * or failure) to stop the polling interval.
+ */
+export function wireEarlyDisconnectDetection(
+  request: any,
+  abortController: AbortController
+): { cleanup: () => void } {
+  const rawSocket = request?.raw?.socket;
+  const symHandle = rawSocket
+    ? Object.getOwnPropertySymbols(rawSocket).find((s: Symbol) => s.toString() === 'Symbol(handle)')
+    : undefined;
+  const bunHandle = symHandle ? rawSocket[symHandle] : null;
+
+  if (!bunHandle) {
+    // Can't detect disconnect without bunHandle (non-Bun runtime or no socket)
+    return { cleanup: () => {} };
+  }
+
+  let cleanedUp = false;
+  let poll: ReturnType<typeof setInterval> | null = setInterval(() => {
+    if (cleanedUp) return;
+    if (bunHandle.closed) {
+      if (!abortController.signal.aborted) {
+        logger.debug(`Early disconnect detected (bunHandle.closed), aborting upstream fetch`);
+        abortController.abort(new DOMException('Client disconnected', 'AbortError'));
+      }
+      cleanedUp = true;
+      if (poll) {
+        clearInterval(poll);
+        poll = null;
+      }
+    }
+  }, 250);
+
+  return {
+    cleanup: () => {
+      cleanedUp = true;
+      if (poll) {
+        clearInterval(poll);
+        poll = null;
+      }
     },
   };
 }

--- a/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
@@ -38,6 +38,32 @@ export function ProviderAdvancedEditor({
   const [isOpen, setIsOpen] = useState(false);
   const [isHeadersOpen, setIsHeadersOpen] = useState(false);
   const [isExtraBodyOpen, setIsExtraBodyOpen] = useState(false);
+  const [isStallOpen, setIsStallOpen] = useState(false);
+
+  // Draft state for stall number inputs — allows free typing without
+  // range-checking on every keystroke. Values are committed to editingProvider
+  // on blur, where we validate the final value.
+  const [stallTtfbDraft, setStallTtfbDraft] = useState<string>(
+    editingProvider.stallTtfbMs != null
+      ? String(Math.round(editingProvider.stallTtfbMs / 1000))
+      : ''
+  );
+  const [stallTtfbBytesDraft, setStallTtfbBytesDraft] = useState<string>(
+    editingProvider.stallTtfbBytes != null ? String(editingProvider.stallTtfbBytes) : ''
+  );
+  const [stallMinBpsDraft, setStallMinBpsDraft] = useState<string>(
+    editingProvider.stallMinBps != null ? String(editingProvider.stallMinBps) : ''
+  );
+  const [stallWindowDraft, setStallWindowDraft] = useState<string>(
+    editingProvider.stallWindowMs != null
+      ? String(Math.round(editingProvider.stallWindowMs / 1000))
+      : ''
+  );
+  const [stallGraceDraft, setStallGraceDraft] = useState<string>(
+    editingProvider.stallGracePeriodMs != null
+      ? String(Math.round(editingProvider.stallGracePeriodMs / 1000))
+      : ''
+  );
 
   return (
     <div className="border border-border-glass rounded-sm overflow-hidden">
@@ -191,6 +217,222 @@ export function ProviderAdvancedEditor({
                 }}
               />
             </div>
+          </div>
+
+          {/* Stall Detection Overrides */}
+          <div className="border border-border-glass rounded-md overflow-hidden">
+            <div
+              className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover hover:bg-bg-glass"
+              onClick={() => setIsStallOpen(!isStallOpen)}
+            >
+              {isStallOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              <label
+                className="font-body text-[13px] font-medium text-text-secondary"
+                style={{ marginBottom: 0, flex: 1 }}
+              >
+                Stall Detection Overrides
+              </label>
+              {(editingProvider.stallTtfbMs != null ||
+                editingProvider.stallTtfbBytes != null ||
+                editingProvider.stallMinBps != null ||
+                editingProvider.stallWindowMs != null ||
+                editingProvider.stallGracePeriodMs != null) && (
+                <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
+                  Custom
+                </Badge>
+              )}
+            </div>
+            {isStallOpen && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '8px',
+                  padding: '8px',
+                  borderTop: '1px solid var(--color-border-glass)',
+                  background: 'var(--color-bg-deep)',
+                }}
+              >
+                <div
+                  className="font-body text-[11px] text-text-secondary"
+                  style={{ lineHeight: 1.35, marginBottom: '2px' }}
+                >
+                  Override the global stall detection settings for this provider. Leave empty to use
+                  the global setting for each field.
+                </div>
+                {/* TTFB Timeout */}
+                <div>
+                  <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                    TTFB Timeout (seconds)
+                  </label>
+                  <div
+                    className="font-body text-[10px] text-text-muted"
+                    style={{ lineHeight: 1.3, marginBottom: '3px' }}
+                  >
+                    5–120 seconds. Leave empty for global default.
+                  </div>
+                  <input
+                    className="w-full max-w-[200px] py-2 pl-3 pr-7 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    type="number"
+                    step="1"
+                    placeholder="Global default"
+                    value={stallTtfbDraft}
+                    onChange={(e) => setStallTtfbDraft(e.target.value)}
+                    onBlur={() => {
+                      const num = Number(stallTtfbDraft);
+                      if (stallTtfbDraft === '') {
+                        setEditingProvider({ ...editingProvider, stallTtfbMs: undefined });
+                      } else if (Number.isFinite(num) && num >= 5 && num <= 120) {
+                        setEditingProvider({ ...editingProvider, stallTtfbMs: num * 1000 });
+                      } else {
+                        // Revert to current value
+                        setStallTtfbDraft(
+                          editingProvider.stallTtfbMs != null
+                            ? String(Math.round(editingProvider.stallTtfbMs / 1000))
+                            : ''
+                        );
+                      }
+                    }}
+                  />
+                </div>
+                {/* TTFB Byte Threshold */}
+                <div>
+                  <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                    TTFB Byte Threshold
+                  </label>
+                  <div
+                    className="font-body text-[10px] text-text-muted"
+                    style={{ lineHeight: 1.3, marginBottom: '3px' }}
+                  >
+                    50–10,000 bytes. Leave empty for global default.
+                  </div>
+                  <input
+                    className="w-full max-w-[200px] py-2 pl-3 pr-7 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    type="number"
+                    step="1"
+                    placeholder="Global default"
+                    value={stallTtfbBytesDraft}
+                    onChange={(e) => setStallTtfbBytesDraft(e.target.value)}
+                    onBlur={() => {
+                      const num = Number(stallTtfbBytesDraft);
+                      if (stallTtfbBytesDraft === '') {
+                        setEditingProvider({ ...editingProvider, stallTtfbBytes: undefined });
+                      } else if (Number.isFinite(num) && num >= 50 && num <= 10000) {
+                        setEditingProvider({ ...editingProvider, stallTtfbBytes: num });
+                      } else {
+                        setStallTtfbBytesDraft(
+                          editingProvider.stallTtfbBytes != null
+                            ? String(editingProvider.stallTtfbBytes)
+                            : ''
+                        );
+                      }
+                    }}
+                  />
+                </div>
+                {/* Min Bytes/Sec */}
+                <div>
+                  <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                    Min Bytes Per Second
+                  </label>
+                  <div
+                    className="font-body text-[10px] text-text-muted"
+                    style={{ lineHeight: 1.3, marginBottom: '3px' }}
+                  >
+                    50–5,000 B/s. Leave empty for global default.
+                  </div>
+                  <input
+                    className="w-full max-w-[200px] py-2 pl-3 pr-7 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    type="number"
+                    step="1"
+                    placeholder="Global default"
+                    value={stallMinBpsDraft}
+                    onChange={(e) => setStallMinBpsDraft(e.target.value)}
+                    onBlur={() => {
+                      const num = Number(stallMinBpsDraft);
+                      if (stallMinBpsDraft === '') {
+                        setEditingProvider({ ...editingProvider, stallMinBps: undefined });
+                      } else if (Number.isFinite(num) && num >= 50 && num <= 5000) {
+                        setEditingProvider({ ...editingProvider, stallMinBps: num });
+                      } else {
+                        setStallMinBpsDraft(
+                          editingProvider.stallMinBps != null
+                            ? String(editingProvider.stallMinBps)
+                            : ''
+                        );
+                      }
+                    }}
+                  />
+                </div>
+                {/* Stall Window */}
+                <div>
+                  <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                    Stall Window (seconds)
+                  </label>
+                  <div
+                    className="font-body text-[10px] text-text-muted"
+                    style={{ lineHeight: 1.3, marginBottom: '3px' }}
+                  >
+                    3–30 seconds. Leave empty for global default.
+                  </div>
+                  <input
+                    className="w-full max-w-[200px] py-2 pl-3 pr-7 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    type="number"
+                    step="1"
+                    placeholder="Global default"
+                    value={stallWindowDraft}
+                    onChange={(e) => setStallWindowDraft(e.target.value)}
+                    onBlur={() => {
+                      const num = Number(stallWindowDraft);
+                      if (stallWindowDraft === '') {
+                        setEditingProvider({ ...editingProvider, stallWindowMs: undefined });
+                      } else if (Number.isFinite(num) && num >= 3 && num <= 30) {
+                        setEditingProvider({ ...editingProvider, stallWindowMs: num * 1000 });
+                      } else {
+                        setStallWindowDraft(
+                          editingProvider.stallWindowMs != null
+                            ? String(Math.round(editingProvider.stallWindowMs / 1000))
+                            : ''
+                        );
+                      }
+                    }}
+                  />
+                </div>
+                {/* Grace Period */}
+                <div>
+                  <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                    Stall Grace Period (seconds)
+                  </label>
+                  <div
+                    className="font-body text-[10px] text-text-muted"
+                    style={{ lineHeight: 1.3, marginBottom: '3px' }}
+                  >
+                    0–120 seconds. Leave empty for global default.
+                  </div>
+                  <input
+                    className="w-full max-w-[200px] py-2 pl-3 pr-7 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    type="number"
+                    step="1"
+                    placeholder="Global default"
+                    value={stallGraceDraft}
+                    onChange={(e) => setStallGraceDraft(e.target.value)}
+                    onBlur={() => {
+                      const num = Number(stallGraceDraft);
+                      if (stallGraceDraft === '') {
+                        setEditingProvider({ ...editingProvider, stallGracePeriodMs: undefined });
+                      } else if (Number.isFinite(num) && num >= 0 && num <= 120) {
+                        setEditingProvider({ ...editingProvider, stallGracePeriodMs: num * 1000 });
+                      } else {
+                        setStallGraceDraft(
+                          editingProvider.stallGracePeriodMs != null
+                            ? String(Math.round(editingProvider.stallGracePeriodMs / 1000))
+                            : ''
+                        );
+                      }
+                    }}
+                  />
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Custom Headers */}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -238,6 +238,12 @@ export interface Provider {
   gpu_power_draw_watts?: number;
   adapter?: string[];
   timeoutMs?: number;
+  // Per-provider stall detection overrides
+  stallTtfbMs?: number | null;
+  stallTtfbBytes?: number | null;
+  stallMinBps?: number | null;
+  stallWindowMs?: number | null;
+  stallGracePeriodMs?: number | null;
 }
 
 export interface McpServer {
@@ -1669,6 +1675,11 @@ export const api = {
           quotaChecker: normalizeProviderQuotaChecker(val.quota_checker),
           adapter: val.adapter ? (Array.isArray(val.adapter) ? val.adapter : [val.adapter]) : [],
           timeoutMs: val.timeoutMs ?? undefined,
+          stallTtfbMs: val.stallTtfbMs ?? undefined,
+          stallTtfbBytes: val.stallTtfbBytes ?? undefined,
+          stallMinBps: val.stallMinBps ?? undefined,
+          stallWindowMs: val.stallWindowMs ?? undefined,
+          stallGracePeriodMs: val.stallGracePeriodMs ?? undefined,
         };
       });
     } catch (e) {
@@ -1714,6 +1725,13 @@ export const api = {
         : {}),
       ...(provider.adapter && provider.adapter.length > 0 ? { adapter: provider.adapter } : {}),
       ...(provider.timeoutMs != null ? { timeoutMs: provider.timeoutMs } : {}),
+      ...(provider.stallTtfbMs != null ? { stallTtfbMs: provider.stallTtfbMs } : {}),
+      ...(provider.stallTtfbBytes != null ? { stallTtfbBytes: provider.stallTtfbBytes } : {}),
+      ...(provider.stallMinBps != null ? { stallMinBps: provider.stallMinBps } : {}),
+      ...(provider.stallWindowMs != null ? { stallWindowMs: provider.stallWindowMs } : {}),
+      ...(provider.stallGracePeriodMs != null
+        ? { stallGracePeriodMs: provider.stallGracePeriodMs }
+        : {}),
     };
 
     const res = await fetchWithAuth(
@@ -3176,6 +3194,44 @@ export const api = {
       body: JSON.stringify(updates),
     });
     if (!res.ok) throw new Error('Failed to update timeout settings');
+    return res.json();
+  },
+
+  // ─── Stall Detection Settings ────────────────────────────────────
+
+  /** Fetch current stall detection settings. */
+  getStallConfig: async (): Promise<{
+    ttfbSeconds: number | null;
+    ttfbBytes: number;
+    minBytesPerSecond: number | null;
+    windowSeconds: number;
+    gracePeriodSeconds: number;
+  }> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/stall`);
+    if (!res.ok) throw new Error('Failed to fetch stall detection settings');
+    return res.json();
+  },
+
+  /** Patch stall detection settings. */
+  patchStallConfig: async (updates: {
+    ttfbSeconds?: number | null;
+    ttfbBytes?: number;
+    minBytesPerSecond?: number | null;
+    windowSeconds?: number;
+    gracePeriodSeconds?: number;
+  }): Promise<{
+    ttfbSeconds: number | null;
+    ttfbBytes: number;
+    minBytesPerSecond: number | null;
+    windowSeconds: number;
+    gracePeriodSeconds: number;
+  }> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/stall`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    });
+    if (!res.ok) throw new Error('Failed to update stall detection settings');
     return res.json();
   },
 };

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -14,6 +14,7 @@ import {
   Timer,
   Compass,
   Radar,
+  Activity,
 } from 'lucide-react';
 import { api } from '../lib/api';
 import { formatMinutesToMinSec } from '@plexus/shared';
@@ -87,8 +88,24 @@ interface TimeoutConfig {
   defaultSeconds: number;
 }
 
+interface StallConfig {
+  ttfbSeconds: number | null;
+  ttfbBytes: number;
+  minBytesPerSecond: number | null;
+  windowSeconds: number;
+  gracePeriodSeconds: number;
+}
+
 const DEFAULT_TIMEOUT_CONFIG: TimeoutConfig = {
   defaultSeconds: 300,
+};
+
+const DEFAULT_STALL_CONFIG: StallConfig = {
+  ttfbSeconds: null,
+  ttfbBytes: 100,
+  minBytesPerSecond: null,
+  windowSeconds: 10,
+  gracePeriodSeconds: 30,
 };
 
 const DEFAULT_BACKGROUND_EXPLORATION: BackgroundExplorationConfig = {
@@ -156,6 +173,16 @@ export const Config = () => {
   const [timeoutSaving, setTimeoutSaving] = useState(false);
   const [timeoutDefaultInput, setTimeoutDefaultInput] = useState('');
 
+  // Stall detection settings state
+  const [stallConfig, setStallConfig] = useState<StallConfig>(DEFAULT_STALL_CONFIG);
+  const [stallLoaded, setStallLoaded] = useState(false);
+  const [stallSaving, setStallSaving] = useState(false);
+  const [stallTtfbInput, setStallTtfbInput] = useState('');
+  const [stallTtfbBytesInput, setStallTtfbBytesInput] = useState('');
+  const [stallMinBpsInput, setStallMinBpsInput] = useState('');
+  const [stallWindowInput, setStallWindowInput] = useState('');
+  const [stallGraceInput, setStallGraceInput] = useState('');
+
   // Validate timeout input
   const validateTimeoutInput = (
     raw: string
@@ -178,6 +205,38 @@ export const Config = () => {
 
   const timeoutDefaultValidation = validateTimeoutInput(timeoutDefaultInput);
   const isTimeoutValid = timeoutLoaded && timeoutDefaultValidation.valid;
+
+  // Validate stall detection inputs
+  const validateStallInput = (
+    raw: string,
+    min: number,
+    max: number,
+    allowNull: boolean = false
+  ): { valid: boolean; value?: number | null; error?: string } => {
+    if (raw === '') {
+      if (allowNull) return { valid: true, value: null };
+      return { valid: true }; // Empty for non-nullable fields means "use default" / unchanged
+    }
+    const num = Number(raw);
+    if (!Number.isFinite(num)) return { valid: false, error: 'Must be a number' };
+    if (!Number.isInteger(num)) return { valid: false, error: 'Must be an integer' };
+    if (num < min) return { valid: false, error: `Must be at least ${min}` };
+    if (num > max) return { valid: false, error: `Must be at most ${max}` };
+    return { valid: true, value: num };
+  };
+
+  const stallTtfbValidation = validateStallInput(stallTtfbInput, 5, 120, true);
+  const stallTtfbBytesValidation = validateStallInput(stallTtfbBytesInput, 50, 10000, false);
+  const stallMinBpsValidation = validateStallInput(stallMinBpsInput, 50, 5000, true);
+  const stallWindowValidation = validateStallInput(stallWindowInput, 3, 30, false);
+  const stallGraceValidation = validateStallInput(stallGraceInput, 0, 120, false);
+  const isStallValid =
+    stallLoaded &&
+    stallTtfbValidation.valid &&
+    stallTtfbBytesValidation.valid &&
+    stallMinBpsValidation.valid &&
+    stallWindowValidation.valid &&
+    stallGraceValidation.valid;
 
   const initialValidation = validateCooldownInput(cooldownInitialInput);
   const maxValidation = validateCooldownInput(cooldownMaxInput);
@@ -379,6 +438,22 @@ export const Config = () => {
     }
   };
 
+  const loadStallConfig = useCallback(async () => {
+    try {
+      const cfg = await api.getStallConfig();
+      setStallConfig(cfg);
+      setStallTtfbInput(cfg.ttfbSeconds != null ? String(cfg.ttfbSeconds) : '');
+      setStallTtfbBytesInput(String(cfg.ttfbBytes));
+      setStallMinBpsInput(cfg.minBytesPerSecond != null ? String(cfg.minBytesPerSecond) : '');
+      setStallWindowInput(String(cfg.windowSeconds));
+      setStallGraceInput(String(cfg.gracePeriodSeconds));
+      setStallLoaded(true);
+    } catch (e) {
+      console.error('Failed to load stall config:', e);
+      toast.error('Failed to load stall detection settings');
+    }
+  }, [toast]);
+
   const handleSaveTimeout = async () => {
     if (!timeoutDefaultValidation.valid) return;
     setTimeoutSaving(true);
@@ -394,6 +469,59 @@ export const Config = () => {
       toast.error((e as Error).message, 'Failed to save timeout settings');
     } finally {
       setTimeoutSaving(false);
+    }
+  };
+
+  const handleSaveStall = async () => {
+    setStallSaving(true);
+    try {
+      const updates: Record<string, unknown> = {};
+      if (stallTtfbInput === '') {
+        updates.ttfbSeconds = null;
+      } else if (stallTtfbValidation.valid && stallTtfbValidation.value !== undefined) {
+        updates.ttfbSeconds = stallTtfbValidation.value;
+      }
+      if (
+        stallTtfbBytesInput !== '' &&
+        stallTtfbBytesValidation.valid &&
+        stallTtfbBytesValidation.value !== undefined
+      ) {
+        updates.ttfbBytes = stallTtfbBytesValidation.value;
+      }
+      if (stallMinBpsInput === '') {
+        updates.minBytesPerSecond = null;
+      } else if (stallMinBpsValidation.valid && stallMinBpsValidation.value !== undefined) {
+        updates.minBytesPerSecond = stallMinBpsValidation.value;
+      }
+      if (
+        stallWindowInput !== '' &&
+        stallWindowValidation.valid &&
+        stallWindowValidation.value !== undefined
+      ) {
+        updates.windowSeconds = stallWindowValidation.value;
+      }
+      if (
+        stallGraceInput !== '' &&
+        stallGraceValidation.valid &&
+        stallGraceValidation.value !== undefined
+      ) {
+        updates.gracePeriodSeconds = stallGraceValidation.value;
+      }
+
+      const updated = await api.patchStallConfig(updates);
+      setStallConfig(updated);
+      setStallTtfbInput(updated.ttfbSeconds != null ? String(updated.ttfbSeconds) : '');
+      setStallTtfbBytesInput(String(updated.ttfbBytes));
+      setStallMinBpsInput(
+        updated.minBytesPerSecond != null ? String(updated.minBytesPerSecond) : ''
+      );
+      setStallWindowInput(String(updated.windowSeconds));
+      setStallGraceInput(String(updated.gracePeriodSeconds));
+      toast.success('Stall detection settings saved');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to save stall detection settings');
+    } finally {
+      setStallSaving(false);
     }
   };
 
@@ -472,6 +600,7 @@ export const Config = () => {
     loadFailoverPolicy();
     loadCooldownPolicy();
     loadTimeoutConfig();
+    loadStallConfig();
     loadExplorationRates();
     loadBackgroundExploration();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -973,6 +1102,191 @@ export const Config = () => {
                         : `${timeoutConfig.defaultSeconds}s`
                       : '\u2014'}
                 </span>
+              </div>
+            </div>
+          </div>
+        </Disclosure>
+
+        {/* ─── Stall Detection Settings ────────────────────────────── */}
+        <Disclosure
+          title="Stall Detection"
+          defaultOpen={false}
+          extra={
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleSaveStall}
+              isLoading={stallSaving}
+              disabled={!isStallValid}
+              leftIcon={<Save size={14} />}
+            >
+              Save
+            </Button>
+          }
+        >
+          <div className="flex flex-col gap-5">
+            {/* Description */}
+            <div className="flex items-start gap-2">
+              <Activity size={16} className="text-primary mt-0.5" />
+              <div>
+                <p className="text-sm font-medium text-text">Stream Stall Detection</p>
+                <p className="text-xs text-text-muted">
+                  Detect when an upstream provider is taking too long to start responding (TTFB
+                  stall) or is producing data too slowly (throughput stall). When a stall is
+                  detected, the request is aborted so the client can retry with a different
+                  provider. Leave TTFB seconds and min bytes/sec empty to disable each dimension
+                  independently.
+                </p>
+                {stallLoaded && (
+                  <p className="text-xs text-text-muted mt-1">
+                    Status:{' '}
+                    {stallConfig.ttfbSeconds != null || stallConfig.minBytesPerSecond != null
+                      ? 'Enabled'
+                      : 'Disabled (no thresholds set)'}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* TTFB Seconds */}
+            <div>
+              <label
+                htmlFor="stallTtfbSeconds"
+                className="block text-sm font-medium text-text mb-1"
+              >
+                TTFB Timeout (seconds)
+              </label>
+              <p className="text-xs text-text-muted mb-2">
+                Time allowed for the provider to start producing meaningful output. Leave empty to
+                disable TTFB stall detection. Must be between 5 and 120 seconds.
+              </p>
+              <div className="flex flex-col gap-1">
+                <input
+                  id="stallTtfbSeconds"
+                  type="number"
+                  min={5}
+                  max={120}
+                  step={1}
+                  placeholder="Disabled"
+                  value={stallTtfbInput}
+                  onChange={(e) => setStallTtfbInput(e.target.value)}
+                  className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                />
+                {!stallTtfbValidation.valid && stallTtfbInput !== '' && (
+                  <span className="text-xs text-warning">{stallTtfbValidation.error}</span>
+                )}
+              </div>
+            </div>
+
+            {/* TTFB Bytes */}
+            <div>
+              <label htmlFor="stallTtfbBytes" className="block text-sm font-medium text-text mb-1">
+                TTFB Byte Threshold
+              </label>
+              <p className="text-xs text-text-muted mb-2">
+                Byte threshold that confirms the provider is actually producing content. 100 bytes
+                is roughly half a token. Must be between 50 and 10,000.
+              </p>
+              <div className="flex flex-col gap-1">
+                <input
+                  id="stallTtfbBytes"
+                  type="number"
+                  min={50}
+                  max={10000}
+                  step={1}
+                  value={stallTtfbBytesInput}
+                  onChange={(e) => setStallTtfbBytesInput(e.target.value)}
+                  className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                />
+                {!stallTtfbBytesValidation.valid && stallTtfbBytesInput !== '' && (
+                  <span className="text-xs text-warning">{stallTtfbBytesValidation.error}</span>
+                )}
+              </div>
+            </div>
+
+            {/* Min Bytes Per Second */}
+            <div>
+              <label htmlFor="stallMinBps" className="block text-sm font-medium text-text mb-1">
+                Minimum Bytes Per Second
+              </label>
+              <p className="text-xs text-text-muted mb-2">
+                Throughput floor after the grace period. Sliding window check. Leave empty to
+                disable throughput stall detection. 500 B/s is approximately 2-3 tokens/sec. Must be
+                between 50 and 5,000.
+              </p>
+              <div className="flex flex-col gap-1">
+                <input
+                  id="stallMinBps"
+                  type="number"
+                  min={50}
+                  max={5000}
+                  step={1}
+                  placeholder="Disabled"
+                  value={stallMinBpsInput}
+                  onChange={(e) => setStallMinBpsInput(e.target.value)}
+                  className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                />
+                {!stallMinBpsValidation.valid && stallMinBpsInput !== '' && (
+                  <span className="text-xs text-warning">{stallMinBpsValidation.error}</span>
+                )}
+              </div>
+            </div>
+
+            {/* Window Seconds */}
+            <div>
+              <label
+                htmlFor="stallWindowSeconds"
+                className="block text-sm font-medium text-text mb-1"
+              >
+                Sliding Window (seconds)
+              </label>
+              <p className="text-xs text-text-muted mb-2">
+                Width of the sliding window for throughput calculation. Longer = more stable,
+                shorter = more responsive. Must be between 3 and 30 seconds.
+              </p>
+              <div className="flex flex-col gap-1">
+                <input
+                  id="stallWindowSeconds"
+                  type="number"
+                  min={3}
+                  max={30}
+                  step={1}
+                  value={stallWindowInput}
+                  onChange={(e) => setStallWindowInput(e.target.value)}
+                  className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                />
+                {!stallWindowValidation.valid && stallWindowInput !== '' && (
+                  <span className="text-xs text-warning">{stallWindowValidation.error}</span>
+                )}
+              </div>
+            </div>
+
+            {/* Grace Period Seconds */}
+            <div>
+              <label
+                htmlFor="stallGraceSeconds"
+                className="block text-sm font-medium text-text mb-1"
+              >
+                Grace Period (seconds)
+              </label>
+              <p className="text-xs text-text-muted mb-2">
+                Time after TTFB threshold is met before throughput enforcement begins. Allows for
+                natural thinking/reasoning pauses. Must be between 0 and 120 seconds.
+              </p>
+              <div className="flex flex-col gap-1">
+                <input
+                  id="stallGraceSeconds"
+                  type="number"
+                  min={0}
+                  max={120}
+                  step={1}
+                  value={stallGraceInput}
+                  onChange={(e) => setStallGraceInput(e.target.value)}
+                  className="w-full max-w-[200px] rounded-md border border-border bg-bg-glass px-3 py-2 text-sm text-text font-mono placeholder:text-text-muted/50 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                />
+                {!stallGraceValidation.valid && stallGraceInput !== '' && (
+                  <span className="text-xs text-warning">{stallGraceValidation.error}</span>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Stream Stall Detection

When an LLM provider is functional but excessively slow to begin responding, Plexus now detects the stall and automatically retries with the next available provider — no user intervention required.

### How it works

**TTFB stall detection** (time-to-first-bytes) runs inside the dispatcher's failover loop. When a provider takes longer than the configured TTFB threshold to produce enough bytes, the request is aborted and the next provider is tried. This happens before any data reaches the client, so failover is transparent.

**Throughput stall detection** monitors ongoing streaming after data has started flowing. If the upstream drops below the configured minimum bytes/second threshold over a sliding window, the stream is aborted. Since bytes have already been sent to the client, failover is not possible at this stage — but the client can retry on its own.

### Configuration

Stall detection is off by default (all settings null/zero) — zero risk to existing deployments.

Settings are available both globally and per-provider (per-provider overrides take precedence):

- TTFB timeout (ms) — Max time to wait for first meaningful bytes before considering it a stall
- TTFB bytes — Byte threshold that must be received within the TTFB timeout
- Min throughput (B/s) — Floor for ongoing streaming throughput
- Window (ms) — Sliding window width for throughput calculation
- Grace period (ms) — Time after TTFB threshold met before throughput enforcement begins

Frontend: Global settings in Config > Stall Detection; per-provider overrides in Provider Advanced Editor.

### Additional fixes

- **Early client disconnect detection**: Bun's node:http layer does not reliably signal client disconnects during pending fetch() calls. Added bunHandle.closed polling that starts before dispatch, so disconnects are detected within ~250ms and the upstream fetch is aborted.

- **Cancelled/timeout usage records**: Requests that end due to client disconnect or upstream timeout are now properly persisted to the usage DB with the correct response status instead of being silently dropped.

- **Client abort classification**: Client aborts are now correctly classified as client_disconnected (HTTP 499) rather than being misidentified as retryable network errors, preventing wasteful failover retries after the client is gone.

### Schema changes

Adds 5 columns to the providers table (SQLite + Postgres): stall_ttfb_ms, stall_ttfb_bytes, stall_min_bps, stall_window_ms, stall_grace_period_ms. Migrations are committed with the schema changes.