### PR TITLE
fix(logs): stop duration timer and reconnect SSE on disconnect

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "plexus2",
       "devDependencies": {
-        "@biomejs/biome": "^2.4.16",
+        "@biomejs/biome": "2.4.16",
         "@redocly/cli": "^2.31.5",
         "agent-browser": "^0.27.0",
         "bun-types": "1.3.14",

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -431,10 +431,14 @@ export const Logs = () => {
         // Wait before retrying, but bail early if aborted.
         await new Promise<void>((resolve) => {
           const timer = setTimeout(resolve, delay);
-          controller.signal.addEventListener('abort', () => {
-            clearTimeout(timer);
-            resolve();
-          });
+          controller.signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            { once: true }
+          );
         });
 
         if (!controller.signal.aborted) {
@@ -537,7 +541,7 @@ export const Logs = () => {
         actions={
           <>
             {/* SSE live-update connection status — only visible when on page 1, sorted by date desc */}
-            {offset === 0 && sortBy === 'date' && sortDir === 'desc' && (
+            {!!adminKey && offset === 0 && sortBy === 'date' && sortDir === 'desc' && (
               <span
                 className={clsx(
                   'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium border select-none',

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -277,9 +277,12 @@ export const Logs = () => {
       );
     };
 
-    // Attempt a single SSE connection. Returns true if it connected successfully
-    // (even if the stream subsequently ended), false if the connection itself failed.
-    const connectOnce = async (): Promise<boolean> => {
+    // Attempt a single SSE connection.
+    // Returns:
+    //   true  — connected and stream ended (transient; safe to retry)
+    //   false — connection-level error (transient; safe to retry)
+    //   null  — permanent server error (4xx); stop retrying
+    const connectOnce = async (): Promise<boolean | null> => {
       try {
         const response = await fetch('/v0/management/events', {
           headers: { 'x-admin-key': adminKey },
@@ -287,6 +290,12 @@ export const Logs = () => {
         });
 
         if (!response.ok) {
+          // Non-transient HTTP errors (401, 403, 404, etc.) — no point retrying.
+          if (response.status >= 400 && response.status < 500) {
+            handleDisconnect();
+            console.error(`SSE: permanent error ${response.status} — stopping reconnect`);
+            return null;
+          }
           throw new Error(`Failed to connect: ${response.statusText}`);
         }
 
@@ -416,14 +425,23 @@ export const Logs = () => {
     };
 
     // Reconnect loop with exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s (cap).
+    // Delay resets to 1s after any successful connection so a brief outage
+    // following a long stable session doesn't start with an accumulated delay.
     const run = async () => {
       const MAX_DELAY_MS = 30_000;
       let delay = 1_000;
 
       while (!controller.signal.aborted) {
-        await connectOnce();
+        const result = await connectOnce();
 
         if (controller.signal.aborted) break;
+
+        // Permanent server error (4xx) — stop retrying entirely.
+        if (result === null) break;
+
+        // Reset backoff after a successful connection so the next drop after a
+        // long stable session starts back at 1 s instead of the accumulated delay.
+        if (result === true) delay = 1_000;
 
         // Stream ended unexpectedly — start reconnecting.
         setSseStatus('reconnecting');

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -66,6 +66,9 @@ import {
   CheckCircle,
   XCircle,
   Gauge,
+  Wifi,
+  WifiOff,
+  Loader,
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { useNavigate } from 'react-router-dom';
@@ -151,6 +154,13 @@ export const Logs = () => {
   const [isRetryModalOpen, setIsRetryModalOpen] = useState(false);
 
   const filtersRef = useRef(filters);
+  // sseConnected tracks whether the live-update SSE stream is currently active.
+  // Used to stop the liveTick timer when the stream drops so duration counters freeze.
+  const sseConnected = useRef(false);
+  // sseStatus drives the visible connection indicator in the UI.
+  const [sseStatus, setSseStatus] = useState<'connected' | 'reconnecting' | 'disconnected'>(
+    'disconnected'
+  );
 
   useEffect(() => {
     filtersRef.current = filters;
@@ -172,7 +182,10 @@ export const Logs = () => {
   const [, setLiveTick] = useState(0);
 
   useEffect(() => {
-    const interval = setInterval(() => setLiveTick((t) => t + 1), 100);
+    // Only tick while the SSE stream is active so duration counters freeze when it drops.
+    const interval = setInterval(() => {
+      if (sseConnected.current) setLiveTick((t) => t + 1);
+    }, 100);
     return () => clearInterval(interval);
   }, []);
 
@@ -252,12 +265,24 @@ export const Logs = () => {
 
     const controller = new AbortController();
 
-    const connect = async () => {
+    // Freeze pending logs and update connection status when the stream drops.
+    const handleDisconnect = () => {
+      sseConnected.current = false;
+      setLogs((prev) =>
+        prev.map((log) =>
+          log.responseStatus === 'pending' && log.durationMs == null
+            ? { ...log, durationMs: Date.now() - log.startTime }
+            : log
+        )
+      );
+    };
+
+    // Attempt a single SSE connection. Returns true if it connected successfully
+    // (even if the stream subsequently ended), false if the connection itself failed.
+    const connectOnce = async (): Promise<boolean> => {
       try {
         const response = await fetch('/v0/management/events', {
-          headers: {
-            'x-admin-key': adminKey,
-          },
+          headers: { 'x-admin-key': adminKey },
           signal: controller.signal,
         });
 
@@ -266,14 +291,20 @@ export const Logs = () => {
         }
 
         const reader = response.body?.getReader();
-        if (!reader) return;
+        if (!reader) return false;
+
+        sseConnected.current = true;
+        setSseStatus('connected');
 
         const decoder = new TextDecoder();
         let buffer = '';
 
         while (true) {
           const { done, value } = await reader.read();
-          if (done) break;
+          if (done) {
+            handleDisconnect();
+            break;
+          }
 
           buffer += decoder.decode(value, { stream: true });
           const lines = buffer.split('\n\n'); // SSE messages are separated by double newline
@@ -371,17 +402,67 @@ export const Logs = () => {
             }
           }
         }
+
+        return true;
       } catch (err: any) {
-        if (err.name !== 'AbortError') {
-          console.error('Log stream error:', err);
+        handleDisconnect();
+        if (err.name === 'AbortError') {
+          // Intentional teardown — do not retry.
+          throw err;
         }
+        console.error('Log stream error:', err);
+        return false;
       }
     };
 
-    connect();
+    // Reconnect loop with exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s (cap).
+    const run = async () => {
+      const MAX_DELAY_MS = 30_000;
+      let delay = 1_000;
+
+      while (!controller.signal.aborted) {
+        await connectOnce();
+
+        if (controller.signal.aborted) break;
+
+        // Stream ended unexpectedly — start reconnecting.
+        setSseStatus('reconnecting');
+
+        // Wait before retrying, but bail early if aborted.
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, delay);
+          controller.signal.addEventListener('abort', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+
+        if (!controller.signal.aborted) {
+          delay = Math.min(delay * 2, MAX_DELAY_MS);
+        }
+      }
+
+      setSseStatus('disconnected');
+    };
+
+    run().catch(() => {
+      // AbortError from intentional teardown — suppress.
+      setSseStatus('disconnected');
+    });
 
     return () => {
+      sseConnected.current = false;
+      setSseStatus('disconnected');
       controller.abort();
+      // Freeze any in-flight logs that are still 'pending' so their duration
+      // counter stops at the moment the stream dropped rather than continuing forever.
+      setLogs((prev) =>
+        prev.map((log) =>
+          log.responseStatus === 'pending' && log.durationMs == null
+            ? { ...log, durationMs: Date.now() - log.startTime }
+            : log
+        )
+      );
     };
   }, [offset, limit, adminKey, sortBy, sortDir]);
 
@@ -454,18 +535,51 @@ export const Logs = () => {
             : 'All API requests routed through the gateway'
         }
         actions={
-          isAdmin ? (
-            <Button
-              onClick={handleDeleteAll}
-              variant="danger"
-              size="sm"
-              leftIcon={<Trash2 size={14} />}
-              disabled={logs.length === 0}
-              type="button"
-            >
-              Delete All
-            </Button>
-          ) : undefined
+          <>
+            {/* SSE live-update connection status — only visible when on page 1, sorted by date desc */}
+            {offset === 0 && sortBy === 'date' && sortDir === 'desc' && (
+              <span
+                className={clsx(
+                  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium border select-none',
+                  sseStatus === 'connected' && 'bg-green-500/10 text-green-400 border-green-500/20',
+                  sseStatus === 'reconnecting' &&
+                    'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+                  sseStatus === 'disconnected' &&
+                    'bg-red-500/10 text-text-muted border-border-glass'
+                )}
+                title={
+                  sseStatus === 'connected'
+                    ? 'Live updates active'
+                    : sseStatus === 'reconnecting'
+                      ? 'Reconnecting to live updates…'
+                      : 'Live updates disconnected'
+                }
+              >
+                {sseStatus === 'connected' && <Wifi size={12} />}
+                {sseStatus === 'reconnecting' && <Loader size={12} className="animate-spin" />}
+                {sseStatus === 'disconnected' && <WifiOff size={12} />}
+                <span className="hidden sm:inline">
+                  {sseStatus === 'connected'
+                    ? 'Live'
+                    : sseStatus === 'reconnecting'
+                      ? 'Reconnecting…'
+                      : 'Disconnected'}
+                </span>
+              </span>
+            )}
+            {isAdmin && (
+              <Button
+                onClick={handleDeleteAll}
+                variant="danger"
+                size="sm"
+                leftIcon={<Trash2 size={14} />}
+                disabled={logs.length === 0}
+                type="button"
+              >
+                Delete All
+              </Button>
+            )}
+          </>
         }
       >
         <form
@@ -653,11 +767,14 @@ export const Logs = () => {
                                 log.responseStatus === 'pending'
                                   ? progressMapRef.current.get(log.requestId)
                                   : undefined;
-                              const liveDuration = formatMs(
+                              const rawDurationMs =
                                 log.durationMs != null && log.durationMs > 0
                                   ? log.durationMs
-                                  : Date.now() - log.startTime
-                              );
+                                  : log.responseStatus === 'pending'
+                                    ? Date.now() - log.startTime
+                                    : null;
+                              const liveDuration =
+                                rawDurationMs != null ? formatMs(rawDurationMs) : '-';
                               if (progress) {
                                 return (
                                   <div
@@ -1241,11 +1358,14 @@ export const Logs = () => {
                             log.responseStatus === 'pending'
                               ? progressMapRef.current.get(log.requestId)
                               : undefined;
-                          const liveDuration = formatMs(
+                          const rawDurationMs =
                             log.durationMs != null && log.durationMs > 0
                               ? log.durationMs
-                              : Date.now() - log.startTime
-                          );
+                              : log.responseStatus === 'pending'
+                                ? Date.now() - log.startTime
+                                : null;
+                          const liveDuration =
+                            rawDurationMs != null ? formatMs(rawDurationMs) : '-';
                           if (progress) {
                             return (
                               <div style={{ display: 'flex', flexDirection: 'column' }}>


### PR DESCRIPTION
## Summary

Fixes #544

The Duration counter in `/ui/logs` continued incrementing forever — even minutes after a request completed or the server restarted — because the live-tick interval never stopped and the duration fallback applied to all logs regardless of status.

## Root causes

1. **liveTick interval ran unconditionally** — the 100ms re-render tick never stopped, even when the SSE stream was gone.
2. **Duration fallback applied to all logs** — `Date.now() - log.startTime` was used for any log with `durationMs == null`, regardless of `responseStatus`. Logs stuck in `pending` after a server crash kept counting forever.

## Changes

### Duration fix
- `liveTick` interval now only ticks while `sseConnected.current === true`
- Duration fallback (`Date.now() - startTime`) is only used when `responseStatus === 'pending'`; completed/errored logs with no `durationMs` show `-`
- On SSE disconnect, any still-pending logs have their `durationMs` stamped at the moment the stream dropped

### SSE reconnect system
- Extracted single connection attempt into `connectOnce()`
- `run()` loop wraps it with exponential backoff: **1s → 2s → 4s → 8s → 16s → 30s** (capped)
- Backoff timer is wired to the `AbortController` signal so unmount/filter-change exits immediately without waiting out the delay
- Abort listeners use `{ once: true }` to prevent accumulation across reconnect cycles

### Connection status badge
- New `sseStatus` state: `'connected'` | `'reconnecting'` | `'disconnected'`
- Badge renders in the `PageHeader` actions area (admin-key users only, page 1, default sort)
  - Green `Wifi` + "Live" when connected
  - Yellow spinning `Loader` + "Reconnecting…" during backoff
  - Muted `WifiOff` + "Disconnected" after teardown
- Label hidden on mobile; icon only