### PR TITLE
fix(frontend): improve Logs page UX — live duration, cost layout, null display

### DIFF
--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -62,19 +62,21 @@ export function formatTokens(tokens: number): string {
 }
 
 /**
- * Format cost in dollars (e.g., "$0.001234", "$1.23")
+ * Format cost in dollars, always showing 4 decimal places.
+ * Costs below $0.0001 are shown as "$<0.0001" to avoid implying zero.
+ * Costs of exactly $0 show "$0.0000".
  */
-export function formatCost(cost: number, maxDecimals: number = 6): string {
-  if (cost === 0) return '$0';
+export function formatCost(cost: number, decimals: number = 4): string {
+  if (cost === 0) return `$${cost.toFixed(decimals)}`;
+  const threshold = Math.pow(10, -decimals);
+  if (cost > 0 && cost < threshold) return `$<${threshold.toFixed(decimals)}`;
   if (cost >= 0.01) {
-    // For costs >= 1 cent, use 2-4 decimals
     return `$${cost.toLocaleString(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 4,
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
     })}`;
   }
-  // For small costs, show up to maxDecimals
-  return `$${cost.toFixed(maxDecimals)}`;
+  return `$${cost.toFixed(decimals)}`;
 }
 
 /**

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -65,6 +65,7 @@ import {
   Timer,
   CheckCircle,
   XCircle,
+  Gauge,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useNavigate } from 'react-router-dom';
@@ -167,6 +168,13 @@ export const Logs = () => {
   // progressTick is incremented to trigger re-renders when progress data changes.
   // The value itself is intentionally unused; only the setter is called.
   const [, setProgressTick] = useState(0);
+  // liveTick triggers re-renders every 100ms so pending-request durations update live.
+  const [, setLiveTick] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => setLiveTick((t) => t + 1), 100);
+    return () => clearInterval(interval);
+  }, []);
 
   const loadLogs = async () => {
     setLoading(true);
@@ -645,31 +653,45 @@ export const Logs = () => {
                                 log.responseStatus === 'pending'
                                   ? progressMapRef.current.get(log.requestId)
                                   : undefined;
+                              const liveDuration = formatMs(
+                                log.durationMs != null ? log.durationMs : Date.now() - log.startTime
+                              );
                               if (progress) {
                                 return (
                                   <div
                                     style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}
                                   >
-                                    <div
-                                      style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
+                                    <span>Duration: {liveDuration}</span>
+                                    <span
+                                      style={{
+                                        color: 'var(--color-text-secondary)',
+                                        fontSize: '0.85em',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: '4px',
+                                      }}
                                     >
                                       <CloudDownload size={11} className="text-yellow-400" />
                                       <span>{formatBytes(progress.bytesReceived)}</span>
-                                    </div>
+                                    </span>
                                     {progress.bytesPerSec != null && (
                                       <span
                                         style={{
                                           color: 'var(--color-text-secondary)',
                                           fontSize: '0.85em',
+                                          display: 'flex',
+                                          alignItems: 'center',
+                                          gap: '4px',
                                         }}
                                       >
+                                        <Gauge size={11} className="text-text-secondary" />
                                         {formatBytes(progress.bytesPerSec)}/s
                                       </span>
                                     )}
                                   </div>
                                 );
                               }
-                              return formatMs(log.durationMs);
+                              return liveDuration;
                             })()}
                           </div>
                         </div>
@@ -678,7 +700,8 @@ export const Logs = () => {
                             Meta
                           </div>
                           <div className="text-text">
-                            {log.messageCount || 0} msg / {log.toolCallsCount || 0} tools
+                            {(log.messageCount || 0) === 0 ? '-' : log.messageCount} msg /{' '}
+                            {(log.toolCallsCount || 0) === 0 ? '-' : log.toolCallsCount} tools
                           </div>
                         </div>
                       </div>
@@ -754,7 +777,7 @@ export const Logs = () => {
                   </th>
                   <th
                     className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap"
-                    style={{ minWidth: '70px' }}
+                    style={{ minWidth: '130px' }}
                   >
                     {renderSortableHeader('Cost', 'costTotal')}
                   </th>
@@ -1135,81 +1158,78 @@ export const Logs = () => {
                       </td>
                       <td className="px-2 py-1.5 border-b border-border-glass text-text align-middle">
                         {log.costTotal !== undefined && log.costTotal !== null ? (
-                          <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-                            {/* Left side: Total cost */}
-                            <div style={{ minWidth: '50px' }}>
+                          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                            {/* Row 1: Total cost */}
+                            <div>
                               {log.costSource ? (
                                 <CostToolTip
                                   source={log.costSource}
                                   costMetadata={log.costMetadata}
                                 >
                                   <span style={{ fontWeight: '500', cursor: 'help' }}>
-                                    {log.costTotal === 0 ? '∅' : formatCost(log.costTotal)}
+                                    {log.costTotal === 0 ? '-' : formatCost(log.costTotal, 6)}
                                   </span>
                                 </CostToolTip>
                               ) : (
                                 <span style={{ fontWeight: '500' }}>
-                                  {log.costTotal === 0 ? '∅' : formatCost(log.costTotal)}
+                                  {log.costTotal === 0 ? '-' : formatCost(log.costTotal, 6)}
                                 </span>
                               )}
                             </div>
