### PR TITLE
feat: model_override adapter with parameterized adapter config

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -140,6 +140,7 @@ Adapters can be set at **provider level** (applied to every model under the prov
 |---------|-------------|
 | `reasoning_content` | Renames `reasoning` / `thinking.content` → `reasoning_content` on outbound assistant messages for providers that use Fireworks/DeepSeek field naming (e.g. Fireworks DeepSeek-R1). Fixes *"Extra inputs are not permitted, field: messages[N].reasoning"* errors. |
 | `suppress_developer_role` | Rewrites the `developer` role to `system` on outbound messages for providers that do not support the newer OpenAI `developer` role. |
+| `model_override` | Conditionally rewrites the provider model name based on request payload fields. Used for providers that expose reasoning variants as separate model names rather than respecting reasoning-related fields in the request body. See [Model Override Adapter](#model-override-adapter) below. |
 
 **Example — provider-level:**
 ```json
@@ -163,6 +164,66 @@ PUT /v0/management/providers/fireworks
 ```
 
 Adapters are applied in order on outbound (preDispatch) and in reverse on inbound (postDispatch). Pass-through optimisation is automatically disabled when any adapter is active.
+
+### Model Override Adapter
+
+The `model_override` adapter conditionally rewrites the provider model name based on the values or presence of fields in the request payload. This is useful for providers that expose reasoning variants as **separate model names** (e.g. `model-name` with reasoning, `model-name-fast` without) rather than respecting reasoning-related fields in the request body.
+
+**How it works:**
+
+When the resolved provider model matches a rule's `model` field AND **any** of the rule's conditions are satisfied (OR semantics), the model name is rewritten to `rewriteTo`. Conditions use dotted paths into the request payload.
+
+**Configuration:**
+
+The `model_override` adapter is configured at **model level** only (not provider level). It accepts a `rules` array in its options:
+
+```json
+{
+  "models": {
+    "zai-org/GLM-5.1-FP8": {
+      "adapter": [
+        {
+          "name": "model_override",
+          "options": {
+            "rules": [
+              {
+                "model": "zai-org/GLM-5.1-FP8",
+                "rewriteTo": "glm-5.1-fast",
+                "conditions": [
+                  { "field": "enable_thinking", "value": false },
+                  { "field": "reasoning.enabled", "value": false },
+                  { "field": "reasoning.effort", "value": "none" },
+                  { "field": "budget_tokens", "value": 0 }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+**Rule fields:**
+
+| Field | Description |
+|-------|-------------|
+| `model` | The provider model name to match against (must match the resolved target model) |
+| `rewriteTo` | The model name to send to the provider instead |
+| `conditions` | Array of conditions; **any** match triggers the rewrite |
+
+**Condition fields:**
+
+| Field | Description |
+|-------|-------------|
+| `field` | Dotted path into the request payload (e.g. `reasoning.enabled`, `chat_template_kwargs.enable_thinking`) |
+| `value` | Value to match (strict equality). If omitted, the condition matches when the field is present (any value) |
+
+**Notes:**
+- The adapter operates on the **transformed provider payload**, so fields must survive API transformation to be matchable. For chat-to-chat requests, all fields from the original request body are preserved (including non-standard fields like `enable_thinking`, `thinking_budget`, etc.).
+- Multiple rules are evaluated in order; only the first matching rule applies.
+- The rewrite is transparent to the client — billing and usage tracking still reference the original canonical model name.
 
 ### Provider Quota Checkers
 

--- a/docs/openapi/components/schemas/ProviderConfig.yaml
+++ b/docs/openapi/components/schemas/ProviderConfig.yaml
@@ -109,11 +109,25 @@ properties:
                 - type: string
                 - type: array
                   items:
-                    type: string
+                    oneOf:
+                      - type: string
+                      - type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            type: string
+                            description: Adapter name.
+                          options:
+                            type: object
+                            additionalProperties: true
+                            description: Adapter-specific options.
               description: >
                 Adapter name(s) applied to this specific model. Appended after
-                any provider-level adapters. See the provider-level `adapter`
-                field for available values.
+                any provider-level adapters. Accepts bare strings or
+                `{ name, options }` objects for parameterized adapters
+                (e.g. `model_override` with rules). See the provider-level
+                `adapter` field for available values.
         description: >
           Map of model ID → per-model configuration. Allows per-model pricing
           overrides and access aliases.
@@ -176,12 +190,27 @@ properties:
       - type: string
       - type: array
         items:
-          type: string
+          oneOf:
+            - type: string
+            - type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  description: Adapter name.
+                options:
+                  type: object
+                  additionalProperties: true
+                  description: Adapter-specific options.
     description: >
       Adapter name(s) applied to every model under this provider.
       Adapters rewrite outbound request payloads (preDispatch) and inbound
       provider responses (postDispatch) to fix provider-specific field-name
       incompatibilities. Applied before model-level adapters.
+
+      Adapters can be specified as bare strings (backward compatible) or as
+      objects with `{ name, options }` for adapters that require configuration.
 
       Available adapters:
 
@@ -191,6 +220,13 @@ properties:
 
       - `suppress_developer_role` — Rewrites the `developer` role to `system`
         for providers that do not support the OpenAI `developer` role.
+
+      - `model_override` — Conditionally rewrites the provider model name
+        based on request payload fields. Accepts a `rules` array in options
+        where each rule specifies a `model` to match, a `rewriteTo` model name,
+        and an array of `conditions` (OR semantics) using dotted field paths.
+        Used for providers that expose reasoning variants as separate model
+        names rather than respecting reasoning-related request fields.
 
       Pass-through optimisation is automatically disabled when any adapter
       is active.

--- a/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
+++ b/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
@@ -3,10 +3,7 @@ import { resolveAdapters } from '../../services/adapter-resolver';
 import type { RouteResult } from '../../services/router';
 
 // Minimal RouteResult factory
-function makeRoute(
-  providerAdapter?: string | string[],
-  modelAdapter?: string | string[]
-): RouteResult {
+function makeRoute(providerAdapter?: any[], modelAdapter?: any[]): RouteResult {
   return {
     provider: 'test-provider',
     model: 'test-model',
@@ -29,48 +26,86 @@ describe('resolveAdapters', () => {
     expect(resolveAdapters(route)).toHaveLength(0);
   });
 
-  it('resolves a provider-level string adapter', () => {
-    const route = makeRoute('reasoning_content');
-    const adapters = resolveAdapters(route);
-    expect(adapters).toHaveLength(1);
-    expect(adapters[0]!.name).toBe('reasoning_content');
+  it('resolves a provider-level adapter entry', () => {
+    const route = makeRoute([{ name: 'reasoning_content', options: {} }]);
+    const resolved = resolveAdapters(route);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.adapter.name).toBe('reasoning_content');
+    expect(resolved[0]!.options).toEqual({});
   });
 
-  it('resolves a provider-level array adapter', () => {
-    const route = makeRoute(['reasoning_content', 'suppress_developer_role']);
-    const adapters = resolveAdapters(route);
-    expect(adapters.map((a) => a.name)).toEqual(['reasoning_content', 'suppress_developer_role']);
-  });
-
-  it('resolves a model-level string adapter', () => {
-    const route = makeRoute(undefined, 'suppress_developer_role');
-    const adapters = resolveAdapters(route);
-    expect(adapters).toHaveLength(1);
-    expect(adapters[0]!.name).toBe('suppress_developer_role');
+  it('resolves a model-level adapter entry', () => {
+    const route = makeRoute(undefined, [{ name: 'suppress_developer_role', options: {} }]);
+    const resolved = resolveAdapters(route);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.adapter.name).toBe('suppress_developer_role');
+    expect(resolved[0]!.options).toEqual({});
   });
 
   it('merges provider-level then model-level adapters in order', () => {
-    const route = makeRoute('reasoning_content', 'suppress_developer_role');
-    const adapters = resolveAdapters(route);
-    expect(adapters.map((a) => a.name)).toEqual(['reasoning_content', 'suppress_developer_role']);
+    const route = makeRoute(
+      [{ name: 'reasoning_content', options: {} }],
+      [{ name: 'suppress_developer_role', options: {} }]
+    );
+    const resolved = resolveAdapters(route);
+    expect(resolved.map((r) => r.adapter.name)).toEqual([
+      'reasoning_content',
+      'suppress_developer_role',
+    ]);
+  });
+
+  it('passes options through from config', () => {
+    const rules = [
+      {
+        model: 'deepseek-r1',
+        rewriteTo: 'deepseek-r1-fast',
+        conditions: [{ field: 'reasoning.enabled', value: false }],
+      },
+    ];
+    const route = makeRoute([{ name: 'model_override', options: { rules } }]);
+    const resolved = resolveAdapters(route);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.adapter.name).toBe('model_override');
+    expect(resolved[0]!.options).toEqual({ rules });
   });
 
   it('skips and warns on unknown adapter names (does not throw)', () => {
-    const route = makeRoute('nonexistent_adapter');
-    // Should not throw; unknown names are skipped
-    const adapters = resolveAdapters(route);
-    expect(adapters).toHaveLength(0);
+    const route = makeRoute([{ name: 'nonexistent_adapter', options: {} }]);
+    const resolved = resolveAdapters(route);
+    expect(resolved).toHaveLength(0);
   });
 
   it('handles mixed valid and invalid adapter names', () => {
-    const route = makeRoute(['reasoning_content', 'bogus'], 'suppress_developer_role');
-    const adapters = resolveAdapters(route);
-    expect(adapters.map((a) => a.name)).toEqual(['reasoning_content', 'suppress_developer_role']);
+    const route = makeRoute(
+      [
+        { name: 'reasoning_content', options: {} },
+        { name: 'bogus', options: {} },
+      ],
+      [{ name: 'suppress_developer_role', options: {} }]
+    );
+    const resolved = resolveAdapters(route);
+    expect(resolved.map((r) => r.adapter.name)).toEqual([
+      'reasoning_content',
+      'suppress_developer_role',
+    ]);
   });
 
-  it('handles model-level array adapters', () => {
-    const route = makeRoute(undefined, ['reasoning_content', 'suppress_developer_role']);
-    const adapters = resolveAdapters(route);
-    expect(adapters.map((a) => a.name)).toEqual(['reasoning_content', 'suppress_developer_role']);
+  it('handles multiple provider-level adapter entries', () => {
+    const route = makeRoute([
+      { name: 'reasoning_content', options: {} },
+      { name: 'suppress_developer_role', options: {} },
+    ]);
+    const resolved = resolveAdapters(route);
+    expect(resolved.map((r) => r.adapter.name)).toEqual([
+      'reasoning_content',
+      'suppress_developer_role',
+    ]);
+  });
+
+  it('resolves model_override adapter', () => {
+    const route = makeRoute([{ name: 'model_override', options: { rules: [] } }]);
+    const resolved = resolveAdapters(route);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]!.adapter.name).toBe('model_override');
   });
 });

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -61,7 +61,61 @@ const PricingSchema = z.discriminatedUnion('source', [
   }),
 ]);
 
-const AdapterConfigSchema = z.union([z.string(), z.array(z.string())]).optional();
+// ─── Adapter Config ─────────────────────────────────────────────────
+// Adapters are configured as an array of { name, options } entries.
+// Legacy bare-string forms are normalized at read time in config-repository.
+
+const ModelOverrideConditionSchema = z.object({
+  /** JSON dotted path into the payload (e.g. "reasoning.enabled", "reasoning.effort"). */
+  field: z.string().min(1),
+  /** If omitted, matches when the field is present (any value). If set, matches when value equals this. */
+  value: z.any().optional(),
+});
+
+const ModelOverrideRuleSchema = z.object({
+  /** The model name in the payload to match against (e.g. "deepseek-r1"). */
+  model: z.string().min(1),
+  /** The model name to rewrite to when conditions match (e.g. "deepseek-r1-fast"). */
+  rewriteTo: z.string().min(1),
+  /** Conditions — ANY match triggers the rewrite (OR semantics). */
+  conditions: z.array(ModelOverrideConditionSchema).min(1),
+});
+
+const ModelOverrideOptionsSchema = z.object({
+  rules: z.array(ModelOverrideRuleSchema).min(1),
+});
+
+const AdapterEntrySchema = z.object({
+  name: z.string().min(1),
+  options: z.record(z.string(), z.any()).default({}),
+});
+
+/**
+ * Accepts both the legacy format (string | string[]) and the new
+ * uniform format ({ name, options }[]) and normalizes everything
+ * to AdapterEntry[]. This ensures backward compatibility with
+ * existing YAML configs while enforcing the canonical shape at
+ * validation time.
+ */
+const AdapterConfigSchema = z.preprocess((val) => {
+  if (val === undefined || val === null) return undefined;
+  // Already an array (or single entry) — normalize each element
+  const arr = Array.isArray(val) ? val : [val];
+  return arr.map((entry: any) => {
+    if (typeof entry === 'string') {
+      return { name: entry, options: {} };
+    }
+    if (entry && typeof entry === 'object' && 'name' in entry) {
+      return { name: entry.name, options: entry.options ?? {} };
+    }
+    return entry; // Let Zod produce a clear validation error
+  });
+}, z.array(AdapterEntrySchema).optional());
+
+export type ModelOverrideCondition = z.infer<typeof ModelOverrideConditionSchema>;
+export type ModelOverrideRule = z.infer<typeof ModelOverrideRuleSchema>;
+export type ModelOverrideOptions = z.infer<typeof ModelOverrideOptionsSchema>;
+export type AdapterEntry = z.infer<typeof AdapterEntrySchema>;
 
 const ModelProviderConfigSchema = z.object({
   pricing: PricingSchema.default({

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -51,6 +51,43 @@ function toJson(value: unknown): string | unknown {
 }
 
 /**
+ * Normalize adapter entries from DB storage to the canonical { name, options } form.
+ *
+ * Legacy rows stored adapter entries as bare strings (e.g. ["reasoning_content"]).
+ * This function converts them to the uniform object form:
+ * [{ name: "reasoning_content", options: {} }]
+ *
+ * Rows are self-healing: on next save through the API, the normalized form
+ * is persisted back to the DB.
+ */
+function normalizeAdapterEntries(
+  raw: unknown
+): Array<{ name: string; options: Record<string, any> }> | null {
+  if (raw === null || raw === undefined) return null;
+  const arr = Array.isArray(raw) ? raw : [raw];
+  if (arr.length === 0) return null;
+
+  return arr
+    .map((entry) => {
+      if (typeof entry === 'string') {
+        // Legacy bare-string form
+        return { name: entry, options: {} };
+      }
+      if (entry && typeof entry === 'object' && 'name' in entry) {
+        // Already in object form
+        return {
+          name: (entry as any).name,
+          options: (entry as any).options ?? {},
+        };
+      }
+      // Malformed entry — skip with a warning (don't crash)
+      logger.warn(`Skipping malformed adapter entry: ${JSON.stringify(entry)}`);
+      return null;
+    })
+    .filter((e): e is { name: string; options: Record<string, any> } => e !== null);
+}
+
+/**
  * Encrypt a JSON value for storage in a TEXT column.
  * JSON-serializes the value, then encrypts the resulting string.
  * If encryption is disabled, returns the JSON string as-is.
@@ -311,8 +348,8 @@ export class ConfigRepository {
       gpuFlopsTflop: config.gpu_flops_tflop ?? null,
       gpuPowerDrawWatts: config.gpu_power_draw_watts ?? null,
       adapter:
-        config.adapter && (Array.isArray(config.adapter) ? config.adapter.length > 0 : true)
-          ? toJson(Array.isArray(config.adapter) ? config.adapter : [config.adapter])
+        config.adapter && Array.isArray(config.adapter) && config.adapter.length > 0
+          ? toJson(config.adapter)
           : null,
       timeoutMs: config.timeoutMs ?? null,
       maxConcurrency: config.maxConcurrency ?? null,
@@ -375,8 +412,8 @@ export class ConfigRepository {
           accessVia: cfg.access_via ? toJson(cfg.access_via) : null,
           extraBody: cfg.extraBody ? toJson(cfg.extraBody) : null,
           adapter:
-            cfg.adapter && (Array.isArray(cfg.adapter) ? cfg.adapter.length > 0 : true)
-              ? toJson(Array.isArray(cfg.adapter) ? cfg.adapter : [cfg.adapter])
+            cfg.adapter && Array.isArray(cfg.adapter) && cfg.adapter.length > 0
+              ? toJson(cfg.adapter)
               : null,
           maxConcurrency: cfg.maxConcurrency ?? null,
           sortOrder: idx,
@@ -450,7 +487,7 @@ export class ConfigRepository {
             ...(m.modelType ? { type: m.modelType } : {}),
             ...(m.accessVia ? { access_via: parseJson(m.accessVia) } : {}),
             ...(m.extraBody ? { extraBody: parseJson(m.extraBody) } : {}),
-            ...(m.adapter ? { adapter: parseJson(m.adapter) } : {}),
+            ...(m.adapter ? { adapter: normalizeAdapterEntries(parseJson(m.adapter)) } : {}),
             ...(m.maxConcurrency != null ? { maxConcurrency: m.maxConcurrency } : {}),
           };
         }
@@ -495,8 +532,9 @@ export class ConfigRepository {
       })(),
       ...(quota_checker ? { quota_checker } : {}),
       ...(() => {
-        const adapterVal = parseJson<string[]>(row.adapter);
-        return Array.isArray(adapterVal) && adapterVal.length > 0 ? { adapter: adapterVal } : {};
+        const adapterVal = parseJson(row.adapter);
+        const normalized = normalizeAdapterEntries(adapterVal);
+        return normalized && normalized.length > 0 ? { adapter: normalized } : {};
       })(),
       // GPU Profile settings — resolve named profiles to concrete values for
       // backward compatibility with existing DB rows that may only have gpuProfile

--- a/packages/backend/src/services/adapter-resolver.ts
+++ b/packages/backend/src/services/adapter-resolver.ts
@@ -1,5 +1,6 @@
-import type { ProviderAdapter } from '../types/provider-adapter';
+import type { ProviderAdapter, ResolvedAdapter } from '../types/provider-adapter';
 import type { RouteResult } from './router';
+import type { AdapterEntry } from '../config';
 import { ADAPTER_REGISTRY } from '../transformers/adapters';
 import { logger } from '../utils/logger';
 
@@ -10,40 +11,32 @@ import { logger } from '../utils/logger';
  *   1. Provider-level `adapter` (applies to all models under the provider)
  *   2. Model-level `adapter`   (appended after provider-level adapters)
  *
- * Both fields accept either a single string or an array of strings.
- * Unknown adapter names are logged as warnings and skipped (rather than
- * throwing) so that a misconfigured adapter doesn't take down the whole route.
+ * Each entry is an { name, options } object. Unknown adapter names are logged
+ * as warnings and skipped (rather than throwing) so that a misconfigured
+ * adapter doesn't take down the whole route.
  *
  * Returns an empty array when no adapters are configured — zero-cost path.
  */
-export function resolveAdapters(route: RouteResult): ProviderAdapter[] {
-  const names: string[] = [
-    ...normalizeAdapterField(route.config.adapter),
-    ...normalizeAdapterField(route.modelConfig?.adapter),
+export function resolveAdapters(route: RouteResult): ResolvedAdapter[] {
+  const entries: AdapterEntry[] = [
+    ...(route.config.adapter ?? []),
+    ...(route.modelConfig?.adapter ?? []),
   ];
 
-  if (names.length === 0) return [];
+  if (entries.length === 0) return [];
 
-  const adapters: ProviderAdapter[] = [];
-  for (const name of names) {
-    const adapter = ADAPTER_REGISTRY[name];
+  const resolved: ResolvedAdapter[] = [];
+  for (const entry of entries) {
+    const adapter = ADAPTER_REGISTRY[entry.name];
     if (!adapter) {
       logger.warn(
-        `Unknown adapter '${name}' configured for provider '${route.provider}' ` +
+        `Unknown adapter '${entry.name}' configured for provider '${route.provider}' ` +
           `model '${route.model}' — skipping`
       );
       continue;
     }
-    adapters.push(adapter);
+    resolved.push({ adapter, options: entry.options });
   }
 
-  return adapters;
-}
-
-/**
- * Coerce the adapter config field (string | string[] | undefined) to string[].
- */
-function normalizeAdapterField(field: string | string[] | undefined): string[] {
-  if (!field) return [];
-  return Array.isArray(field) ? field : [field];
+  return resolved;
 }

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -24,7 +24,7 @@ import { CooldownParserRegistry } from './cooldown-parsers';
 import { getConfig, getProviderTypes } from '../config';
 import { applyModelBehaviors } from './model-behaviors';
 import { resolveAdapters } from './adapter-resolver';
-import type { ProviderAdapter } from '../types/provider-adapter';
+import type { ResolvedAdapter } from '../types/provider-adapter';
 import { getModels } from '@earendil-works/pi-ai';
 import type { StallConfig } from './inspectors/stall-inspector';
 import { VisionDescriptorService } from './vision-descriptor-service';
@@ -2325,7 +2325,7 @@ export class Dispatcher {
     route: RouteResult,
     transformer: any,
     targetApiType: string,
-    adapters: ProviderAdapter[] = []
+    adapters: ResolvedAdapter[] = []
   ): Promise<{ payload: any; bypassTransformation: boolean }> {
     let providerPayload: any;
     let bypassTransformation = false;
@@ -2399,13 +2399,13 @@ export class Dispatcher {
     }
 
     // Apply provider/model adapters (preDispatch) in configured order
-    for (const adapter of adapters) {
-      providerPayload = adapter.preDispatch(providerPayload);
+    for (const { adapter, options } of adapters) {
+      providerPayload = adapter.preDispatch(providerPayload, options);
     }
 
     if (adapters.length > 0) {
       logger.debug(
-        `Adapters applied (preDispatch): [${adapters.map((a) => a.name).join(', ')}] ` +
+        `Adapters applied (preDispatch): [${adapters.map((a) => a.adapter.name).join(', ')}] ` +
           `for ${route.provider}/${route.model}`
       );
     }
@@ -2634,7 +2634,7 @@ export class Dispatcher {
     route: RouteResult,
     targetApiType: string,
     bypassTransformation: boolean,
-    adapters: ProviderAdapter[] = []
+    adapters: ResolvedAdapter[] = []
   ): UnifiedChatResponse {
     logger.debug('Streaming response detected');
 
@@ -2642,11 +2642,11 @@ export class Dispatcher {
 
     // If any adapter defines preDispatchStreamChunk, pipe the raw SSE stream
     // through a rewrite transform before it reaches transformStream().
-    const streamAdapters = adapters.filter((a) => a.preDispatchStreamChunk);
+    const streamAdapters = adapters.filter((a) => a.adapter.preDispatchStreamChunk);
     if (streamAdapters.length > 0) {
       rawStream = rawStream.pipeThrough(this.buildSseRewriteTransform(streamAdapters));
       logger.debug(
-        `Stream adapters applied (preDispatchStreamChunk): [${streamAdapters.map((a) => a.name).join(', ')}] ` +
+        `Stream adapters applied (preDispatchStreamChunk): [${streamAdapters.map((a) => a.adapter.name).join(', ')}] ` +
           `for ${route.provider}/${route.model}`
       );
     }
@@ -2670,7 +2670,7 @@ export class Dispatcher {
    * Handles chunked delivery — lines may arrive split across multiple chunks.
    */
   private buildSseRewriteTransform(
-    adapters: ProviderAdapter[]
+    adapters: ResolvedAdapter[]
   ): TransformStream<Uint8Array, Uint8Array> {
     const encoder = new TextEncoder();
     const decoder = new TextDecoder();
@@ -2684,8 +2684,8 @@ export class Dispatcher {
         buffer = lines.pop() ?? '';
         for (const line of lines) {
           let rewritten = line;
-          for (const adapter of adapters) {
-            rewritten = adapter.preDispatchStreamChunk!(rewritten);
+          for (const { adapter, options } of adapters) {
+            rewritten = adapter.preDispatchStreamChunk!(rewritten, options);
           }
           controller.enqueue(encoder.encode(rewritten + '\n'));
         }
@@ -2693,8 +2693,8 @@ export class Dispatcher {
       flush(controller) {
         if (buffer.length > 0) {
           let rewritten = buffer;
-          for (const adapter of adapters) {
-            rewritten = adapter.preDispatchStreamChunk!(rewritten);
+          for (const { adapter, options } of adapters) {
+            rewritten = adapter.preDispatchStreamChunk!(rewritten, options);
           }
           controller.enqueue(encoder.encode(rewritten));
         }
@@ -2712,7 +2712,7 @@ export class Dispatcher {
     targetApiType: string,
     transformer: any,
     bypassTransformation: boolean,
-    adapters: ProviderAdapter[] = []
+    adapters: ResolvedAdapter[] = []
   ): Promise<UnifiedChatResponse> {
     let responseBody = await this.parseJsonResponseBody(
       response,
@@ -2725,12 +2725,12 @@ export class Dispatcher {
     // Apply provider/model adapters (postDispatch) in reverse order
     if (adapters.length > 0) {
       for (let i = adapters.length - 1; i >= 0; i--) {
-        responseBody = adapters[i]!.postDispatch(responseBody);
+        responseBody = adapters[i]!.adapter.postDispatch(responseBody, adapters[i]!.options);
       }
       logger.debug(
         `Adapters applied (postDispatch): [${[...adapters]
           .reverse()
-          .map((a) => a.name)
+          .map((a) => a.adapter.name)
           .join(', ')}] ` + `for ${route.provider}/${route.model}`
       );
     }

--- a/packages/backend/src/transformers/adapters/__tests__/model-override.adapter.test.ts
+++ b/packages/backend/src/transformers/adapters/__tests__/model-override.adapter.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest';
+import { modelOverrideAdapter, resolveDottedPath } from '../model-override.adapter';
+
+// ── resolveDottedPath ────────────────────────────────────────────────────
+
+describe('resolveDottedPath', () => {
+  it('resolves a top-level field', () => {
+    expect(resolveDottedPath({ model: 'x' }, 'model')).toBe('x');
+  });
+
+  it('resolves a nested field', () => {
+    expect(resolveDottedPath({ reasoning: { enabled: false } }, 'reasoning.enabled')).toBe(false);
+  });
+
+  it('resolves deeply nested field', () => {
+    expect(resolveDottedPath({ a: { b: { c: 42 } } }, 'a.b.c')).toBe(42);
+  });
+
+  it('returns undefined for missing path', () => {
+    expect(resolveDottedPath({ foo: 1 }, 'bar')).toBeUndefined();
+  });
+
+  it('returns undefined for partially missing path', () => {
+    expect(resolveDottedPath({ a: {} }, 'a.b.c')).toBeUndefined();
+  });
+
+  it('returns undefined when traversing through null', () => {
+    expect(resolveDottedPath({ a: null }, 'a.b')).toBeUndefined();
+  });
+
+  it('returns undefined when traversing through primitive', () => {
+    expect(resolveDottedPath({ a: 5 }, 'a.b')).toBeUndefined();
+  });
+});
+
+// ── preDispatch ──────────────────────────────────────────────────────────
+
+describe('model_override adapter', () => {
+  describe('preDispatch', () => {
+    it('returns payload unchanged when no options provided', () => {
+      const payload = { model: 'deepseek-r1', messages: [] };
+      expect(modelOverrideAdapter.preDispatch(payload)).toBe(payload);
+    });
+
+    it('returns payload unchanged when options has no rules', () => {
+      const payload = { model: 'deepseek-r1', messages: [] };
+      expect(modelOverrideAdapter.preDispatch(payload, {})).toBe(payload);
+    });
+
+    it('returns payload unchanged when rules is empty array', () => {
+      const payload = { model: 'deepseek-r1', messages: [] };
+      expect(modelOverrideAdapter.preDispatch(payload, { rules: [] })).toBe(payload);
+    });
+
+    it('returns payload unchanged when no rule matches the model', () => {
+      const payload = { model: 'other-model', messages: [] };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [{ field: 'reasoning.enabled', value: false }],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('other-model');
+    });
+
+    it('rewrites model when condition with value matches', () => {
+      const payload = { model: 'deepseek-r1', reasoning: { enabled: false }, messages: [] };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [{ field: 'reasoning.enabled', value: false }],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1-fast');
+    });
+
+    it('rewrites model when condition with presence check matches (field exists)', () => {
+      const payload = { model: 'deepseek-r1', reasoning: {}, messages: [] };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [{ field: 'reasoning' }], // no value = presence check
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1-fast');
+    });
+
+    it('does not rewrite when presence check fails (field absent)', () => {
+      const payload = { model: 'deepseek-r1', messages: [] };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [{ field: 'reasoning' }], // no value = presence check
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1');
+    });
+
+    it('does not rewrite when value check fails', () => {
+      const payload = { model: 'deepseek-r1', reasoning: { enabled: true }, messages: [] };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [{ field: 'reasoning.enabled', value: false }],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1');
+    });
+
+    it('rewrites when ANY condition matches (OR semantics)', () => {
+      const payload = {
+        model: 'deepseek-r1',
+        reasoning: { enabled: true, effort: 'none' },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [
+              { field: 'reasoning.enabled', value: false }, // doesn't match
+              { field: 'reasoning.effort', value: 'none' }, // matches
+            ],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1-fast');
+    });
+
+    it('does not rewrite when NO condition matches (OR semantics, all fail)', () => {
+      const payload = {
+        model: 'deepseek-r1',
+        reasoning: { enabled: true, effort: 'high' },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [
+              { field: 'reasoning.enabled', value: false }, // doesn't match
+              { field: 'reasoning.effort', value: 'none' }, // doesn't match
+            ],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1');
+    });
+
+    it('supports multiple rules — only the first matching rule applies', () => {
+      const payload = {
+        model: 'deepseek-r1',
+        reasoning: { enabled: false },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [{ field: 'reasoning.enabled', value: false }],
+          },
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-mini',
+            conditions: [{ field: 'reasoning.enabled', value: false }],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1-fast');
+    });
+
+    it('supports reverse rule (fast → full when reasoning enabled)', () => {
+      const payload = {
+        model: 'deepseek-r1-fast',
+        reasoning: { enabled: true },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1-fast',
+            rewriteTo: 'deepseek-r1',
+            conditions: [{ field: 'reasoning.enabled', value: true }],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1');
+    });
+
+    it('preserves all other payload fields', () => {
+      const payload = {
+        model: 'deepseek-r1',
+        reasoning: { enabled: false },
+        messages: [{ role: 'user', content: 'hello' }],
+        temperature: 0.7,
+        stream: true,
+      };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [{ field: 'reasoning.enabled', value: false }],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1-fast');
+      expect(result.messages).toEqual([{ role: 'user', content: 'hello' }]);
+      expect(result.temperature).toBe(0.7);
+      expect(result.stream).toBe(true);
+    });
+
+    it('matches value using strict equality', () => {
+      // String "false" should not match boolean false
+      const payload = {
+        model: 'deepseek-r1',
+        reasoning: { enabled: 'false' },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            model: 'deepseek-r1',
+            rewriteTo: 'deepseek-r1-fast',
+            conditions: [{ field: 'reasoning.enabled', value: false }],
+          },
+        ],
+      };
+      const result = modelOverrideAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('deepseek-r1'); // no rewrite — strict equality
+    });
+  });
+
+  describe('postDispatch', () => {
+    it('returns response unchanged', () => {
+      const response = { id: 'resp-1', model: 'deepseek-r1-fast' };
+      expect(modelOverrideAdapter.postDispatch(response)).toBe(response);
+    });
+
+    it('returns response unchanged even with options', () => {
+      const response = { id: 'resp-1', model: 'deepseek-r1-fast' };
+      expect(modelOverrideAdapter.postDispatch(response, { rules: [] })).toBe(response);
+    });
+  });
+});

--- a/packages/backend/src/transformers/adapters/index.ts
+++ b/packages/backend/src/transformers/adapters/index.ts
@@ -1,12 +1,14 @@
 import type { ProviderAdapter } from '../../types/provider-adapter';
 import { reasoningContentAdapter } from './reasoning-content.adapter';
 import { suppressDeveloperRoleAdapter } from './suppress-developer-role.adapter';
+import { modelOverrideAdapter } from './model-override.adapter';
 
 /**
  * Registry of all built-in provider adapters.
- * Keys must match the strings used in provider/model config `adapter` fields.
+ * Keys must match the name field used in provider/model config `adapter` entries.
  */
 export const ADAPTER_REGISTRY: Record<string, ProviderAdapter> = {
   [reasoningContentAdapter.name]: reasoningContentAdapter,
   [suppressDeveloperRoleAdapter.name]: suppressDeveloperRoleAdapter,
+  [modelOverrideAdapter.name]: modelOverrideAdapter,
 };

--- a/packages/backend/src/transformers/adapters/model-override.adapter.ts
+++ b/packages/backend/src/transformers/adapters/model-override.adapter.ts
@@ -1,0 +1,114 @@
+import type { ProviderAdapter } from '../../types/provider-adapter';
+import type { ModelOverrideOptions } from '../../config';
+import { logger } from '../../utils/logger';
+
+/**
+ * model_override adapter
+ *
+ * Conditionally rewrites `payload.model` based on the presence or values of
+ * arbitrary fields in the outgoing request payload.
+ *
+ * This enables providers that expose reasoning variants as separate model
+ * names (e.g. `deepseek-r1` with reasoning, `deepseek-r1-fast` without) to
+ * be routed correctly even though the upstream client sets a `reasoning`
+ * field rather than picking the variant model.
+ *
+ * Options schema (ModelOverrideOptions):
+ *   rules: [
+ *     {
+ *       model: "deepseek-r1",            // match payload.model
+ *       rewriteTo: "deepseek-r1-fast",  // rewrite to this model
+ *       conditions: [                    // ANY match triggers rewrite (OR)
+ *         { field: "reasoning.enabled", value: false },
+ *         { field: "reasoning.effort", value: "none" },
+ *       ]
+ *     },
+ *     {
+ *       model: "deepseek-r1-fast",
+ *       rewriteTo: "deepseek-r1",
+ *       conditions: [
+ *         { field: "reasoning.enabled", value: true },
+ *       ]
+ *     },
+ *   ]
+ *
+ * Outbound (preDispatch):
+ *   - If payload.model matches a rule's `model` field AND any condition is satisfied,
+ *     payload.model is rewritten to `rewriteTo`.
+ *
+ * Inbound (postDispatch): no-op — model name in responses is not rewritten.
+ *
+ * Stream: no-op — providers do not typically echo model names in SSE chunks.
+ */
+export const modelOverrideAdapter: ProviderAdapter = {
+  name: 'model_override',
+
+  preDispatch(payload: Record<string, any>, options?: Record<string, any>): Record<string, any> {
+    if (!options || !options.rules || !Array.isArray(options.rules)) return payload;
+
+    const rules = options.rules as ModelOverrideOptions['rules'];
+
+    for (const rule of rules) {
+      if (payload.model !== rule.model) continue;
+
+      // Check conditions — any match (OR) triggers the rewrite
+      const matched = rule.conditions.some((condition) => evaluateCondition(payload, condition));
+
+      if (matched) {
+        logger.debug(
+          `model_override: rewriting model '${payload.model}' → '${rule.rewriteTo}' ` +
+            `(rule matched on ${rule.model})`
+        );
+        return { ...payload, model: rule.rewriteTo };
+      }
+    }
+
+    return payload;
+  },
+
+  postDispatch(response: Record<string, any>, _options?: Record<string, any>): Record<string, any> {
+    return response;
+  },
+};
+
+/**
+ * Evaluate a single condition against a payload.
+ *
+ * - If `condition.value` is provided: matches when the field at the dotted path
+ *   equals that value (strict equality).
+ * - If `condition.value` is omitted: matches when the field at the dotted path
+ *   is present (not undefined).
+ */
+function evaluateCondition(
+  payload: Record<string, any>,
+  condition: { field: string; value?: any }
+): boolean {
+  const actual = resolveDottedPath(payload, condition.field);
+
+  if (condition.value !== undefined) {
+    // Value match — strict equality
+    return actual === condition.value;
+  }
+
+  // Presence check — field must exist (not undefined)
+  return actual !== undefined;
+}
+
+/**
+ * Resolve a dotted path (e.g. "reasoning.enabled") into the corresponding
+ * value in a nested object. Returns `undefined` if the path cannot be fully
+ * resolved.
+ */
+export function resolveDottedPath(obj: Record<string, any>, path: string): any {
+  const segments = path.split('.');
+  let current: any = obj;
+
+  for (const segment of segments) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return undefined;
+    }
+    current = current[segment];
+  }
+
+  return current;
+}

--- a/packages/backend/src/transformers/adapters/reasoning-content.adapter.ts
+++ b/packages/backend/src/transformers/adapters/reasoning-content.adapter.ts
@@ -24,7 +24,7 @@ import type { ProviderAdapter } from '../../types/provider-adapter';
 export const reasoningContentAdapter: ProviderAdapter = {
   name: 'reasoning_content',
 
-  preDispatch(payload: Record<string, any>): Record<string, any> {
+  preDispatch(payload: Record<string, any>, _options?: Record<string, any>): Record<string, any> {
     if (!Array.isArray(payload.messages)) return payload;
 
     const messages = payload.messages.map((msg: any) => {
@@ -47,14 +47,14 @@ export const reasoningContentAdapter: ProviderAdapter = {
     return { ...payload, messages };
   },
 
-  postDispatch(response: Record<string, any>): Record<string, any> {
+  postDispatch(response: Record<string, any>, _options?: Record<string, any>): Record<string, any> {
     // The OpenAI transformer's transformResponse() already reads
     // `message.reasoning_content` natively, so no field rename is needed
     // on the inbound path. This is intentionally a no-op.
     return response;
   },
 
-  preDispatchStreamChunk(line: string): string {
+  preDispatchStreamChunk(line: string, _options?: Record<string, any>): string {
     // Replace `"reasoning":` with `"reasoning_content":` in the JSON payload
     // of SSE data lines so the provider receives the correct field name.
     if (!line.startsWith('data:')) return line;

--- a/packages/backend/src/transformers/adapters/suppress-developer-role.adapter.ts
+++ b/packages/backend/src/transformers/adapters/suppress-developer-role.adapter.ts
@@ -20,7 +20,7 @@ import type { ProviderAdapter } from '../../types/provider-adapter';
 export const suppressDeveloperRoleAdapter: ProviderAdapter = {
   name: 'suppress_developer_role',
 
-  preDispatch(payload: Record<string, any>): Record<string, any> {
+  preDispatch(payload: Record<string, any>, _options?: Record<string, any>): Record<string, any> {
     if (!Array.isArray(payload.messages)) return payload;
 
     const messages = payload.messages.map((msg: any) => {
@@ -31,11 +31,11 @@ export const suppressDeveloperRoleAdapter: ProviderAdapter = {
     return { ...payload, messages };
   },
 
-  postDispatch(response: Record<string, any>): Record<string, any> {
+  postDispatch(response: Record<string, any>, _options?: Record<string, any>): Record<string, any> {
     return response;
   },
 
-  preDispatchStreamChunk(line: string): string {
+  preDispatchStreamChunk(line: string, _options?: Record<string, any>): string {
     if (!line.startsWith('data:')) return line;
     return line.replace(/"role":"developer"/g, '"role":"system"');
   },

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -84,15 +84,25 @@ export class OpenAITransformer implements Transformer {
           })
         : undefined;
 
-    const out: any = {
-      model: request.model,
-      messages,
-      max_tokens: request.max_tokens,
-      temperature: request.temperature,
-      stream: request.stream,
-      tools: normalizedTools && normalizedTools.length > 0 ? normalizedTools : undefined,
-      tool_choice: request.tool_choice,
-    };
+    // When the incoming API type matches our outgoing type (chat -> chat),
+    // start from the original body to preserve unknown fields (e.g.
+    // enable_thinking, chat_template_kwargs, budget_tokens) that the
+    // explicit mapping below would otherwise drop. The explicitly-mapped
+    // fields are then overlaid on top to apply any necessary transformations.
+    // Cross-API transformations (chat -> messages, chat -> gemini) remain
+    // fully explicit since they're fundamentally different protocols.
+    const isSameApiType = request.originalBody && request.incomingApiType?.toLowerCase() === 'chat';
+
+    const out: any = isSameApiType ? { ...request.originalBody } : {};
+
+    // Override with explicitly-transformed fields
+    out.model = request.model;
+    out.messages = messages;
+    out.max_tokens = request.max_tokens;
+    out.temperature = request.temperature;
+    out.stream = request.stream;
+    out.tools = normalizedTools && normalizedTools.length > 0 ? normalizedTools : undefined;
+    out.tool_choice = request.tool_choice;
 
     if (request.response_format) {
       if (request.response_format.type === 'json_schema' && request.response_format.json_schema) {

--- a/packages/backend/src/types/provider-adapter.ts
+++ b/packages/backend/src/types/provider-adapter.ts
@@ -1,6 +1,15 @@
 import type { UnifiedChatRequest } from './unified';
 
 /**
+ * Resolved adapter paired with its per-config options.
+ * Produced by resolveAdapters() and consumed by the dispatcher.
+ */
+export interface ResolvedAdapter {
+  adapter: ProviderAdapter;
+  options?: Record<string, any>;
+}
+
+/**
  * ProviderAdapter
  *
  * A programmatic hook that rewrites request payloads outbound to a provider
@@ -11,6 +20,9 @@ import type { UnifiedChatRequest } from './unified';
  *
  * Implementing preDispatch/postDispatch is mandatory. Stream chunk hooks are
  * optional — omitting them means stream chunks pass through unmodified.
+ *
+ * The `options` parameter receives the per-entry options from config, if any.
+ * Stateless adapters can ignore it.
  */
 export interface ProviderAdapter {
   /** Unique registry key (matches config adapter name). */
@@ -21,26 +33,26 @@ export interface ProviderAdapter {
    * Called after transformRequest(), before the HTTP call.
    * Must return a (potentially new) provider payload object.
    */
-  preDispatch(payload: Record<string, any>): Record<string, any>;
+  preDispatch(payload: Record<string, any>, options?: Record<string, any>): Record<string, any>;
 
   /**
    * Rewrite the raw provider JSON response before it is passed to
    * transformResponse(). Called only for non-streaming responses.
    * Must return a (potentially new) response object.
    */
-  postDispatch(response: Record<string, any>): Record<string, any>;
+  postDispatch(response: Record<string, any>, options?: Record<string, any>): Record<string, any>;
 
   /**
    * Rewrite a raw SSE line (e.g. `data: {...}`) on its way out of the
    * provider, before transformStream() consumes it.
    * Return the line unchanged if no rewrite is needed.
    */
-  preDispatchStreamChunk?(line: string): string;
+  preDispatchStreamChunk?(line: string, options?: Record<string, any>): string;
 
   /**
    * Rewrite a raw SSE line after transformStream() / formatStream() have
    * produced it, just before it is written to the client.
    * Return the line unchanged if no rewrite is needed.
    */
-  postDispatchStreamChunk?(line: string): string;
+  postDispatchStreamChunk?(line: string, options?: Record<string, any>): string;
 }

--- a/packages/backend/test/integration/reasoning-content-adapter.test.ts
+++ b/packages/backend/test/integration/reasoning-content-adapter.test.ts
@@ -36,7 +36,7 @@ const BASE_CONFIG = {
           pricing: { source: 'simple', input: 0, output: 0 },
           access_via: ['chat'],
           // adapter configured at model level — matches the real production setup
-          adapter: ['reasoning_content'],
+          adapter: [{ name: 'reasoning_content', options: {} }],
         },
       },
     },

--- a/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
@@ -19,6 +19,12 @@ export const KNOWN_ADAPTERS: { value: string; label: string; description: string
     label: 'Suppress Developer Role',
     description: 'Rewrites the "developer" role to "system" for providers that do not support it.',
   },
+  {
+    value: 'model_override',
+    label: 'Model Override',
+    description:
+      'Conditionally rewrites the model name based on request fields (e.g. switching to a -fast variant when reasoning is disabled).',
+  },
 ];
 
 interface Props {
@@ -122,8 +128,11 @@ export function ProviderAdvancedEditor({
                   per-model.
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px' }}>
-                  {KNOWN_ADAPTERS.map((a) => {
-                    const active = (editingProvider.adapter ?? []).includes(a.value);
+                  {KNOWN_ADAPTERS.filter((a) => a.value !== 'model_override').map((a) => {
+                    const adapterEntries: any[] = editingProvider.adapter ?? [];
+                    const active = adapterEntries.some(
+                      (e: any) => (typeof e === 'string' ? e : e.name) === a.value
+                    );
                     return (
                       <label
                         key={a.value}
@@ -143,10 +152,12 @@ export function ProviderAdvancedEditor({
                           checked={active}
                           style={{ marginTop: '2px', flexShrink: 0 }}
                           onChange={() => {
-                            const current = editingProvider.adapter ?? [];
+                            const current: any[] = editingProvider.adapter ?? [];
                             const next = active
-                              ? current.filter((v) => v !== a.value)
-                              : [...current, a.value];
+                              ? current.filter(
+                                  (e: any) => (typeof e === 'string' ? e : e.name) !== a.value
+                                )
+                              : [...current, { name: a.value, options: {} }];
                             setEditingProvider({ ...editingProvider, adapter: next });
                           }}
                         />

--- a/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
@@ -903,28 +903,22 @@ export function ProviderModelsEditor({
                                           alignItems: 'center',
                                         }}
                                       >
-                                        <Input
-                                          placeholder="Match model (e.g. deepseek-r1)"
-                                          value={rule.model ?? ''}
-                                          onChange={(e: any) => {
-                                            const updated = [...rules];
-                                            updated[rIdx] = {
-                                              ...updated[rIdx],
-                                              model: e.target.value,
-                                            };
-                                            const newAdapters = modelAdapters.map((entry: any) =>
-                                              typeof entry !== 'string' &&
-                                              entry.name === 'model_override'
-                                                ? {
-                                                    ...entry,
-                                                    options: { ...entry.options, rules: updated },
-                                                  }
-                                                : entry
-                                            );
-                                            updateModelConfig(mId, { adapter: newAdapters });
+                                        <div
+                                          className="font-body text-[12px] text-text-muted"
+                                          style={{
+                                            flex: 2,
+                                            padding: '5px 8px',
+                                            background: 'var(--color-bg-glass)',
+                                            border: '1px solid var(--color-border-glass)',
+                                            borderRadius: 'var(--radius-sm)',
+                                            overflow: 'hidden',
+                                            textOverflow: 'ellipsis',
+                                            whiteSpace: 'nowrap',
                                           }}
-                                          style={{ flex: 2 }}
-                                        />
+                                          title={mId}
+                                        >
+                                          {mId}
+                                        </div>
                                         <span className="font-body text-[11px] text-text-muted">
                                           →
                                         </span>
@@ -1155,7 +1149,7 @@ export function ProviderModelsEditor({
                                     size="sm"
                                     onClick={() => {
                                       const newRule = {
-                                        model: '',
+                                        model: mId,
                                         rewriteTo: '',
                                         conditions: [{ field: '' }],
                                       };

--- a/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
@@ -889,11 +889,19 @@ export function ProviderModelsEditor({
                                         borderRadius: 'var(--radius-sm)',
                                         padding: '6px',
                                         marginBottom: '4px',
-                                        background: 'var(--color-bg-deep)',
+                                        background: 'var(--color-bg-subtle)',
                                       }}
                                     >
+                                      {/* Rewrite rule */}
+                                      <div className="font-body text-[10px] font-medium text-text-muted mb-1">
+                                        Rewrite
+                                      </div>
                                       <div
-                                        style={{ display: 'flex', gap: '4px', marginBottom: '4px' }}
+                                        style={{
+                                          display: 'flex',
+                                          gap: '4px',
+                                          alignItems: 'center',
+                                        }}
                                       >
                                         <Input
                                           placeholder="Match model (e.g. deepseek-r1)"
@@ -915,12 +923,9 @@ export function ProviderModelsEditor({
                                             );
                                             updateModelConfig(mId, { adapter: newAdapters });
                                           }}
-                                          style={{ flex: 1 }}
+                                          style={{ flex: 2 }}
                                         />
-                                        <span
-                                          className="font-body text-[11px] text-text-muted"
-                                          style={{ lineHeight: '28px' }}
-                                        >
+                                        <span className="font-body text-[11px] text-text-muted">
                                           →
                                         </span>
                                         <Input
@@ -971,6 +976,40 @@ export function ProviderModelsEditor({
                                           />
                                         </Button>
                                       </div>
+                                      {/* Conditions separator */}
+                                      <div
+                                        style={{
+                                          borderTop: '1px solid var(--color-border-glass)',
+                                          margin: '6px 0 4px 0',
+                                        }}
+                                      />
+                                      <div className="font-body text-[10px] font-medium text-text-muted mb-1">
+                                        Conditions (any match triggers rewrite)
+                                      </div>
+                                      {/* Condition column headers */}
+                                      <div
+                                        style={{
+                                          display: 'flex',
+                                          gap: '4px',
+                                          marginBottom: '2px',
+                                          marginLeft: '8px',
+                                        }}
+                                      >
+                                        <span
+                                          className="font-body text-[9px] font-medium text-text-muted"
+                                          style={{ flex: 1, paddingLeft: '8px' }}
+                                        >
+                                          Field path (dotted)
+                                        </span>
+                                        <span
+                                          className="font-body text-[9px] font-medium text-text-muted"
+                                          style={{ flex: 1, paddingLeft: '8px' }}
+                                        >
+                                          Value (blank = presence check)
+                                        </span>
+                                        {/* spacer for delete button column */}
+                                        <span style={{ width: '28px' }} />
+                                      </div>
                                       {/* Conditions */}
                                       {(rule.conditions ?? []).map((cond: any, cIdx: number) => (
                                         <div
@@ -983,7 +1022,7 @@ export function ProviderModelsEditor({
                                           }}
                                         >
                                           <Input
-                                            placeholder="Field path (e.g. reasoning.enabled)"
+                                            placeholder="e.g. reasoning.enabled"
                                             value={cond.field ?? ''}
                                             onChange={(e: any) => {
                                               const updated = [...rules];
@@ -1010,7 +1049,7 @@ export function ProviderModelsEditor({
                                             style={{ flex: 1 }}
                                           />
                                           <Input
-                                            placeholder="Value (empty = presence check)"
+                                            placeholder="e.g. false, 0, none"
                                             value={
                                               cond.value !== undefined ? String(cond.value) : ''
                                             }

--- a/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
@@ -756,7 +756,7 @@ export function ProviderModelsEditor({
                             Model Adapters
                           </span>
                           {(() => {
-                            const modelAdapters: string[] = mCfg.adapter
+                            const modelAdapters: any[] = mCfg.adapter
                               ? Array.isArray(mCfg.adapter)
                                 ? mCfg.adapter
                                 : [mCfg.adapter]
@@ -783,12 +783,14 @@ export function ProviderModelsEditor({
                             }}
                           >
                             {KNOWN_ADAPTERS.map((a) => {
-                              const modelAdapters: string[] = mCfg.adapter
+                              const modelAdapters: any[] = mCfg.adapter
                                 ? Array.isArray(mCfg.adapter)
                                   ? mCfg.adapter
                                   : [mCfg.adapter]
                                 : [];
-                              const active = modelAdapters.includes(a.value);
+                              const active = modelAdapters.some(
+                                (e: any) => (typeof e === 'string' ? e : e.name) === a.value
+                              );
                               return (
                                 <label
                                   key={a.value}
@@ -810,9 +812,24 @@ export function ProviderModelsEditor({
                                     checked={active}
                                     style={{ marginTop: '2px', flexShrink: 0 }}
                                     onChange={() => {
+                                      const modelAdapters: any[] = mCfg.adapter
+                                        ? Array.isArray(mCfg.adapter)
+                                          ? mCfg.adapter
+                                          : [mCfg.adapter]
+                                        : [];
                                       const next = active
-                                        ? modelAdapters.filter((v) => v !== a.value)
-                                        : [...modelAdapters, a.value];
+                                        ? modelAdapters.filter(
+                                            (e: any) =>
+                                              (typeof e === 'string' ? e : e.name) !== a.value
+                                          )
+                                        : [
+                                            ...modelAdapters,
+                                            {
+                                              name: a.value,
+                                              options:
+                                                a.value === 'model_override' ? { rules: [] } : {},
+                                            },
+                                          ];
                                       updateModelConfig(mId, {
                                         adapter: next.length > 0 ? next : undefined,
                                       });
@@ -832,6 +849,296 @@ export function ProviderModelsEditor({
                                 </label>
                               );
                             })}
+                            {/* model_override rules editor */}
+                            {(() => {
+                              const modelAdapters: any[] = mCfg.adapter
+                                ? Array.isArray(mCfg.adapter)
+                                  ? mCfg.adapter
+                                  : [mCfg.adapter]
+                                : [];
+                              const overrideEntry = modelAdapters.find(
+                                (e: any) =>
+                                  (typeof e === 'string' ? e : e.name) === 'model_override'
+                              );
+                              if (!overrideEntry || typeof overrideEntry === 'string') return null;
+                              const rules: any[] = overrideEntry.options?.rules ?? [];
+                              return (
+                                <div
+                                  style={{
+                                    gridColumn: '1 / -1',
+                                    borderTop: '1px solid var(--color-border-glass)',
+                                    marginTop: '4px',
+                                    paddingTop: '6px',
+                                  }}
+                                >
+                                  <div className="font-body text-[11px] font-medium text-text-secondary mb-1">
+                                    Model Override Rules
+                                  </div>
+                                  <div
+                                    className="font-body text-[10px] text-text-muted mb-2"
+                                    style={{ lineHeight: 1.3 }}
+                                  >
+                                    When ANY condition matches, rewrite the model name. Use dotted
+                                    paths like reasoning.enabled.
+                                  </div>
+                                  {rules.map((rule: any, rIdx: number) => (
+                                    <div
+                                      key={rIdx}
+                                      style={{
+                                        border: '1px solid var(--color-border-glass)',
+                                        borderRadius: 'var(--radius-sm)',
+                                        padding: '6px',
+                                        marginBottom: '4px',
+                                        background: 'var(--color-bg-deep)',
+                                      }}
+                                    >
+                                      <div
+                                        style={{ display: 'flex', gap: '4px', marginBottom: '4px' }}
+                                      >
+                                        <Input
+                                          placeholder="Match model (e.g. deepseek-r1)"
+                                          value={rule.model ?? ''}
+                                          onChange={(e: any) => {
+                                            const updated = [...rules];
+                                            updated[rIdx] = {
+                                              ...updated[rIdx],
+                                              model: e.target.value,
+                                            };
+                                            const newAdapters = modelAdapters.map((entry: any) =>
+                                              typeof entry !== 'string' &&
+                                              entry.name === 'model_override'
+                                                ? {
+                                                    ...entry,
+                                                    options: { ...entry.options, rules: updated },
+                                                  }
+                                                : entry
+                                            );
+                                            updateModelConfig(mId, { adapter: newAdapters });
+                                          }}
+                                          style={{ flex: 1 }}
+                                        />
+                                        <span
+                                          className="font-body text-[11px] text-text-muted"
+                                          style={{ lineHeight: '28px' }}
+                                        >
+                                          →
+                                        </span>
+                                        <Input
+                                          placeholder="Rewrite to (e.g. deepseek-r1-fast)"
+                                          value={rule.rewriteTo ?? ''}
+                                          onChange={(e: any) => {
+                                            const updated = [...rules];
+                                            updated[rIdx] = {
+                                              ...updated[rIdx],
+                                              rewriteTo: e.target.value,
+                                            };
+                                            const newAdapters = modelAdapters.map((entry: any) =>
+                                              typeof entry !== 'string' &&
+                                              entry.name === 'model_override'
+                                                ? {
+                                                    ...entry,
+                                                    options: { ...entry.options, rules: updated },
+                                                  }
+                                                : entry
+                                            );
+                                            updateModelConfig(mId, { adapter: newAdapters });
+                                          }}
+                                          style={{ flex: 1 }}
+                                        />
+                                        <Button
+                                          variant="ghost"
+                                          size="sm"
+                                          onClick={() => {
+                                            const updated = rules.filter(
+                                              (_: any, i: number) => i !== rIdx
+                                            );
+                                            const newAdapters = modelAdapters.map((entry: any) =>
+                                              typeof entry !== 'string' &&
+                                              entry.name === 'model_override'
+                                                ? {
+                                                    ...entry,
+                                                    options: { ...entry.options, rules: updated },
+                                                  }
+                                                : entry
+                                            );
+                                            updateModelConfig(mId, { adapter: newAdapters });
+                                          }}
+                                          style={{ padding: '4px' }}
+                                        >
+                                          <Trash2
+                                            size={14}
+                                            style={{ color: 'var(--color-danger)' }}
+                                          />
+                                        </Button>
+                                      </div>
+                                      {/* Conditions */}
+                                      {(rule.conditions ?? []).map((cond: any, cIdx: number) => (
+                                        <div
+                                          key={cIdx}
+                                          style={{
+                                            display: 'flex',
+                                            gap: '4px',
+                                            marginBottom: '2px',
+                                            marginLeft: '8px',
+                                          }}
+                                        >
+                                          <Input
+                                            placeholder="Field path (e.g. reasoning.enabled)"
+                                            value={cond.field ?? ''}
+                                            onChange={(e: any) => {
+                                              const updated = [...rules];
+                                              const newConditions = [...updated[rIdx].conditions];
+                                              newConditions[cIdx] = {
+                                                ...newConditions[cIdx],
+                                                field: e.target.value,
+                                              };
+                                              updated[rIdx] = {
+                                                ...updated[rIdx],
+                                                conditions: newConditions,
+                                              };
+                                              const newAdapters = modelAdapters.map((entry: any) =>
+                                                typeof entry !== 'string' &&
+                                                entry.name === 'model_override'
+                                                  ? {
+                                                      ...entry,
+                                                      options: { ...entry.options, rules: updated },
+                                                    }
+                                                  : entry
+                                              );
+                                              updateModelConfig(mId, { adapter: newAdapters });
+                                            }}
+                                            style={{ flex: 1 }}
+                                          />
+                                          <Input
+                                            placeholder="Value (empty = presence check)"
+                                            value={
+                                              cond.value !== undefined ? String(cond.value) : ''
+                                            }
+                                            onChange={(e: any) => {
+                                              const raw = e.target.value;
+                                              const parsed =
+                                                raw === ''
+                                                  ? undefined
+                                                  : raw === 'true'
+                                                    ? true
+                                                    : raw === 'false'
+                                                      ? false
+                                                      : isNaN(Number(raw))
+                                                        ? raw
+                                                        : Number(raw);
+                                              const updated = [...rules];
+                                              const newConditions = [...updated[rIdx].conditions];
+                                              newConditions[cIdx] = {
+                                                field: newConditions[cIdx].field,
+                                                value: parsed,
+                                              };
+                                              updated[rIdx] = {
+                                                ...updated[rIdx],
+                                                conditions: newConditions,
+                                              };
+                                              const newAdapters = modelAdapters.map((entry: any) =>
+                                                typeof entry !== 'string' &&
+                                                entry.name === 'model_override'
+                                                  ? {
+                                                      ...entry,
+                                                      options: { ...entry.options, rules: updated },
+                                                    }
+                                                  : entry
+                                              );
+                                              updateModelConfig(mId, { adapter: newAdapters });
+                                            }}
+                                            style={{ flex: 1 }}
+                                          />
+                                          <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => {
+                                              const updated = [...rules];
+                                              const newConditions = updated[rIdx].conditions.filter(
+                                                (_: any, i: number) => i !== cIdx
+                                              );
+                                              updated[rIdx] = {
+                                                ...updated[rIdx],
+                                                conditions: newConditions,
+                                              };
+                                              const newAdapters = modelAdapters.map((entry: any) =>
+                                                typeof entry !== 'string' &&
+                                                entry.name === 'model_override'
+                                                  ? {
+                                                      ...entry,
+                                                      options: { ...entry.options, rules: updated },
+                                                    }
+                                                  : entry
+                                              );
+                                              updateModelConfig(mId, { adapter: newAdapters });
+                                            }}
+                                            style={{ padding: '4px' }}
+                                          >
+                                            <Trash2
+                                              size={12}
+                                              style={{ color: 'var(--color-danger)' }}
+                                            />
+                                          </Button>
+                                        </div>
+                                      ))}
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() => {
+                                          const updated = [...rules];
+                                          updated[rIdx] = {
+                                            ...updated[rIdx],
+                                            conditions: [
+                                              ...(updated[rIdx].conditions ?? []),
+                                              { field: '' },
+                                            ],
+                                          };
+                                          const newAdapters = modelAdapters.map((entry: any) =>
+                                            typeof entry !== 'string' &&
+                                            entry.name === 'model_override'
+                                              ? {
+                                                  ...entry,
+                                                  options: { ...entry.options, rules: updated },
+                                                }
+                                              : entry
+                                          );
+                                          updateModelConfig(mId, { adapter: newAdapters });
+                                        }}
+                                        style={{ marginLeft: '8px', padding: '2px 6px' }}
+                                      >
+                                        <Plus size={12} />{' '}
+                                        <span className="font-body text-[10px]">Condition</span>
+                                      </Button>
+                                    </div>
+                                  ))}
+                                  <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={() => {
+                                      const newRule = {
+                                        model: '',
+                                        rewriteTo: '',
+                                        conditions: [{ field: '' }],
+                                      };
+                                      const updated = [...rules, newRule];
+                                      const newAdapters = modelAdapters.map((entry: any) =>
+                                        typeof entry !== 'string' && entry.name === 'model_override'
+                                          ? {
+                                              ...entry,
+                                              options: { ...entry.options, rules: updated },
+                                            }
+                                          : entry
+                                      );
+                                      updateModelConfig(mId, { adapter: newAdapters });
+                                    }}
+                                    style={{ marginTop: '2px' }}
+                                  >
+                                    <Plus size={12} />{' '}
+                                    <span className="font-body text-[10px]">Rule</span>
+                                  </Button>
+                                </div>
+                              );
+                            })()}
                           </div>
                         )}
                       </div>

--- a/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
@@ -1040,7 +1040,7 @@ export function ProviderModelsEditor({
                                               );
                                               updateModelConfig(mId, { adapter: newAdapters });
                                             }}
-                                            style={{ flex: 1 }}
+                                            style={{ flex: 2 }}
                                           />
                                           <Input
                                             placeholder="e.g. false, 0, none"

--- a/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
@@ -922,28 +922,29 @@ export function ProviderModelsEditor({
                                         <span className="font-body text-[11px] text-text-muted">
                                           →
                                         </span>
-                                        <Input
-                                          placeholder="Rewrite to (e.g. deepseek-r1-fast)"
-                                          value={rule.rewriteTo ?? ''}
-                                          onChange={(e: any) => {
-                                            const updated = [...rules];
-                                            updated[rIdx] = {
-                                              ...updated[rIdx],
-                                              rewriteTo: e.target.value,
-                                            };
-                                            const newAdapters = modelAdapters.map((entry: any) =>
-                                              typeof entry !== 'string' &&
-                                              entry.name === 'model_override'
-                                                ? {
-                                                    ...entry,
-                                                    options: { ...entry.options, rules: updated },
-                                                  }
-                                                : entry
-                                            );
-                                            updateModelConfig(mId, { adapter: newAdapters });
-                                          }}
-                                          style={{ flex: 1 }}
-                                        />
+                                        <div style={{ flex: 1 }}>
+                                          <Input
+                                            placeholder="Rewrite to (e.g. deepseek-r1-fast)"
+                                            value={rule.rewriteTo ?? ''}
+                                            onChange={(e: any) => {
+                                              const updated = [...rules];
+                                              updated[rIdx] = {
+                                                ...updated[rIdx],
+                                                rewriteTo: e.target.value,
+                                              };
+                                              const newAdapters = modelAdapters.map((entry: any) =>
+                                                typeof entry !== 'string' &&
+                                                entry.name === 'model_override'
+                                                  ? {
+                                                      ...entry,
+                                                      options: { ...entry.options, rules: updated },
+                                                    }
+                                                  : entry
+                                              );
+                                              updateModelConfig(mId, { adapter: newAdapters });
+                                            }}
+                                          />
+                                        </div>
                                         <Button
                                           variant="ghost"
                                           size="sm"
@@ -1015,73 +1016,83 @@ export function ProviderModelsEditor({
                                             marginLeft: '8px',
                                           }}
                                         >
-                                          <Input
-                                            placeholder="e.g. reasoning.enabled"
-                                            value={cond.field ?? ''}
-                                            onChange={(e: any) => {
-                                              const updated = [...rules];
-                                              const newConditions = [...updated[rIdx].conditions];
-                                              newConditions[cIdx] = {
-                                                ...newConditions[cIdx],
-                                                field: e.target.value,
-                                              };
-                                              updated[rIdx] = {
-                                                ...updated[rIdx],
-                                                conditions: newConditions,
-                                              };
-                                              const newAdapters = modelAdapters.map((entry: any) =>
-                                                typeof entry !== 'string' &&
-                                                entry.name === 'model_override'
-                                                  ? {
-                                                      ...entry,
-                                                      options: { ...entry.options, rules: updated },
-                                                    }
-                                                  : entry
-                                              );
-                                              updateModelConfig(mId, { adapter: newAdapters });
-                                            }}
-                                            style={{ flex: 2 }}
-                                          />
-                                          <Input
-                                            placeholder="e.g. false, 0, none"
-                                            value={
-                                              cond.value !== undefined ? String(cond.value) : ''
-                                            }
-                                            onChange={(e: any) => {
-                                              const raw = e.target.value;
-                                              const parsed =
-                                                raw === ''
-                                                  ? undefined
-                                                  : raw === 'true'
-                                                    ? true
-                                                    : raw === 'false'
-                                                      ? false
-                                                      : isNaN(Number(raw))
-                                                        ? raw
-                                                        : Number(raw);
-                                              const updated = [...rules];
-                                              const newConditions = [...updated[rIdx].conditions];
-                                              newConditions[cIdx] = {
-                                                field: newConditions[cIdx].field,
-                                                value: parsed,
-                                              };
-                                              updated[rIdx] = {
-                                                ...updated[rIdx],
-                                                conditions: newConditions,
-                                              };
-                                              const newAdapters = modelAdapters.map((entry: any) =>
-                                                typeof entry !== 'string' &&
-                                                entry.name === 'model_override'
-                                                  ? {
-                                                      ...entry,
-                                                      options: { ...entry.options, rules: updated },
-                                                    }
-                                                  : entry
-                                              );
-                                              updateModelConfig(mId, { adapter: newAdapters });
-                                            }}
-                                            style={{ flex: 1 }}
-                                          />
+                                          <div style={{ flex: 2 }}>
+                                            <Input
+                                              placeholder="e.g. reasoning.enabled"
+                                              value={cond.field ?? ''}
+                                              onChange={(e: any) => {
+                                                const updated = [...rules];
+                                                const newConditions = [...updated[rIdx].conditions];
+                                                newConditions[cIdx] = {
+                                                  ...newConditions[cIdx],
+                                                  field: e.target.value,
+                                                };
+                                                updated[rIdx] = {
+                                                  ...updated[rIdx],
+                                                  conditions: newConditions,
+                                                };
+                                                const newAdapters = modelAdapters.map(
+                                                  (entry: any) =>
+                                                    typeof entry !== 'string' &&
+                                                    entry.name === 'model_override'
+                                                      ? {
+                                                          ...entry,
+                                                          options: {
+                                                            ...entry.options,
+                                                            rules: updated,
+                                                          },
+                                                        }
+                                                      : entry
+                                                );
+                                                updateModelConfig(mId, { adapter: newAdapters });
+                                              }}
+                                            />
+                                          </div>
+                                          <div style={{ flex: 1 }}>
+                                            <Input
+                                              placeholder="e.g. false, 0, none"
+                                              value={
+                                                cond.value !== undefined ? String(cond.value) : ''
+                                              }
+                                              onChange={(e: any) => {
+                                                const raw = e.target.value;
+                                                const parsed =
+                                                  raw === ''
+                                                    ? undefined
+                                                    : raw === 'true'
+                                                      ? true
+                                                      : raw === 'false'
+                                                        ? false
+                                                        : isNaN(Number(raw))
+                                                          ? raw
+                                                          : Number(raw);
+                                                const updated = [...rules];
+                                                const newConditions = [...updated[rIdx].conditions];
+                                                newConditions[cIdx] = {
+                                                  field: newConditions[cIdx].field,
+                                                  value: parsed,
+                                                };
+                                                updated[rIdx] = {
+                                                  ...updated[rIdx],
+                                                  conditions: newConditions,
+                                                };
+                                                const newAdapters = modelAdapters.map(
+                                                  (entry: any) =>
+                                                    typeof entry !== 'string' &&
+                                                    entry.name === 'model_override'
+                                                      ? {
+                                                          ...entry,
+                                                          options: {
+                                                            ...entry.options,
+                                                            rules: updated,
+                                                          },
+                                                        }
+                                                      : entry
+                                                );
+                                                updateModelConfig(mId, { adapter: newAdapters });
+                                              }}
+                                            />
+                                          </div>
                                           <Button
                                             variant="ghost"
                                             size="sm"


### PR DESCRIPTION
## Why

Some LLM providers don't respect reasoning-related fields in the request body. Instead, they expose reasoning variants as **separate model names** — e.g. `deepseek-r1` (with reasoning) vs `deepseek-r1-fast` (without). When a client sends `reasoning: { effort: "none" }` or `enable_thinking: false`, the provider ignores it because the client addressed the "thinking" model, not the "fast" one.

Plexus currently has no way to bridge this gap — the router picks a target model, and that's what gets sent to the provider. There was no mechanism to say "if the client is asking for no reasoning, switch to the fast variant instead."

## What This Enables

**Conditional model rewriting based on request content.** You can now configure rules that say:

> "When the target model is `deepseek-r1` AND any of these conditions are true (reasoning disabled, thinking turned off, budget set to zero, etc.), rewrite the model name to `deepseek-r1-fast` before sending it to the provider."

This means:
- Clients can keep using a single model alias (e.g. `glm-5.1`) and let Plexus automatically pick the right provider variant based on what features they're requesting
- Providers that use separate model names for reasoning/non-reasoning variants are now first-class citizens in Plexus — no manual model switching required
- The rewrite is transparent to the client — they still see the canonical model name in billing/usage tracking

## Bonus Fix

The OpenAI chat→chat transformer was silently dropping any fields it didn't explicitly know about (e.g. `enable_thinking`, `chat_template_kwargs`, `thinking_budget`, `budget_tokens`, `thinking`). This meant even if you configured conditions for those fields, the adapter could never match them because the fields were gone by the time it saw the payload.

Now, same-API-type transformations (chat→chat) preserve all unknown fields from the original request body, overlaying only the fields that need explicit transformation. This makes the adapter useful for any non-standard field a provider might use.

## How to Use It

Configure the `model_override` adapter on a **per-model** basis in the provider settings (via the Plexus UI or management API):

1. Open the provider in the UI, expand the model entry (e.g. `zai-org/GLM-5.1-FP8`)
2. Under **Model Adapters**, enable **Model Override**
3. Add rules specifying:
   - **Match model** — the provider model name to match against (e.g. `zai-org/GLM-5.1-FP8`)
   - **Rewrite to** — the model name to send instead (e.g. `glm-5.1-fast`)
   - **Conditions** — dotted-path fields and values, any match triggers the rewrite (OR semantics)

Example conditions for detecting "no reasoning" requests:

| Field path | Value |
|---|---|
| `reasoning.enabled` | `false` |
| `reasoning.effort` | `"none"` |
| `enable_thinking` | `false` |
| `thinking.type` | `"disabled"` |
| `chat_template_kwargs.enable_thinking` | `false` |
| `thinking_budget` | `0` |
| `budget_tokens` | `0` |

If `value` is left empty, the condition matches on field presence alone (any value).

## Implementation Notes

- **Adapter config** upgraded from bare strings to uniform `{ name, options }` entries. Legacy format is normalized lazily on read — no DB migration needed, rows self-heal on next save
- **Adapter interface** gains optional `options` parameter on all hooks; existing adapters are backward-compatible
- **Frontend** includes an inline rule editor for model_override conditions in the per-model adapter section
- 1344 backend tests passing, frontend build + typecheck + lint clean