### PR TITLE
Fix concurrency leak during enforceContextLimit and during stall retry

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-concurrency.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-concurrency.test.ts
@@ -361,4 +361,43 @@ describe('Dispatcher concurrency slot release', () => {
     expect(tracker.getTargetCount('p1', 'model-a')).toBe(0);
     expect(tracker.getProviderCount('p1')).toBe(0);
   });
+
+  test('TTFB stall timeout releases concurrency slot', async () => {
+    // Enable stall detection with a very short TTFB timeout so the
+    // fetch itself gets aborted before the provider responds.
+    setConfigForTesting({
+      ...makeConfig(2),
+      stall: { ttfbSeconds: 0.05, ttfbBytes: 100 },
+    } as any);
+
+    // Simulate a slow provider that respects abort signals.
+    // The stall timeout will abort before this resolves.
+    fetchMock.mockImplementation(async (_url: string, opts: any) => {
+      return new Promise((_resolve, reject) => {
+        const timer = setTimeout(() => {
+          _resolve(streamingResponse());
+        }, 500);
+        opts?.signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(new DOMException('The operation was aborted', 'AbortError'));
+        });
+      });
+    });
+
+    const tracker = ConcurrencyTracker.getInstance();
+    expect(tracker.getTargetCount('p1', 'model-a')).toBe(0);
+
+    const dispatcher = new Dispatcher();
+    try {
+      await dispatcher.dispatch(makeChatRequest(true));
+    } catch {
+      // Expected — stall timeout error propagates
+    }
+
+    // The slot must be released after the TTFB stall abort
+    expect(tracker.getTargetCount('p1', 'model-a')).toBe(0);
+    expect(tracker.getProviderCount('p1')).toBe(0);
+    expect(tracker.getTargetCount('p2', 'model-b')).toBe(0);
+    expect(tracker.getProviderCount('p2')).toBe(0);
+  });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-concurrency.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-concurrency.test.ts
@@ -317,4 +317,48 @@ describe('Dispatcher concurrency slot release', () => {
     // Verify no slots are leaked after a normal non-streaming dispatch
     expect(tracker.getProviderCount('p1')).toBe(0);
   });
+
+  test('enforceContextLimit does not leak concurrency slot', async () => {
+    setConfigForTesting({
+      ...makeConfig(2),
+      models: {
+        'test-alias': {
+          selector: 'in_order',
+          target_groups: [
+            {
+              name: 'default',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-a', enabled: true }],
+            },
+          ],
+        },
+        // model-a config with enforce_limits enabled and a tiny context window
+        'model-a': {
+          enforce_limits: true,
+          context_length: 100,
+        },
+      },
+    } as any);
+
+    const tracker = ConcurrencyTracker.getInstance();
+    expect(tracker.getTargetCount('p1', 'model-a')).toBe(0);
+
+    const dispatcher = new Dispatcher();
+    try {
+      // Request with messages that exceed the tiny 100-token context limit
+      await dispatcher.dispatch({
+        model: 'test-alias',
+        messages: [{ role: 'user', content: 'x'.repeat(1000) }],
+        incomingApiType: 'chat',
+        stream: false,
+      });
+    } catch (e: any) {
+      // Error is expected (may be wrapped by buildAllTargetsFailedError)
+      expect(e).toBeDefined();
+    }
+
+    // The slot must NOT be leaked — enforceContextLimit ran before acquire()
+    expect(tracker.getTargetCount('p1', 'model-a')).toBe(0);
+    expect(tracker.getProviderCount('p1')).toBe(0);
+  });
 });

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -357,6 +357,18 @@ export class Dispatcher {
         continue;
       }
 
