### PR TITLE
docs(openapi): add 9 missing fields across alias, provider, and key config schemas

### DIFF
--- a/docs/openapi/components/schemas/AliasConfig.yaml
+++ b/docs/openapi/components/schemas/AliasConfig.yaml
@@ -84,6 +84,18 @@ properties:
       - **selector** — Apply each group's selector across its targets regardless of API type.
       - **api_match** — Filter targets to those whose provider supports the
         requested API type first, then apply the selector.
+  preferred_api:
+    type: array
+    description: >
+      Advertised in /v1/models to inform clients of the recommended API
+      surface for this alias.
+    items:
+      type: string
+      enum:
+        - chat_completions
+        - messages
+        - gemini
+        - responses
   additional_aliases:
     type: array
     items:
@@ -103,6 +115,20 @@ properties:
     description: >
       When true, enforces the model's `max_tokens` / `max_output_tokens`
       constraint from metadata, rejecting requests that exceed it.
+  extraBody:
+    type: object
+    additionalProperties: true
+    description: >
+      Extra JSON body fields merged into every request dispatched through
+      this alias. Merged after provider-level and model-level extraBody,
+      so alias values win.
+  sticky_session:
+    type: boolean
+    default: false
+    description: >
+      When enabled, multi-turn conversations prefer the same provider/model
+      from the previous turn (when still healthy) for better prompt-cache
+      hit rates.
   metadata:
     description: >
       Optional reference to an external model catalog entry. When configured,
@@ -225,6 +251,21 @@ properties:
     description: >
       Shorthand simple pricing: output price per million tokens. See
       `input_price_per_million`.
+  pi_model:
+    type: object
+    description: >
+      Link to a pi-ai model to include its compatibility options as
+      `pi_options` in `GET /v1/models`.
+    properties:
+      provider:
+        type: string
+        description: pi-ai provider identifier (e.g. openai, anthropic).
+      model_id:
+        type: string
+        description: pi-ai model ID (e.g. gpt-4o, claude-sonnet-4-20250514).
+    required:
+      - provider
+      - model_id
   pricing:
     description: >
       Advanced pricing configuration. Takes precedence over

--- a/docs/openapi/components/schemas/KeyConfig.yaml
+++ b/docs/openapi/components/schemas/KeyConfig.yaml
@@ -23,6 +23,18 @@ properties:
     description: >
       Restrict this key to specific providers only. If empty, the key
       can be used with any provider.
+  excludedProviders:
+    type: array
+    items:
+      type: string
+    description: >
+      Optional denylist. If set, routing will not use these provider IDs.
+  excludedModels:
+    type: array
+    items:
+      type: string
+    description: >
+      Optional denylist. If set, this key cannot use these model aliases.
   allowedModels:
     type: array
     items:

--- a/docs/openapi/components/schemas/ProviderConfig.yaml
+++ b/docs/openapi/components/schemas/ProviderConfig.yaml
@@ -63,6 +63,12 @@ properties:
     description: >
       When true, disables automatic cooldown for this provider. Failed
       requests won't trigger exponential backoff. Use with caution.
+  stall_cooldown:
+    type: boolean
+    default: false
+    description: >
+      When enabled, stall detection cancellations will trigger cooldown for
+      this provider.
   discount:
     type: number
     minimum: 0
@@ -141,6 +147,13 @@ properties:
     description: >
       Static headers forwarded on every request to this provider. Useful for
       custom authentication schemes or provider-specific requirements.
+  maxConcurrency:
+    type: [integer, "null"]
+    minimum: 1
+    description: >
+      Max concurrency across all models. Optional per-provider limit on
+      how many requests can be in-flight simultaneously. Empty/null means
+      no limit.
   extraBody:
     type: object
     additionalProperties: true
@@ -152,6 +165,11 @@ properties:
     description: >
       When true, token counts are estimated locally rather than relying on
       the provider's response. Useful for providers that omit usage fields.
+  geminiThinkingEnabled:
+    type: boolean
+    description: >
+      When true, enables Gemini-native thinking (extended reasoning) for this
+      provider. Only applicable to Gemini-compatible providers.
   useClaudeMasking:
     type: boolean
     default: false


### PR DESCRIPTION
Add 9 missing OpenAPI schema fields:

**AliasConfig** — `preferred_api`, `extraBody`, `sticky_session`, `pi_model`
**ProviderConfig** — `stall_cooldown`, `maxConcurrency`, `geminiThinkingEnabled`
**KeyConfig** — `excludedProviders`, `excludedModels`