### PR TITLE
fix(minimax): update balance checker to use _token cookie and x-group-id header

### DIFF
--- a/packages/backend/src/__tests__/config-quota-validation.test.ts
+++ b/packages/backend/src/__tests__/config-quota-validation.test.ts
@@ -72,11 +72,11 @@ describe('config quota checker validation', () => {
     });
   });
 
-  it('accepts minimax quota checker when groupid and hertzSession are provided', () => {
+  it('accepts minimax quota checker when groupid and token are provided', () => {
     const config = validateConfig(
       makeConfigJson({
         groupid: 'group-123',
-        hertzSession: 'session-secret',
+        token: 'jwt-token-secret',
       })
     );
 
@@ -87,21 +87,19 @@ describe('config quota checker validation', () => {
       type: 'minimax',
       options: {
         groupid: 'group-123',
-        hertzSession: 'session-secret',
+        token: 'jwt-token-secret',
       },
     });
   });
 
   it('rejects minimax quota checker when groupid is missing', () => {
-    expect(() => validateConfig(makeConfigJson({ hertzSession: 'session-secret' }))).toThrow(
+    expect(() => validateConfig(makeConfigJson({ token: 'jwt-token-secret' }))).toThrow(
       '"groupid"'
     );
   });
 
-  it('rejects minimax quota checker when hertzSession is missing', () => {
-    expect(() => validateConfig(makeConfigJson({ groupid: 'group-123' }))).toThrow(
-      '"hertzSession"'
-    );
+  it('rejects minimax quota checker when token is missing', () => {
+    expect(() => validateConfig(makeConfigJson({ groupid: 'group-123' }))).toThrow('"token"');
   });
 
   it('rejects minimax quota checker when required fields are empty strings', () => {
@@ -109,7 +107,7 @@ describe('config quota checker validation', () => {
       validateConfig(
         makeConfigJson({
           groupid: '   ',
-          hertzSession: '   ',
+          token: '   ',
         })
       )
     ).toThrow('MiniMax groupid is required');

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -229,7 +229,7 @@ const NovitaQuotaCheckerOptionsSchema = z.object({
 
 const MiniMaxQuotaCheckerOptionsSchema = z.object({
   groupid: z.string().trim().min(1, 'MiniMax groupid is required'),
-  hertzSession: z.string().trim().min(1, 'MiniMax HERTZ-SESSION cookie value is required'),
+  token: z.string().trim().min(1, 'MiniMax _token cookie value is required'),
 });
 
 const MiniMaxCodingQuotaCheckerOptionsSchema = z.object({

--- a/packages/backend/src/services/quota/checkers/__tests__/minimax-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/minimax-checker.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMeterContext, isCheckerRegistered } from '../../checker-registry';
 import checkerDef from '../minimax-checker';
 
-const makeCtx = (groupid = '1234567890', hertzSession = 'test_hertz_session_cookie_value') =>
-  createMeterContext('minimax-test', 'minimax', { groupid, hertzSession });
+const makeCtx = (groupid = '1234567890', token = 'test_jwt_token_value') =>
+  createMeterContext('minimax-test', 'minimax', { groupid, token });
 
 describe('minimax checker', () => {
   const setFetchMock = (impl: (...args: unknown[]) => Promise<Response>): void => {
@@ -18,14 +18,16 @@ describe('minimax checker', () => {
     expect(isCheckerRegistered('minimax')).toBe(true);
   });
 
-  it('queries balance with GroupId and HERTZ-SESSION cookie', async () => {
+  it('queries balance with _token cookie and x-group-id header', async () => {
     let capturedUrl: string | undefined;
     let capturedCookie: string | undefined;
+    let capturedGroupHeader: string | undefined;
 
     setFetchMock(async (input: unknown, init: unknown) => {
       capturedUrl = String(input as string);
-      capturedCookie =
-        new Headers((init as RequestInit | undefined)?.headers).get('Cookie') ?? undefined;
+      const headers = new Headers((init as RequestInit | undefined)?.headers);
+      capturedCookie = headers.get('Cookie') ?? undefined;
+      capturedGroupHeader = headers.get('x-group-id') ?? undefined;
       return new Response(
         JSON.stringify({
           available_amount: '22.91',
@@ -35,10 +37,11 @@ describe('minimax checker', () => {
       );
     });
 
-    const meters = await checkerDef.check(makeCtx('group-abc', 'cookie-secret-value'));
+    const meters = await checkerDef.check(makeCtx('group-abc', 'jwt-token-value'));
 
-    expect(capturedUrl).toBe('https://platform.minimax.io/account/query_balance?GroupId=group-abc');
-    expect(capturedCookie).toBe('HERTZ-SESSION=cookie-secret-value');
+    expect(capturedUrl).toBe('https://platform.minimax.io/account/query_balance');
+    expect(capturedCookie).toBe('_token=jwt-token-value');
+    expect(capturedGroupHeader).toBe('group-abc');
     expect(meters).toHaveLength(1);
     expect(meters[0]?.kind).toBe('balance');
     expect(meters[0]?.unit).toBe('usd');

--- a/packages/backend/src/services/quota/checkers/minimax-checker.ts
+++ b/packages/backend/src/services/quota/checkers/minimax-checker.ts
@@ -12,18 +12,22 @@ export default defineChecker({
   displayName: 'MiniMax',
   optionsSchema: z.object({
     groupid: z.string().trim().min(1, 'MiniMax groupid is required'),
-    hertzSession: z.string().trim().min(1, 'MiniMax HERTZ-SESSION cookie value is required'),
+    token: z.string().trim().min(1, 'MiniMax _token cookie value is required'),
   }),
   async check(ctx) {
     const groupid = ctx.requireOption<string>('groupid').trim();
-    const hertzSession = ctx.requireOption<string>('hertzSession').trim();
+    const token = ctx.requireOption<string>('token').trim();
 
-    const endpoint = `https://platform.minimax.io/account/query_balance?GroupId=${encodeURIComponent(groupid)}`;
+    const endpoint = `https://platform.minimax.io/account/query_balance`;
     logger.silly(`Calling ${endpoint}`);
 
     const response = await fetch(endpoint, {
       method: 'GET',
-      headers: { Cookie: `HERTZ-SESSION=${hertzSession}`, Accept: 'application/json' },
+      headers: {
+        Cookie: `_token=${token}`,
+        'x-group-id': groupid,
+        Accept: 'application/json',
+      },
     });
 
     if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/packages/frontend/src/components/quota/MiniMaxQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/MiniMaxQuotaConfig.tsx
@@ -26,13 +26,13 @@ export const MiniMaxQuotaConfig: React.FC<MiniMaxQuotaConfigProps> = ({ options,
 
       <div className="flex flex-col gap-1">
         <label className="font-body text-[13px] font-medium text-text-secondary">
-          HERTZ-SESSION Cookie <span className="text-danger">*</span>
+          _token Cookie <span className="text-danger">*</span>
         </label>
         <Input
           type="password"
-          value={(options.hertzSession as string) ?? ''}
-          onChange={(e) => handleChange('hertzSession', e.target.value)}
-          placeholder="Paste HERTZ-SESSION cookie value"
+          value={(options.token as string) ?? ''}
+          onChange={(e) => handleChange('token', e.target.value)}
+          placeholder="Paste _token cookie value"
         />
         <span className="text-[10px] text-text-muted">
           Treated as a password. Used to query MiniMax balance.

--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -760,8 +760,8 @@ export function useProviderForm() {
     if (quotaType === 'minimax') {
       if (!options.groupid || !(options.groupid as string).trim())
         return 'Group ID is required for MiniMax quota checker';
-      if (!options.hertzSession || !(options.hertzSession as string).trim())
-        return 'HERTZ-SESSION cookie value is required for MiniMax quota checker';
+      if (!options.token || !(options.token as string).trim())
+        return '_token cookie value is required for MiniMax quota checker';
     }
     if (quotaType === 'wisdomgate' && (!options.session || !(options.session as string).trim()))
       return 'Session cookie is required for Wisdom Gate quota checker';


### PR DESCRIPTION
## Summary

- MiniMax changed their platform auth from `HERTZ-SESSION` cookie to JWT-based `_token` cookie
- Group selection moved from a `GroupId` query param to an `x-group-id` request header
- Minimum required auth confirmed via curl before making changes
- Updates checker, test, and frontend config field accordingly

## Test plan

- [x] All existing tests pass (1507 tests, 139 files)
- [x] All pre-commit hooks pass (biome lint/format, typecheck, frontend build)
- [x] Auth mechanism verified with live curl against `platform.minimax.io` before implementation