### PR TITLE
fix: add multiple targets in the auto-add menu

### DIFF
--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -112,7 +112,8 @@ export const Models = () => {
         const updatedTargets = [...(prev.target_groups[0]?.targets ?? [])];
         for (const t of targets) {
           const alreadyExists = updatedTargets.some(
-            (x: any) => x.provider === t.provider && x.model === t.model
+            (x: { provider: string; model: string }) =>
+              x.provider === t.provider && x.model === t.model
           );
           if (!alreadyExists) {
             updatedTargets.push({ ...t, enabled: true });

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -109,19 +109,17 @@ export const Models = () => {
   const handleAutoAddTargets = useCallback(
     (targets: Array<{ provider: string; model: string }>) => {
       setEditingAlias((prev: Alias) => {
-        const groups = [...prev.target_groups];
-        const g0 = groups[0];
+        const updatedTargets = [...(prev.target_groups[0]?.targets ?? [])];
         for (const t of targets) {
-          const alreadyExists = g0?.targets.some(
+          const alreadyExists = updatedTargets.some(
             (x: any) => x.provider === t.provider && x.model === t.model
           );
           if (!alreadyExists) {
-            groups[0] = {
-              ...g0,
-              targets: [...(g0?.targets ?? []), { ...t, enabled: true }],
-            };
+            updatedTargets.push({ ...t, enabled: true });
           }
         }
+        const groups = [...prev.target_groups];
+        groups[0] = { ...groups[0], targets: updatedTargets };
         return { ...prev, target_groups: groups };
       });
       setIsAutoAddModalOpen(false);


### PR DESCRIPTION
# Here is what Kimi said:

Fixed! The bug was in `packages/frontend/src/pages/Models.tsx` in `handleAutoAddTargets`.

**Root cause:** In the loop, `groups[0]` was being reassigned on every iteration using `...(g0?.targets ?? [])`. But `g0` was captured once before the loop started, so each iteration overwrote the previous one with only the *current* target appended to the original array. This meant only the last selected target survived.

**Fix:** Build up the targets array progressively, then assign it once:

```tsx
const updatedTargets = [...(prev.target_groups[0]?.targets ?? [])];
for (const t of targets) {
  const alreadyExists = updatedTargets.some(...);
  if (!alreadyExists) {
    updatedTargets.push({ ...t, enabled: true });
  }
}
const groups = [...prev.target_groups];
groups[0] = { ...groups[0], targets: updatedTargets };
```

Frontend typecheck passes cleanly.

# Me

looks like a simple lambda capture by reference mistake