### PR TITLE
feat(quota): add includeAllowance option to Wafer checker

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -304,6 +304,7 @@ const ZenmuxQuotaCheckerOptionsSchema = z.object({
 
 const WaferQuotaCheckerOptionsSchema = z.object({
   endpoint: z.string().url().optional(),
+  includeAllowance: z.boolean().optional(),
 });
 
 const PoeQuotaCheckerOptionsSchema = z.object({

--- a/packages/backend/src/services/quota/checkers/__tests__/wafer-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/wafer-checker.test.ts
@@ -5,11 +5,29 @@ import checkerDef from '../wafer-checker';
 const makeCtx = (options: Record<string, unknown> = {}) =>
   createMeterContext('wafer-test', 'wafer', { apiKey: 'test-key', ...options });
 
-describe('wafer checker', () => {
-  const setFetchMock = (impl: (...args: unknown[]) => Promise<Response>): void => {
-    global.fetch = vi.fn(impl) as unknown as typeof fetch;
-  };
+const QUOTA_RESPONSE = {
+  window_start: '2023-01-01T00:00:00Z',
+  window_end: '2023-01-01T05:00:00Z',
+  included_request_limit: 2000,
+  included_request_count: 35,
+  remaining_included_requests: 1965,
+  current_period_used_percent: 1.75,
+};
 
+const makeQuotaMock = (body: unknown = QUOTA_RESPONSE, status = 200) => {
+  const urls: string[] = [];
+  const mock = vi.fn(async (input: unknown, init: unknown) => {
+    urls.push(String(input));
+    return new Response(status === 200 ? JSON.stringify(body) : 'error', {
+      status,
+      statusText: status === 200 ? 'OK' : 'Internal Server Error',
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  return { mock, urls };
+};
+
+describe('wafer checker', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
@@ -19,30 +37,12 @@ describe('wafer checker', () => {
   });
 
   it('queries quota endpoint and returns allowance meter', async () => {
-    let capturedUrl: string | undefined;
-    let capturedHeaders: Headers | undefined;
-
-    setFetchMock(async (input: unknown, init: unknown) => {
-      capturedUrl = String(input as string);
-      capturedHeaders = new Headers((init as RequestInit | undefined)?.headers);
-      return new Response(
-        JSON.stringify({
-          window_start: '2023-01-01T00:00:00Z',
-          window_end: '2023-01-01T05:00:00Z',
-          included_request_limit: 2000,
-          included_request_count: 35,
-          remaining_included_requests: 1965,
-          current_period_used_percent: 1.75,
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      );
-    });
+    const { mock, urls } = makeQuotaMock();
+    global.fetch = mock;
 
     const meters = await checkerDef.check(makeCtx());
 
-    expect(capturedUrl).toBe('https://pass.wafer.ai/v1/inference/quota');
-    expect(capturedHeaders!.get('Accept-Encoding')).toBe('identity');
-    expect(capturedHeaders!.get('Accept')).toBe('application/json');
+    expect(urls[0]).toBe('https://pass.wafer.ai/v1/inference/quota');
     expect(meters).toHaveLength(1);
 
     const m = meters[0]!;
@@ -58,30 +58,44 @@ describe('wafer checker', () => {
     expect(m.resetsAt).toBe('2023-01-01T05:00:00.000Z');
   });
 
+  it('sends correct headers', async () => {
+    let capturedHeaders: Headers | undefined;
+    global.fetch = vi.fn(async (_input: unknown, init: unknown) => {
+      capturedHeaders = new Headers((init as RequestInit | undefined)?.headers);
+      return new Response(JSON.stringify(QUOTA_RESPONSE), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    await checkerDef.check(makeCtx());
+
+    expect(capturedHeaders!.get('Accept-Encoding')).toBe('identity');
+    expect(capturedHeaders!.get('Accept')).toBe('application/json');
+    expect(capturedHeaders!.get('Authorization')).toBe('Bearer test-key');
+  });
+
+  it('uses custom endpoint when provided', async () => {
+    const { mock, urls } = makeQuotaMock();
+    global.fetch = mock;
+
+    await checkerDef.check(makeCtx({ endpoint: 'https://custom.wafer.example.com/quota' }));
+
+    expect(urls[0]).toBe('https://custom.wafer.example.com/quota');
+  });
+
   it('handles non-ok HTTP response', async () => {
-    setFetchMock(
+    global.fetch = vi.fn(
       async () =>
         new Response('Internal Server Error', { status: 500, statusText: 'Internal Server Error' })
-    );
+    ) as unknown as typeof fetch;
 
     await expect(checkerDef.check(makeCtx())).rejects.toThrow('HTTP 500: Internal Server Error');
   });
 
   it('handles invalid included_request_limit', async () => {
-    setFetchMock(
-      async () =>
-        new Response(
-          JSON.stringify({
-            window_start: '2023-01-01T00:00:00Z',
-            window_end: '2023-01-01T05:00:00Z',
-            included_request_limit: 'not-a-number',
-            included_request_count: 0,
-            remaining_included_requests: 2000,
-            current_period_used_percent: 0,
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-    );
+    const { mock } = makeQuotaMock({ ...QUOTA_RESPONSE, included_request_limit: 'not-a-number' });
+    global.fetch = mock;
 
     await expect(checkerDef.check(makeCtx())).rejects.toThrow(
       'Invalid included_request_limit received: not-a-number'
@@ -89,20 +103,8 @@ describe('wafer checker', () => {
   });
 
   it('handles negative included_request_count', async () => {
-    setFetchMock(
-      async () =>
-        new Response(
-          JSON.stringify({
-            window_start: '2023-01-01T00:00:00Z',
-            window_end: '2023-01-01T05:00:00Z',
-            included_request_limit: 2000,
-            included_request_count: -5,
-            remaining_included_requests: 2005,
-            current_period_used_percent: 0,
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-    );
+    const { mock } = makeQuotaMock({ ...QUOTA_RESPONSE, included_request_count: -5 });
+    global.fetch = mock;
 
     await expect(checkerDef.check(makeCtx())).rejects.toThrow(
       'Invalid included_request_count received: -5'
@@ -110,20 +112,8 @@ describe('wafer checker', () => {
   });
 
   it('handles negative remaining_included_requests', async () => {
-    setFetchMock(
-      async () =>
-        new Response(
-          JSON.stringify({
-            window_start: '2023-01-01T00:00:00Z',
-            window_end: '2023-01-01T05:00:00Z',
-            included_request_limit: 2000,
-            included_request_count: 0,
-            remaining_included_requests: -10,
-            current_period_used_percent: 0,
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-    );
+    const { mock } = makeQuotaMock({ ...QUOTA_RESPONSE, remaining_included_requests: -10 });
+    global.fetch = mock;
 
     await expect(checkerDef.check(makeCtx())).rejects.toThrow(
       'Invalid remaining_included_requests received: -10'
@@ -131,45 +121,34 @@ describe('wafer checker', () => {
   });
 
   it('handles invalid window_end', async () => {
-    setFetchMock(
-      async () =>
-        new Response(
-          JSON.stringify({
-            window_start: '2023-01-01T00:00:00Z',
-            window_end: 'invalid-date',
-            included_request_limit: 2000,
-            included_request_count: 0,
-            remaining_included_requests: 2000,
-            current_period_used_percent: 0,
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-    );
+    const { mock } = makeQuotaMock({ ...QUOTA_RESPONSE, window_end: 'invalid-date' });
+    global.fetch = mock;
 
     await expect(checkerDef.check(makeCtx())).rejects.toThrow(
       'Invalid window_end date received: invalid-date'
     );
   });
 
-  it('uses custom endpoint when provided', async () => {
-    let capturedUrl: string | undefined;
+  describe('includeAllowance: false', () => {
+    it('makes no fetch calls and returns no meters', async () => {
+      const fetchSpy = vi.fn();
+      global.fetch = fetchSpy as unknown as typeof fetch;
 
-    setFetchMock(async (input: unknown) => {
-      capturedUrl = String(input as string);
-      return new Response(
-        JSON.stringify({
-          window_start: '2023-01-01T00:00:00Z',
-          window_end: '2023-01-01T05:00:00Z',
-          included_request_limit: 100,
-          included_request_count: 10,
-          remaining_included_requests: 90,
-          current_period_used_percent: 10,
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      );
+      const meters = await checkerDef.check(makeCtx({ includeAllowance: false }));
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(meters).toHaveLength(0);
     });
 
-    await checkerDef.check(makeCtx({ endpoint: 'https://custom.wafer.example.com/quota' }));
-    expect(capturedUrl).toBe('https://custom.wafer.example.com/quota');
+    it('does not call a custom endpoint even if one is configured', async () => {
+      const fetchSpy = vi.fn();
+      global.fetch = fetchSpy as unknown as typeof fetch;
+
+      await checkerDef.check(
+        makeCtx({ includeAllowance: false, endpoint: 'https://custom.wafer.example.com/quota' })
+      );
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/backend/src/services/quota/checkers/wafer-checker.ts
+++ b/packages/backend/src/services/quota/checkers/wafer-checker.ts
@@ -16,67 +16,78 @@ export default defineChecker({
   displayName: 'Wafer',
   optionsSchema: z.object({
     endpoint: z.string().optional(),
+    includeAllowance: z.boolean().optional().default(true),
     apiKey: z.string().min(1, 'Wafer API key is required'),
   }),
   async check(ctx) {
     const apiKey = ctx.requireOption<string>('apiKey');
+    const includeAllowance = ctx.getOption<boolean>('includeAllowance', true);
     const endpoint = ctx.getOption<string>('endpoint', 'https://pass.wafer.ai/v1/inference/quota');
-    logger.silly(`[wafer] Calling ${endpoint}`);
 
-    const response = await fetch(endpoint, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        Accept: 'application/json',
-        'Accept-Encoding': 'identity',
-      },
-    });
+    const meters = [];
 
-    if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    if (includeAllowance) {
+      logger.silly(`[wafer] Calling ${endpoint}`);
 
-    const data: WaferQuotaResponse = await response.json();
+      const response = await fetch(endpoint, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: 'application/json',
+          'Accept-Encoding': 'identity',
+        },
+      });
 
-    const {
-      included_request_limit,
-      included_request_count,
-      remaining_included_requests,
-      window_end,
-    } = data;
+      if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
-    const resetsAt = new Date(window_end);
-    if (isNaN(resetsAt.getTime())) {
-      throw new Error(`Invalid window_end date received: ${window_end}`);
-    }
+      const data: WaferQuotaResponse = await response.json();
 
-    const limit = Number(included_request_limit);
-    if (!Number.isFinite(limit) || limit < 0) {
-      throw new Error(`Invalid included_request_limit received: ${String(included_request_limit)}`);
-    }
-    const used = Number(included_request_count);
-    if (!Number.isFinite(used) || used < 0) {
-      throw new Error(`Invalid included_request_count received: ${String(included_request_count)}`);
-    }
-    const remaining = Number(remaining_included_requests);
-    if (!Number.isFinite(remaining) || remaining < 0) {
-      throw new Error(
-        `Invalid remaining_included_requests received: ${String(remaining_included_requests)}`
+      const {
+        included_request_limit,
+        included_request_count,
+        remaining_included_requests,
+        window_end,
+      } = data;
+
+      const resetsAt = new Date(window_end);
+      if (isNaN(resetsAt.getTime())) {
+        throw new Error(`Invalid window_end date received: ${window_end}`);
+      }
+
+      const limit = Number(included_request_limit);
+      if (!Number.isFinite(limit) || limit < 0) {
+        throw new Error(
+          `Invalid included_request_limit received: ${String(included_request_limit)}`
+        );
+      }
+      const used = Number(included_request_count);
+      if (!Number.isFinite(used) || used < 0) {
+        throw new Error(
+          `Invalid included_request_count received: ${String(included_request_count)}`
+        );
+      }
+      const remaining = Number(remaining_included_requests);
+      if (!Number.isFinite(remaining) || remaining < 0) {
+        throw new Error(
+          `Invalid remaining_included_requests received: ${String(remaining_included_requests)}`
+        );
+      }
+
+      meters.push(
+        ctx.allowance({
+          key: 'wafer_5h',
+          label: '5-hour request quota',
+          unit: 'requests',
+          limit,
+          used,
+          remaining,
+          periodValue: 5,
+          periodUnit: 'hour',
+          periodCycle: 'fixed',
+          resetsAt: resetsAt.toISOString(),
+        })
       );
     }
-
-    const meters = [
-      ctx.allowance({
-        key: 'wafer_5h',
-        label: '5-hour request quota',
-        unit: 'requests',
-        limit,
-        used,
-        remaining,
-        periodValue: 5,
-        periodUnit: 'hour',
-        periodCycle: 'fixed',
-        resetsAt: resetsAt.toISOString(),
-      }),
-    ];
 
     logger.silly(`Returning ${meters.length} meters`);
     return meters;

--- a/packages/frontend/src/components/quota/WaferQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/WaferQuotaConfig.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Input } from '../ui/Input';
+import { Switch } from '../ui/Switch';
 
 export interface WaferQuotaConfigProps {
   options: Record<string, unknown>;
@@ -7,9 +8,7 @@ export interface WaferQuotaConfigProps {
 }
 
 export const WaferQuotaConfig: React.FC<WaferQuotaConfigProps> = ({ options, onChange }) => {
-  const handleChange = (key: string, value: string) => {
-    onChange({ ...options, [key]: value });
-  };
+  const includeAllowance = options.includeAllowance !== false;
 
   return (
     <div className="space-y-3">
@@ -19,11 +18,27 @@ export const WaferQuotaConfig: React.FC<WaferQuotaConfigProps> = ({ options, onC
         </label>
         <Input
           value={(options.endpoint as string) ?? ''}
-          onChange={(e) => handleChange('endpoint', e.target.value)}
+          onChange={(e) => onChange({ ...options, endpoint: e.target.value })}
           placeholder="https://pass.wafer.ai/v1/inference/quota"
+          disabled={!includeAllowance}
         />
+        <span className="text-[10px] text-text-muted">Override the Wafer Pass quota endpoint.</span>
+      </div>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <label className="font-body text-[13px] font-medium text-text-secondary">
+            Include Wafer Pass quota
+          </label>
+          <Switch
+            size="sm"
+            checked={includeAllowance}
+            onChange={(checked) => onChange({ ...options, includeAllowance: checked })}
+            aria-label="Include Wafer Pass allowance meter"
+          />
+        </div>
         <span className="text-[10px] text-text-muted">
-          Custom endpoint URL. Defaults to Wafer.ai API.
+          Disable if you only have a PAYG (serverless) account and not a Wafer Pass plan — prevents
+          a zeroed-out quota meter from triggering unnecessary cooldowns.
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Adds an `includeAllowance` opt-out toggle to the Wafer quota checker, useful for accounts that only use the PAYG (serverless) billing model rather than a Wafer Pass plan.

## Problem

The Wafer Pass quota endpoint returns zeroed-out data (`0 / 0 requests`) for accounts that don't have an active Pass plan. This causes the checker to produce a permanently exhausted allowance meter, which triggers unnecessary provider cooldowns for PAYG-only users.

## Changes

### Backend
- **`wafer-checker.ts`**: Guard the quota endpoint fetch behind `includeAllowance` (defaults `true`). When `false`, no HTTP request is made and no meters are returned — clean and side-effect-free.
- **`config.ts`**: Add `includeAllowance: z.boolean().optional()` to `WaferQuotaCheckerOptionsSchema`.

### Frontend
- **`WaferQuotaConfig.tsx`**: Add a `Switch` toggle for "Include Wafer Pass quota". When toggled off, the endpoint override input is also disabled (since it becomes irrelevant). Help text explains the use case.

### Tests
- Refactored test file with shared fixtures and a `makeQuotaMock` helper (cleaner than the previous per-test inline mocks).
- Added `includeAllowance: false` sub-suite covering: no fetch calls made, no meters returned, custom endpoint also skipped.

## UI

The Wafer quota checker config form now shows:

1. **Endpoint** (existing, greyed out when allowance disabled)
2. **Include Wafer Pass quota** — Switch toggle, on by default
