### PR TITLE
`primaryMeterKey` for Quota Checkeres to control what gets shown on the provider page

### DIFF
--- a/packages/backend/src/routes/management/quotas.ts
+++ b/packages/backend/src/routes/management/quotas.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { QuotaScheduler } from '../../services/quota/quota-scheduler';
 import { getConfig } from '../../config';
 import { logger } from '../../utils/logger';
-import { getCheckerDefinitions } from '../../services/quota/checker-registry';
+import { getCheckerDefinitions, getCheckerDefinition } from '../../services/quota/checker-registry';
 import {
   getLegacySnapshotStatus,
   migrateLegacySnapshots,
@@ -83,11 +83,14 @@ export async function registerQuotaRoutes(
       for (const checkerId of checkerIds) {
         try {
           const latest = await quotaScheduler.getLatestQuota(checkerId);
+          const checkerType = getCheckerType(checkerId);
+          const def = checkerType ? getCheckerDefinition(checkerType) : undefined;
           results.push({
             ...getOAuthMetadata(checkerId),
             ...(latest ?? { success: false, meters: [] }),
             checkerId,
-            checkerType: getCheckerType(checkerId),
+            checkerType,
+            primaryMeterKey: def?.primaryMeterKey,
           });
         } catch (error) {
           logger.error(`Failed to get latest quota for '${checkerId}': ${error}`);
@@ -113,11 +116,14 @@ export async function registerQuotaRoutes(
     try {
       const { checkerId } = request.params as { checkerId: string };
       const latest = await quotaScheduler.getLatestQuota(checkerId);
+      const checkerType = getCheckerType(checkerId);
+      const def = checkerType ? getCheckerDefinition(checkerType) : undefined;
       return {
         ...getOAuthMetadata(checkerId),
         ...(latest ?? { success: false, meters: [] }),
         checkerId,
-        checkerType: getCheckerType(checkerId),
+        checkerType,
+        primaryMeterKey: def?.primaryMeterKey,
       };
     } catch (error) {
       logger.error(`Failed to get quota for '${(request.params as any).checkerId}': ${error}`);

--- a/packages/backend/src/services/quota/checker-registry.ts
+++ b/packages/backend/src/services/quota/checker-registry.ts
@@ -46,6 +46,7 @@ interface AllowanceParams {
 export interface CheckerDefinition<TOptions extends z.ZodTypeAny = z.ZodTypeAny> {
   type: string;
   displayName: string;
+  primaryMeterKey?: string;
   optionsSchema: TOptions;
   check(ctx: MeterContext): Promise<Meter[]>;
 }

--- a/packages/backend/src/services/quota/checkers/neuralwatt-checker.ts
+++ b/packages/backend/src/services/quota/checkers/neuralwatt-checker.ts
@@ -32,6 +32,7 @@ interface NeuralwattQuotaResponse {
 export default defineChecker({
   type: 'neuralwatt',
   displayName: 'Neuralwatt',
+  primaryMeterKey: 'energy_quota',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'Neuralwatt API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api, Provider, OAuthSession, fetchQuotaCheckers } from '../lib/api';
-import type { QuotaCheckerInfo } from '../types/quota';
+import type { QuotaCheckerInfo, Meter } from '../types/quota';
 import { formatMeterValue } from '../components/quota/MeterValue';
 import { Badge } from '../components/ui/Badge';
 import { useToast } from '../contexts/ToastContext';
@@ -783,39 +783,56 @@ export function useProviderForm() {
       e.stopPropagation();
       navigate('/quotas');
     };
-    const balanceMeter = quota.meters.find(
-      (m) => m.kind === 'balance' && m.remaining !== undefined
-    );
-    if (balanceMeter && balanceMeter.remaining !== undefined) {
+
+    let target: Meter | undefined;
+    if (quota.primaryMeterKey) {
+      target = quota.meters.find((m) => m.key === quota.primaryMeterKey);
+    }
+    if (!target) {
+      // Find balance meter
+      target = quota.meters.find(
+        (m) => m.kind === 'balance' && m.remaining !== undefined
+      );
+    }
+    if (!target) {
+      // Find (worst) allowance meter 
+      const allowances = quota.meters.filter((m) => m.kind === 'allowance');
+      target = allowances.reduce<(typeof allowances)[0] | undefined>((worst, m) => {
+        if (!worst) return m;
+        const wu = typeof worst.utilizationPercent === 'number' ? worst.utilizationPercent : 0;
+        const mu = typeof m.utilizationPercent === 'number' ? m.utilizationPercent : 0;
+        return mu > wu ? m : worst;
+      }, undefined);
+    }
+
+    if (!target) return null;
+
+    // Display balance meter
+    if (target.remaining !== undefined) {
       return (
         <Badge
           status="neutral"
           className="[&_.connection-dot]:hidden cursor-pointer text-[10px] py-0.5 px-2 bg-bg-subtle border border-border text-text-secondary"
           onClick={handleQuotaClick}
         >
-          {formatMeterValue(balanceMeter.remaining, balanceMeter.unit)}
+          {formatMeterValue(target.remaining, target.unit)}
+        </Badge>
+      );
+    } else if (typeof target.utilizationPercent === 'number') {
+      const pct = Math.round(target.utilizationPercent);
+      const status = pct >= 90 ? 'error' : pct >= 70 ? 'warning' : 'connected';
+      return (
+        <Badge
+          status={status}
+          className="[&_.connection-dot]:hidden cursor-pointer text-[10px] py-0.5 px-2"
+          onClick={handleQuotaClick}
+        >
+          {pct}%
         </Badge>
       );
     }
-    const allowances = quota.meters.filter((m) => m.kind === 'allowance');
-    const primary = allowances.reduce<(typeof allowances)[0] | undefined>((worst, m) => {
-      if (!worst) return m;
-      const wu = typeof worst.utilizationPercent === 'number' ? worst.utilizationPercent : 0;
-      const mu = typeof m.utilizationPercent === 'number' ? m.utilizationPercent : 0;
-      return mu > wu ? m : worst;
-    }, undefined);
-    if (!primary || typeof primary.utilizationPercent !== 'number') return null;
-    const pct = Math.round(primary.utilizationPercent);
-    const status = pct >= 90 ? 'error' : pct >= 70 ? 'warning' : 'connected';
-    return (
-      <Badge
-        status={status}
-        className="[&_.connection-dot]:hidden cursor-pointer text-[10px] py-0.5 px-2"
-        onClick={handleQuotaClick}
-      >
-        {pct}%
-      </Badge>
-    );
+
+    return null;
   };
 
   const sortedProviders = [...providers].sort((a, b) => a.id.localeCompare(b.id));

--- a/packages/frontend/src/types/quota.ts
+++ b/packages/frontend/src/types/quota.ts
@@ -30,6 +30,7 @@ export interface QuotaCheckerInfo {
   meters: Meter[];
   oauthAccountId?: string;
   oauthProvider?: string;
+  primaryMeterKey?: string;
 }
 
 export interface QuotaWindow {


### PR DESCRIPTION
I noticed that when there is both a balance and allowance (eg crof, neuralwatt, apertis) then only the balance gets shown in the provider page. personally it made more sense to show the allowance for crof and neuralwatt (those get used first). I have no idea about apertis. the most flexible way that made sense to me was a primaryMeterKey attribute to control this