+      // Pre-dispatch context limit enforcement (opt-in per alias). Runs on
+      // the finalized per-target request — after any vision fallthrough has
+      // expanded the prompt and after cooldown has selected a live target —
+      // so we reject oversized prompts locally with a 400 instead of
+      // burning an upstream round trip on a guaranteed failure. Checked
+      // BEFORE acquiring a concurrency slot so that a thrown
+      // ContextLengthExceededError (a client-side problem; failing over to
+      // another target won't help) never leaks an acquired slot.
+      if (aliasConfig?.enforce_limits && route.canonicalModel) {
+        enforceContextLimit(currentRequest, aliasConfig, route.canonicalModel);
+      }
+
       // Acquire concurrency slot before upstream request
       const acquired = ConcurrencyTracker.getInstance().acquire(route.provider, route.model);
       if (!acquired) {
@@ -370,17 +382,6 @@ export class Dispatcher {
           `Provider ${route.provider}/${route.model} concurrency limit exceeded`
         );
         continue;
-      }
-
-      // Pre-dispatch context limit enforcement (opt-in per alias). Runs on
-      // the finalized per-target request — after any vision fallthrough has
-      // expanded the prompt and after cooldown has selected a live target —
-      // so we reject oversized prompts locally with a 400 instead of
-      // burning an upstream round trip on a guaranteed failure. A thrown
-      // ContextLengthExceededError escapes the loop (it's a client-side
-      // problem; failing over to another target won't help).
-      if (aliasConfig?.enforce_limits && route.canonicalModel) {
-        enforceContextLimit(currentRequest, aliasConfig, route.canonicalModel);
       }
 
       attemptedProviders.push(`${route.provider}/${route.model}`);

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -642,9 +642,10 @@ export class Dispatcher {
                 logger.info(
                   `TTFB stall: fetch timed out after ${ttfbMs}ms for ${route.provider}/${route.model}, retrying with next provider`
                 );
+                doRelease();
                 continue;
               }
-
+              doRelease();
               throw stallError;
             }
             throw fetchError;


### PR DESCRIPTION
This PR fixes two concurrency leaks.

## enforceContextLimit leaks concurrency slot

When "Enforce Limits" is on for an alias, an API call that hit that limit will cause concurrently to be permanently leaked.

### Steps to reproduce

1. Configure an alias with `enforce_limit: true` with a small `context_length` (e.g. 100).
2. Send a request to that alias that exceed `context_length` 
3. Gets `context_length_exceeded` and concurrency permanently increased by 1

### Root cause

In `dispatcher.ts`, `acquire()` was called before context length check (`enforceContextLimit`). When the check fails, it throws `ContextLengthExceededError` and never fall through to the path where `doRelease` is called. This caused the concurrency count to get permanently leaked. 

### Fix 

Move `enforceContextLimit` before `acquire()` so context length.

## TTFB stall timeout leaks concurrency slot

When TTFB stall timeout is configured with multiple targets, and both of them happen to fail, the first provider's concurrency count will be permanently leaked.

### Steps to reproduce

1. Configure global stall detection with some value of TTFB timeout and TTFB byte threshold (e.g. 5s timeout/50B threshold)
2. Configure an alias with two providers, both pointing to a slow provider that takes longer than TTFB timeout
3. Send a request to that alias with `"stream": true`.
4. Concurrency counter for the first provider permanently increased by 1 for each failed requests

```bash
$ cat <<EOF | tee slow-proxy.ts
Bun.serve({
    port: 9876,
    async fetch(req) {
        await Bun.sleep(6000);
        return new Response("ok", { status: 200 });
    },
});

console.log("Slow mock on :9876");
EOF

$ bun run slow-proxy.ts
Slow mock on :9876

# Configure Plexus per instructions above, then:
$ curl -H "Authorization: Bearer sk-78f8aff4-ab34-4ebe-98b0-876495443a34" -H "Content-Type: application/json" -d '{"model":"test","messages":[{"role": "user","content": "hi"}],"stream":true}' http://localhost:4000/v1/chat/completions
```

### Root cause

After TTFB stall detection aborts the fetch and failover is configured (`canRetryStall` is `true`), it skips `throw` and calls `continue`. Since `doRelease()` is only done in the outer `catch` block, this means that `doRelease()` was never gets called except for the last provider. This caused the concurrency count to get permanently leaked.

### Fix

Add `doRelease()` in the inner catch block too.