### PR TITLE
fix: embed release version in frontend build

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -63,13 +63,13 @@ jobs:
         working-directory: ./packages/frontend
 
       - name: Build frontend
+        env:
+          APP_VERSION: dev-${{ steps.sha.outputs.sha }}
         run: bun run build:frontend
 
       - name: Compile Binaries
         # compiling each platform separately
         # Frontend is built above; compile:* scripts skip the rebuild in CI via build:frontend:if-needed.
-        env:
-          APP_VERSION: dev-${{ steps.sha.outputs.sha }}
         run: |
           bun run compile:linux-amd64
           bun run compile:linux-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,8 @@ jobs:
     name: Build Binaries
     needs: [setup, quality-gates]
     runs-on: ubuntu-latest
+    env:
+      APP_VERSION: ${{ needs.setup.outputs.tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -290,8 +292,6 @@ jobs:
         run: bun run build:frontend
 
       - name: Compile all binaries
-        env:
-          APP_VERSION: ${{ needs.setup.outputs.tag }}
         run: |
           bun run compile:linux-amd64
           bun run compile:linux-arm64


### PR DESCRIPTION
## Summary
- set `APP_VERSION` before the release frontend build runs in `release.yml`
- set `APP_VERSION` before the dev frontend build runs in `dev-release.yml`
- keep binary compile steps unchanged except for removing redundant step-local env blocks

## Why
The frontend was being built before `APP_VERSION` was set, so tagged binaries still showed `dev` in the UI.

Closes #533