### PR TITLE
ci: treat github-actions bot as internal in migration check

### DIFF
--- a/.github/workflows/check-no-migrations-in-pr.yml
+++ b/.github/workflows/check-no-migrations-in-pr.yml
@@ -16,8 +16,9 @@ jobs:
         id: author-check
         run: |
           ASSOC="${{ github.event.pull_request.author_association }}"
+          SENDER="${{ github.event.pull_request.user.login }}"
           echo "association=$ASSOC" >> "$GITHUB_OUTPUT"
-          if [[ "$ASSOC" == "COLLABORATOR" || "$ASSOC" == "OWNER" || "$ASSOC" == "MEMBER" ]]; then
+          if [[ "$ASSOC" == "COLLABORATOR" || "$ASSOC" == "OWNER" || "$ASSOC" == "MEMBER" || "$SENDER" == "app/github-actions" || "$SENDER" == "github-actions[bot]" ]]; then
             echo "is_internal=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_internal=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

PRs created by the GitHub Actions bot (e.g., auto-generated migration PRs) were being hard-blocked by the `check-no-migrations-in-pr` workflow because the bot's `author_association` is not `COLLABORATOR`/`OWNER`/`MEMBER`.

See failing run: https://github.com/mcowger/plexus/actions/runs/26016764214/job/76468440209?pr=430

## Fix

Add `app/github-actions` and `github-actions[bot]` to the internal author check so those PRs get a **warning** instead of a hard error, consistent with how collaborators/owners/members are treated.