### PR TITLE
fix(frontend): provider-reported cost tooltip shows $0 for usage.cost_details format

### DIFF
--- a/packages/frontend/src/components/ui/CostToolTip.tsx
+++ b/packages/frontend/src/components/ui/CostToolTip.tsx
@@ -113,12 +113,14 @@ export const CostToolTip: React.FC<CostToolTipProps> = ({ source, costMetadata, 
         </div>
       );
     } else if (s === 'provider_reported') {
+      // Support both SSE `: cost` format (request_cost_usd) and usage.cost_details format
+      const reportedCost = data.request_cost_usd ?? data.cost_details?.total_cost;
       content = (
         <div style={containerStyle}>
           <div style={headerStyle}>Source: Provider Reported</div>
           <div style={gridStyle}>
             <span style={labelStyle}>Cost:</span>
-            <span style={valueStyle}>${formatRate(data.request_cost_usd)}</span>
+            <span style={valueStyle}>${formatRate(reportedCost)}</span>
 
             {data.cache_savings_usd !== undefined && (
               <>


### PR DESCRIPTION
When provider-reported cost arrives via `usage.cost_details` (not SSE `: cost`), the tooltip read `data.request_cost_usd` which was undefined, causing it to display **$0** while the logs row correctly showed the real cost.

**Fix:** Read cost from both formats:
- `data.request_cost_usd` — SSE `: cost` comments  
- `data.cost_details?.total_cost` — `usage.cost_details` path

**File changed:**
- `packages/frontend/src/components/ui/CostToolTip.tsx`