-                            {/* Right side: Breakdown */}
-                            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                                <CloudUpload size={10} className="text-blue-400" />
-                                <span
-                                  style={{
-                                    color: 'var(--color-text-secondary)',
-                                    fontSize: '0.85em',
-                                    minWidth: '35px',
-                                  }}
-                                >
-                                  {log.costInput === 0 ? '∅' : formatCost(log.costInput || 0)}
-                                </span>
-                              </div>
-                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                                <CloudDownload size={10} className="text-green-400" />
-                                <span
-                                  style={{
-                                    color: 'var(--color-text-secondary)',
-                                    fontSize: '0.85em',
-                                    minWidth: '35px',
-                                  }}
-                                >
-                                  {log.costOutput === 0 ? '∅' : formatCost(log.costOutput || 0)}
-                                </span>
-                              </div>
-                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                                <PackageOpen size={10} className="text-orange-400" />
-                                <span
-                                  style={{
-                                    color: 'var(--color-text-secondary)',
-                                    fontSize: '0.85em',
-                                    minWidth: '35px',
-                                  }}
-                                >
-                                  {log.costCached === 0 ? '∅' : formatCost(log.costCached || 0)}
-                                </span>
-                              </div>
-                              <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                                <PencilLine size={10} className="text-fuchsia-400" />
-                                <span
-                                  style={{
-                                    color: 'var(--color-text-secondary)',
-                                    fontSize: '0.85em',
-                                    minWidth: '35px',
-                                  }}
-                                >
-                                  {log.costCacheWrite === 0
-                                    ? '∅'
-                                    : formatCost(log.costCacheWrite || 0)}
-                                </span>
-                              </div>
+                            {/* Separator */}
+                            <div
+                              style={{
+                                borderTop: '1px solid var(--color-border-glass)',
+                                margin: '1px 2px',
+                              }}
+                            />
+                            {/* Breakdown grid: 2 rows x 4 columns (icon, value, icon, value) */}
+                            <div
+                              style={{
+                                display: 'grid',
+                                gridTemplateColumns: 'auto 1fr auto 1fr',
+                                gap: '2px 4px',
+                                alignItems: 'center',
+                              }}
+                            >
+                              <CloudUpload size={10} className="text-blue-400" />
+                              <span
+                                style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}
+                              >
+                                {log.costInput === 0 ? '$-.----' : formatCost(log.costInput || 0)}
+                              </span>
+                              <CloudDownload size={10} className="text-green-400" />
+                              <span
+                                style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}
+                              >
+                                {log.costOutput === 0 ? '$-.----' : formatCost(log.costOutput || 0)}
+                              </span>
+                              <PackageOpen size={10} className="text-orange-400" />
+                              <span
+                                style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}
+                              >
+                                {log.costCached === 0 ? '$-.----' : formatCost(log.costCached || 0)}
+                              </span>
+                              <PencilLine size={10} className="text-fuchsia-400" />
+                              <span
+                                style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}
+                              >
+                                {log.costCacheWrite === 0
+                                  ? '$-.----'
+                                  : formatCost(log.costCacheWrite || 0)}
+                              </span>
                             </div>
                           </div>
                         ) : (
-                          <span style={{ color: 'var(--color-text-secondary)', fontSize: '1.2em' }}>
-                            ∅
+                          <span
+                            style={{
+                              color: 'var(--color-text-secondary)',
+                              fontSize: '1.2em',
+                              display: 'block',
+                              textAlign: 'center',
+                            }}
+                          >
+                            -
                           </span>
                         )}
                       </td>
