### PR TITLE
Fix provider timeout failover

### DIFF
--- a/packages/backend/src/routes/inference/chat.ts
+++ b/packages/backend/src/routes/inference/chat.ts
@@ -91,13 +91,13 @@ export async function registerChatRoute(
       }
 
       const abortController = new AbortController();
-      const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
       earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,
         dispatchSignal,
-        addTimeoutSource,
+        resolveTimeoutMs,
         stallDetectionResult?.addStallConfig
       );
 
@@ -138,12 +138,8 @@ export async function registerChatRoute(
       return result;
     } catch (e: any) {
       earlyDisconnect?.cleanup();
-      if (
-        e?.routingContext?.code === 'client_disconnected' ||
-        e?.routingContext?.code === 'upstream_timeout'
-      ) {
-        usageRecord.responseStatus =
-          e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled';
+      if (e?.routingContext?.code === 'client_disconnected') {
+        usageRecord.responseStatus = 'cancelled';
         usageRecord.durationMs = Date.now() - startTime;
         usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
         usageRecord.retryHistory =
@@ -154,7 +150,8 @@ export async function registerChatRoute(
         );
         return;
       }
-      usageRecord.responseStatus = 'error';
+      usageRecord.responseStatus =
+        e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'error';
       usageRecord.durationMs = Date.now() - startTime;
       usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
       usageRecord.retryHistory = e.routingContext?.retryHistory || usageRecord.retryHistory || null;

--- a/packages/backend/src/routes/inference/gemini.ts
+++ b/packages/backend/src/routes/inference/gemini.ts
@@ -99,13 +99,13 @@ export async function registerGeminiRoute(
       }
 
       const abortController = new AbortController();
-      const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
       earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,
         dispatchSignal,
-        addTimeoutSource,
+        resolveTimeoutMs,
         stallDetectionResult?.addStallConfig
       );
 
@@ -147,12 +147,8 @@ export async function registerGeminiRoute(
       return result;
     } catch (e: any) {
       earlyDisconnect?.cleanup();
-      if (
-        e?.routingContext?.code === 'client_disconnected' ||
-        e?.routingContext?.code === 'upstream_timeout'
-      ) {
-        usageRecord.responseStatus =
-          e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled';
+      if (e?.routingContext?.code === 'client_disconnected') {
+        usageRecord.responseStatus = 'cancelled';
         usageRecord.durationMs = Date.now() - startTime;
         usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
         usageRecord.retryHistory =
@@ -163,7 +159,8 @@ export async function registerGeminiRoute(
         );
         return;
       }
-      usageRecord.responseStatus = 'error';
+      usageRecord.responseStatus =
+        e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'error';
       usageRecord.durationMs = Date.now() - startTime;
       usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
       usageRecord.retryHistory = e.routingContext?.retryHistory || usageRecord.retryHistory || null;

--- a/packages/backend/src/routes/inference/messages.ts
+++ b/packages/backend/src/routes/inference/messages.ts
@@ -89,13 +89,13 @@ export async function registerMessagesRoute(
       }
 
       const abortController = new AbortController();
-      const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
       earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,
         dispatchSignal,
-        addTimeoutSource,
+        resolveTimeoutMs,
         stallDetectionResult?.addStallConfig
       );
 
@@ -137,12 +137,8 @@ export async function registerMessagesRoute(
       return result;
     } catch (e: any) {
       earlyDisconnect?.cleanup();
-      if (
-        e?.routingContext?.code === 'client_disconnected' ||
-        e?.routingContext?.code === 'upstream_timeout'
-      ) {
-        usageRecord.responseStatus =
-          e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled';
+      if (e?.routingContext?.code === 'client_disconnected') {
+        usageRecord.responseStatus = 'cancelled';
         usageRecord.durationMs = Date.now() - startTime;
         usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
         usageRecord.retryHistory =
@@ -153,7 +149,8 @@ export async function registerMessagesRoute(
         );
         return;
       }
-      usageRecord.responseStatus = 'error';
+      usageRecord.responseStatus =
+        e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'error';
       usageRecord.durationMs = Date.now() - startTime;
       usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
       usageRecord.retryHistory = e.routingContext?.retryHistory || usageRecord.retryHistory || null;

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -172,13 +172,13 @@ export async function registerResponsesRoute(
       }
 
       const abortController = new AbortController();
-      const { signal: dispatchSignal, addTimeoutSource } = wireUpstreamTimeout(abortController);
+      const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
       earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,
         dispatchSignal,
-        addTimeoutSource,
+        resolveTimeoutMs,
         stallDetectionResult.addStallConfig
       );
 
@@ -239,12 +239,8 @@ export async function registerResponsesRoute(
       return result;
     } catch (e: any) {
       earlyDisconnect?.cleanup();
-      if (
-        e?.routingContext?.code === 'client_disconnected' ||
-        e?.routingContext?.code === 'upstream_timeout'
-      ) {
-        usageRecord.responseStatus =
-          e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'cancelled';
+      if (e?.routingContext?.code === 'client_disconnected') {
+        usageRecord.responseStatus = 'cancelled';
         usageRecord.durationMs = Date.now() - startTime;
         usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
         usageRecord.retryHistory =
@@ -255,7 +251,8 @@ export async function registerResponsesRoute(
         );
         return;
       }
-      usageRecord.responseStatus = 'error';
+      usageRecord.responseStatus =
+        e?.routingContext?.code === 'upstream_timeout' ? 'timeout' : 'error';
       usageRecord.durationMs = Date.now() - startTime;
       usageRecord.attemptCount = e.routingContext?.attemptCount || usageRecord.attemptCount || 1;
       usageRecord.retryHistory = e.routingContext?.retryHistory || usageRecord.retryHistory || null;

--- a/packages/backend/src/services/__tests__/dispatcher-abort.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-abort.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { Dispatcher } from '../dispatcher';
 
 // Prevent real network calls
@@ -9,6 +9,10 @@ describe('Dispatcher — AbortSignal / cancellation', () => {
 
   beforeEach(() => {
     dispatcher = new Dispatcher();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   test('buildCancelledError returns 499 and client_disconnected for a plain abort', () => {
@@ -30,6 +34,31 @@ describe('Dispatcher — AbortSignal / cancellation', () => {
     controller.abort(timeoutReason);
 
     const err = (dispatcher as any).buildCancelledError(controller.signal);
+    expect(err.message).toBe('Upstream timeout');
+    expect(err.routingContext.statusCode).toBe(504);
+    expect(err.routingContext.code).toBe('upstream_timeout');
+  });
+
+  test('per-attempt timeout does not abort the route signal', async () => {
+    vi.useFakeTimers();
+    const routeController = new AbortController();
+
+    const attemptTimeout = (dispatcher as any).createAttemptTimeout(
+      routeController.signal,
+      35_000,
+      () => 4_000
+    );
+
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expect(attemptTimeout.isTimedOut()).toBe(true);
+    expect(attemptTimeout.signal.aborted).toBe(true);
+    expect(routeController.signal.aborted).toBe(false);
+  });
+
+  test('buildTimeoutError returns retryable upstream timeout metadata', () => {
+    const err = (dispatcher as any).buildTimeoutError();
+
     expect(err.message).toBe('Upstream timeout');
     expect(err.routingContext.statusCode).toBe(504);
     expect(err.routingContext.code).toBe('upstream_timeout');

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -60,6 +60,8 @@ interface RetryHistoryLikeEntry {
   reason?: unknown;
 }
 
+type ResolveTimeoutMs = (timeoutMs?: number | null) => number;
+
 /**
  * Strips trailing /v1beta* path segments from Gemini base URLs.
  * Gemini's transformer adds /v1beta to the path, so we need to ensure
@@ -247,7 +249,7 @@ export class Dispatcher {
   async dispatch(
     request: UnifiedChatRequest,
     signal?: AbortSignal,
-    addTimeoutSource?: (timeoutMs: number) => void,
+    resolveTimeoutMs?: ResolveTimeoutMs,
     addStallConfig?: (providerOverrides: {
       stallTtfbMs?: number | null;
       stallTtfbBytes?: number | null;
@@ -292,6 +294,11 @@ export class Dispatcher {
       if (signal?.aborted) throw this.buildCancelledError(signal);
       let currentRequest = { ...request };
       const route = targets[i]!;
+      const attemptTimeout = this.createAttemptTimeout(
+        signal,
+        route.config.timeoutMs,
+        resolveTimeoutMs
+      );
 
       // Vision Fallthrough (Image-to-Text Preprocessing)
       // Check if:
@@ -349,6 +356,7 @@ export class Dispatcher {
         route.model
       );
       if (!isHealthy) {
+        attemptTimeout.cleanup();
         logger.warn(`Skipping ${route.provider}/${route.model} - provider is on cooldown`);
         lastError = new Error(`Provider ${route.provider}/${route.model} is on cooldown`);
         this.appendSkippedAttempt(
@@ -374,6 +382,7 @@ export class Dispatcher {
       // Acquire concurrency slot before upstream request
       const acquired = ConcurrencyTracker.getInstance().acquire(route.provider, route.model);
       if (!acquired) {
+        attemptTimeout.cleanup();
         logger.warn(`Skipping ${route.provider}/${route.model} - concurrency limit exceeded`);
         lastError = new Error(
           `Provider ${route.provider}/${route.model} concurrency limit exceeded`
@@ -436,13 +445,6 @@ export class Dispatcher {
           );
         }
 
-        // Wire per-provider timeout override if set. This fires sooner than the
-        // global timeout and aborts the upstream fetch + the route's AbortController
-        // (via addTimeoutSource) so response-handler.ts stream monitoring detects it.
-        if (route.config.timeoutMs && addTimeoutSource) {
-          addTimeoutSource(route.config.timeoutMs);
-        }
-
         // Wire per-provider stall detection overrides. Always call addStallConfig
         // so the StallInspector is reset on each failover iteration — even when
         // the current provider has no overrides, this clears a previous provider's
@@ -492,9 +494,10 @@ export class Dispatcher {
               route,
               targetApiType,
               transformer,
-              signal,
+              attemptTimeout.signal,
               effectiveStallConfig
             );
+            attemptTimeout.cleanup();
             await this.recordAttemptMetric(route, currentRequest.requestId, true, {
               isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
               isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
@@ -511,22 +514,26 @@ export class Dispatcher {
             doRelease();
             return oauthResponse;
           } catch (oauthError: any) {
+            const effectiveOAuthError = attemptTimeout.isTimedOut()
+              ? this.buildTimeoutError()
+              : oauthError;
             if (signal?.aborted) throw this.buildCancelledError(signal);
-            lastError = oauthError;
+            lastError = effectiveOAuthError;
 
             // Handle TTFB stall errors with failover support
-            const isStallError = (oauthError as any).isStallError === true;
+            const isStallError = (effectiveOAuthError as any).isStallError === true;
             if (isStallError) {
               const canRetryStall = failoverEnabled && i < targets.length - 1;
               this.appendFailureAttempt(
                 retryHistory,
                 route,
-                oauthError,
+                effectiveOAuthError,
                 targetApiType,
                 canRetryStall
               );
 
               if (canRetryStall) {
+                attemptTimeout.cleanup();
                 await this.recordAttemptMetric(route, currentRequest.requestId, false, {
                   isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
                   isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
@@ -535,12 +542,12 @@ export class Dispatcher {
                 CooldownManager.getInstance().markProviderStallFailure(
                   route.provider,
                   route.model,
-                  this.formatFailureReason(oauthError)
+                  this.formatFailureReason(effectiveOAuthError)
                 );
                 this.saveIntermediateError(
                   currentRequest.requestId,
                   targetApiType || 'chat',
-                  oauthError
+                  effectiveOAuthError
                 );
                 logger.info(
                   `TTFB stall: OAuth request timed out for ${route.provider}/${route.model}, retrying`
@@ -555,38 +562,48 @@ export class Dispatcher {
               CooldownManager.getInstance().markProviderStallFailure(
                 route.provider,
                 route.model,
-                this.formatFailureReason(oauthError)
+                this.formatFailureReason(effectiveOAuthError)
               );
-              throw oauthError;
+              throw effectiveOAuthError;
             }
 
             const canRetry =
-              failoverEnabled && i < targets.length - 1 && this.isRetryableOAuthError(oauthError);
+              failoverEnabled &&
+              i < targets.length - 1 &&
+              (attemptTimeout.isTimedOut() || this.isRetryableOAuthError(effectiveOAuthError));
 
-            this.appendFailureAttempt(retryHistory, route, oauthError, targetApiType, canRetry);
+            this.appendFailureAttempt(
+              retryHistory,
+              route,
+              effectiveOAuthError,
+              targetApiType,
+              canRetry
+            );
 
             if (canRetry) {
+              attemptTimeout.cleanup();
               await this.recordAttemptMetric(route, currentRequest.requestId, false, {
                 isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
                 isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
                 visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
               });
-              await this.markOAuthProviderFailure(route, oauthError);
+              await this.markOAuthProviderFailure(route, effectiveOAuthError);
               this.saveIntermediateError(
                 currentRequest.requestId,
                 targetApiType || 'chat',
-                oauthError
+                effectiveOAuthError
               );
               logger.warn(
-                `Failover: retrying after OAuth error from ${route.provider}/${route.model}: ${oauthError.message}`
+                `Failover: retrying after OAuth error from ${route.provider}/${route.model}: ${effectiveOAuthError.message}`
               );
               doRelease();
               continue;
             }
 
-            await this.markOAuthProviderFailure(route, oauthError);
+            attemptTimeout.cleanup();
+            await this.markOAuthProviderFailure(route, effectiveOAuthError);
             doRelease();
-            throw oauthError;
+            throw effectiveOAuthError;
           }
         }
 
@@ -617,9 +634,10 @@ export class Dispatcher {
           // means the client disconnected — we need a distinct signal for
           // "provider is too slow to start responding".
           stallAbortController = new AbortController();
-          const combinedSignal = signal
-            ? AbortSignal.any([signal, stallAbortController.signal])
-            : stallAbortController.signal;
+          const combinedSignal = AbortSignal.any([
+            attemptTimeout.signal,
+            stallAbortController.signal,
+          ]);
 
           const ttfbMs = effectiveStallConfig.ttfbMs!;
           ttfbTimerId = setTimeout(() => {
@@ -663,6 +681,7 @@ export class Dispatcher {
                   stallError.message?.includes('stalled'));
 
               if (canRetryStall) {
+                attemptTimeout.cleanup();
                 await this.recordAttemptMetric(route, currentRequest.requestId, false, {
                   isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
                   isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
@@ -708,7 +727,12 @@ export class Dispatcher {
             effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: remainingTtfbMs };
           }
         } else {
-          response = await this.executeProviderRequest(url, headers, providerPayload, signal);
+          response = await this.executeProviderRequest(
+            url,
+            headers,
+            providerPayload,
+            attemptTimeout.signal
+          );
         }
 
         if (!response.ok) {
@@ -734,6 +758,7 @@ export class Dispatcher {
             this.appendFailureAttempt(retryHistory, route, e, targetApiType, canRetry);
 
             if (canRetry) {
+              attemptTimeout.cleanup();
               doRelease();
               await this.recordAttemptMetric(route, currentRequest.requestId, false, {
                 isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
@@ -781,6 +806,7 @@ export class Dispatcher {
                 error.message?.includes('stalled'));
 
             if (canRetry) {
+              attemptTimeout.cleanup();
               await this.recordAttemptMetric(route, currentRequest.requestId, false, {
                 isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
                 isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
@@ -873,6 +899,7 @@ export class Dispatcher {
             route,
             targetApiType
           );
+          attemptTimeout.cleanup();
           return streamResponse;
         }
 
@@ -906,9 +933,12 @@ export class Dispatcher {
           targetApiType
         );
         doRelease();
+        attemptTimeout.cleanup();
         return nonStreamingResponse;
       } catch (error: any) {
-        lastError = error;
+        const effectiveError = attemptTimeout.isTimedOut() ? this.buildTimeoutError() : error;
+        lastError = effectiveError;
+        attemptTimeout.cleanup();
         doRelease();
 
         // If the client disconnected (abort signal), don't treat this as a
@@ -918,22 +948,23 @@ export class Dispatcher {
 
         // If the error came from handleProviderError, it already called markProviderFailure.
         // Only call it here for network/transport errors that have no HTTP status code.
-        const isHttpError = error?.routingContext?.statusCode !== undefined;
+        const isHttpError = effectiveError?.routingContext?.statusCode !== undefined;
+        const isUpstreamTimeout = effectiveError?.routingContext?.code === 'upstream_timeout';
 
-        if (!isHttpError) {
+        if (!isHttpError || isUpstreamTimeout) {
           // Pure network/transport error — mark the provider as failed
-          if (error.message?.includes('stalled')) {
+          if (effectiveError.message?.includes('stalled')) {
             CooldownManager.getInstance().markProviderStallFailure(
               route.provider,
               route.model,
-              this.formatFailureReason(error)
+              this.formatFailureReason(effectiveError)
             );
           } else {
             CooldownManager.getInstance().markProviderFailure(
               route.provider,
               route.model,
               undefined,
-              this.formatFailureReason(error)
+              this.formatFailureReason(effectiveError)
             );
           }
         }
@@ -946,19 +977,20 @@ export class Dispatcher {
         const canRetryNetwork =
           failoverEnabled &&
           i < targets.length - 1 &&
-          (this.isRetryableNetworkError(error, failover?.retryableErrors || []) ||
-            error.message?.includes('stalled'));
+          (isUpstreamTimeout ||
+            this.isRetryableNetworkError(effectiveError, failover?.retryableErrors || []) ||
+            effectiveError.message?.includes('stalled'));
 
-        this.appendFailureAttempt(retryHistory, route, error, undefined, canRetryNetwork);
+        this.appendFailureAttempt(retryHistory, route, effectiveError, undefined, canRetryNetwork);
 
         if (canRetryNetwork) {
           this.saveIntermediateError(
             currentRequest.requestId,
-            error?.routingContext?.targetApiType || 'chat',
-            error
+            effectiveError?.routingContext?.targetApiType || 'chat',
+            effectiveError
           );
           logger.warn(
-            `Failover: retrying after network/transport error from ${route.provider}/${route.model}: ${error.message}`
+            `Failover: retrying after network/transport error from ${route.provider}/${route.model}: ${effectiveError.message}`
           );
           continue;
         }
@@ -2392,6 +2424,38 @@ export class Dispatcher {
     } catch (error: any) {
       throw this.wrapOAuthError(error, route, targetApiType);
     }
+  }
+
+  private createAttemptTimeout(
+    signal: AbortSignal | undefined,
+    providerTimeoutMs: number | null | undefined,
+    resolveTimeoutMs?: ResolveTimeoutMs
+  ): { signal: AbortSignal; isTimedOut: () => boolean; cleanup: () => void } {
+    const timeoutMs = resolveTimeoutMs
+      ? resolveTimeoutMs(providerTimeoutMs ?? null)
+      : (providerTimeoutMs ?? (getConfig().timeout?.defaultSeconds ?? 300) * 1000);
+    const timeoutController = new AbortController();
+    const timeoutId = setTimeout(() => {
+      timeoutController.abort(new DOMException('Upstream request timed out', 'TimeoutError'));
+    }, timeoutMs);
+    timeoutId.unref?.();
+
+    return {
+      signal: signal
+        ? AbortSignal.any([signal, timeoutController.signal])
+        : timeoutController.signal,
+      isTimedOut: () => timeoutController.signal.aborted,
+      cleanup: () => clearTimeout(timeoutId),
+    };
+  }
+
+  private buildTimeoutError(): Error {
+    const err = new Error('Upstream timeout') as any;
+    err.routingContext = {
+      statusCode: 504,
+      code: 'upstream_timeout',
+    };
+    return err;
   }
 
   private buildCancelledError(signal: AbortSignal): Error {

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -290,9 +290,8 @@ export async function handleResponse(
     // abort signal is consumed by fetch() at call time; aborting it afterwards has
     // no effect on the streaming body read. nodeStream.destroy() is required in all
     // cases. We wire abortController.signal's 'abort' event to onDisconnect() so
-    // that any future timeout wiring (e.g. AbortSignal.any([signal, AbortSignal.timeout(ms)]))
-    // at the route level will automatically flow through the correct cancellation path
-    // with no further changes needed here. See test-timeout-*.ts.
+    // that route-level timeout wiring automatically flows through the correct
+    // cancellation path with no further changes needed here. See test-timeout-*.ts.
     // =============================================================================
     let disconnected = false;
     let disconnectPoll: ReturnType<typeof setInterval> | null = null;

--- a/packages/backend/src/utils/__tests__/timeout.test.ts
+++ b/packages/backend/src/utils/__tests__/timeout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('../../config', () => ({
+  getConfig: () => ({ timeout: { defaultSeconds: 4 } }),
+}));
+
+import { wireUpstreamTimeout } from '../timeout';
+
+describe('wireUpstreamTimeout', () => {
+  test('per-provider timeout can be longer than global timeout', () => {
+    const abortController = new AbortController();
+    const { resolveTimeoutMs, signal } = wireUpstreamTimeout(abortController);
+
+    expect(resolveTimeoutMs(35_000)).toBe(35_000);
+    expect(signal.aborted).toBe(false);
+  });
+
+  test('null provider timeout resolves to global timeout', () => {
+    const abortController = new AbortController();
+    const { resolveTimeoutMs } = wireUpstreamTimeout(abortController);
+
+    expect(resolveTimeoutMs(null)).toBe(4_000);
+  });
+});

--- a/packages/backend/src/utils/timeout.ts
+++ b/packages/backend/src/utils/timeout.ts
@@ -1,94 +1,40 @@
 /**
  * Upstream request timeout utilities.
  *
- * When AbortSignal.timeout() fires, AbortSignal.any() creates a combined signal
- * that aborts, but does NOT propagate the abort back to the original source signals.
- * The response-handler.ts stream-monitoring code listens on the route's
- * abortController.signal — so if the timeout fires and that signal never aborts,
- * onDisconnect() is never called, nodeStream.destroy() is never called, and the
- * upstream fetch keeps running, generating unhandled TimeoutError rejections.
+ * Route-level timeout utilities.
  *
- * To fix this, when the timeout fires we must also abort the route's
- * AbortController so the listener in response-handler.ts detects it.
+ * The route AbortController is reserved for client disconnects. Upstream
+ * timeouts are resolved here but enforced per provider attempt in the
+ * dispatcher so a timed-out provider can fail over without aborting the whole
+ * route.
  */
 
 import { getConfig } from '../config';
 import { logger } from './logger';
 
 /**
- * Wire a timeout signal into the route's AbortController.
+ * Resolve timeout settings for a route.
  *
- * Creates `AbortSignal.timeout(effectiveTimeoutMs)`, combines it with the
- * existing signal via `AbortSignal.any()`, and adds a listener that calls
- * `abortController.abort()` when the timeout fires. This ensures that
- * both the upstream fetch AND the response-handler.ts stream-monitoring
- * code detect the timeout.
+ * The dispatcher calls `resolveTimeoutMs` after routing picks a provider.
+ * Provider timeouts override the global default and may be shorter or longer.
  *
  * @param abortController The route's AbortController (the one passed to
  *   handleResponse for stream disconnect detection).
  * @param defaultTimeoutMs Override for the effective timeout in milliseconds.
  *   When null/undefined, the global default is used.
- * @returns An object containing the combined signal and an `addTimeoutSource`
- *   method for adding per-provider timeout overrides after routing resolves.
+ * @returns The route signal plus a timeout resolver for provider attempts.
  */
 export function wireUpstreamTimeout(
   abortController: AbortController,
   defaultTimeoutMs?: number | null
-): { signal: AbortSignal; addTimeoutSource: (timeoutMs: number) => void } {
+): { signal: AbortSignal; resolveTimeoutMs: (timeoutMs?: number | null) => number } {
   const config = getConfig();
   const globalTimeoutSeconds = config.timeout?.defaultSeconds ?? 300;
-  const effectiveTimeoutMs = defaultTimeoutMs ?? globalTimeoutSeconds * 1000;
-
-  const timeoutSignal = AbortSignal.timeout(effectiveTimeoutMs);
-
-  // Create a combined signal that aborts when EITHER the client disconnects
-  // OR the timeout fires.
-  const combinedSignal = AbortSignal.any([abortController.signal, timeoutSignal]);
-
-  // KEY: AbortSignal.any() does NOT propagate abort back to source signals.
-  // When the timeout fires, combinedSignal aborts but abortController.signal
-  // does NOT. The stream-monitoring code in response-handler.ts only listens
-  // on abortController.signal, so it would never detect the timeout. We bridge
-  // the gap by aborting the route's AbortController when the timeout fires.
-  // This triggers onDisconnect() → nodeStream.destroy() → upstream cancellation.
-  timeoutSignal.addEventListener(
-    'abort',
-    () => {
-      if (!abortController.signal.aborted) {
-        abortController.abort(timeoutSignal.reason);
-      }
-    },
-    { once: true }
-  );
+  const globalTimeoutMs = defaultTimeoutMs ?? globalTimeoutSeconds * 1000;
 
   return {
-    signal: combinedSignal,
-    /**
-     * Add a per-provider timeout source.
-     *
-     * After the dispatcher resolves the route and knows which provider
-     * handles the request, it can add a per-provider timeout that may be
-     * shorter than the global default. When this timeout fires:
-     * 1. The upstream fetch is aborted (the signal passed to the fetch aborts).
-     * 2. The route's abortController is aborted (so response-handler.ts detects it).
-     *
-     * @param providerTimeoutMs Per-provider timeout in milliseconds.
-     */
-    addTimeoutSource: (providerTimeoutMs: number) => {
-      const providerTimeoutSignal = AbortSignal.timeout(providerTimeoutMs);
-
-      // Re-wire: when the provider timeout fires, abort the route's
-      // abortController so response-handler.ts stream monitoring detects it.
-      providerTimeoutSignal.addEventListener(
-        'abort',
-        () => {
-          if (!abortController.signal.aborted) {
-            abortController.abort(providerTimeoutSignal.reason);
-          }
-        },
-        { once: true }
-      );
-    },
+    signal: abortController.signal,
+    resolveTimeoutMs: (providerTimeoutMs?: number | null) => providerTimeoutMs ?? globalTimeoutMs,
   };
 }
 
@@ -106,7 +52,7 @@ export function wireUpstreamTimeout(
  *
  * This function starts the bunHandle.closed polling BEFORE the dispatch,
  * and aborts the route's AbortController when the client disconnects.
- * This propagates through the combined signal to fetch(), causing it to
+ * This propagates through the route signal to fetch(), causing it to
  * throw AbortError and the dispatcher to stop waiting.
  *
  * Callers must call cleanup() after the dispatch completes (whether success


### PR DESCRIPTION
## Summary
- enforce upstream timeouts per dispatcher attempt so timed-out providers can fail over
- make per-provider timeout override the global timeout, including longer overrides
- return real 504 responses for final upstream timeouts while preserving timeout usage logging

## Verification
- bun run test:force
- pre-commit hooks: backend tests, biome format/lint, no migrations, typecheck

Fixes #522
Fixes #531