### PR TITLE
feat: add Reset All Logs button and endpoint

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -532,6 +532,8 @@ paths:
     $ref: paths/v0_management_restart.yaml
   /v0/management/backup:
     $ref: paths/v0_management_backup.yaml
+  /v0/management/logs/reset:
+    $ref: paths/v0_management_logs_reset.yaml
   /v0/management/restore:
     $ref: paths/v0_management_restore.yaml
   /v0/management/events:

--- a/docs/openapi/paths/v0_management_logs_reset.yaml
+++ b/docs/openapi/paths/v0_management_logs_reset.yaml
@@ -1,0 +1,34 @@
+delete:
+  tags:
+    - Management — Backup
+  summary: Reset all request logs, error logs, and debug trace logs (admin only)
+  description: |
+    Deletes all request logs (usage), error logs, and debug trace logs.
+    Configuration settings, provider configurations, model aliases, keys, MCP servers,
+    and provider cooldowns remain untouched.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Logs successfully reset.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              success:
+                type: boolean
+                example: true
+              message:
+                type: string
+                example: "All logs have been reset successfully"
+            required:
+              - success
+              - message
+    '401':
+      description: Authentication required or invalid credentials.
+    '403':
+      description: Limited principals cannot access this endpoint.
+  operationId: deleteV0ManagementLogsReset

--- a/packages/backend/src/routes/management.ts
+++ b/packages/backend/src/routes/management.ts
@@ -117,7 +117,7 @@ export async function registerManagementRoutes(
       // Model routes for AI energy calculations
       await registerModelRoutes(adminOnly);
       // Backup and restore routes
-      await registerBackupRoutes(adminOnly);
+      await registerBackupRoutes(adminOnly, usageStorage, mcpUsageStorage);
       // Concurrency (live snapshot + historical timeline)
       await registerConcurrencyRoutes(adminOnly, usageStorage);
     });

