### PR TITLE
Fix OAuth per-provider stall overrides and failover config leak

### DIFF
--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -178,7 +178,7 @@ export async function registerResponsesRoute(
         unifiedRequest,
         dispatchSignal,
         addTimeoutSource,
-        stallDetectionResult?.addStallConfig
+        stallDetectionResult.addStallConfig
       );
 
       // Emit 'updated' event with routing decision details

--- a/packages/backend/src/services/__tests__/oauth-probe-bookkeeping.test.ts
+++ b/packages/backend/src/services/__tests__/oauth-probe-bookkeeping.test.ts
@@ -36,8 +36,8 @@ async function consumeStream(stream: ReadableStream<any>): Promise<any[]> {
 /**
  * Helper to access the private probeOAuthStreamStart method for testing
  */
-function probeStreamStart(dispatcher: any, stream: ReadableStream<any>) {
-  return dispatcher.probeOAuthStreamStart(stream);
+function probeStreamStart(dispatcher: any, stream: ReadableStream<any>, stallConfig?: any) {
+  return dispatcher.probeOAuthStreamStart(stream, stallConfig);
 }
 
 function makeConfig() {
@@ -219,5 +219,132 @@ describe('OAuth probe: bookkeeping event buffering', () => {
     expect(result.ok).toBe(false);
     expect(result.error).toBeDefined();
     expect(result.error!.message).toContain('429');
+  });
+
+  test('TTFB deadline exceeded returns stall error', async () => {
+    const dispatcher = new Dispatcher();
+    // Stream that keeps producing bookkeeping events slowly — never reaches content.
+    // The first event arrives after the TTFB deadline, so the deadline fires first.
+    const slowStream = new ReadableStream({
+      start(controller) {
+        setTimeout(() => {
+          controller.enqueue({ type: 'start', role: 'assistant' });
+          // More bookkeeping events would follow, but the deadline fires first
+          setTimeout(() => {
+            controller.enqueue({ type: 'text_start', contentIndex: 0 });
+          }, 500);
+        }, 500);
+      },
+    });
+
+    const result = await probeStreamStart(dispatcher, slowStream, {
+      ttfbMs: 50, // Very short deadline
+      ttfbBytes: 100,
+      minBytesPerSecond: null,
+      windowMs: 10000,
+      gracePeriodMs: 30000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.streamStarted).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toContain('stalled');
+  });
+
+  test('TTFB timeout fires during slow read', async () => {
+    const dispatcher = new Dispatcher();
+    // Stream that delivers a bookkeeping event slowly, then content after
+    const delayedStream = new ReadableStream({
+      start(controller) {
+        // Delay the first event past the TTFB timeout
+        setTimeout(() => {
+          controller.enqueue({ type: 'start', role: 'assistant' });
+          // The content arrives way after the deadline
+          setTimeout(() => {
+            controller.enqueue({ type: 'text_delta', delta: 'Hello', contentIndex: 0 });
+            controller.close();
+          }, 200);
+        }, 200);
+      },
+    });
+
+    const result = await probeStreamStart(dispatcher, delayedStream, {
+      ttfbMs: 50,
+      ttfbBytes: 100,
+      minBytesPerSecond: null,
+      windowMs: 10000,
+      gracePeriodMs: 30000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.streamStarted).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toContain('stalled');
+  });
+
+  test('Content event before deadline returns ok:true', async () => {
+    const dispatcher = new Dispatcher();
+    // Stream with bookkeeping then content — arrives well within deadline
+    const fastStream = createEventStream([
+      { type: 'start', role: 'assistant' },
+      { type: 'text_delta', delta: 'Hello', contentIndex: 0 },
+    ]);
+
+    const result = await probeStreamStart(dispatcher, fastStream, {
+      ttfbMs: 5000, // Generous deadline
+      ttfbBytes: 100,
+      minBytesPerSecond: null,
+      windowMs: 10000,
+      gracePeriodMs: 30000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.stream).toBeDefined();
+
+    const events = await consumeStream(result.stream!);
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe('start');
+    expect(events[1].type).toBe('text_delta');
+  });
+
+  test('Error event before deadline returns ok:false (not stall)', async () => {
+    const dispatcher = new Dispatcher();
+    const errorStream = createEventStream([
+      { type: 'start', role: 'assistant' },
+      {
+        type: 'error',
+        error: { type: 'rate_limit_error', message: 'Rate limit exceeded' },
+      },
+    ]);
+
+    const result = await probeStreamStart(dispatcher, errorStream, {
+      ttfbMs: 5000,
+      ttfbBytes: 100,
+      minBytesPerSecond: null,
+      windowMs: 10000,
+      gracePeriodMs: 30000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toContain('Rate limit');
+    // Should NOT be a stall error
+    expect(result.error!.message).not.toContain('stalled');
+  });
+
+  test('No stallConfig preserves existing behavior', async () => {
+    const dispatcher = new Dispatcher();
+    const streamWithBookkeeping = createEventStream([
+      { type: 'start', role: 'assistant' },
+      { type: 'text_delta', delta: 'Hello', contentIndex: 0 },
+    ]);
+
+    const result = await probeStreamStart(dispatcher, streamWithBookkeeping);
+
+    expect(result.ok).toBe(true);
+    expect(result.stream).toBeDefined();
+
+    const events = await consumeStream(result.stream!);
+    expect(events).toHaveLength(2);
   });
 });

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -511,6 +511,53 @@ export class Dispatcher {
           } catch (oauthError: any) {
             if (signal?.aborted) throw this.buildCancelledError(signal);
             lastError = oauthError;
+
+            // Handle TTFB stall errors with failover support
+            const isStallError = (oauthError as any).isStallError === true;
+            if (isStallError) {
+              const canRetryStall = failoverEnabled && i < targets.length - 1;
+              this.appendFailureAttempt(
+                retryHistory,
+                route,
+                oauthError,
+                targetApiType,
+                canRetryStall
+              );
+
+              if (canRetryStall) {
+                await this.recordAttemptMetric(route, currentRequest.requestId, false, {
+                  isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+                  isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+                  visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
+                });
+                CooldownManager.getInstance().markProviderStallFailure(
+                  route.provider,
+                  route.model,
+                  this.formatFailureReason(oauthError)
+                );
+                this.saveIntermediateError(
+                  currentRequest.requestId,
+                  targetApiType || 'chat',
+                  oauthError
+                );
+                logger.info(
+                  `TTFB stall: OAuth request timed out for ${route.provider}/${route.model}, retrying`
+                );
+                doRelease();
+                continue;
+              }
+
+              doRelease();
+
+              // Mark stall failure for cooldown tracking even on the last target
+              CooldownManager.getInstance().markProviderStallFailure(
+                route.provider,
+                route.model,
+                this.formatFailureReason(oauthError)
+              );
+              throw oauthError;
+            }
+
             const canRetry =
               failoverEnabled && i < targets.length - 1 && this.isRetryableOAuthError(oauthError);
 
@@ -1737,7 +1784,8 @@ export class Dispatcher {
   }
 
   private async probeOAuthStreamStart(
-    stream: ReadableStream<any>
+    stream: ReadableStream<any>,
+    stallConfig?: StallConfig | null
   ): Promise<
     { ok: true; stream: ReadableStream<any> } | { ok: false; error: Error; streamStarted: boolean }
   > {
@@ -1762,36 +1810,132 @@ export class Dispatcher {
 
     const reader = stream.getReader();
     const buffered: any[] = [];
+    const ttfbMs = stallConfig?.ttfbMs;
 
     try {
-      while (true) {
-        const { value, done } = await reader.read();
+      if (ttfbMs != null) {
+        // TTFB deadline mode: race each read against remaining time from
+        // a single absolute deadline. The deadline never resets after each
+        // bookkeeping event — a slow trickle of bookkeeping events cannot
+        // avoid timeout. TTFB for OAuth is "time to first non-bookkeeping event".
+        const deadline = Date.now() + ttfbMs;
+        const stallReason = new DOMException(
+          `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`,
+          'TimeoutError'
+        );
 
-        if (done) {
-          // Stream closed — quota exhausted (no events) or provider gave up.
-          reader.releaseLock();
-          return {
-            ok: false,
-            error: new Error('OAuth provider returned empty stream (quota exhausted)'),
-            streamStarted: false,
-          };
+        while (true) {
+          const remaining = deadline - Date.now();
+          if (remaining <= 0) {
+            try {
+              await reader.cancel(stallReason);
+            } catch {}
+            try {
+              reader.releaseLock();
+            } catch {}
+            return {
+              ok: false,
+              error: new Error(stallReason.message),
+              streamStarted: false,
+            };
+          }
+
+          let readTimerId: ReturnType<typeof setTimeout> | undefined;
+          try {
+            const readPromise = reader.read();
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              readTimerId = setTimeout(() => reject(stallReason), remaining);
+              readTimerId.unref?.();
+            });
+
+            const { value, done } = await Promise.race([readPromise, timeoutPromise]);
+
+            if (done) {
+              try {
+                await reader.cancel();
+              } catch {}
+              try {
+                reader.releaseLock();
+              } catch {}
+              return {
+                ok: false,
+                error: new Error('OAuth provider returned empty stream (quota exhausted)'),
+                streamStarted: false,
+              };
+            }
+
+            if (value?.type === 'error' || value?.reason === 'error') {
+              try {
+                await reader.cancel();
+              } catch {}
+              try {
+                reader.releaseLock();
+              } catch {}
+              return {
+                ok: false,
+                error: this.buildOAuthStreamEventError(value),
+                streamStarted: false,
+              };
+            }
+
+            buffered.push(value);
+
+            // If this event is not pure bookkeeping, the stream is healthy.
+            if (!BOOKKEEPING_TYPES.has(value?.type)) {
+              break;
+            }
+          } catch (err: any) {
+            if (err?.name === 'TimeoutError' || err?.message?.includes('stalled')) {
+              try {
+                await reader.cancel(err);
+              } catch {}
+              try {
+                reader.releaseLock();
+              } catch {}
+              return {
+                ok: false,
+                error: err instanceof Error ? err : new Error(String(err)),
+                streamStarted: false,
+              };
+            }
+            throw err;
+          } finally {
+            if (readTimerId !== undefined) {
+              clearTimeout(readTimerId);
+            }
+          }
         }
+      } else {
+        // No TTFB deadline — use existing indefinite read loop
+        while (true) {
+          const { value, done } = await reader.read();
 
-        if (value?.type === 'error' || value?.reason === 'error') {
-          reader.releaseLock();
-          return {
-            ok: false,
-            error: this.buildOAuthStreamEventError(value),
-            streamStarted: false,
-          };
-        }
+          if (done) {
+            // Stream closed — quota exhausted (no events) or provider gave up.
+            reader.releaseLock();
+            return {
+              ok: false,
+              error: new Error('OAuth provider returned empty stream (quota exhausted)'),
+              streamStarted: false,
+            };
+          }
 
-        buffered.push(value);
+          if (value?.type === 'error' || value?.reason === 'error') {
+            reader.releaseLock();
+            return {
+              ok: false,
+              error: this.buildOAuthStreamEventError(value),
+              streamStarted: false,
+            };
+          }
 
-        // If this event is not pure bookkeeping, the stream is healthy.
-        // Replay all buffered events then continue from the reader.
-        if (!BOOKKEEPING_TYPES.has(value?.type)) {
-          break;
+          buffered.push(value);
+
+          // If this event is not pure bookkeeping, the stream is healthy.
+          // Replay all buffered events then continue from the reader.
+          if (!BOOKKEEPING_TYPES.has(value?.type)) {
+            break;
+          }
         }
       }
 
@@ -1885,7 +2029,7 @@ export class Dispatcher {
    *
    * This is needed because pi-ai retries HTTP 429s internally with exponential
    * backoff (delays of 1 s, 2 s, 4 s …), so the final error event may arrive
-   * many seconds after the 100 ms probe timeout has already declared the stream
+   * many seconds after the probe has already declared the stream
    * healthy.  Without this wrapper the cooldown is never triggered and the
    * exhausted provider keeps receiving traffic.
    */
@@ -2067,48 +2211,181 @@ export class Dispatcher {
         oauthContext.systemPrompt =
           this.resolveOAuthInstructions(request, oauthProvider) || oauthContext.systemPrompt;
       }
-      const result = await transformer.executeRequest(
-        oauthContext,
-        oauthProvider,
-        route.model,
-        !!request.stream,
-        oauthOptions,
-        authConfig,
-        signal
-      );
 
-      if (request.stream) {
-        const rawStream = this.normalizeOAuthStream(result);
-        const streamProbe = await this.probeOAuthStreamStart(rawStream);
+      // TTFB stall detection for streaming OAuth requests.
+      // The stallAbortController is separate from the client signal — aborting
+      // it means the provider is too slow to start responding, not that the
+      // client disconnected. We intercept stall aborts BEFORE wrapOAuthError
+      // can swallow them — the OAuth transformer converts AbortError
+      // to generic 'Upstream timeout', losing the stall message).
+      const originalSignal = signal;
+      let requestSignal = signal;
+      let stallAbortController: AbortController | undefined;
+      let ttfbTimerId: ReturnType<typeof setTimeout> | undefined;
+      let raceTimerId: ReturnType<typeof setTimeout> | undefined;
+      const dispatchStartTime = Date.now();
 
-        if (!streamProbe.ok) {
-          throw streamProbe.error;
-        }
+      if (request.stream && effectiveStallConfig?.ttfbMs != null) {
+        stallAbortController = new AbortController();
+        requestSignal = originalSignal
+          ? AbortSignal.any([originalSignal, stallAbortController.signal])
+          : stallAbortController.signal;
 
-        logger.debug('OAuth: Normalized stream result', this.describeStreamResult(result));
-
-        // Wrap the probed stream with an error monitor so that quota/error events
-        // arriving AFTER the 100ms probe timeout still trigger a cooldown.  This
-        // is necessary because pi-ai retries HTTP 429s with exponential backoff
-        // (1 s, 2 s, 4 s) before emitting the final error event, which takes far
-        // longer than the probe's 100 ms window.
-        const monitoredStream = this.monitorOAuthStreamForErrors(streamProbe.stream, route);
-
-        const streamResponse: UnifiedChatResponse = {
-          id: 'stream-' + Date.now(),
-          model: request.model,
-          content: null,
-          stream: monitoredStream,
-          bypassTransformation: false,
-        };
-
-        this.enrichResponseWithMetadata(streamResponse, route, 'oauth');
-        return streamResponse;
+        const ttfbMs = effectiveStallConfig.ttfbMs!;
+        ttfbTimerId = setTimeout(() => {
+          stallAbortController!.abort(
+            new DOMException(
+              `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`,
+              'TimeoutError'
+            )
+          );
+        }, ttfbMs);
+        ttfbTimerId.unref?.();
       }
 
-      const unified = await transformer.transformResponse(result);
-      this.enrichResponseWithMetadata(unified, route, 'oauth');
-      return unified;
+      try {
+        // Race executeRequest against the TTFB deadline. The abort signal
+        // is passed for cooperative cancellation, but if the upstream
+        // doesn't observe it, the Promise.race ensures we don't hang.
+        let executePromise: Promise<any>;
+        if (request.stream && stallAbortController && effectiveStallConfig?.ttfbMs != null) {
+          const deadlineMs = effectiveStallConfig.ttfbMs!;
+          executePromise = Promise.race([
+            transformer.executeRequest(
+              oauthContext,
+              oauthProvider,
+              route.model,
+              !!request.stream,
+              oauthOptions,
+              authConfig,
+              requestSignal
+            ),
+            new Promise<never>((_, reject) => {
+              // Redundant with the timer above, but guarantees we reject
+              // even if the upstream ignores the abort signal.
+              raceTimerId = setTimeout(
+                () => {
+                  reject(
+                    new DOMException(
+                      `Stream stalled: TTFB timeout — no response within ${deadlineMs}ms`,
+                      'TimeoutError'
+                    )
+                  );
+                },
+                deadlineMs - (Date.now() - dispatchStartTime)
+              );
+            }),
+          ]);
+        } else {
+          executePromise = transformer.executeRequest(
+            oauthContext,
+            oauthProvider,
+            route.model,
+            !!request.stream,
+            oauthOptions,
+            authConfig,
+            requestSignal
+          );
+        }
+
+        const result = await executePromise;
+
+        // executeRequest succeeded — clear stall timer
+        if (ttfbTimerId !== undefined) {
+          clearTimeout(ttfbTimerId);
+          ttfbTimerId = undefined;
+        }
+        if (raceTimerId !== undefined) {
+          clearTimeout(raceTimerId);
+          raceTimerId = undefined;
+        }
+
+        // Client disconnect check after executeRequest
+        if (originalSignal?.aborted) throw this.buildCancelledError(originalSignal);
+
+        if (request.stream) {
+          // Compute remaining TTFB for the probe using absolute deadline
+          let probeStallConfig: StallConfig | null = effectiveStallConfig ?? null;
+          if (effectiveStallConfig?.ttfbMs != null) {
+            const deadline = dispatchStartTime + effectiveStallConfig.ttfbMs;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) {
+              // Deadline already exceeded after executeRequest — cancel the
+              // returned stream before failing, otherwise the upstream
+              // connection leaks while failover proceeds.
+              try {
+                const rawStream = this.normalizeOAuthStream(result);
+                if (rawStream && typeof rawStream.cancel === 'function') {
+                  await rawStream.cancel();
+                }
+              } catch {}
+              const err = new Error(
+                `Stream stalled: TTFB timeout — no response within ${effectiveStallConfig.ttfbMs}ms`
+              ) as any;
+              err.isStallError = true;
+              throw err;
+            }
+            probeStallConfig = { ...effectiveStallConfig, ttfbMs: remainingMs };
+          }
+
+          const rawStream = this.normalizeOAuthStream(result);
+          const streamProbe = await this.probeOAuthStreamStart(rawStream, probeStallConfig);
+
+          if (!streamProbe.ok) {
+            throw streamProbe.error;
+          }
+
+          logger.debug('OAuth: Normalized stream result', this.describeStreamResult(result));
+
+          // Wrap the probed stream with an error monitor so that quota/error events
+          // arriving AFTER the 100ms probe timeout still trigger a cooldown.  This
+          // is necessary because pi-ai retries HTTP 429s with exponential backoff
+          // (1 s, 2 s, 4 s) before emitting the final error event, which takes far
+          // longer than the probe's window.
+          const monitoredStream = this.monitorOAuthStreamForErrors(streamProbe.stream, route);
+
+          const streamResponse: UnifiedChatResponse = {
+            id: 'stream-' + Date.now(),
+            model: request.model,
+            content: null,
+            stream: monitoredStream,
+            bypassTransformation: false,
+          };
+
+          this.enrichResponseWithMetadata(streamResponse, route, 'oauth');
+          return streamResponse;
+        }
+
+        const unified = await transformer.transformResponse(result);
+        this.enrichResponseWithMetadata(unified, route, 'oauth');
+        return unified;
+      } catch (error: any) {
+        // ALWAYS clear timer on any error
+        if (ttfbTimerId !== undefined) {
+          clearTimeout(ttfbTimerId);
+          ttfbTimerId = undefined;
+        }
+        if (raceTimerId !== undefined) {
+          clearTimeout(raceTimerId);
+          raceTimerId = undefined;
+        }
+
+        // Client disconnect takes priority over stall detection
+        if (originalSignal?.aborted) throw this.buildCancelledError(originalSignal);
+
+        // TTFB stall abort — re-throw with correct stall message BEFORE
+        // wrapOAuthError can swallow it
+        if (stallAbortController?.signal.aborted) {
+          const stallError = new Error(
+            `Stream stalled: TTFB timeout — no response within ${effectiveStallConfig?.ttfbMs}ms`
+          );
+          (stallError as any).isStallError = true;
+          throw stallError;
+        }
+
+        // Non-stall error — let wrapOAuthError handle it
+        throw error;
+      }
     } catch (error: any) {
       throw this.wrapOAuthError(error, route, targetApiType);
     }

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -27,6 +27,7 @@ import { resolveAdapters } from './adapter-resolver';
 import type { ResolvedAdapter } from '../types/provider-adapter';
 import { getModels } from '@earendil-works/pi-ai';
 import type { StallConfig } from './inspectors/stall-inspector';
+import { getGlobalStallConfig, resolveStallConfig } from '../utils/stall';
 import { VisionDescriptorService } from './vision-descriptor-service';
 import { ModelMetadataManager } from './model-metadata-manager';
 import { enforceContextLimit } from './enforce-limits';
@@ -433,6 +434,54 @@ export class Dispatcher {
           );
         }
 
+        // Wire per-provider timeout override if set. This fires sooner than the
+        // global timeout and aborts the upstream fetch + the route's AbortController
+        // (via addTimeoutSource) so response-handler.ts stream monitoring detects it.
+        if (route.config.timeoutMs && addTimeoutSource) {
+          addTimeoutSource(route.config.timeoutMs);
+        }
+
+        // Wire per-provider stall detection overrides. Always call addStallConfig
+        // so the StallInspector is reset on each failover iteration — even when
+        // the current provider has no overrides, this clears a previous provider's
+        // overrides from the inspector.
+        if (addStallConfig) {
+          const providerStallOverrides: Parameters<typeof addStallConfig>[0] = {};
+          if (route.config.stallTtfbMs !== undefined)
+            providerStallOverrides.stallTtfbMs = route.config.stallTtfbMs;
+          if (route.config.stallTtfbBytes !== undefined)
+            providerStallOverrides.stallTtfbBytes = route.config.stallTtfbBytes;
+          if (route.config.stallMinBps !== undefined)
+            providerStallOverrides.stallMinBps = route.config.stallMinBps;
+          if (route.config.stallWindowMs !== undefined)
+            providerStallOverrides.stallWindowMs = route.config.stallWindowMs;
+          if (route.config.stallGracePeriodMs !== undefined)
+            providerStallOverrides.stallGracePeriodMs = route.config.stallGracePeriodMs;
+          logger.debug(
+            `Dispatcher: provider stall overrides for ${route.provider}: ${JSON.stringify(providerStallOverrides)}, ` +
+              `route.config stall fields: stallTtfbMs=${route.config.stallTtfbMs}, stallMinBps=${route.config.stallMinBps}`
+          );
+          addStallConfig(providerStallOverrides);
+        }
+
+        // Resolve stall config BEFORE the dispatch so we can wrap fetch+probe
+        // in a TTFB timeout. This is critical because fetch() itself may block
+        // for a long time waiting for HTTP response headers — the TTFB timeout
+        // must cover this "headers phase" too, not just the body reading.
+        // This applies to BOTH OAuth and non-OAuth routes.
+        let effectiveStallConfig = resolveStallConfig(getGlobalStallConfig(), {
+          stallTtfbMs: route.config.stallTtfbMs,
+          stallTtfbBytes: route.config.stallTtfbBytes,
+          stallMinBps: route.config.stallMinBps,
+          stallWindowMs: route.config.stallWindowMs,
+          stallGracePeriodMs: route.config.stallGracePeriodMs,
+        });
+
+        logger.debug(
+          `Dispatcher: effectiveStallConfig for ${route.provider}: ${JSON.stringify(effectiveStallConfig)}, ` +
+            `route.config.stallTtfbMs=${route.config.stallTtfbMs}, route.config.stallMinBps=${route.config.stallMinBps}`
+        );
+
         if (this.isPiAiRoute(route, targetApiType)) {
           try {
             const oauthResponse = await this.dispatchOAuthRequest(
@@ -441,7 +490,8 @@ export class Dispatcher {
               route,
               targetApiType,
               transformer,
-              signal
+              signal,
+              effectiveStallConfig
             );
             await this.recordAttemptMetric(route, currentRequest.requestId, true, {
               isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
@@ -491,69 +541,10 @@ export class Dispatcher {
           }
         }
 
-        // 4. Execute Request
+        // 4. Execute Request (non-OAuth)
+        const incomingApi = currentRequest.incomingApiType || 'unknown';
         const url = this.buildRequestUrl(route, transformer, requestWithTargetModel, targetApiType);
         const headers = this.setupHeaders(route, targetApiType, requestWithTargetModel);
-
-        // Wire per-provider timeout override if set. This fires sooner than the
-        // global timeout and aborts the upstream fetch + the route's AbortController
-        // (via addTimeoutSource) so response-handler.ts stream monitoring detects it.
-        if (route.config.timeoutMs && addTimeoutSource) {
-          addTimeoutSource(route.config.timeoutMs);
-        }
-
-        // Wire per-provider stall detection overrides. Always call addStallConfig
-        // so the StallInspector is reset on each failover iteration — even when
-        // the current provider has no overrides, this clears a previous provider's
-        // overrides from the inspector.
-        if (addStallConfig) {
-          const providerStallOverrides: Parameters<typeof addStallConfig>[0] = {};
-          if (route.config.stallTtfbMs !== undefined)
-            providerStallOverrides.stallTtfbMs = route.config.stallTtfbMs;
-          if (route.config.stallTtfbBytes !== undefined)
-            providerStallOverrides.stallTtfbBytes = route.config.stallTtfbBytes;
-          if (route.config.stallMinBps !== undefined)
-            providerStallOverrides.stallMinBps = route.config.stallMinBps;
-          if (route.config.stallWindowMs !== undefined)
-            providerStallOverrides.stallWindowMs = route.config.stallWindowMs;
-          if (route.config.stallGracePeriodMs !== undefined)
-            providerStallOverrides.stallGracePeriodMs = route.config.stallGracePeriodMs;
-          logger.debug(
-            `Dispatcher: provider stall overrides for ${route.provider}: ${JSON.stringify(providerStallOverrides)}, ` +
-              `route.config stall fields: stallTtfbMs=${route.config.stallTtfbMs}, stallMinBps=${route.config.stallMinBps}`
-          );
-          addStallConfig(providerStallOverrides);
-        }
-
-        const incomingApi = currentRequest.incomingApiType || 'unknown';
-
-        // Resolve stall config BEFORE the fetch so we can wrap fetch+probe
-        // in a TTFB timeout. This is critical because fetch() itself may block
-        // for a long time waiting for HTTP response headers — the TTFB timeout
-        // must cover this "headers phase" too, not just the body reading.
-        const globalStall = (getConfig() as any).stall;
-        const stallTtfbMs =
-          route.config.stallTtfbMs ??
-          (globalStall?.ttfbSeconds != null ? globalStall.ttfbSeconds * 1000 : null);
-        let effectiveStallConfig: StallConfig | null =
-          stallTtfbMs != null ||
-          route.config.stallMinBps != null ||
-          globalStall?.minBytesPerSecond != null
-            ? {
-                ttfbMs: stallTtfbMs,
-                ttfbBytes: route.config.stallTtfbBytes ?? globalStall?.ttfbBytes ?? 100,
-                minBytesPerSecond:
-                  route.config.stallMinBps ?? globalStall?.minBytesPerSecond ?? null,
-                windowMs: route.config.stallWindowMs ?? (globalStall?.windowSeconds ?? 10) * 1000,
-                gracePeriodMs:
-                  route.config.stallGracePeriodMs ?? (globalStall?.gracePeriodSeconds ?? 30) * 1000,
-              }
-            : null;
-
-        logger.debug(
-          `Dispatcher: effectiveStallConfig for ${route.provider}: ${JSON.stringify(effectiveStallConfig)}, ` +
-            `route.config.stallTtfbMs=${route.config.stallTtfbMs}, route.config.stallMinBps=${route.config.stallMinBps}`
-        );
 
         logger.info(
           `Dispatching ${currentRequest.model} to ${route.provider}:${route.model} ${incomingApi} <-> ${transformer.name}`
@@ -2012,7 +2003,8 @@ export class Dispatcher {
     route: RouteResult,
     targetApiType: string,
     transformer: any,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    effectiveStallConfig?: StallConfig | null
   ): Promise<UnifiedChatResponse> {
     if (!transformer.executeRequest) {
       throw new Error('OAuth transformer missing executeRequest()');
@@ -2062,6 +2054,13 @@ export class Dispatcher {
         targetApiType,
         streaming: !!request.stream,
         hasOptions: !!oauthOptions,
+      });
+
+      logger.debug('OAuth: Stall detection config', {
+        ttfbMs: effectiveStallConfig?.ttfbMs,
+        ttfbBytes: effectiveStallConfig?.ttfbBytes,
+        minBytesPerSecond: effectiveStallConfig?.minBytesPerSecond,
+        provider: route.provider,
       });
 
       if (!oauthContext.systemPrompt) {

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -502,7 +502,10 @@ export class Dispatcher {
           addTimeoutSource(route.config.timeoutMs);
         }
 
-        // Wire per-provider stall detection overrides if set.
+        // Wire per-provider stall detection overrides. Always call addStallConfig
+        // so the StallInspector is reset on each failover iteration — even when
+        // the current provider has no overrides, this clears a previous provider's
+        // overrides from the inspector.
         if (addStallConfig) {
           const providerStallOverrides: Parameters<typeof addStallConfig>[0] = {};
           if (route.config.stallTtfbMs !== undefined)
@@ -519,9 +522,7 @@ export class Dispatcher {
             `Dispatcher: provider stall overrides for ${route.provider}: ${JSON.stringify(providerStallOverrides)}, ` +
               `route.config stall fields: stallTtfbMs=${route.config.stallTtfbMs}, stallMinBps=${route.config.stallMinBps}`
           );
-          if (Object.keys(providerStallOverrides).length > 0) {
-            addStallConfig(providerStallOverrides);
-          }
+          addStallConfig(providerStallOverrides);
         }
 
         const incomingApi = currentRequest.incomingApiType || 'unknown';

--- a/packages/backend/src/services/inspectors/stall-inspector.ts
+++ b/packages/backend/src/services/inspectors/stall-inspector.ts
@@ -121,6 +121,11 @@ export class StallInspector extends PassThrough {
     this.requestId = requestId;
   }
 
+  /** Get the current stall config. */
+  getConfig(): StallConfig {
+    return this.config;
+  }
+
   override _transform(chunk: any, encoding: BufferEncoding, callback: Function) {
     if (this.state === StallState.THROUGHPUT_STALLED) {
       // Already stalled — just pass through (abort is already triggered)

--- a/packages/backend/src/utils/__tests__/stall.test.ts
+++ b/packages/backend/src/utils/__tests__/stall.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'vitest';
+import { wireStallDetection, resolveStallConfig } from '../stall';
+import type { StallConfig } from '../../services/inspectors/stall-inspector';
+
+describe('wireStallDetection', () => {
+  test('addStallConfig with empty overrides reverts to global config', () => {
+    // Simulates failover: Provider A has overrides, Provider B has none.
+    // After calling addStallConfig({}) for B, the inspector must use
+    // the global config — not retain A's overrides.
+    const abortController = new AbortController();
+    const globalConfig: StallConfig = {
+      ttfbMs: 30000,
+      ttfbBytes: 200,
+      minBytesPerSecond: 2000,
+      windowMs: 30000,
+      gracePeriodMs: 45000,
+    };
+
+    const result = wireStallDetection(abortController, globalConfig);
+
+    // Provider A: relaxed overrides
+    result!.addStallConfig({
+      stallTtfbMs: 60000,
+      stallMinBps: 100,
+    });
+
+    const afterA = result!.stallInspector.getConfig();
+    expect(afterA.ttfbMs).toBe(60000);
+    expect(afterA.minBytesPerSecond).toBe(100);
+
+    // Provider B: no overrides — should revert to global
+    result!.addStallConfig({});
+
+    const afterB = result!.stallInspector.getConfig();
+    // After the fix, the inspector reverts to global config instead of
+    // retaining the previous provider's overrides.
+    expect(afterB.ttfbMs).toBe(30000);
+    expect(afterB.minBytesPerSecond).toBe(2000);
+  });
+
+  test('addStallConfig with empty overrides resets inspector when no global config', () => {
+    // No global config. Provider A has overrides, Provider B has none.
+    // addStallConfig({}) for B must reset the inspector, not retain A's config.
+    // On main this leaks: resolveStallConfig(null, {}) returns null, and
+    // addStallConfig skips updateConfig when merged is null.
+    const abortController = new AbortController();
+    const result = wireStallDetection(abortController, null);
+
+    // Provider A: has overrides
+    result!.addStallConfig({
+      stallTtfbMs: 60000,
+      stallMinBps: 100,
+    });
+
+    const afterA = result!.stallInspector.getConfig();
+    expect(afterA.ttfbMs).toBe(60000);
+    expect(afterA.minBytesPerSecond).toBe(100);
+
+    // Provider B: no overrides — should reset to disabled skeleton
+    result!.addStallConfig({});
+
+    const afterB = result!.stallInspector.getConfig();
+    expect(afterB.ttfbMs).toBeNull();
+    expect(afterB.minBytesPerSecond).toBeNull();
+  });
+
+  test('addStallConfig does not throw with empty overrides and no global config', () => {
+    const abortController = new AbortController();
+    const result = wireStallDetection(abortController, null);
+    expect(result).not.toBeNull();
+
+    expect(() => {
+      result!.addStallConfig({});
+    }).not.toThrow();
+  });
+
+  test('addStallConfig applies per-provider overrides on top of global config', () => {
+    const abortController = new AbortController();
+    const globalConfig: StallConfig = {
+      ttfbMs: 30000,
+      ttfbBytes: 200,
+      minBytesPerSecond: 2000,
+      windowMs: 30000,
+      gracePeriodMs: 45000,
+    };
+
+    const result = wireStallDetection(abortController, globalConfig);
+
+    result!.addStallConfig({
+      stallTtfbMs: 10000,
+      stallMinBps: 100,
+    });
+
+    const config = result!.stallInspector.getConfig();
+    expect(config.ttfbMs).toBe(10000);
+    expect(config.minBytesPerSecond).toBe(100);
+    expect(config.ttfbBytes).toBe(200); // From global
+    expect(config.windowMs).toBe(30000); // From global
+  });
+});
+
+describe('resolveStallConfig', () => {
+  test('returns null when no global config and no overrides', () => {
+    const result = resolveStallConfig(null, undefined);
+    expect(result).toBeNull();
+  });
+
+  test('returns global config when no overrides', () => {
+    const global: StallConfig = {
+      ttfbMs: 5000,
+      ttfbBytes: 100,
+      minBytesPerSecond: 2000,
+      windowMs: 10000,
+      gracePeriodMs: 30000,
+    };
+    const result = resolveStallConfig(global, {});
+    expect(result).toEqual(global);
+  });
+
+  test('merges provider overrides with global config', () => {
+    const global: StallConfig = {
+      ttfbMs: 30000,
+      ttfbBytes: 200,
+      minBytesPerSecond: 2000,
+      windowMs: 30000,
+      gracePeriodMs: 45000,
+    };
+    const result = resolveStallConfig(global, {
+      stallTtfbMs: 10000,
+      stallMinBps: 100,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.ttfbMs).toBe(10000);
+    expect(result!.minBytesPerSecond).toBe(100);
+    expect(result!.ttfbBytes).toBe(200); // From global
+    expect(result!.windowMs).toBe(30000); // From global
+  });
+  test('returns null when no global config and empty overrides', () => {
+    const result = resolveStallConfig(null, {});
+    expect(result).toBeNull();
+  });
+
+  test('returns provider-only config when no global config but overrides exist', () => {
+    const result = resolveStallConfig(null, {
+      stallTtfbMs: 5000,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.ttfbMs).toBe(5000);
+    expect(result!.minBytesPerSecond).toBeNull();
+  });
+});

--- a/packages/backend/src/utils/stall.ts
+++ b/packages/backend/src/utils/stall.ts
@@ -13,6 +13,14 @@ import { getConfig } from '../config';
 import { logger } from './logger';
 import { StallInspector, type StallConfig } from '../services/inspectors/stall-inspector';
 
+const DEFAULT_STALL_CONFIG: StallConfig = {
+  ttfbMs: null,
+  ttfbBytes: 100,
+  minBytesPerSecond: null,
+  windowMs: 10000,
+  gracePeriodMs: 30000,
+};
+
 /**
  * Resolve the effective stall configuration by merging global settings
  * with per-provider overrides.
@@ -28,13 +36,7 @@ export function resolveStallConfig(
   }
 ): StallConfig | null {
   // Base defaults used when there is no global config
-  const defaults: StallConfig = {
-    ttfbMs: null,
-    ttfbBytes: 100,
-    minBytesPerSecond: null,
-    windowMs: 10000,
-    gracePeriodMs: 30000,
-  };
+  const defaults: StallConfig = DEFAULT_STALL_CONFIG;
 
   const base = globalConfig ?? defaults;
 
@@ -112,9 +114,10 @@ export function getGlobalStallConfig(): StallConfig | null {
  * @param abortController The route's AbortController (same one passed to
  *   `handleResponse` for stream disconnect detection and `wireUpstreamTimeout`).
  * @param globalStallConfig The resolved global stall config (or null if disabled).
- * @returns An object with the `stallInspector` stream to insert into the pipeline
- *   and an `addStallConfig` callback for per-provider overrides, or null if
- *   stall detection is globally disabled.
+ * @returns An object with the `stallInspector` stream and an `addStallConfig`
+ *   callback. Always returns a non-null result — without a global config the
+ *   inspector starts with a disabled skeleton that per-provider overrides can
+ *   activate later.
  */
 export function wireStallDetection(
   abortController: AbortController,
@@ -128,7 +131,7 @@ export function wireStallDetection(
     stallWindowMs?: number | null;
     stallGracePeriodMs?: number | null;
   }) => void;
-} | null {
+} {
   // When global stall config is null, we still create a StallInspector
   // with a "disabled" skeleton config so that per-provider overrides can
   // activate it later via addStallConfig(). This handles the case where
@@ -139,13 +142,7 @@ export function wireStallDetection(
   // simply pass all data through without monitoring (both ttfbMs and
   // minBytesPerSecond are null = no timers, no checks). The periodic
   // check never starts because we never enter MONITORING state.
-  const baseConfig: StallConfig = globalStallConfig ?? {
-    ttfbMs: null,
-    ttfbBytes: 100,
-    minBytesPerSecond: null,
-    windowMs: 10000,
-    gracePeriodMs: 30000,
-  };
+  const baseConfig: StallConfig = globalStallConfig ?? DEFAULT_STALL_CONFIG;
 
   const stallInspector = new StallInspector(
     crypto.randomUUID(), // Will be overwritten by the request ID in the pipeline
@@ -172,9 +169,10 @@ export function wireStallDetection(
         `wireStallDetection.addStallConfig: overrides=${JSON.stringify(providerOverrides)}, ` +
           `merged=${JSON.stringify(merged)}`
       );
-      if (!merged) return;
-
-      stallInspector.updateConfig(merged);
+      // Always update the inspector — even when merged is null, we must reset
+      // the StallInspector to a disabled skeleton so that a previous provider's
+      // overrides don't leak into the next failover target.
+      stallInspector.updateConfig(merged ?? DEFAULT_STALL_CONFIG);
     },
   };
 }


### PR DESCRIPTION
This PR fixes the following issues with stall detection:

## Per-provider stall configuration leak

Since `StallInspector` is shared between all providers in a request, when failover moves from Provider A (with per-provider overrides) to Provider B (without per-provider overrides), Provider A's overrides is leaked onto Provider B.

### Steps to reproduce

1. Make sure no stall configuration in global config
2. Configure Provider A (with a mock slow server) with a strict TTFB timeout/TTFB byte threshold, e.g. `5s/5000B`
3. Configure Provider B (with the same mock slow server) without TTFB timeout/TTFB byte threshold (use default)
4. Configure model alias with Provider A and B
5. Send a request to Provider A, fails, failover to Provider B
6. Provider B also treated as stall despite having no stall config (should use global)

### Root cause

The dispatcher has a guard around `addStallConfig`. When Provider B has no overrides, the `StallInspector` is never reconfigured. Additionally, when `resolveStallConfig` is `null` (stall detection off), `addStallConfig` skipped `updateConfig` instead of resetting it, so global "null" default (i.e. no stall check) is never applied. 

### Fix

Made sure `addStallConfig` is always called and make `addStallConfig` use the default stall settings when `resolveStallConfig` returns `null`.

## Per-provider stall configuration were not being applied to OAuth providers

OAuth providers have its own code path (`if (this.isPiAiRoute(...))`), but it was being called before provider stall overrides are computed. This means that OAuth providers will always use global stall configuration regardless of the presence of the stall configuration overrides.

### Steps to reproduce

1. Configure global stall configuration with a strict TTFB timeout/TTFB byte threshold, e.g. `5s/5000B`
2. Configure OAuth provider with a relaxed TTFB timeout/TTFB byte threshold, e.g. `30s/50B`
3. Send a streaming request to heavy OAuth models (e.g. `gpt-5.5`)
4. OAuth provider stalled despite having a very relaxed configuration

### Fix

Moved the per-provider wiring before dispatching to pi-ai. Also deduplicated `resolveStallConfig` logic and added a debug log.

## OAuth providers have no TTFB detection code path

`probeOAuthStreamStart` has no TTFB abort mechanism.

### Fix

Wired per-request TTFB abort controller inside `dispatchOAuthRequest`.