### PR TITLE
feat(frontend): improve usage charts UX

### DIFF
--- a/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
@@ -354,8 +354,13 @@ export const UsageTab: React.FC<UsageTabProps> = ({
     const CustomTooltip = ({ active, payload }: any) => {
       if (active && payload && payload.length) {
         const value = payload[0].value;
-        const label = payload[0].name;
+        const name = payload[0].payload?.name || payload[0].name;
         const formattedValue = dataKey === 'requests' ? formatNumber(value) : formatTokens(value);
+        const total = sortedData.reduce(
+          (sum, d) => sum + (d[dataKey as keyof PieChartDataPoint] as number),
+          0
+        );
+        const percent = total > 0 ? ((value / total) * 100).toFixed(1) : 0;
         return (
           <div
             style={{
@@ -366,10 +371,13 @@ export const UsageTab: React.FC<UsageTabProps> = ({
             }}
           >
             <p style={{ margin: 0, color: '#ffffff', fontSize: '14px' }}>
-              <strong>{label}</strong>
+              <strong>{name}</strong>
             </p>
             <p style={{ margin: '4px 0 0 0', color: '#ffffff', fontSize: '13px' }}>
               {dataKey === 'requests' ? 'Requests' : 'Tokens'}: {formattedValue}
+            </p>
+            <p style={{ margin: '2px 0 0 0', color: '#ffffff', fontSize: '13px' }}>
+              ({percent}%)
             </p>
           </div>
         );
@@ -377,6 +385,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
       return null;
     };
 
+    const total = data.reduce((sum, d) => sum + (d[dataKey] as number), 0);
     const sortedData = [...data].sort((a, b) => (b[dataKey] as number) - (a[dataKey] as number));
 
     const toggleBtnStyle = (active: boolean): React.CSSProperties => ({
@@ -418,22 +427,17 @@ export const UsageTab: React.FC<UsageTabProps> = ({
                   dataKey={dataKey}
                   nameKey="name"
                 >
-                  {data.map((_entry, index) => (
+                  {sortedData.map((_entry, index) => (
                     <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                   ))}
                 </Pie>
                 <Legend
-                  verticalAlign="bottom"
                   align="left"
-                  height={36}
-                  formatter={(value) => {
+                  formatter={(value: string) => {
                     const item = sortedData.find((d) => d.name === value);
                     if (!item) return value;
-                    const itemValue = item[dataKey as keyof PieChartDataPoint] as number;
-                    const total = sortedData.reduce(
-                      (sum, d) => sum + (d[dataKey as keyof PieChartDataPoint] as number),
-                      0
-                    );
+                    const itemValue = item[dataKey] as number;
+                    const total = sortedData.reduce((sum, d) => sum + (d[dataKey] as number), 0);
                     const percent = total > 0 ? ((itemValue / total) * 100).toFixed(0) : 0;
                     return `${value} (${percent}%)`;
                   }}
@@ -445,7 +449,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={sortedData}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-glass)" />
-                <XAxis dataKey="name" stroke="var(--color-text-secondary)" />
+                <XAxis dataKey="name" stroke="var(--color-text-secondary)" angle={-35} textAnchor="end" height={60} tick={{ fontSize: 11 }} />
                 <YAxis
                   stroke="var(--color-text-secondary)"
                   tickFormatter={(v) =>
@@ -454,7 +458,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
                 />
                 <Tooltip content={<CustomTooltip />} />
                 <Bar dataKey={dataKey} radius={[4, 4, 0, 0]} activeBar={false}>
-                  {data.map((_entry, index) => (
+                  {sortedData.map((_entry, index) => (
                     <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                   ))}
                 </Bar>
@@ -561,7 +565,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
                       borderRadius: '8px',
                     }}
                   />
-                  <Legend />
+                  <Legend align="left" />
                   {providerKeys.map((provider, index) => (
                     <Area
                       key={provider}
@@ -615,7 +619,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
                       borderRadius: '8px',
                     }}
                   />
-                  <Legend />
+                  <Legend align="left" />
                   {modelKeys.map((model, index) => (
                     <Bar
                       key={model}

--- a/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
@@ -385,7 +385,6 @@ export const UsageTab: React.FC<UsageTabProps> = ({
       return null;
     };
 
-    const total = data.reduce((sum, d) => sum + (d[dataKey] as number), 0);
     const sortedData = [...data].sort((a, b) => (b[dataKey] as number) - (a[dataKey] as number));
 
     const toggleBtnStyle = (active: boolean): React.CSSProperties => ({

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1330,6 +1330,7 @@ export const api = {
 
       records.forEach((r) => {
         const name = r.incomingModelAlias || 'Unknown';
+        if (name.startsWith('direct/')) return;
         if (!aggregated[name]) {
           aggregated[name] = { name, requests: 0, tokens: 0 };
         }
@@ -1441,7 +1442,8 @@ export const api = {
       const aggregated: Record<string, PieChartDataPoint> = {};
 
       records.forEach((r) => {
-        const name = r.apiKey ? `${r.apiKey.slice(0, 8)}...` : 'Unknown';
+        const name = r.apiKey ? (r.apiKey.length > 8 ? `${r.apiKey.slice(0, 8)}...` : r.apiKey) : 'Unknown';
+        if (r.apiKey === 'probe') return;
         if (!aggregated[name]) {
           aggregated[name] = { name, requests: 0, tokens: 0 };
         }


### PR DESCRIPTION
## Summary
- Sort pie/bar chart data by value (descending) for better readability
- Add percentage display in chart tooltips
- Add angled x-axis labels for bar charts
- Left-align legend data across all usage charts
- Filter out `direct/` prefixed models from Usage by Model Alias
- Filter out `probe` API key from Usage by API Key charts
- Fix API key name truncation to only add ellipsis when key > 8 chars

## Test plan
- [ ] Verify pie charts display data sorted from large to small
- [ ] Verify tooltip shows percentage on hover
- [ ] Verify bar chart x-axis labels are angled and readable
- [ ] Verify all chart legends are left-aligned
- [ ] Verify `direct/` models are excluded from Usage by Model Alias
- [ ] Verify `probe` key is excluded from Usage by API Key charts
- [ ] Verify short API keys (≤8 chars) display without ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)