### PR TITLE
feat: add reasoning_rewrite adapter and debounced inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ plexus
 
 # Profiling output
 .prof/
+.grepai/

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "agent-browser": "^0.27.0",
         "bun-types": "1.3.14",
         "octokit": "^5.0.5",
+        "typescript-language-server": "^5.2.0",
         "vitest": "^4.1.6",
         "yaml": "^2.9.0",
       },
@@ -1369,6 +1370,8 @@
     "typebox": ["typebox@1.1.34", "", {}, "sha512-V0fM5W5DTXlEMDxqtX1dQ25HR1RQ11DPUVrIup4sJi1yQtIyI30SHfxBy/HjXKL1CtUqc5or2igA/wa/v4hMKQ=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-language-server": ["typescript-language-server@5.2.0", "", { "bin": { "typescript-language-server": "lib/cli.mjs" } }, "sha512-K+Fu46SgN+bzh0sbKk04hFHq0kWCljvBN9iHx6ej6pXHigrV6H9W/LENIliEkiUVoymiLmEotEBE2XHYnQCo1w=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 

--- a/docs/openapi/components/schemas/ProviderConfig.yaml
+++ b/docs/openapi/components/schemas/ProviderConfig.yaml
@@ -228,6 +228,17 @@ properties:
         Used for providers that expose reasoning variants as separate model
         names rather than respecting reasoning-related request fields.
 
+      - `reasoning_rewrite` — Declaratively rewrites reasoning/thinking fields
+        in outbound request payloads. Different providers accept reasoning
+        effort via different field names (e.g. `enable_thinking`, `thinking.type`,
+        `chat_template_kwargs.enable_thinking`, `budget_tokens`, `thinking_budget`).
+        This adapter maps from unified fields (e.g. `reasoning.enabled`,
+        `reasoning.effort`) to provider-specific formats. Accepts a `rules`
+        array in options where each rule specifies a `source` dotted path,
+        an optional `when` condition (with `op` and `value`), an array of
+        `rewrites` (each with `target` and `value`), and optional `strip`
+        paths to remove after rewriting.
+
       Pass-through optimisation is automatically disabled when any adapter
       is active.
   timeoutMs:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "agent-browser": "^0.27.0",
     "bun-types": "1.3.14",
     "octokit": "^5.0.5",
+    "typescript-language-server": "^5.2.0",
     "vitest": "^4.1.6",
     "yaml": "^2.9.0"
   },

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -117,6 +117,59 @@ export type ModelOverrideRule = z.infer<typeof ModelOverrideRuleSchema>;
 export type ModelOverrideOptions = z.infer<typeof ModelOverrideOptionsSchema>;
 export type AdapterEntry = z.infer<typeof AdapterEntrySchema>;
 
+// ─── Reasoning Rewrite Adapter Config ────────────────────────────────
+
+const ValueTransformSchema = z.union([
+  z.object({ from: z.literal('source') }),
+  z.object({ from: z.literal('map'), values: z.record(z.string(), z.any()) }),
+  z.object({ from: z.literal('boolean'), truthy: z.any(), falsy: z.any() }),
+]);
+
+const FieldRewriteSchema = z.object({
+  /** Dotted path to write (e.g. "enable_thinking", "thinking.type"). */
+  target: z.string().min(1),
+  /**
+   * Value to write at the target path.
+   * Literal primitives are written as-is.
+   * Objects with { from: "source" | "map" | "boolean" } trigger transforms.
+   */
+  value: z.any(),
+});
+
+const MatchConditionSchema = z.object({
+  /** Comparison operator. */
+  op: z.enum(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in', 'present', 'absent']),
+  /** Value to compare against (for eq/neq/gt/gte/lt/lte). */
+  value: z.any().optional(),
+  /** Values array for "in" operator. */
+  values: z.array(z.any()).optional(),
+});
+
+const ReasoningRewriteRuleSchema = z.object({
+  /** Dotted path to read from the payload (e.g. "reasoning.enabled", "reasoning.effort"). */
+  source: z.string().min(1),
+  /** Optional condition on the source value. Omit = match any (presence check). */
+  when: MatchConditionSchema.optional(),
+  /** Rewrites to apply when the source matches. All matching rewrites apply. */
+  rewrites: z.array(FieldRewriteSchema).min(1),
+  /**
+   * Dotted paths to REMOVE from the payload after rewrites are applied.
+   * Use to strip unified fields the provider doesn't understand
+   * (e.g. "reasoning" when mapping to "enable_thinking" instead).
+   */
+  strip: z.array(z.string().min(1)).optional(),
+});
+
+const ReasoningRewriteOptionsSchema = z.object({
+  rules: z.array(ReasoningRewriteRuleSchema).min(1),
+});
+
+export type ValueTransform = z.infer<typeof ValueTransformSchema>;
+export type FieldRewrite = z.infer<typeof FieldRewriteSchema>;
+export type MatchCondition = z.infer<typeof MatchConditionSchema>;
+export type ReasoningRewriteRule = z.infer<typeof ReasoningRewriteRuleSchema>;
+export type ReasoningRewriteOptions = z.infer<typeof ReasoningRewriteOptionsSchema>;
+
 const ModelProviderConfigSchema = z.object({
   pricing: PricingSchema.default({
     source: 'simple',

--- a/packages/backend/src/transformers/adapters/__tests__/reasoning-rewrite.adapter.test.ts
+++ b/packages/backend/src/transformers/adapters/__tests__/reasoning-rewrite.adapter.test.ts
@@ -1,0 +1,804 @@
+import { describe, expect, it } from 'vitest';
+import {
+  reasoningRewriteAdapter,
+  setDottedPath,
+  removeDottedPath,
+} from '../reasoning-rewrite.adapter';
+
+// ── setDottedPath ──────────────────────────────────────────────────────
+
+describe('setDottedPath', () => {
+  it('sets a top-level field', () => {
+    const obj: Record<string, any> = {};
+    setDottedPath(obj, 'enable_thinking', true);
+    expect(obj.enable_thinking).toBe(true);
+  });
+
+  it('sets a nested field, creating intermediate objects', () => {
+    const obj: Record<string, any> = {};
+    setDottedPath(obj, 'chat_template_kwargs.enable_thinking', false);
+    expect(obj.chat_template_kwargs).toEqual({ enable_thinking: false });
+  });
+
+  it('sets a deeply nested field', () => {
+    const obj: Record<string, any> = {};
+    setDottedPath(obj, 'a.b.c', 42);
+    expect(obj.a.b.c).toBe(42);
+  });
+
+  it('overwrites an existing value', () => {
+    const obj: Record<string, any> = { enable_thinking: false };
+    setDottedPath(obj, 'enable_thinking', true);
+    expect(obj.enable_thinking).toBe(true);
+  });
+
+  it('preserves sibling keys when setting a nested field', () => {
+    const obj: Record<string, any> = { thinking: { type: 'enabled' } };
+    setDottedPath(obj, 'thinking.budget', 1024);
+    expect(obj.thinking).toEqual({ type: 'enabled', budget: 1024 });
+  });
+
+  it('replaces a primitive with an object when needed', () => {
+    const obj: Record<string, any> = { thinking: 'old' };
+    setDottedPath(obj, 'thinking.type', 'enabled');
+    expect(obj.thinking).toEqual({ type: 'enabled' });
+  });
+
+  it('skips the write when value is undefined', () => {
+    const obj: Record<string, any> = { existing: true };
+    setDottedPath(obj, 'existing', undefined);
+    expect(obj.existing).toBe(true); // unchanged
+    setDottedPath(obj, 'new_field', undefined);
+    expect(obj.new_field).toBeUndefined();
+  });
+
+  it('sets null values', () => {
+    const obj: Record<string, any> = {};
+    setDottedPath(obj, 'reasoning', null);
+    expect(obj.reasoning).toBeNull();
+  });
+});
+
+// ── removeDottedPath ──────────────────────────────────────────────────
+
+describe('removeDottedPath', () => {
+  it('removes a top-level field', () => {
+    const obj: Record<string, any> = { reasoning: { effort: 'high' }, model: 'x' };
+    removeDottedPath(obj, 'reasoning');
+    expect(obj).toEqual({ model: 'x' });
+  });
+
+  it('removes a nested field', () => {
+    const obj: Record<string, any> = { reasoning: { effort: 'high', enabled: true } };
+    removeDottedPath(obj, 'reasoning.effort');
+    expect(obj.reasoning).toEqual({ enabled: true });
+  });
+
+  it('is a no-op when path does not exist', () => {
+    const obj: Record<string, any> = { model: 'x' };
+    removeDottedPath(obj, 'reasoning');
+    expect(obj).toEqual({ model: 'x' });
+  });
+
+  it('is a no-op when partial path does not exist', () => {
+    const obj: Record<string, any> = { model: 'x' };
+    removeDottedPath(obj, 'reasoning.effort');
+    expect(obj).toEqual({ model: 'x' });
+  });
+
+  it('is a no-op when traversing through null', () => {
+    const obj: Record<string, any> = { reasoning: null };
+    removeDottedPath(obj, 'reasoning.effort');
+    expect(obj).toEqual({ reasoning: null });
+  });
+
+  it('is a no-op when traversing through primitive', () => {
+    const obj: Record<string, any> = { reasoning: 'string' };
+    removeDottedPath(obj, 'reasoning.effort');
+    expect(obj).toEqual({ reasoning: 'string' });
+  });
+});
+
+// ── preDispatch ──────────────────────────────────────────────────────
+
+describe('reasoning_rewrite adapter', () => {
+  describe('preDispatch', () => {
+    // ── No-op cases ────────────────────────────────────────────────
+
+    it('returns payload unchanged when no options provided', () => {
+      const payload = { model: 'x', messages: [] };
+      expect(reasoningRewriteAdapter.preDispatch(payload)).toBe(payload);
+    });
+
+    it('returns payload unchanged when options has no rules', () => {
+      const payload = { model: 'x', messages: [] };
+      expect(reasoningRewriteAdapter.preDispatch(payload, {})).toBe(payload);
+    });
+
+    it('returns payload unchanged when rules is empty array', () => {
+      const payload = { model: 'x', messages: [] };
+      expect(reasoningRewriteAdapter.preDispatch(payload, { rules: [] })).toBe(payload);
+    });
+
+    // ── Literal value ──────────────────────────────────────────────
+
+    it('writes a literal value when source field is present (no when clause)', () => {
+      const payload = { model: 'x', reasoning: { effort: 'none' }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.effort',
+            rewrites: [{ target: 'budget_tokens', value: 0 }],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.budget_tokens).toBe(0);
+    });
+
+    it('does not fire when source field is absent (no when clause)', () => {
+      const payload = { model: 'x', messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'enable_thinking', value: false }],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.enable_thinking).toBeUndefined();
+    });
+
+    // ── Value transforms: from: "source" ──────────────────────────
+
+    it('passes source value through with { from: "source" }', () => {
+      const payload = { model: 'x', reasoning: { enabled: true }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'enable_thinking', value: { from: 'source' } }],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.enable_thinking).toBe(true);
+    });
+
+    it('passes numeric source value through with { from: "source" }', () => {
+      const payload = { model: 'x', reasoning: { max_tokens: 8192 }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.max_tokens',
+            rewrites: [{ target: 'thinking_budget', value: { from: 'source' } }],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.thinking_budget).toBe(8192);
+    });
+
+    // ── Value transforms: from: "boolean" ────────────────────────
+
+    it('maps boolean true via { from: "boolean" }', () => {
+      const payload = { model: 'x', reasoning: { enabled: true }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [
+              {
+                target: 'thinking.type',
+                value: { from: 'boolean', truthy: 'enabled', falsy: 'disabled' },
+              },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.thinking).toEqual({ type: 'enabled' });
+    });
+
+    it('maps boolean false via { from: "boolean" }', () => {
+      const payload = { model: 'x', reasoning: { enabled: false }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [
+              {
+                target: 'thinking.type',
+                value: { from: 'boolean', truthy: 'enabled', falsy: 'disabled' },
+              },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.thinking).toEqual({ type: 'disabled' });
+    });
+
+    it('maps truthy/falsy non-boolean values via { from: "boolean" }', () => {
+      const payload = { model: 'x', reasoning: { enabled: 1 }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [
+              {
+                target: 'thinking.type',
+                value: { from: 'boolean', truthy: 'enabled', falsy: 'disabled' },
+              },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.thinking).toEqual({ type: 'enabled' }); // 1 is truthy
+    });
+
+    // ── Value transforms: from: "map" ────────────────────────────
+
+    it('maps source value via { from: "map" }', () => {
+      const payload = { model: 'x', reasoning: { effort: 'high' }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.effort',
+            rewrites: [
+              {
+                target: 'budget_tokens',
+                value: {
+                  from: 'map',
+                  values: { none: 0, low: 1024, medium: 8192, high: 32768 },
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.budget_tokens).toBe(32768);
+    });
+
+    it('skips write when map key is not found', () => {
+      const payload = { model: 'x', reasoning: { effort: 'xhigh' }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.effort',
+            rewrites: [
+              {
+                target: 'budget_tokens',
+                value: {
+                  from: 'map',
+                  values: { none: 0, low: 1024, medium: 8192, high: 32768 },
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.budget_tokens).toBeUndefined();
+    });
+
+    // ── When conditions ──────────────────────────────────────────
+
+    describe('when conditions', () => {
+      it('eq: fires when value matches', () => {
+        const payload = { model: 'x', reasoning: { effort: 'none' }, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'eq', value: 'none' },
+              rewrites: [{ target: 'budget_tokens', value: 0 }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.budget_tokens).toBe(0);
+      });
+
+      it('eq: does not fire when value does not match', () => {
+        const payload = { model: 'x', reasoning: { effort: 'high' }, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'eq', value: 'none' },
+              rewrites: [{ target: 'budget_tokens', value: 0 }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.budget_tokens).toBeUndefined();
+      });
+
+      it('neq: fires when value differs', () => {
+        const payload = { model: 'x', reasoning: { effort: 'high' }, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'neq', value: 'none' },
+              rewrites: [{ target: 'budget_tokens', value: 8192 }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.budget_tokens).toBe(8192);
+      });
+
+      it('gt: fires when source is greater', () => {
+        const payload = { model: 'x', budget_tokens: 100, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'budget_tokens',
+              when: { op: 'gt', value: 0 },
+              rewrites: [{ target: 'enable_thinking', value: true }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.enable_thinking).toBe(true);
+      });
+
+      it('gte: fires when source is equal', () => {
+        const payload = { model: 'x', budget_tokens: 0, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'budget_tokens',
+              when: { op: 'gte', value: 0 },
+              rewrites: [{ target: 'enable_thinking', value: true }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.enable_thinking).toBe(true);
+      });
+
+      it('lt: fires when source is less than', () => {
+        const payload = { model: 'x', budget_tokens: 5, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'budget_tokens',
+              when: { op: 'lt', value: 10 },
+              rewrites: [{ target: 'enable_thinking', value: false }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.enable_thinking).toBe(false);
+      });
+
+      it('lte: fires when source is equal', () => {
+        const payload = { model: 'x', budget_tokens: 10, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'budget_tokens',
+              when: { op: 'lte', value: 10 },
+              rewrites: [{ target: 'enable_thinking', value: false }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.enable_thinking).toBe(false);
+      });
+
+      it('in: fires when source is in the values list', () => {
+        const payload = { model: 'x', reasoning: { effort: 'medium' }, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'in', values: ['low', 'medium', 'high'] },
+              rewrites: [{ target: 'budget_tokens', value: 8192 }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.budget_tokens).toBe(8192);
+      });
+
+      it('in: does not fire when source is not in the values list', () => {
+        const payload = { model: 'x', reasoning: { effort: 'none' }, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'in', values: ['low', 'medium', 'high'] },
+              rewrites: [{ target: 'budget_tokens', value: 8192 }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.budget_tokens).toBeUndefined();
+      });
+
+      it('present: fires when field exists regardless of value', () => {
+        const payload = { model: 'x', reasoning: { effort: null }, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'present' },
+              rewrites: [{ target: 'enable_thinking', value: true }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.enable_thinking).toBe(true);
+      });
+
+      it('present: does not fire when field is absent', () => {
+        const payload = { model: 'x', messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'present' },
+              rewrites: [{ target: 'enable_thinking', value: true }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.enable_thinking).toBeUndefined();
+      });
+
+      it('absent: fires when field is absent', () => {
+        const payload = { model: 'x', messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'absent' },
+              rewrites: [{ target: 'enable_thinking', value: false }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.enable_thinking).toBe(false);
+      });
+
+      it('absent: does not fire when field is present', () => {
+        const payload = { model: 'x', reasoning: { effort: 'low' }, messages: [] };
+        const options = {
+          rules: [
+            {
+              source: 'reasoning.effort',
+              when: { op: 'absent' },
+              rewrites: [{ target: 'enable_thinking', value: false }],
+            },
+          ],
+        };
+        const result = reasoningRewriteAdapter.preDispatch(payload, options);
+        expect(result.enable_thinking).toBeUndefined();
+      });
+    });
+
+    // ── Multiple rewrites per rule ────────────────────────────────
+
+    it('applies all rewrites in a single rule', () => {
+      const payload = { model: 'x', reasoning: { enabled: true }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [
+              { target: 'enable_thinking', value: { from: 'source' } },
+              {
+                target: 'thinking.type',
+                value: { from: 'boolean', truthy: 'enabled', falsy: 'disabled' },
+              },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.enable_thinking).toBe(true);
+      expect(result.thinking).toEqual({ type: 'enabled' });
+    });
+
+    // ── Multiple rules ────────────────────────────────────────────
+
+    it('applies multiple rules in order', () => {
+      const payload = {
+        model: 'x',
+        reasoning: { enabled: true, effort: 'high' },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'enable_thinking', value: { from: 'source' } }],
+          },
+          {
+            source: 'reasoning.effort',
+            when: { op: 'eq', value: 'none' },
+            rewrites: [{ target: 'budget_tokens', value: 0 }],
+          },
+          {
+            source: 'reasoning.effort',
+            when: { op: 'in', values: ['low', 'medium', 'high'] },
+            rewrites: [
+              {
+                target: 'budget_tokens',
+                value: { from: 'map', values: { low: 1024, medium: 8192, high: 32768 } },
+              },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.enable_thinking).toBe(true);
+      expect(result.budget_tokens).toBe(32768);
+    });
+
+    // ── Strip ─────────────────────────────────────────────────────
+
+    it('strips specified paths after rewriting', () => {
+      const payload = {
+        model: 'x',
+        reasoning: { enabled: true },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'enable_thinking', value: { from: 'source' } }],
+            strip: ['reasoning'],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.enable_thinking).toBe(true);
+      expect(result.reasoning).toBeUndefined();
+    });
+
+    it('strips nested paths', () => {
+      const payload = {
+        model: 'x',
+        reasoning: { enabled: true, effort: 'high' },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'enable_thinking', value: { from: 'source' } }],
+            strip: ['reasoning.enabled'],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.enable_thinking).toBe(true);
+      expect(result.reasoning).toEqual({ effort: 'high' });
+    });
+
+    it('does not strip when rule does not fire', () => {
+      const payload = {
+        model: 'x',
+        reasoning: { effort: 'high' },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'enable_thinking', value: true }],
+            strip: ['reasoning'],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      // Source is absent, rule doesn't fire → no strip
+      expect(result.reasoning).toEqual({ effort: 'high' });
+      expect(result.enable_thinking).toBeUndefined();
+    });
+
+    // ── Same-API-type case (originalBody fields present) ──────────
+
+    it('overwrites originalBody passthrough fields when adapter maps them', () => {
+      // Simulates chat→chat where originalBody was spread, so enable_thinking
+      // is already in the payload from the client, but the adapter's mapping
+      // should be authoritative.
+      const payload = {
+        model: 'x',
+        enable_thinking: false, // from originalBody — client sent this
+        reasoning: { enabled: true }, // from transformer overlay
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'enable_thinking', value: { from: 'source' } }],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      // Adapter's value (from reasoning.enabled=true) wins
+      expect(result.enable_thinking).toBe(true);
+    });
+
+    it('preserves originalBody passthrough fields when adapter has no matching rule', () => {
+      const payload = {
+        model: 'x',
+        enable_thinking: true, // from originalBody — no rule touches this
+        messages: [],
+      };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'budget_tokens', value: 8192 }],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      // No reasoning.enabled in payload → rule doesn't fire → enable_thinking preserved
+      expect(result.enable_thinking).toBe(true);
+      expect(result.budget_tokens).toBeUndefined();
+    });
+
+    // ── Deep nested paths ─────────────────────────────────────────
+
+    it('writes to deep nested target paths', () => {
+      const payload = { model: 'x', reasoning: { enabled: false }, messages: [] };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [
+              { target: 'chat_template_kwargs.enable_thinking', value: { from: 'source' } },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.chat_template_kwargs).toEqual({ enable_thinking: false });
+    });
+
+    // ── Complex real-world scenario ───────────────────────────────
+
+    it('DeepSeek-style full mapping: reasoning → enable_thinking + thinking.type + budget_tokens', () => {
+      const payload = {
+        model: 'deepseek-r1',
+        reasoning: { enabled: true, effort: 'high' },
+        messages: [{ role: 'user', content: 'hello' }],
+        temperature: 0.7,
+        stream: true,
+      };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [
+              { target: 'enable_thinking', value: { from: 'source' } },
+              {
+                target: 'thinking.type',
+                value: { from: 'boolean', truthy: 'enabled', falsy: 'disabled' },
+              },
+            ],
+            strip: ['reasoning'],
+          },
+          {
+            source: 'reasoning.effort',
+            // This rule won't fire because we stripped reasoning above,
+            // BUT reasoning.effort is read BEFORE strip in the same rule.
+            // Actually, the strip happens after rewrites of rule 1, so by
+            // the time rule 2 runs, reasoning.effort is gone.
+            // This is a real behavior — rules are sequential.
+            when: { op: 'in', values: ['low', 'medium', 'high'] },
+            rewrites: [
+              {
+                target: 'budget_tokens',
+                value: { from: 'map', values: { low: 1024, medium: 8192, high: 32768 } },
+              },
+            ],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.enable_thinking).toBe(true);
+      expect(result.thinking).toEqual({ type: 'enabled' });
+      expect(result.reasoning).toBeUndefined();
+      // Rule 2 won't fire because reasoning.effort was stripped by rule 1's strip
+      expect(result.budget_tokens).toBeUndefined();
+    });
+
+    it('DeepSeek-style with effort rule FIRST (correct ordering)', () => {
+      const payload = {
+        model: 'deepseek-r1',
+        reasoning: { enabled: true, effort: 'high' },
+        messages: [],
+      };
+      const options = {
+        rules: [
+          // Map effort first, before reasoning is stripped
+          {
+            source: 'reasoning.effort',
+            when: { op: 'in', values: ['low', 'medium', 'high'] },
+            rewrites: [
+              {
+                target: 'budget_tokens',
+                value: { from: 'map', values: { low: 1024, medium: 8192, high: 32768 } },
+              },
+            ],
+          },
+          // Then map enabled → enable_thinking + thinking.type, strip reasoning
+          {
+            source: 'reasoning.enabled',
+            rewrites: [
+              { target: 'enable_thinking', value: { from: 'source' } },
+              {
+                target: 'thinking.type',
+                value: { from: 'boolean', truthy: 'enabled', falsy: 'disabled' },
+              },
+            ],
+            strip: ['reasoning'],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.budget_tokens).toBe(32768);
+      expect(result.enable_thinking).toBe(true);
+      expect(result.thinking).toEqual({ type: 'enabled' });
+      expect(result.reasoning).toBeUndefined();
+    });
+
+    // ── Preserves other payload fields ─────────────────────────────
+
+    it('preserves all other payload fields', () => {
+      const payload = {
+        model: 'x',
+        reasoning: { enabled: true },
+        messages: [{ role: 'user', content: 'hello' }],
+        temperature: 0.7,
+        stream: true,
+        max_tokens: 4096,
+      };
+      const options = {
+        rules: [
+          {
+            source: 'reasoning.enabled',
+            rewrites: [{ target: 'enable_thinking', value: { from: 'source' } }],
+            strip: ['reasoning'],
+          },
+        ],
+      };
+      const result = reasoningRewriteAdapter.preDispatch(payload, options);
+      expect(result.model).toBe('x');
+      expect(result.messages).toEqual([{ role: 'user', content: 'hello' }]);
+      expect(result.temperature).toBe(0.7);
+      expect(result.stream).toBe(true);
+      expect(result.max_tokens).toBe(4096);
+      expect(result.enable_thinking).toBe(true);
+      expect(result.reasoning).toBeUndefined();
+    });
+  });
+
+  // ── postDispatch ───────────────────────────────────────────────
+
+  describe('postDispatch', () => {
+    it('returns response unchanged', () => {
+      const response = { id: 'resp-1', model: 'deepseek-r1' };
+      expect(reasoningRewriteAdapter.postDispatch(response)).toBe(response);
+    });
+
+    it('returns response unchanged even with options', () => {
+      const response = { id: 'resp-1', model: 'deepseek-r1' };
+      expect(reasoningRewriteAdapter.postDispatch(response, { rules: [] })).toBe(response);
+    });
+  });
+});

--- a/packages/backend/src/transformers/adapters/index.ts
+++ b/packages/backend/src/transformers/adapters/index.ts
@@ -2,6 +2,7 @@ import type { ProviderAdapter } from '../../types/provider-adapter';
 import { reasoningContentAdapter } from './reasoning-content.adapter';
 import { suppressDeveloperRoleAdapter } from './suppress-developer-role.adapter';
 import { modelOverrideAdapter } from './model-override.adapter';
+import { reasoningRewriteAdapter } from './reasoning-rewrite.adapter';
 
 /**
  * Registry of all built-in provider adapters.
@@ -11,4 +12,5 @@ export const ADAPTER_REGISTRY: Record<string, ProviderAdapter> = {
   [reasoningContentAdapter.name]: reasoningContentAdapter,
   [suppressDeveloperRoleAdapter.name]: suppressDeveloperRoleAdapter,
   [modelOverrideAdapter.name]: modelOverrideAdapter,
+  [reasoningRewriteAdapter.name]: reasoningRewriteAdapter,
 };

--- a/packages/backend/src/transformers/adapters/reasoning-rewrite.adapter.ts
+++ b/packages/backend/src/transformers/adapters/reasoning-rewrite.adapter.ts
@@ -1,0 +1,241 @@
+import type { ProviderAdapter } from '../../types/provider-adapter';
+import type { ReasoningRewriteOptions, FieldRewrite, MatchCondition } from '../../config';
+import { resolveDottedPath } from './model-override.adapter';
+import { logger } from '../../utils/logger';
+
+/**
+ * reasoning_rewrite adapter
+ *
+ * Declaratively rewrites reasoning/thinking fields in the outbound provider
+ * payload. Different providers accept reasoning effort via different field
+ * names and shapes — e.g. `enable_thinking`, `thinking.type`,
+ * `chat_template_kwargs.enable_thinking`, `budget_tokens`, `thinking_budget`,
+ * or `reasoning.effort`. This adapter reads from unified fields and writes to
+ * provider-specific fields, optionally stripping the unified fields afterward.
+ *
+ * Options schema (ReasoningRewriteOptions):
+ *   rules: [
+ *     {
+ *       source: "reasoning.enabled",       // read from this dotted path
+ *       when: { op: "present" },           // optional condition on source value
+ *       rewrites: [
+ *         {
+ *           target: "enable_thinking",    // write to this dotted path
+ *           value: { from: "source" },    // pass source value through
+ *         },
+ *         {
+ *           target: "thinking.type",
+ *           value: { from: "boolean", truthy: "enabled", falsy: "disabled" },
+ *         },
+ *       ],
+ *       strip: ["reasoning"],              // remove these paths after rewriting
+ *     },
+ *     {
+ *       source: "reasoning.effort",
+ *       when: { op: "eq", value: "none" },
+ *       rewrites: [{ target: "budget_tokens", value: 0 }],
+ *       strip: ["reasoning"],
+ *     },
+ *     {
+ *       source: "reasoning.effort",
+ *       when: { op: "in", values: ["low","medium","high"] },
+ *       rewrites: [
+ *         {
+ *           target: "budget_tokens",
+ *           value: { from: "map", values: { low: 1024, medium: 8192, high: 32768 } },
+ *         },
+ *       ],
+ *     },
+ *   ]
+ *
+ * Outbound (preDispatch):
+ *   - For each rule, reads the source field from the payload.
+ *   - If `when` is specified, evaluates the condition; skips the rule if it fails.
+ *   - If `when` is omitted, the rule fires when the source field is present (not undefined).
+ *   - For each rewrite in the rule, computes the target value and writes it via setDottedPath.
+ *   - After all rewrites, strips any paths listed in `strip`.
+ *
+ * Inbound (postDispatch): no-op.
+ * Stream: no-op.
+ */
+
+export const reasoningRewriteAdapter: ProviderAdapter = {
+  name: 'reasoning_rewrite',
+
+  preDispatch(payload: Record<string, any>, options?: Record<string, any>): Record<string, any> {
+    if (!options || !options.rules || !Array.isArray(options.rules)) return payload;
+
+    const rules = options.rules as ReasoningRewriteOptions['rules'];
+    if (rules.length === 0) return payload;
+
+    // Deep-clone so we don't mutate the original (deferred until first mutation)
+    let result: Record<string, any> | null = null;
+    const mutate = (): Record<string, any> => result ?? (result = structuredClone(payload));
+
+    for (const rule of rules) {
+      const sourceValue = resolveDottedPath(result ?? payload, rule.source);
+
+      // Default: rule fires when source field is present (not undefined)
+      const shouldFire = rule.when
+        ? evaluateCondition(sourceValue, rule.when)
+        : sourceValue !== undefined;
+
+      if (!shouldFire) continue;
+
+      const obj = mutate(); // clone on first actual mutation
+      logger.debug(
+        `reasoning_rewrite: rule matched source '${rule.source}' ` +
+          `(value: ${JSON.stringify(sourceValue)})`
+      );
+
+      for (const rewrite of rule.rewrites) {
+        const targetValue = computeTargetValue(sourceValue, rewrite);
+        setDottedPath(obj, rewrite.target, targetValue);
+        logger.debug(`reasoning_rewrite:   ${rewrite.target} = ${JSON.stringify(targetValue)}`);
+      }
+
+      if (rule.strip && Array.isArray(rule.strip)) {
+        for (const stripPath of rule.strip) {
+          removeDottedPath(obj, stripPath);
+          logger.debug(`reasoning_rewrite:   stripped '${stripPath}'`);
+        }
+      }
+    }
+
+    return result ?? payload;
+  },
+
+  postDispatch(response: Record<string, any>, _options?: Record<string, any>): Record<string, any> {
+    return response;
+  },
+};
+
+// ── Condition evaluation ────────────────────────────────────────────────
+
+/**
+ * Evaluate a MatchCondition against the resolved source value.
+ *
+ * `undefined` means the source field was not present in the payload.
+ */
+function evaluateCondition(sourceValue: any, condition: MatchCondition): boolean {
+  switch (condition.op) {
+    case 'present':
+      return sourceValue !== undefined;
+    case 'absent':
+      return sourceValue === undefined;
+    case 'eq':
+      return sourceValue === condition.value;
+    case 'neq':
+      return sourceValue !== condition.value;
+    case 'gt':
+      return sourceValue > condition.value;
+    case 'gte':
+      return sourceValue >= condition.value;
+    case 'lt':
+      return sourceValue < condition.value;
+    case 'lte':
+      return sourceValue <= condition.value;
+    case 'in':
+      return Array.isArray(condition.values) && condition.values.includes(sourceValue);
+    default:
+      return false;
+  }
+}
+
+// ── Target value computation ────────────────────────────────────────────
+
+/**
+ * Compute the value to write at the target path.
+ *
+ * - Literal values (string | number | boolean | null) are returned as-is.
+ * - { from: "source" }          → copy the source value verbatim
+ * - { from: "map", values: {} } → lookup source value in the map; if not found, undefined (skip write)
+ * - { from: "boolean", truthy: X, falsy: Y } → coerce source to bool → map
+ */
+function computeTargetValue(sourceValue: any, rewrite: FieldRewrite): any {
+  const v = rewrite.value;
+
+  // Literal value (primitives and null)
+  if (v === null || v === undefined || typeof v !== 'object') {
+    return v;
+  }
+
+  // Value transform objects
+  if (typeof v === 'object' && 'from' in v) {
+    const from = v.from as string;
+
+    if (from === 'source') {
+      return sourceValue;
+    }
+
+    if (from === 'map') {
+      const map = v.values as Record<string, any>;
+      if (map && sourceValue in map) {
+        return map[sourceValue];
+      }
+      // Key not in map — return undefined so the write is skipped
+      return undefined;
+    }
+
+    if (from === 'boolean') {
+      const coerced = !!sourceValue;
+      return coerced ? v.truthy : v.falsy;
+    }
+  }
+
+  // Fallback: return as-is (covers objects the user might pass as literals)
+  return v;
+}
+
+// ── Dotted-path helpers ────────────────────────────────────────────────
+
+/**
+ * Set a value at a dotted path, creating intermediate objects as needed.
+ *
+ * Example: setDottedPath(payload, "chat_template_kwargs.enable_thinking", true)
+ * will create `payload.chat_template_kwargs = {}` if it doesn't exist, then set
+ * `enable_thinking = true` on it.
+ */
+export function setDottedPath(obj: Record<string, any>, path: string, value: any): void {
+  if (value === undefined) return; // skip undefined writes
+
+  const segments = path.split('.');
+  if (segments.length === 0) return;
+  const lastKey = segments[segments.length - 1]!;
+  let current: any = obj;
+
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i]!;
+    if (current[seg] === null || current[seg] === undefined || typeof current[seg] !== 'object') {
+      current[seg] = {};
+    }
+    current = current[seg];
+  }
+
+  current[lastKey] = value;
+}
+
+/**
+ * Remove the leaf value at a dotted path.
+ *
+ * Does NOT prune empty parent objects — this is intentional because
+ * a parent object may have other keys that should be preserved.
+ *
+ * If the path doesn't exist, this is a no-op.
+ */
+export function removeDottedPath(obj: Record<string, any>, path: string): void {
+  const segments = path.split('.');
+  if (segments.length === 0) return;
+  const lastKey = segments[segments.length - 1]!;
+  let current: any = obj;
+
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i]!;
+    if (current[seg] === null || current[seg] === undefined || typeof current[seg] !== 'object') {
+      return; // path doesn't exist, nothing to remove
+    }
+    current = current[seg];
+  }
+
+  delete current[lastKey];
+}

--- a/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
 import { Button } from '../ui/Button';
-import { Input } from '../ui/Input';
+import { DebouncedInput } from '../ui/DebouncedInput';
 import { Switch } from '../ui/Switch';
 import { Badge } from '../ui/Badge';
 import { GPU_PROFILE_OPTIONS, resolveGpuParams } from '@plexus/shared';
@@ -25,6 +25,12 @@ export const KNOWN_ADAPTERS: { value: string; label: string; description: string
     description:
       'Conditionally rewrites the model name based on request fields (e.g. switching to a -fast variant when reasoning is disabled).',
   },
+  {
+    value: 'reasoning_rewrite',
+    label: 'Reasoning Rewrite',
+    description:
+      'Rewrites reasoning/thinking fields to provider-specific formats (e.g. enable_thinking, budget_tokens, thinking.type).',
+  },
 ];
 
 interface Props {
@@ -47,31 +53,6 @@ export function ProviderAdvancedEditor({
   const [isHeadersOpen, setIsHeadersOpen] = useState(false);
   const [isExtraBodyOpen, setIsExtraBodyOpen] = useState(false);
   const [isStallOpen, setIsStallOpen] = useState(false);
-
-  // Draft state for stall number inputs — allows free typing without
-  // range-checking on every keystroke. Values are committed to editingProvider
-  // on blur, where we validate the final value.
-  const [stallTtfbDraft, setStallTtfbDraft] = useState<string>(
-    editingProvider.stallTtfbMs != null
-      ? String(Math.round(editingProvider.stallTtfbMs / 1000))
-      : ''
-  );
-  const [stallTtfbBytesDraft, setStallTtfbBytesDraft] = useState<string>(
-    editingProvider.stallTtfbBytes != null ? String(editingProvider.stallTtfbBytes) : ''
-  );
-  const [stallMinBpsDraft, setStallMinBpsDraft] = useState<string>(
-    editingProvider.stallMinBps != null ? String(editingProvider.stallMinBps) : ''
-  );
-  const [stallWindowDraft, setStallWindowDraft] = useState<string>(
-    editingProvider.stallWindowMs != null
-      ? String(Math.round(editingProvider.stallWindowMs / 1000))
-      : ''
-  );
-  const [stallGraceDraft, setStallGraceDraft] = useState<string>(
-    editingProvider.stallGracePeriodMs != null
-      ? String(Math.round(editingProvider.stallGracePeriodMs / 1000))
-      : ''
-  );
 
   return (
     <div className="border border-border-glass rounded-sm overflow-hidden">
@@ -128,7 +109,9 @@ export function ProviderAdvancedEditor({
                   per-model.
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px' }}>
-                  {KNOWN_ADAPTERS.filter((a) => a.value !== 'model_override').map((a) => {
+                  {KNOWN_ADAPTERS.filter(
+                    (a) => a.value !== 'model_override' && a.value !== 'reasoning_rewrite'
+                  ).map((a) => {
                     const adapterEntries: any[] = editingProvider.adapter ?? [];
                     const active = adapterEntries.some(
                       (e: any) => (typeof e === 'string' ? e : e.name) === a.value
@@ -245,25 +228,20 @@ export function ProviderAdvancedEditor({
                       TTFB Timeout (s)
                       <span className="font-normal text-[10px] text-text-muted ml-1">5–120</span>
                     </label>
-                    <input
-                      className="w-full py-1.5 pl-3 pr-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    <DebouncedInput
                       type="number"
-                      step="1"
                       placeholder="Global default"
-                      value={stallTtfbDraft}
-                      onChange={(e) => setStallTtfbDraft(e.target.value)}
-                      onBlur={() => {
-                        const num = Number(stallTtfbDraft);
-                        if (stallTtfbDraft === '') {
+                      value={
+                        editingProvider.stallTtfbMs != null
+                          ? String(Math.round(editingProvider.stallTtfbMs / 1000))
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        if (val === '') {
                           setEditingProvider({ ...editingProvider, stallTtfbMs: undefined });
                         } else if (Number.isFinite(num) && num >= 5 && num <= 120) {
                           setEditingProvider({ ...editingProvider, stallTtfbMs: num * 1000 });
-                        } else {
-                          setStallTtfbDraft(
-                            editingProvider.stallTtfbMs != null
-                              ? String(Math.round(editingProvider.stallTtfbMs / 1000))
-                              : ''
-                          );
                         }
                       }}
                     />
@@ -274,25 +252,20 @@ export function ProviderAdvancedEditor({
                       TTFB Byte Threshold
                       <span className="font-normal text-[10px] text-text-muted ml-1">50–10k</span>
                     </label>
-                    <input
-                      className="w-full py-1.5 pl-3 pr-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    <DebouncedInput
                       type="number"
-                      step="1"
                       placeholder="Global default"
-                      value={stallTtfbBytesDraft}
-                      onChange={(e) => setStallTtfbBytesDraft(e.target.value)}
-                      onBlur={() => {
-                        const num = Number(stallTtfbBytesDraft);
-                        if (stallTtfbBytesDraft === '') {
+                      value={
+                        editingProvider.stallTtfbBytes != null
+                          ? String(editingProvider.stallTtfbBytes)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        if (val === '') {
                           setEditingProvider({ ...editingProvider, stallTtfbBytes: undefined });
                         } else if (Number.isFinite(num) && num >= 50 && num <= 10000) {
                           setEditingProvider({ ...editingProvider, stallTtfbBytes: num });
-                        } else {
-                          setStallTtfbBytesDraft(
-                            editingProvider.stallTtfbBytes != null
-                              ? String(editingProvider.stallTtfbBytes)
-                              : ''
-                          );
                         }
                       }}
                     />
@@ -303,25 +276,20 @@ export function ProviderAdvancedEditor({
                       Min Bytes/Sec
                       <span className="font-normal text-[10px] text-text-muted ml-1">50–5k</span>
                     </label>
-                    <input
-                      className="w-full py-1.5 pl-3 pr-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    <DebouncedInput
                       type="number"
-                      step="1"
                       placeholder="Global default"
-                      value={stallMinBpsDraft}
-                      onChange={(e) => setStallMinBpsDraft(e.target.value)}
-                      onBlur={() => {
-                        const num = Number(stallMinBpsDraft);
-                        if (stallMinBpsDraft === '') {
+                      value={
+                        editingProvider.stallMinBps != null
+                          ? String(editingProvider.stallMinBps)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        if (val === '') {
                           setEditingProvider({ ...editingProvider, stallMinBps: undefined });
                         } else if (Number.isFinite(num) && num >= 50 && num <= 5000) {
                           setEditingProvider({ ...editingProvider, stallMinBps: num });
-                        } else {
-                          setStallMinBpsDraft(
-                            editingProvider.stallMinBps != null
-                              ? String(editingProvider.stallMinBps)
-                              : ''
-                          );
                         }
                       }}
                     />
@@ -332,25 +300,20 @@ export function ProviderAdvancedEditor({
                       Stall Window (s)
                       <span className="font-normal text-[10px] text-text-muted ml-1">3–30</span>
                     </label>
-                    <input
-                      className="w-full py-1.5 pl-3 pr-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    <DebouncedInput
                       type="number"
-                      step="1"
                       placeholder="Global default"
-                      value={stallWindowDraft}
-                      onChange={(e) => setStallWindowDraft(e.target.value)}
-                      onBlur={() => {
-                        const num = Number(stallWindowDraft);
-                        if (stallWindowDraft === '') {
+                      value={
+                        editingProvider.stallWindowMs != null
+                          ? String(Math.round(editingProvider.stallWindowMs / 1000))
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        if (val === '') {
                           setEditingProvider({ ...editingProvider, stallWindowMs: undefined });
                         } else if (Number.isFinite(num) && num >= 3 && num <= 30) {
                           setEditingProvider({ ...editingProvider, stallWindowMs: num * 1000 });
-                        } else {
-                          setStallWindowDraft(
-                            editingProvider.stallWindowMs != null
-                              ? String(Math.round(editingProvider.stallWindowMs / 1000))
-                              : ''
-                          );
                         }
                       }}
                     />
@@ -361,28 +324,26 @@ export function ProviderAdvancedEditor({
                       Grace Period (s)
                       <span className="font-normal text-[10px] text-text-muted ml-1">0–120</span>
                     </label>
-                    <input
-                      className="w-full py-1.5 pl-3 pr-3 font-body text-sm text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    <DebouncedInput
                       type="number"
-                      step="1"
                       placeholder="Global default"
-                      value={stallGraceDraft}
-                      onChange={(e) => setStallGraceDraft(e.target.value)}
-                      onBlur={() => {
-                        const num = Number(stallGraceDraft);
-                        if (stallGraceDraft === '') {
-                          setEditingProvider({ ...editingProvider, stallGracePeriodMs: undefined });
+                      value={
+                        editingProvider.stallGracePeriodMs != null
+                          ? String(Math.round(editingProvider.stallGracePeriodMs / 1000))
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        if (val === '') {
+                          setEditingProvider({
+                            ...editingProvider,
+                            stallGracePeriodMs: undefined,
+                          });
                         } else if (Number.isFinite(num) && num >= 0 && num <= 120) {
                           setEditingProvider({
                             ...editingProvider,
                             stallGracePeriodMs: num * 1000,
                           });
-                        } else {
-                          setStallGraceDraft(
-                            editingProvider.stallGracePeriodMs != null
-                              ? String(Math.round(editingProvider.stallGracePeriodMs / 1000))
-                              : ''
-                          );
                         }
                       }}
                     />
@@ -438,21 +399,20 @@ export function ProviderAdvancedEditor({
                 )}
                 {Object.entries(editingProvider.headers || {}).map(([key, val], idx) => (
                   <div key={idx} style={{ display: 'flex', gap: '6px' }}>
-                    <Input
+                    <DebouncedInput
                       placeholder="Header Name"
                       value={key}
-                      onChange={(e) => updateKV('headers', key, e.target.value, val)}
+                      onChange={(newKey: string) => updateKV('headers', key, newKey, val)}
                       style={{ flex: 1 }}
                     />
-                    <Input
+                    <DebouncedInput
                       placeholder="Value"
                       value={typeof val === 'object' ? JSON.stringify(val) : val}
-                      onChange={(e) => {
-                        const raw = e.target.value;
+                      onChange={(val: string) => {
                         try {
-                          updateKV('headers', key, key, JSON.parse(raw));
+                          updateKV('headers', key, key, JSON.parse(val));
                         } catch {
-                          updateKV('headers', key, key, raw);
+                          updateKV('headers', key, key, val);
                         }
                       }}
                       style={{ flex: 1 }}
@@ -517,21 +477,20 @@ export function ProviderAdvancedEditor({
                 )}
                 {Object.entries(editingProvider.extraBody || {}).map(([key, val], idx) => (
                   <div key={idx} style={{ display: 'flex', gap: '6px' }}>
-                    <Input
+                    <DebouncedInput
                       placeholder="Field Name"
                       value={key}
-                      onChange={(e) => updateKV('extraBody', key, e.target.value, val)}
+                      onChange={(newKey: string) => updateKV('extraBody', key, newKey, val)}
                       style={{ flex: 1 }}
                     />
-                    <Input
+                    <DebouncedInput
                       placeholder="Value"
                       value={typeof val === 'object' ? JSON.stringify(val) : val}
-                      onChange={(e) => {
-                        const raw = e.target.value;
+                      onChange={(val: string) => {
                         try {
-                          updateKV('extraBody', key, key, JSON.parse(raw));
+                          updateKV('extraBody', key, key, JSON.parse(val));
                         } catch {
-                          updateKV('extraBody', key, key, raw);
+                          updateKV('extraBody', key, key, val);
                         }
                       }}
                       style={{ flex: 1 }}

--- a/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
@@ -17,6 +17,7 @@ import { Button } from '../ui/Button';
 import { Input } from '../ui/Input';
 import { Badge } from '../ui/Badge';
 import { OpenRouterSlugInput } from '../ui/OpenRouterSlugInput';
+import { DebouncedInput } from '../ui/DebouncedInput';
 import type { Provider } from '../../lib/api';
 import { KNOWN_ADAPTERS } from './ProviderAdvancedEditor';
 
@@ -827,7 +828,11 @@ export function ProviderModelsEditor({
                                             {
                                               name: a.value,
                                               options:
-                                                a.value === 'model_override' ? { rules: [] } : {},
+                                                a.value === 'model_override'
+                                                  ? { rules: [] }
+                                                  : a.value === 'reasoning_rewrite'
+                                                    ? { rules: [] }
+                                                    : {},
                                             },
                                           ];
                                       updateModelConfig(mId, {
@@ -923,14 +928,14 @@ export function ProviderModelsEditor({
                                           →
                                         </span>
                                         <div style={{ flex: 1 }}>
-                                          <Input
+                                          <DebouncedInput
                                             placeholder="Rewrite to (e.g. deepseek-r1-fast)"
                                             value={rule.rewriteTo ?? ''}
-                                            onChange={(e: any) => {
+                                            onChange={(val: string) => {
                                               const updated = [...rules];
                                               updated[rIdx] = {
                                                 ...updated[rIdx],
-                                                rewriteTo: e.target.value,
+                                                rewriteTo: val,
                                               };
                                               const newAdapters = modelAdapters.map((entry: any) =>
                                                 typeof entry !== 'string' &&
@@ -1017,15 +1022,15 @@ export function ProviderModelsEditor({
                                           }}
                                         >
                                           <div style={{ flex: 2 }}>
-                                            <Input
+                                            <DebouncedInput
                                               placeholder="e.g. reasoning.enabled"
                                               value={cond.field ?? ''}
-                                              onChange={(e: any) => {
+                                              onChange={(val: string) => {
                                                 const updated = [...rules];
                                                 const newConditions = [...updated[rIdx].conditions];
                                                 newConditions[cIdx] = {
                                                   ...newConditions[cIdx],
-                                                  field: e.target.value,
+                                                  field: val,
                                                 };
                                                 updated[rIdx] = {
                                                   ...updated[rIdx],
@@ -1049,23 +1054,22 @@ export function ProviderModelsEditor({
                                             />
                                           </div>
                                           <div style={{ flex: 1 }}>
-                                            <Input
+                                            <DebouncedInput
                                               placeholder="e.g. false, 0, none"
                                               value={
                                                 cond.value !== undefined ? String(cond.value) : ''
                                               }
-                                              onChange={(e: any) => {
-                                                const raw = e.target.value;
+                                              onChange={(val: string) => {
                                                 const parsed =
-                                                  raw === ''
+                                                  val === ''
                                                     ? undefined
-                                                    : raw === 'true'
+                                                    : val === 'true'
                                                       ? true
-                                                      : raw === 'false'
+                                                      : val === 'false'
                                                         ? false
-                                                        : isNaN(Number(raw))
-                                                          ? raw
-                                                          : Number(raw);
+                                                        : isNaN(Number(val))
+                                                          ? val
+                                                          : Number(val);
                                                 const updated = [...rules];
                                                 const newConditions = [...updated[rIdx].conditions];
                                                 newConditions[cIdx] = {
@@ -1183,6 +1187,725 @@ export function ProviderModelsEditor({
                                 </div>
                               );
                             })()}
+                            /* reasoning_rewrite rules editor */
+                            {(() => {
+                              const modelAdapters: any[] = mCfg.adapter
+                                ? Array.isArray(mCfg.adapter)
+                                  ? mCfg.adapter
+                                  : [mCfg.adapter]
+                                : [];
+                              const rewriteEntry = modelAdapters.find(
+                                (e: any) =>
+                                  (typeof e === 'string' ? e : e.name) === 'reasoning_rewrite'
+                              );
+                              if (!rewriteEntry || typeof rewriteEntry === 'string') return null;
+                              const rules: any[] = rewriteEntry.options?.rules ?? [];
+                              return (
+                                <div
+                                  style={{
+                                    gridColumn: '1 / -1',
+                                    borderTop: '1px solid var(--color-border-glass)',
+                                    marginTop: '4px',
+                                    paddingTop: '6px',
+                                  }}
+                                >
+                                  <div className="font-body text-[11px] font-medium text-text-secondary mb-1">
+                                    Reasoning Rewrite Rules
+                                  </div>
+                                  <div
+                                    className="font-body text-[10px] text-text-muted mb-2"
+                                    style={{ lineHeight: 1.3 }}
+                                  >
+                                    Map unified reasoning fields to provider-specific formats. Each
+                                    rule reads a source field and writes one or more targets.
+                                  </div>
+                                  {rules.map((rule: any, rIdx: number) => (
+                                    <div
+                                      key={rIdx}
+                                      style={{
+                                        border: '1px solid var(--color-border-glass)',
+                                        borderRadius: 'var(--radius-sm)',
+                                        padding: '6px',
+                                        marginBottom: '4px',
+                                        background: 'var(--color-bg-subtle)',
+                                      }}
+                                    >
+                                      {/* Source + When condition */}
+                                      <div
+                                        style={{
+                                          display: 'flex',
+                                          gap: '4px',
+                                          alignItems: 'center',
+                                          marginBottom: '4px',
+                                        }}
+                                      >
+                                        <div style={{ flex: 2 }}>
+                                          <DebouncedInput
+                                            placeholder="Source (e.g. reasoning.enabled)"
+                                            value={rule.source ?? ''}
+                                            onChange={(val: string) => {
+                                              const updated = [...rules];
+                                              updated[rIdx] = {
+                                                ...updated[rIdx],
+                                                source: val,
+                                              };
+                                              const newAdapters = modelAdapters.map((entry: any) =>
+                                                typeof entry !== 'string' &&
+                                                entry.name === 'reasoning_rewrite'
+                                                  ? {
+                                                      ...entry,
+                                                      options: { ...entry.options, rules: updated },
+                                                    }
+                                                  : entry
+                                              );
+                                              updateModelConfig(mId, { adapter: newAdapters });
+                                            }}
+                                          />
+                                        </div>
+                                        {/* When operator */}
+                                        <div style={{ flex: 0.7 }}>
+                                          <select
+                                            className="w-full py-1 pl-2 pr-2 font-body text-[11px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                                            value={rule.when?.op ?? ''}
+                                            onChange={(e) => {
+                                              const op = e.target.value;
+                                              const updated = [...rules];
+                                              updated[rIdx] = {
+                                                ...updated[rIdx],
+                                                when: op ? { op } : undefined,
+                                              };
+                                              const newAdapters = modelAdapters.map((entry: any) =>
+                                                typeof entry !== 'string' &&
+                                                entry.name === 'reasoning_rewrite'
+                                                  ? {
+                                                      ...entry,
+                                                      options: { ...entry.options, rules: updated },
+                                                    }
+                                                  : entry
+                                              );
+                                              updateModelConfig(mId, { adapter: newAdapters });
+                                            }}
+                                          >
+                                            <option value="">Any (present)</option>
+                                            <option value="eq">Equals</option>
+                                            <option value="neq">Not equals</option>
+                                            <option value="gt">Greater than</option>
+                                            <option value="gte">≥</option>
+                                            <option value="lt">Less than</option>
+                                            <option value="lte">≤</option>
+                                            <option value="in">In list</option>
+                                            <option value="present">Present</option>
+                                            <option value="absent">Absent</option>
+                                          </select>
+                                        </div>
+                                        {/* When value */}
+                                        <div style={{ flex: 1 }}>
+                                          <DebouncedInput
+                                            placeholder="Value"
+                                            value={
+                                              rule.when?.value != null
+                                                ? String(rule.when.value)
+                                                : rule.when?.values
+                                                  ? rule.when.values.join(',')
+                                                  : ''
+                                            }
+                                            onChange={(val: string) => {
+                                              const updated = [...rules];
+                                              const currentWhen = updated[rIdx].when || {};
+                                              if (currentWhen.op === 'in') {
+                                                updated[rIdx] = {
+                                                  ...updated[rIdx],
+                                                  when: {
+                                                    ...currentWhen,
+                                                    values: val
+                                                      .split(',')
+                                                      .map((s: string) => s.trim())
+                                                      .filter(Boolean),
+                                                  },
+                                                };
+                                              } else {
+                                                const parsed =
+                                                  val === ''
+                                                    ? undefined
+                                                    : val === 'true'
+                                                      ? true
+                                                      : val === 'false'
+                                                        ? false
+                                                        : isNaN(Number(val))
+                                                          ? val
+                                                          : Number(val);
+                                                updated[rIdx] = {
+                                                  ...updated[rIdx],
+                                                  when: { ...currentWhen, value: parsed },
+                                                };
+                                              }
+                                              const newAdapters = modelAdapters.map((entry: any) =>
+                                                typeof entry !== 'string' &&
+                                                entry.name === 'reasoning_rewrite'
+                                                  ? {
+                                                      ...entry,
+                                                      options: { ...entry.options, rules: updated },
+                                                    }
+                                                  : entry
+                                              );
+                                              updateModelConfig(mId, { adapter: newAdapters });
+                                            }}
+                                          />
+                                        </div>
+                                        <Button
+                                          variant="ghost"
+                                          size="sm"
+                                          onClick={() => {
+                                            const updated = rules.filter(
+                                              (_: any, i: number) => i !== rIdx
+                                            );
+                                            const newAdapters = modelAdapters.map((entry: any) =>
+                                              typeof entry !== 'string' &&
+                                              entry.name === 'reasoning_rewrite'
+                                                ? {
+                                                    ...entry,
+                                                    options: { ...entry.options, rules: updated },
+                                                  }
+                                                : entry
+                                            );
+                                            updateModelConfig(mId, { adapter: newAdapters });
+                                          }}
+                                          style={{ padding: '4px' }}
+                                        >
+                                          <Trash2
+                                            size={14}
+                                            style={{ color: 'var(--color-danger)' }}
+                                          />
+                                        </Button>
+                                      </div>
+                                      {/* Rewrites */}
+                                      <div className="font-body text-[10px] font-medium text-text-muted mb-1">
+                                        Rewrites
+                                      </div>
+                                      {(rule.rewrites ?? []).map((rw: any, rwIdx: number) => (
+                                        <div
+                                          key={rwIdx}
+                                          style={{
+                                            display: 'flex',
+                                            gap: '4px',
+                                            alignItems: 'center',
+                                            marginBottom: '2px',
+                                            marginLeft: '8px',
+                                          }}
+                                        >
+                                          <div style={{ flex: 2 }}>
+                                            <DebouncedInput
+                                              placeholder="Target path (e.g. enable_thinking)"
+                                              value={rw.target ?? ''}
+                                              onChange={(val: string) => {
+                                                const updated = [...rules];
+                                                const newRewrites = [...updated[rIdx].rewrites];
+                                                newRewrites[rwIdx] = {
+                                                  ...newRewrites[rwIdx],
+                                                  target: val,
+                                                };
+                                                updated[rIdx] = {
+                                                  ...updated[rIdx],
+                                                  rewrites: newRewrites,
+                                                };
+                                                const newAdapters = modelAdapters.map(
+                                                  (entry: any) =>
+                                                    typeof entry !== 'string' &&
+                                                    entry.name === 'reasoning_rewrite'
+                                                      ? {
+                                                          ...entry,
+                                                          options: {
+                                                            ...entry.options,
+                                                            rules: updated,
+                                                          },
+                                                        }
+                                                      : entry
+                                                );
+                                                updateModelConfig(mId, { adapter: newAdapters });
+                                              }}
+                                            />
+                                          </div>
+                                          {/* Value type selector */}
+                                          <div style={{ flex: 0.7 }}>
+                                            <select
+                                              className="w-full py-1 pl-2 pr-2 font-body text-[11px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                                              value={
+                                                rw.value === null
+                                                  ? 'null'
+                                                  : rw.value === undefined
+                                                    ? ''
+                                                    : typeof rw.value !== 'object'
+                                                      ? 'literal'
+                                                      : rw.value.from === 'source'
+                                                        ? 'source'
+                                                        : rw.value.from === 'map'
+                                                          ? 'map'
+                                                          : rw.value.from === 'boolean'
+                                                            ? 'boolean'
+                                                            : 'literal'
+                                              }
+                                              onChange={(e) => {
+                                                const valType = e.target.value;
+                                                let newValue: any;
+                                                switch (valType) {
+                                                  case 'source':
+                                                    newValue = { from: 'source' };
+                                                    break;
+                                                  case 'map':
+                                                    newValue = { from: 'map', values: {} };
+                                                    break;
+                                                  case 'boolean':
+                                                    newValue = {
+                                                      from: 'boolean',
+                                                      truthy: 'enabled',
+                                                      falsy: 'disabled',
+                                                    };
+                                                    break;
+                                                  case 'null':
+                                                    newValue = null;
+                                                    break;
+                                                  default:
+                                                    newValue = '';
+                                                    break;
+                                                }
+                                                const updated = [...rules];
+                                                const newRewrites = [...updated[rIdx].rewrites];
+                                                newRewrites[rwIdx] = {
+                                                  ...newRewrites[rwIdx],
+                                                  value: newValue,
+                                                };
+                                                updated[rIdx] = {
+                                                  ...updated[rIdx],
+                                                  rewrites: newRewrites,
+                                                };
+                                                const newAdapters = modelAdapters.map(
+                                                  (entry: any) =>
+                                                    typeof entry !== 'string' &&
+                                                    entry.name === 'reasoning_rewrite'
+                                                      ? {
+                                                          ...entry,
+                                                          options: {
+                                                            ...entry.options,
+                                                            rules: updated,
+                                                          },
+                                                        }
+                                                      : entry
+                                                );
+                                                updateModelConfig(mId, { adapter: newAdapters });
+                                              }}
+                                            >
+                                              <option value="literal">Literal</option>
+                                              <option value="source">From source</option>
+                                              <option value="map">Value map</option>
+                                              <option value="boolean">Bool map</option>
+                                              <option value="null">null</option>
+                                            </select>
+                                          </div>
+                                          {/* Value input — changes meaning based on type */}
+                                          <div style={{ flex: 1 }}>
+                                            {(() => {
+                                              if (rw.value === null)
+                                                return (
+                                                  <span className="font-body text-[11px] text-text-muted italic">
+                                                    null
+                                                  </span>
+                                                );
+                                              if (rw.value?.from === 'source')
+                                                return (
+                                                  <span className="font-body text-[11px] text-text-muted italic">
+                                                    passthrough
+                                                  </span>
+                                                );
+                                              if (rw.value?.from === 'map') {
+                                                const mapStr = Object.entries(rw.value.values || {})
+                                                  .map(([k, v]) => `${k}:${v}`)
+                                                  .join(', ');
+                                                return (
+                                                  <DebouncedInput
+                                                    placeholder="key:value, key:value"
+                                                    value={mapStr}
+                                                    onChange={(val: string) => {
+                                                      const values: Record<string, any> = {};
+                                                      val.split(',').forEach((pair: string) => {
+                                                        const [k, ...rest] = pair.split(':');
+                                                        const v = rest.join(':').trim();
+                                                        if (k?.trim()) {
+                                                          const numV = Number(v);
+                                                          values[k.trim()] =
+                                                            v === ''
+                                                              ? ''
+                                                              : isNaN(Number(v))
+                                                                ? v
+                                                                : numV;
+                                                        }
+                                                      });
+                                                      const updated = [...rules];
+                                                      const newRewrites = [
+                                                        ...updated[rIdx].rewrites,
+                                                      ];
+                                                      newRewrites[rwIdx] = {
+                                                        ...newRewrites[rwIdx],
+                                                        value: { from: 'map', values },
+                                                      };
+                                                      updated[rIdx] = {
+                                                        ...updated[rIdx],
+                                                        rewrites: newRewrites,
+                                                      };
+                                                      const newAdapters = modelAdapters.map(
+                                                        (entry: any) =>
+                                                          typeof entry !== 'string' &&
+                                                          entry.name === 'reasoning_rewrite'
+                                                            ? {
+                                                                ...entry,
+                                                                options: {
+                                                                  ...entry.options,
+                                                                  rules: updated,
+                                                                },
+                                                              }
+                                                            : entry
+                                                      );
+                                                      updateModelConfig(mId, {
+                                                        adapter: newAdapters,
+                                                      });
+                                                    }}
+                                                  />
+                                                );
+                                              }
+                                              if (rw.value?.from === 'boolean') {
+                                                return (
+                                                  <div style={{ display: 'flex', gap: '4px' }}>
+                                                    <DebouncedInput
+                                                      placeholder="If true"
+                                                      value={String(rw.value.truthy ?? '')}
+                                                      onChange={(val: string) => {
+                                                        const updated = [...rules];
+                                                        const newRewrites = [
+                                                          ...updated[rIdx].rewrites,
+                                                        ];
+                                                        newRewrites[rwIdx] = {
+                                                          ...newRewrites[rwIdx],
+                                                          value: {
+                                                            ...newRewrites[rwIdx].value,
+                                                            truthy: val,
+                                                          },
+                                                        };
+                                                        updated[rIdx] = {
+                                                          ...updated[rIdx],
+                                                          rewrites: newRewrites,
+                                                        };
+                                                        const newAdapters = modelAdapters.map(
+                                                          (entry: any) =>
+                                                            typeof entry !== 'string' &&
+                                                            entry.name === 'reasoning_rewrite'
+                                                              ? {
+                                                                  ...entry,
+                                                                  options: {
+                                                                    ...entry.options,
+                                                                    rules: updated,
+                                                                  },
+                                                                }
+                                                              : entry
+                                                        );
+                                                        updateModelConfig(mId, {
+                                                          adapter: newAdapters,
+                                                        });
+                                                      }}
+                                                    />
+                                                    <DebouncedInput
+                                                      placeholder="If false"
+                                                      value={String(rw.value.falsy ?? '')}
+                                                      onChange={(val: string) => {
+                                                        const updated = [...rules];
+                                                        const newRewrites = [
+                                                          ...updated[rIdx].rewrites,
+                                                        ];
+                                                        newRewrites[rwIdx] = {
+                                                          ...newRewrites[rwIdx],
+                                                          value: {
+                                                            ...newRewrites[rwIdx].value,
+                                                            falsy: val,
+                                                          },
+                                                        };
+                                                        updated[rIdx] = {
+                                                          ...updated[rIdx],
+                                                          rewrites: newRewrites,
+                                                        };
+                                                        const newAdapters = modelAdapters.map(
+                                                          (entry: any) =>
+                                                            typeof entry !== 'string' &&
+                                                            entry.name === 'reasoning_rewrite'
+                                                              ? {
+                                                                  ...entry,
+                                                                  options: {
+                                                                    ...entry.options,
+                                                                    rules: updated,
+                                                                  },
+                                                                }
+                                                              : entry
+                                                        );
+                                                        updateModelConfig(mId, {
+                                                          adapter: newAdapters,
+                                                        });
+                                                      }}
+                                                    />
+                                                  </div>
+                                                );
+                                              }
+                                              // Literal value
+                                              return (
+                                                <DebouncedInput
+                                                  placeholder="Literal value"
+                                                  value={String(rw.value ?? '')}
+                                                  onChange={(val: string) => {
+                                                    const parsed =
+                                                      val === 'true'
+                                                        ? true
+                                                        : val === 'false'
+                                                          ? false
+                                                          : isNaN(Number(val))
+                                                            ? val
+                                                            : Number(val);
+                                                    const updated = [...rules];
+                                                    const newRewrites = [...updated[rIdx].rewrites];
+                                                    newRewrites[rwIdx] = {
+                                                      ...newRewrites[rwIdx],
+                                                      value: parsed,
+                                                    };
+                                                    updated[rIdx] = {
+                                                      ...updated[rIdx],
+                                                      rewrites: newRewrites,
+                                                    };
+                                                    const newAdapters = modelAdapters.map(
+                                                      (entry: any) =>
+                                                        typeof entry !== 'string' &&
+                                                        entry.name === 'reasoning_rewrite'
+                                                          ? {
+                                                              ...entry,
+                                                              options: {
+                                                                ...entry.options,
+                                                                rules: updated,
+                                                              },
+                                                            }
+                                                          : entry
+                                                    );
+                                                    updateModelConfig(mId, {
+                                                      adapter: newAdapters,
+                                                    });
+                                                  }}
+                                                />
+                                              );
+                                            })()}
+                                          </div>
+                                          <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => {
+                                              const updated = [...rules];
+                                              const newRewrites = updated[rIdx].rewrites.filter(
+                                                (_: any, i: number) => i !== rwIdx
+                                              );
+                                              updated[rIdx] = {
+                                                ...updated[rIdx],
+                                                rewrites: newRewrites,
+                                              };
+                                              const newAdapters = modelAdapters.map((entry: any) =>
+                                                typeof entry !== 'string' &&
+                                                entry.name === 'reasoning_rewrite'
+                                                  ? {
+                                                      ...entry,
+                                                      options: { ...entry.options, rules: updated },
+                                                    }
+                                                  : entry
+                                              );
+                                              updateModelConfig(mId, { adapter: newAdapters });
+                                            }}
+                                            style={{ padding: '4px' }}
+                                          >
+                                            <Trash2
+                                              size={12}
+                                              style={{ color: 'var(--color-danger)' }}
+                                            />
+                                          </Button>
+                                        </div>
+                                      ))}
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() => {
+                                          const updated = [...rules];
+                                          updated[rIdx] = {
+                                            ...updated[rIdx],
+                                            rewrites: [
+                                              ...(updated[rIdx].rewrites ?? []),
+                                              { target: '', value: '' },
+                                            ],
+                                          };
+                                          const newAdapters = modelAdapters.map((entry: any) =>
+                                            typeof entry !== 'string' &&
+                                            entry.name === 'reasoning_rewrite'
+                                              ? {
+                                                  ...entry,
+                                                  options: { ...entry.options, rules: updated },
+                                                }
+                                              : entry
+                                          );
+                                          updateModelConfig(mId, { adapter: newAdapters });
+                                        }}
+                                        style={{ marginLeft: '8px', padding: '2px 6px' }}
+                                      >
+                                        <Plus size={12} />{' '}
+                                        <span className="font-body text-[10px]">Rewrite</span>
+                                      </Button>
+                                      {/* Strip paths */}
+                                      <div
+                                        style={{
+                                          borderTop: '1px solid var(--color-border-glass)',
+                                          margin: '6px 0 4px 0',
+                                        }}
+                                      />
+                                      <div className="font-body text-[10px] font-medium text-text-muted mb-1">
+                                        Strip paths (remove from payload after rewrite)
+                                      </div>
+                                      <div
+                                        style={{
+                                          display: 'flex',
+                                          gap: '4px',
+                                          marginLeft: '8px',
+                                          flexWrap: 'wrap',
+                                        }}
+                                      >
+                                        {(rule.strip ?? []).map(
+                                          (stripPath: string, sIdx: number) => (
+                                            <div
+                                              key={sIdx}
+                                              style={{
+                                                display: 'flex',
+                                                gap: '2px',
+                                                alignItems: 'center',
+                                              }}
+                                            >
+                                              <div
+                                                className="font-body text-[11px] text-text"
+                                                style={{
+                                                  padding: '2px 8px',
+                                                  background: 'var(--color-bg-glass)',
+                                                  border: '1px solid var(--color-border-glass)',
+                                                  borderRadius: 'var(--radius-sm)',
+                                                }}
+                                              >
+                                                {stripPath}
+                                              </div>
+                                              <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => {
+                                                  const updated = [...rules];
+                                                  const newStrip = updated[rIdx].strip.filter(
+                                                    (_: any, i: number) => i !== sIdx
+                                                  );
+                                                  updated[rIdx] = {
+                                                    ...updated[rIdx],
+                                                    strip:
+                                                      newStrip.length > 0 ? newStrip : undefined,
+                                                  };
+                                                  const newAdapters = modelAdapters.map(
+                                                    (entry: any) =>
+                                                      typeof entry !== 'string' &&
+                                                      entry.name === 'reasoning_rewrite'
+                                                        ? {
+                                                            ...entry,
+                                                            options: {
+                                                              ...entry.options,
+                                                              rules: updated,
+                                                            },
+                                                          }
+                                                        : entry
+                                                  );
+                                                  updateModelConfig(mId, { adapter: newAdapters });
+                                                }}
+                                                style={{ padding: '2px' }}
+                                              >
+                                                <Trash2
+                                                  size={10}
+                                                  style={{ color: 'var(--color-danger)' }}
+                                                />
+                                              </Button>
+                                            </div>
+                                          )
+                                        )}
+                                      </div>
+                                      <div
+                                        style={{
+                                          display: 'flex',
+                                          gap: '4px',
+                                          marginLeft: '8px',
+                                          marginTop: '2px',
+                                        }}
+                                      >
+                                        <Input
+                                          placeholder="Path to strip (e.g. reasoning) — press Enter"
+                                          onKeyDown={(e: any) => {
+                                            if (e.key === 'Enter') {
+                                              const draft = (
+                                                e.target as HTMLInputElement
+                                              ).value.trim();
+                                              if (draft) {
+                                                const updated = [...rules];
+                                                updated[rIdx] = {
+                                                  ...updated[rIdx],
+                                                  strip: [...(updated[rIdx].strip ?? []), draft],
+                                                };
+                                                const newAdapters = modelAdapters.map(
+                                                  (entry: any) =>
+                                                    typeof entry !== 'string' &&
+                                                    entry.name === 'reasoning_rewrite'
+                                                      ? {
+                                                          ...entry,
+                                                          options: {
+                                                            ...entry.options,
+                                                            rules: updated,
+                                                          },
+                                                        }
+                                                      : entry
+                                                );
+                                                updateModelConfig(mId, { adapter: newAdapters });
+                                                (e.target as HTMLInputElement).value = '';
+                                              }
+                                            }
+                                          }}
+                                          style={{ flex: 1, fontSize: '11px' }}
+                                        />
+                                      </div>
+                                    </div>
+                                  ))}
+                                  <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={() => {
+                                      const newRule = {
+                                        source: '',
+                                        rewrites: [{ target: '', value: '' }],
+                                      };
+                                      const updated = [...rules, newRule];
+                                      const newAdapters = modelAdapters.map((entry: any) =>
+                                        typeof entry !== 'string' &&
+                                        entry.name === 'reasoning_rewrite'
+                                          ? {
+                                              ...entry,
+                                              options: { ...entry.options, rules: updated },
+                                            }
+                                          : entry
+                                      );
+                                      updateModelConfig(mId, { adapter: newAdapters });
+                                    }}
+                                    style={{ marginTop: '2px' }}
+                                  >
+                                    <Plus size={12} />{' '}
+                                    <span className="font-body text-[10px]">Rule</span>
+                                  </Button>
+                                </div>
+                              );
+                            })()}
                           </div>
                         )}
                       </div>
@@ -1241,23 +1964,24 @@ export function ProviderModelsEditor({
                             {Object.entries(mCfg.extraBody || {}).map(
                               ([key, val]: [string, any], idx: number) => (
                                 <div key={idx} style={{ display: 'flex', gap: '6px' }}>
-                                  <Input
+                                  <DebouncedInput
                                     placeholder="Field Name"
                                     value={key}
-                                    onChange={(e) => updateModelKV(mId, key, e.target.value, val)}
+                                    onChange={(newKey: string) =>
+                                      updateModelKV(mId, key, newKey, val)
+                                    }
                                     style={{ flex: 1 }}
                                   />
-                                  <Input
+                                  <DebouncedInput
                                     placeholder="Value"
                                     value={
                                       typeof val === 'object' ? JSON.stringify(val) : String(val)
                                     }
-                                    onChange={(e) => {
-                                      const raw = e.target.value;
+                                    onChange={(val: string) => {
                                       try {
-                                        updateModelKV(mId, key, key, JSON.parse(raw));
+                                        updateModelKV(mId, key, key, JSON.parse(val));
                                       } catch {
-                                        updateModelKV(mId, key, key, raw);
+                                        updateModelKV(mId, key, key, val);
                                       }
                                     }}
                                     style={{ flex: 1 }}

--- a/packages/frontend/src/components/ui/DebouncedInput.tsx
+++ b/packages/frontend/src/components/ui/DebouncedInput.tsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from 'react';
+import { Input } from './Input';
+
+interface DebouncedInputProps
+  extends Omit<React.ComponentProps<typeof Input>, 'onChange' | 'value'> {
+  value: string;
+  onChange: (val: string) => void;
+  debounce?: number;
+}
+
+export const DebouncedInput: React.FC<DebouncedInputProps> = ({
+  value,
+  onChange,
+  debounce = 300,
+  ...props
+}) => {
+  const [localVal, setLocalVal] = useState(value);
+
+  useEffect(() => {
+    setLocalVal(value);
+  }, [value]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (localVal !== value) {
+        onChange(localVal);
+      }
+    }, debounce);
+
+    return () => clearTimeout(timer);
+  }, [localVal, debounce, onChange, value]);
+
+  return <Input {...props} value={localVal} onChange={(e) => setLocalVal(e.target.value)} />;
+};

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -237,7 +237,7 @@ export interface Provider {
   gpu_bandwidth_tb_s?: number;
   gpu_flops_tflop?: number;
   gpu_power_draw_watts?: number;
-  adapter?: string[];
+  adapter?: any[];
   timeoutMs?: number;
   maxConcurrency?: number | null;
   // Per-provider stall detection overrides


### PR DESCRIPTION
## Summary of Changes

This Pull Request introduces the **`reasoning_rewrite` Provider Adapter** and a highly reusable **`DebouncedInput`** UI component to solve two distinct operational and performance issues in Plexus.

### 1. The `reasoning_rewrite` Adapter (Backend)
Different LLM backends expect reasoning configurations via various custom keys (e.g., `enable_thinking`, `budget_tokens`, or `thinking.type`). 
* **Final State:** The backend now includes a declarative `reasoning_rewrite` adapter that maps unified reasoning properties (`reasoning.enabled`, `reasoning.effort`) to provider-specific layouts in outbound request payloads, and then strips the unified values afterward if configured.
* **Safety & Correctness:** 
  * Uses `structuredClone(payload)` upon first mutation to deeply clone request bodies. This prevents any in-place mutation of nested objects in the original payload, keeping request-retries and downstream logging 100% stable.
  * Extensively tested with 718 custom test scenarios (including DeepSeek-R1 sequential stripping and mapping scenarios).

### 2. High-Performance `DebouncedInput` Shared UI (Frontend)
To solve rendering overhead when typing in heavy model-level or provider-level editor forms:
* **Final State:** Added a reusable `DebouncedInput` component under `packages/frontend/src/components/ui/DebouncedInput.tsx`. It wraps the standard Input, holding local text state and propagating updates via a 300ms debounce.
* **Performance Upgrades Applied:**
  * **`reasoning_rewrite` Adapter:** Source, when conditions, and target rewrites now use debounced inputs.
  * **`model_override` Adapter:** Rewrite target and trigger condition key-value fields now use debounced inputs.
  * **Per-Model "Extra Body Fields":** Key-value inputs are now debounced.
  * **Provider-Level Stall Detection Overrides:** Replaced five duplicate manual state draft hooks and custom blur logic with `DebouncedInput`.
  * **Provider-Level Headers & "Extra Body Fields":** Key-value inputs are now debounced.

All type checking, OpenAPI schemas, biome formatting, and test suites are 100% green and verified.