--- a/packages/backend/src/routes/management/__tests__/backup.test.ts
+++ b/packages/backend/src/routes/management/__tests__/backup.test.ts
@@ -46,10 +46,20 @@ import { registerBackupRoutes } from '../backup';
 
 describe('Backup management routes', () => {
   let fastify: ReturnType<typeof Fastify>;
+  let mockUsageStorage: any;
+  let mockMcpUsageStorage: any;
 
   beforeEach(async () => {
     fastify = Fastify();
-    await registerBackupRoutes(fastify);
+    mockUsageStorage = {
+      deleteAllUsageLogs: vi.fn(async () => true),
+      deleteAllErrors: vi.fn(async () => true),
+      deleteAllDebugLogs: vi.fn(async () => true),
+    };
+    mockMcpUsageStorage = {
+      deleteAllLogs: vi.fn(async () => true),
+    };
+    await registerBackupRoutes(fastify, mockUsageStorage, mockMcpUsageStorage);
   });
 
   afterEach(async () => {
@@ -106,6 +116,37 @@ describe('Backup management routes', () => {
       });
 
       expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('DELETE /v0/management/logs/reset', () => {
+    it('calls delete functions on storage services and returns 200', async () => {
+      const res = await fastify.inject({
+        method: 'DELETE',
+        url: '/v0/management/logs/reset',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({
+        success: true,
+        message: 'All logs have been reset successfully',
+      });
+      expect(mockUsageStorage.deleteAllUsageLogs).toHaveBeenCalled();
+      expect(mockUsageStorage.deleteAllErrors).toHaveBeenCalled();
+      expect(mockUsageStorage.deleteAllDebugLogs).toHaveBeenCalled();
+      expect(mockMcpUsageStorage.deleteAllLogs).toHaveBeenCalled();
+    });
+
+    it('returns 500 if a storage delete operation fails', async () => {
+      mockUsageStorage.deleteAllErrors.mockResolvedValueOnce(false);
+
+      const res = await fastify.inject({
+        method: 'DELETE',
+        url: '/v0/management/logs/reset',
+      });
+
+      expect(res.statusCode).toBe(500);
+      expect(res.json().error).toBeDefined();
     });
   });
 });

--- a/packages/backend/src/routes/management/backup.ts
+++ b/packages/backend/src/routes/management/backup.ts
@@ -1,8 +1,14 @@
 import { FastifyInstance } from 'fastify';
 import { logger } from '../../utils/logger';
 import { BackupService } from '../../services/backup-service';
+import type { UsageStorageService } from '../../services/usage-storage';
+import type { McpUsageStorageService } from '../../services/mcp-proxy/mcp-usage-storage';
 
-export async function registerBackupRoutes(fastify: FastifyInstance) {
+export async function registerBackupRoutes(
+  fastify: FastifyInstance,
+  usageStorage?: UsageStorageService,
+  mcpUsageStorage?: McpUsageStorageService
+) {
   const backupService = new BackupService();
 
   // ─── GET /v0/management/backup ──────────────────────────────────
@@ -93,4 +99,45 @@ export async function registerBackupRoutes(fastify: FastifyInstance) {
       done(null, body);
     }
   );
+
+  // ─── DELETE /v0/management/logs/reset ────────────────────────────
+
+  /**
+   * Reset all request logs, error logs, and debug trace logs.
+   * Cooldowns, configs etc. remain untouched.
+   */
+  fastify.delete('/v0/management/logs/reset', async (request, reply) => {
+    if (!usageStorage) {
+      return reply.code(500).send({ error: 'Usage storage service is not available' });
+    }
+    logger.info('[Backup] Starting logs reset (request logs, error logs, debug trace logs)');
+    try {
+      const [successUsage, successErrors, successDebug] = await Promise.all([
+        usageStorage.deleteAllUsageLogs(),
+        usageStorage.deleteAllErrors(),
+        usageStorage.deleteAllDebugLogs(),
+      ]);
+
+      let successMcp = true;
+      if (mcpUsageStorage) {
+        successMcp = await mcpUsageStorage.deleteAllLogs();
+      }
+
+      if (!successUsage || !successErrors || !successDebug || !successMcp) {
+        logger.error('[Backup] Reset logs partial failure:', {
+          successUsage,
+          successErrors,
+          successDebug,
+          successMcp,
+        });
+        return reply.code(500).send({ error: 'Failed to reset some logs' });
+      }
+
+      logger.info('[Backup] All logs reset successfully');
+      return reply.send({ success: true, message: 'All logs have been reset successfully' });
+    } catch (e: any) {
+      logger.error('[Backup] Reset logs failed:', e);
+      return reply.code(500).send({ error: e.message || 'Reset logs failed' });
+    }
+  });
 }

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -3063,6 +3063,18 @@ export const api = {
     return res.json();
   },
 
+  /** Reset all request logs, error logs, and debug trace logs. */
+  resetLogs: async (): Promise<{ success: boolean; message: string }> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/logs/reset`, {
+      method: 'DELETE',
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: 'Reset logs failed' }));
+      throw new Error(err.error || 'Reset logs failed');
+    }
+    return res.json();
+  },
+
   // ─── Failover Settings ────────────────────────────────────────────
 
   /** Fetch current failover policy. */

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -12,6 +12,7 @@ import {
   Shield,
   Save,
   Radar,
+  Trash2,
 } from 'lucide-react';
 import { api } from '../lib/api';
 import { formatMinutesToMinSec } from '@plexus/shared';
@@ -130,6 +131,7 @@ export const Config = () => {
   const [isBackupLoading, setIsBackupLoading] = useState(false);
   const [isFullBackupLoading, setIsFullBackupLoading] = useState(false);
   const [isRestoreLoading, setIsRestoreLoading] = useState(false);
+  const [isResetLogsLoading, setIsResetLogsLoading] = useState(false);
   const restoreInputRef = useRef<HTMLInputElement>(null);
 
   // Failover settings state
@@ -778,6 +780,27 @@ export const Config = () => {
     }
   };
 
+  const handleResetLogs = async () => {
+    const ok = await toast.confirm({
+      title: 'Reset All Logs?',
+      message:
+        'This will **permanently delete all request logs, error logs, and debug trace logs**. Configuration, cooldowns, and settings will not be touched. This action cannot be undone. Are you sure?',
+      confirmLabel: 'Reset Logs',
+      variant: 'danger',
+    });
+    if (!ok) return;
+
+    setIsResetLogsLoading(true);
+    try {
+      const res = await api.resetLogs();
+      toast.success(res.message || 'All logs have been reset successfully');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to reset logs');
+    } finally {
+      setIsResetLogsLoading(false);
+    }
+  };
+
   return (
     <div className="flex flex-col min-h-full">
       <PageHeader
@@ -1348,6 +1371,15 @@ export const Config = () => {
                 leftIcon={<HardDrive size={14} />}
               >
                 Config Backup
+              </Button>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={handleResetLogs}
+                isLoading={isResetLogsLoading}
+                leftIcon={<Trash2 size={14} />}
+              >
+                Reset All Logs
               </Button>
               <input
                 ref={restoreInputRef}


### PR DESCRIPTION
This PR adds a 'Reset All Logs' button to the Backup & Restore card on the Config page, with a modal confirmation in the style of the application. It adds a corresponding backend endpoint to delete all request, error, and debug trace logs, alongside complete tests and OpenAPI documentation.

Fixes: #532