### PR TITLE
feat: live bytes/sec progress for in-flight requests in Logs view

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ When a provider fails, Plexus removes it from rotation using exponential backoff
 - Client disconnects now cancel the upstream provider request, reducing wasted tokens/quota on abandoned streams.
 - Global and per-provider upstream timeouts cut off requests that run too long.
 - Optional stall detection can fail over slow-to-start providers before bytes reach the client, and can abort streams that become too slow mid-flight.
+- The Request Logs page shows **live bytes received and throughput (KB/s)** for in-flight streaming requests, updated every second via SSE, so you can see whether a provider is actively responding before it completes.
 
 → See [Configuration: Request Timeouts](docs/CONFIGURATION.md#request-timeouts) and [Configuration: Stall Detection](docs/CONFIGURATION.md#stall-detection)
 

--- a/packages/backend/src/routes/management/usage.ts
+++ b/packages/backend/src/routes/management/usage.ts
@@ -449,7 +449,29 @@ export async function registerUsageRoutes(
     // Also listen for 'created' for backward compatibility
     usageStorage.on('created', completedListener);
 
+    // Periodic progress updates for in-flight requests (every 1s, fire-and-forget)
+    const progressInterval = setInterval(() => {
+      if (reply.raw.destroyed) return;
+      const updates = usageStorage.getProgressUpdates();
+      for (const update of updates) {
+        if (scopeKey && update.apiKey !== scopeKey) continue;
+        try {
+          reply.raw.write(
+            encode({
+              data: JSON.stringify(update),
+              event: 'progress',
+              id: String(Date.now()),
+            })
+          );
+        } catch {
+          // Fire-and-forget: ignore write errors
+        }
+      }
+    }, 1000);
+    progressInterval.unref?.();
+
     request.raw.on('close', () => {
+      clearInterval(progressInterval);
       usageStorage.off('started', startedListener);
       usageStorage.off('updated', updatedListener);
       usageStorage.off('completed', completedListener);

--- a/packages/backend/src/services/inspectors/stall-inspector.ts
+++ b/packages/backend/src/services/inspectors/stall-inspector.ts
@@ -257,6 +257,46 @@ export class StallInspector extends PassThrough {
     }
   }
 
+  // ─── Public stats ─────────────────────────────────────────────────
+
+  /**
+   * Return a snapshot of the current throughput state for live progress reporting.
+   * Safe to call from any goroutine — reads only primitive fields.
+   */
+  getStats(): {
+    state: 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED';
+    bytesReceived: number;
+    bytesPerSec: number | null;
+    elapsedMs: number;
+  } {
+    const now = Date.now();
+    let bytesPerSec: number | null = null;
+
+    if (this.samples.length >= 2) {
+      const windowStart = now - this.config.windowMs;
+      // Find oldest sample within the window
+      let oldest = this.samples[0]!;
+      for (let i = 1; i < this.samples.length; i++) {
+        if (this.samples[i]!.timestamp >= windowStart) {
+          oldest = this.samples[i - 1]!;
+          break;
+        }
+      }
+      const bytesInWindow = this.totalBytes - oldest.cumulativeBytes;
+      const timeSpanMs = now - oldest.timestamp;
+      if (timeSpanMs > 0) {
+        bytesPerSec = (bytesInWindow / timeSpanMs) * 1000;
+      }
+    }
+
+    return {
+      state: this.state as 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED',
+      bytesReceived: this.totalBytes,
+      bytesPerSec,
+      elapsedMs: now - this.startTime,
+    };
+  }
+
   // ─── Cleanup ──────────────────────────────────────────────────────
 
   private cleanup(): void {

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -197,6 +197,11 @@ export async function handleResponse(
     const stallInspector = stallDetectionResult?.stallInspector ?? null;
     if (stallInspector) {
       stallInspector.setRequestId(usageRecord.requestId!);
+      usageStorage.registerInFlight(
+        usageRecord.requestId!,
+        stallInspector,
+        (usageRecord.apiKey as string | null) ?? null
+      );
     }
 
     // Pipeline: Source -> StallInspector (if active) -> Usage -> Client
@@ -370,6 +375,9 @@ export async function handleResponse(
         clearInterval(disconnectPoll);
         disconnectPoll = null;
       }
+      if (stallInspector) {
+        usageStorage.deregisterInFlight(usageRecord.requestId!);
+      }
     };
 
     pipeline.once('end', cleanupDisconnectWiring);
@@ -391,7 +399,7 @@ export async function handleResponse(
       ) {
         onDisconnect(isTimeout ? 'pipeline.error.timeout' : 'pipeline.error.' + code);
       }
-      cleanupDisconnectWiring();
+      cleanupDisconnectWiring(); // also deregisters stallInspector
       // Restore debug mode on error
       if (shouldEstimateTokens && !wasDebugEnabled) {
         debugManager.setEnabled(false);

--- a/packages/backend/src/services/usage-storage.ts
+++ b/packages/backend/src/services/usage-storage.ts
@@ -9,6 +9,16 @@ import { getCurrentKeyName } from './request-context';
 import { estimateKwhUsed } from './inference-energy';
 import { resolveModelParams, DEFAULT_GPU_PARAMS } from '@plexus/shared';
 import type { ModelArchitecture, GpuParams } from '@plexus/shared';
+import type { StallInspector } from './inspectors/stall-inspector';
+
+export interface ProgressUpdate {
+  requestId: string;
+  apiKey: string | null;
+  bytesReceived: number;
+  bytesPerSec: number | null;
+  state: 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED';
+  elapsedMs: number;
+}
 
 // ModelArchitecture is now imported from @plexus/shared
 
@@ -54,6 +64,31 @@ export class UsageStorageService extends EventEmitter {
   private schema: any = null;
   private readonly defaultPerformanceRetentionLimit = 100;
   private telemetryQueue: Promise<void> = Promise.resolve();
+  private inFlightRegistry = new Map<
+    string,
+    { inspector: StallInspector; apiKey: string | null }
+  >();
+
+  registerInFlight(requestId: string, inspector: StallInspector, apiKey: string | null): void {
+    this.inFlightRegistry.set(requestId, { inspector, apiKey });
+  }
+
+  deregisterInFlight(requestId: string): void {
+    this.inFlightRegistry.delete(requestId);
+  }
+
+  getProgressUpdates(): ProgressUpdate[] {
+    const updates: ProgressUpdate[] = [];
+    for (const [requestId, { inspector, apiKey }] of this.inFlightRegistry) {
+      try {
+        const stats = inspector.getStats();
+        updates.push({ requestId, apiKey, ...stats });
+      } catch {
+        // Inspector may have been destroyed; skip it
+      }
+    }
+    return updates;
+  }
 
   constructor(connectionString?: string) {
     super();

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -110,6 +110,15 @@ export function formatMs(ms: number): string {
 }
 
 /**
+ * Format byte counts with B/KB/MB suffixes (e.g., 1536 -> "1.5 KB")
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
  * Format tokens per second
  */
 export function formatTPS(tps: number): string {

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -16,6 +16,7 @@ import {
 } from '../lib/api';
 import {
   KWH_PER_SLICE,
+  formatBytes,
   formatCost,
   formatEnergy,
   formatMs,
@@ -154,6 +155,19 @@ export const Logs = () => {
     filtersRef.current = filters;
   }, [filters]);
 
+  interface ProgressUpdate {
+    requestId: string;
+    bytesReceived: number;
+    bytesPerSec: number | null;
+    state: 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED';
+    elapsedMs: number;
+  }
+
+  const progressMapRef = useRef<Map<string, ProgressUpdate>>(new Map());
+  // progressTick is incremented to trigger re-renders when progress data changes.
+  // The value itself is intentionally unused; only the setter is called.
+  const [, setProgressTick] = useState(0);
+
   const loadLogs = async () => {
     setLoading(true);
     try {
@@ -270,6 +284,17 @@ export const Logs = () => {
               }
             }
 
+            // Handle progress updates for in-flight requests
+            if (eventType === 'progress' && eventData) {
+              try {
+                const update: ProgressUpdate = JSON.parse(eventData);
+                progressMapRef.current.set(update.requestId, update);
+                setProgressTick((t) => t + 1);
+              } catch {
+                // ignore malformed progress events
+              }
+            }
+
             // Handle different event types: started, updated, completed
             if (
               (eventType === 'started' || eventType === 'updated' || eventType === 'completed') &&
@@ -312,6 +337,10 @@ export const Logs = () => {
                 }
 
                 if (matches) {
+                  // If a completed event arrives, clear any stale progress entry
+                  if (eventType === 'completed') {
+                    progressMapRef.current.delete(newLog.requestId);
+                  }
                   setLogs((prev) => {
                     const existingIndex = prev.findIndex((l) => l.requestId === newLog.requestId);
                     if (existingIndex >= 0) {
@@ -610,7 +639,39 @@ export const Logs = () => {
                           <div className="text-[10px] uppercase tracking-wider text-text-muted">
                             Latency
                           </div>
-                          <div className="text-text">{formatMs(log.durationMs)}</div>
+                          <div className="text-text">
+                            {(() => {
+                              const progress =
+                                log.responseStatus === 'pending'
+                                  ? progressMapRef.current.get(log.requestId)
+                                  : undefined;
+                              if (progress) {
+                                return (
+                                  <div
+                                    style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}
+                                  >
+                                    <div
+                                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                                    >
+                                      <CloudDownload size={11} className="text-yellow-400" />
+                                      <span>{formatBytes(progress.bytesReceived)}</span>
+                                    </div>
+                                    {progress.bytesPerSec != null && (
+                                      <span
+                                        style={{
+                                          color: 'var(--color-text-secondary)',
+                                          fontSize: '0.85em',
+                                        }}
+                                      >
+                                        {formatBytes(progress.bytesPerSec)}/s
+                                      </span>
+                                    )}
+                                  </div>
+                                );
+                              }
+                              return formatMs(log.durationMs);
+                            })()}
+                          </div>
                         </div>
                         <div className="rounded-md bg-bg-subtle p-2">
                           <div className="text-[10px] uppercase tracking-wider text-text-muted">
@@ -1153,29 +1214,61 @@ export const Logs = () => {
                         )}
                       </td>
                       <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                        <div style={{ display: 'flex', flexDirection: 'column' }}>
-                          <span>Duration: {formatMs(log.durationMs)}</span>
-                          <span
-                            style={{
-                              color: 'var(--color-text-secondary)',
-                              fontSize: '0.85em',
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {log.ttftMs && log.ttftMs > 0 ? `TTFT: ${formatMs(log.ttftMs)}` : ''}
-                          </span>
-                          <span
-                            style={{
-                              color: 'var(--color-text-secondary)',
-                              fontSize: '0.85em',
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {log.tokensPerSec && log.tokensPerSec > 0
-                              ? `TPS: ${formatTPS(log.tokensPerSec)}`
-                              : ''}
-                          </span>
-                        </div>
+                        {(() => {
+                          const progress =
+                            log.responseStatus === 'pending'
+                              ? progressMapRef.current.get(log.requestId)
+                              : undefined;
+                          if (progress) {
+                            return (
+                              <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                                <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                  <CloudDownload size={12} className="text-yellow-400" />
+                                  <span style={{ fontSize: '0.9em' }}>
+                                    {formatBytes(progress.bytesReceived)}
+                                  </span>
+                                </div>
+                                {progress.bytesPerSec != null && (
+                                  <span
+                                    style={{
+                                      color: 'var(--color-text-secondary)',
+                                      fontSize: '0.85em',
+                                    }}
+                                  >
+                                    {formatBytes(progress.bytesPerSec)}/s
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          }
+                          return (
+                            <div style={{ display: 'flex', flexDirection: 'column' }}>
+                              <span>Duration: {formatMs(log.durationMs)}</span>
+                              <span
+                                style={{
+                                  color: 'var(--color-text-secondary)',
+                                  fontSize: '0.85em',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {log.ttftMs && log.ttftMs > 0
+                                  ? `TTFT: ${formatMs(log.ttftMs)}`
+                                  : ''}
+                              </span>
+                              <span
+                                style={{
+                                  color: 'var(--color-text-secondary)',
+                                  fontSize: '0.85em',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {log.tokensPerSec && log.tokensPerSec > 0
+                                  ? `TPS: ${formatTPS(log.tokensPerSec)}`
+                                  : ''}
+                              </span>
+                            </div>
+                          );
+                        })()}
                       </td>
                       <td
                         className="px-2 py-1.5 text-center border-b border-border-glass text-text align-middle"


### PR DESCRIPTION
## Summary

Adds real-time throughput visibility for in-flight streaming requests in the Request Logs page.

Previously, once a request was dispatched to a provider, the Logs UI showed a static pending row with no indication of whether bytes were actually flowing. This change surfaces live byte counts and throughput from the existing `StallInspector` ring buffer via SSE, updated once per second.

<img width="967" height="125" alt="Screenshot 2026-05-16 at 3 06 05 PM" src="https://github.com/user-attachments/assets/89a830b7-b9f1-4230-b958-01108fcee335" />


## How it works

**Backend:**
- `StallInspector.getStats()` — new read-only method that snapshots current state (bytes received, bytes/sec via sliding window) without touching any stream logic. Throughput is computed from the ring buffer regardless of stall enforcement state, so it works even during the grace period.
- `UsageStorageService` — new in-flight registry (`registerInFlight` / `deregisterInFlight` / `getProgressUpdates`). Keyed by `requestId`, stores a reference to the inspector and the owning API key for scoping.
- `response-handler.ts` — registers the inspector when it enters the pipeline; deregisters in `cleanupDisconnectWiring` (fires on both `end` and `error`), so the registry never leaks.
- `/v0/management/events` SSE endpoint — adds a 1s `setInterval` per connected client that calls `getProgressUpdates()`, filters by the client's scoped API key, and emits `progress` events. Fire-and-forget; write errors are swallowed. Interval is cleared on connection close alongside the existing listeners.

**Frontend:**
- New `progress` SSE event handler updates a `progressMapRef` (`Map<requestId, ProgressUpdate>`) and increments a render-tick counter to trigger re-renders without mutating the `logs` array.
- Progress entries are cleared when a `completed` event arrives for the same request.
- **Desktop Perf column** — for pending rows with live data: shows bytes received + KB/s instead of the empty Duration/TTFT/TPS fields.
- **Mobile Latency card** — same conditional rendering.
- New `formatBytes()` helper in `format.ts`.

## What is not changed
- Stall detection/abort logic is untouched — `getStats()` is purely observational.
- No new DB writes or queries; all data comes from the in-memory ring buffer.
- No new API endpoints.
- Only chat/messages/responses/gemini routes have a `StallInspector` in the pipeline; other request types (embeddings, images, speech, transcriptions) simply have no registry entry and are skipped silently.