### PR TITLE
fix: show HTTP status code in debug traces

### DIFF
--- a/packages/backend/src/services/usage-storage.ts
+++ b/packages/backend/src/services/usage-storage.ts
@@ -414,7 +414,7 @@ export class UsageStorageService extends EventEmitter {
     limit: number = 50,
     offset: number = 0,
     apiKey?: string
-  ): Promise<{ requestId: string; createdAt: number }[]> {
+  ): Promise<{ requestId: string; createdAt: number; responseStatus: number | null }[]> {
     try {
       const db = this.ensureDb();
       const where = apiKey ? eq(this.schema.debugLogs.apiKey, apiKey) : undefined;
@@ -422,6 +422,7 @@ export class UsageStorageService extends EventEmitter {
         .select({
           requestId: this.schema.debugLogs.requestId,
           createdAt: this.schema.debugLogs.createdAt,
+          responseStatus: this.schema.debugLogs.responseStatus,
         })
         .from(this.schema.debugLogs)
         .orderBy(desc(this.schema.debugLogs.createdAt))
@@ -432,6 +433,7 @@ export class UsageStorageService extends EventEmitter {
       return results.map((row: any) => ({
         requestId: row.requestId,
         createdAt: row.createdAt,
+        responseStatus: row.responseStatus,
       }));
     } catch (error) {
       logger.error('Failed to get debug logs', error);

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1991,7 +1991,7 @@ export const api = {
   getDebugLogs: async (
     limit: number = 50,
     offset: number = 0
-  ): Promise<{ requestId: string; createdAt: number }[]> => {
+  ): Promise<{ requestId: string; createdAt: number; responseStatus: number | null }[]> => {
     try {
       const res = await fetchWithAuth(
         `${API_BASE}/v0/management/debug/logs?limit=${limit}&offset=${offset}`

--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -237,6 +237,9 @@ export const Debug: React.FC = () => {
     if (status == null) {
       return 'border-border-glass bg-bg-glass text-text-muted';
     }
+    if (status >= 100 && status < 200) {
+      return 'border-border-glass bg-bg-glass text-text-muted';
+    }
     if (status >= 200 && status < 300) {
       return 'border-success/30 bg-emerald-500/15 text-success';
     }

--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -28,6 +28,7 @@ import { useAuth } from '../contexts/AuthContext';
 interface DebugLogMeta {
   requestId: string;
   createdAt: number;
+  responseStatus?: number | null;
 }
 
 interface DebugLogDetail extends DebugLogMeta {
@@ -39,7 +40,6 @@ interface DebugLogDetail extends DebugLogMeta {
   transformedResponseSnapshot?: string | object;
   requestHeaders?: string | object;
   responseHeaders?: string | object;
-  responseStatus?: number;
 }
 
 export const Debug: React.FC = () => {
@@ -233,6 +233,22 @@ export const Debug: React.FC = () => {
     return content;
   };
 
+  const getHttpStatusBadgeClasses = (status?: number | null) => {
+    if (status == null) {
+      return 'border-border-glass bg-bg-glass text-text-muted';
+    }
+    if (status >= 200 && status < 300) {
+      return 'border-success/30 bg-emerald-500/15 text-success';
+    }
+    if (status >= 300 && status < 400) {
+      return 'border-blue-400/30 bg-blue-500/15 text-blue-400';
+    }
+    if (status >= 400 && status < 500) {
+      return 'border-warning/30 bg-yellow-500/15 text-warning';
+    }
+    return 'border-danger/30 bg-red-500/15 text-danger';
+  };
+
   const exportContent = useMemo(() => {
     if (!detail) return '';
     const payload = {
@@ -246,7 +262,7 @@ export const Debug: React.FC = () => {
       transformedResponseSnapshot: normalizeExportContent(detail.transformedResponseSnapshot),
       requestHeaders: normalizeExportContent(detail.requestHeaders),
       responseHeaders: normalizeExportContent(detail.responseHeaders),
-      responseStatus: detail.responseStatus,
+      httpStatusCode: detail.responseStatus ?? null,
     };
     return JSON.stringify(payload, null, 2);
   }, [detail]);
@@ -446,6 +462,16 @@ export const Debug: React.FC = () => {
                   <div className="text-[13px] font-mono text-primary whitespace-nowrap overflow-hidden text-ellipsis mt-1">
                     {log.requestId?.substring(0, 8) ?? '-'}...
                   </div>
+                  <div className="mt-2">
+                    <span
+                      className={clsx(
+                        'inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-semibold',
+                        getHttpStatusBadgeClasses(log.responseStatus)
+                      )}
+                    >
+                      HTTP {log.responseStatus ?? '?'}
+                    </span>
+                  </div>
                 </div>
               </div>
             ))}
@@ -469,6 +495,25 @@ export const Debug: React.FC = () => {
                   <span className="break-all text-xs font-mono text-text-secondary">
                     {detail.requestId}
                   </span>
+                </div>
+                <div className="flex flex-wrap gap-x-4 gap-y-2 text-xs text-text-secondary">
+                  <div className="min-w-0">
+                    <span className="text-text-muted">Captured:</span>
+                    <span className="ml-2 font-mono">
+                      {new Date(detail.createdAt).toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="text-text-muted">HTTP Status:</span>
+                    <span
+                      className={clsx(
+                        'inline-flex items-center rounded-md border px-2 py-0.5 font-mono font-semibold',
+                        getHttpStatusBadgeClasses(detail.responseStatus)
+                      )}
+                    >
+                      {detail.responseStatus ?? 'Not captured'}
+                    </span>
+                  </div>
                 </div>
               </div>
               <AccordionPanel


### PR DESCRIPTION
## Summary
- show the HTTP status code in the /ui/debug trace list
- show the HTTP status code in the selected trace header
- include the status code in copied/downloaded trace payloads under `httpStatusCode`
- include debug log response status in the backend list payload used by the UI

## Testing
- pre-commit hooks
- bun run --workspaces typecheck

Closes #539