@@ -1219,22 +1239,36 @@ export const Logs = () => {
                             log.responseStatus === 'pending'
                               ? progressMapRef.current.get(log.requestId)
                               : undefined;
+                          const liveDuration = formatMs(
+                            log.durationMs != null ? log.durationMs : Date.now() - log.startTime
+                          );
                           if (progress) {
                             return (
-                              <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                                <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                                <span>Duration: {liveDuration}</span>
+                                <span
+                                  style={{
+                                    color: 'var(--color-text-secondary)',
+                                    fontSize: '0.85em',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: '4px',
+                                  }}
+                                >
                                   <CloudDownload size={12} className="text-yellow-400" />
-                                  <span style={{ fontSize: '0.9em' }}>
-                                    {formatBytes(progress.bytesReceived)}
-                                  </span>
-                                </div>
+                                  <span>{formatBytes(progress.bytesReceived)}</span>
+                                </span>
                                 {progress.bytesPerSec != null && (
                                   <span
                                     style={{
                                       color: 'var(--color-text-secondary)',
                                       fontSize: '0.85em',
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      gap: '4px',
                                     }}
                                   >
+                                    <Gauge size={12} className="text-text-secondary" />
                                     {formatBytes(progress.bytesPerSec)}/s
                                   </span>
                                 )}
@@ -1243,7 +1277,7 @@ export const Logs = () => {
                           }
                           return (
                             <div style={{ display: 'flex', flexDirection: 'column' }}>
-                              <span>Duration: {formatMs(log.durationMs)}</span>
+                              <span>Duration: {liveDuration}</span>
                               <span
                                 style={{
                                   color: 'var(--color-text-secondary)',
@@ -1292,7 +1326,7 @@ export const Logs = () => {
                               <span
                                 style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '20px' }}
                               >
-                                {log.messageCount || 0}
+                                {(log.messageCount || 0) === 0 ? '-' : log.messageCount}
                               </span>
                             </div>
                             <div
@@ -1307,7 +1341,7 @@ export const Logs = () => {
                                   minWidth: '20px',
                                 }}
                               >
-                                {log.toolCallsCount || 0}
+                                {(log.toolCallsCount || 0) === 0 ? '-' : log.toolCallsCount}
                               </span>
                             </div>
                           </div>
@@ -1321,7 +1355,7 @@ export const Logs = () => {
                               <span
                                 style={{ fontWeight: '500', fontSize: '0.9em', minWidth: '20px' }}
                               >
-                                {log.toolsDefined || 0}
+                                {(log.toolsDefined || 0) === 0 ? '-' : log.toolsDefined}
                               </span>
                             </div>
                             <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>


### PR DESCRIPTION
## Summary

Several UX improvements to the Logs page desktop view:

### Live Duration for In-Flight Requests
- **Fix NaN duration** — newly received SSE `started` events have no `durationMs`, causing `formatMs` to render "NaNs". Now computes live elapsed time from `startTime` (`Date.now() - startTime`), updated every 100ms.
- **Consistent "Duration:" label** — duration is always shown as the top row in the Perf column, whether the request is in progress (with bytes/throughput below) or completed (with TTFT/TPS below).
- **Gauge icon** — added speedometer icon before bytes/sec rate in the progress view.

<img width="203" height="173" alt="Screenshot 2026-05-16 at 4 08 07 PM" src="https://github.com/user-attachments/assets/70f02033-dd45-4d20-ae6b-ab8768a88ee6" />


### Cost Column Redesign
- **Stacked layout** — replaced side-by-side (total | breakdown) with a compact 3-row layout: total cost on top, 2×2 breakdown grid below.
- **Separator** — subtle border between total cost and breakdown rows.
- **CSS grid alignment** — breakdown uses `grid-template-columns: auto 1fr auto 1fr` so `$` characters align across rows.
- **6-decimal total, 4-decimal breakdown** — total cost shows full precision; components are concise.
- **`$<X` prefix** — `formatCost` now shows `$<0.0001` for sub-threshold values instead of implying zero.
- **`$-.----` for null costs** — replaces `∅` with format-consistent placeholder.

<img width="355" height="177" alt="Screenshot 2026-05-16 at 4 07 48 PM" src="https://github.com/user-attachments/assets/ae0b9ef9-85eb-42b6-a772-25510bb7a786" />


### Null/Zero Display
- **Cost** — centered `-` instead of `∅` for no-data rows; `$-.----` for zero breakdown components.
- **Meta** — `-` instead of `0` for `messageCount`, `toolCallsCount`, `toolsDefined`.