### PR TITLE
Update model import modal with alias selection and suppression

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -63,6 +63,7 @@
         "@plexus/shared": "workspace:*",
         "@types/human-format": "^1.0.3",
         "clsx": "^2.1.1",
+        "fuse.js": "^7.4.1",
         "human-format": "^1.2.1",
         "lucide-react": "^1.16.0",
         "react": "^19.2.6",
@@ -833,6 +834,8 @@
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "fuse.js": ["fuse.js@7.4.1", "", {}, "sha512-AY7lKAXK71hi3WgUvDy6oZL67UEHOOtvCAwVdOXHyJd6ZzftBy7QqxuXt4HxmmAhYjmp/YCuOELZtIvAdlZ+fw=="],
 
     "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -25,6 +25,7 @@
     "@plexus/shared": "workspace:*",
     "@types/human-format": "^1.0.3",
     "clsx": "^2.1.1",
+    "fuse.js": "^7.4.1",
     "human-format": "^1.2.1",
     "lucide-react": "^1.16.0",
     "react": "^19.2.6",

--- a/packages/frontend/src/components/models/ImportModelsModal.tsx
+++ b/packages/frontend/src/components/models/ImportModelsModal.tsx
@@ -8,6 +8,11 @@ interface Props {
   orphanGroups: OrphanGroup[];
   selectedImports: Map<string, Set<string>>;
   setSelectedImports: React.Dispatch<React.SetStateAction<Map<string, Set<string>>>>;
+  selectedModels: Set<string>;
+  setSelectedModels: React.Dispatch<React.SetStateAction<Set<string>>>;
+  selectedAliases: Map<string, string>;
+  setSelectedAliases: React.Dispatch<React.SetStateAction<Map<string, string>>>;
+  onSuppress: (modelId: string) => void;
   onImport: () => Promise<boolean>;
   isImporting: boolean;
 }
@@ -18,9 +23,19 @@ export function ImportModelsModal({
   orphanGroups,
   selectedImports,
   setSelectedImports,
+  selectedModels,
+  setSelectedModels,
+  selectedAliases,
+  setSelectedAliases,
+  onSuppress,
   onImport,
   isImporting,
 }: Props) {
+  const hasSelectedImport = orphanGroups.some(
+    (group) =>
+      selectedModels.has(group.modelId) && (selectedImports.get(group.modelId)?.size ?? 0) > 0
+  );
+
   return (
     <Modal
       isOpen={isOpen}
@@ -35,10 +50,7 @@ export function ImportModelsModal({
           <Button
             onClick={onImport}
             isLoading={isImporting}
-            disabled={
-              Array.from(selectedImports.values()).every((providerIds) => providerIds.size === 0) ||
-              orphanGroups.length === 0
-            }
+            disabled={!hasSelectedImport || orphanGroups.length === 0}
           >
             Import Selected
           </Button>
@@ -48,7 +60,8 @@ export function ImportModelsModal({
       <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
         {orphanGroups.length === 0 ? (
           <div className="text-text-muted italic text-center text-sm py-8">
-            No orphaned models found — all provider models are covered by aliases.
+            No orphaned models found. All provider models are covered by aliases or suppressed
+            locally.
           </div>
         ) : (
           <div
@@ -82,46 +95,69 @@ export function ImportModelsModal({
                   <th className="px-4 py-3 text-left font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
                     Providers
                   </th>
+                  <th
+                    className="px-4 py-3 text-right font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                    style={{ width: '110px' }}
+                  >
+                    Actions
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {orphanGroups.map((group) => {
                   const selected = selectedImports.get(group.modelId) || new Set<string>();
-                  const allChecked =
-                    group.candidates.length > 0 &&
-                    group.candidates.every((c) => selected.has(c.provider.id));
+                  const isModelSelected = selectedModels.has(group.modelId);
+                  const selectedAliasId = selectedAliases.get(group.modelId) ?? '';
 
                   return (
                     <tr key={group.modelId} className="hover:bg-bg-hover">
                       <td className="px-4 py-3 text-left text-text">
                         <input
                           type="checkbox"
-                          checked={allChecked}
+                          checked={isModelSelected}
                           onChange={(e) => {
-                            const next = new Map(selectedImports);
+                            const next = new Set(selectedModels);
                             if (e.target.checked) {
-                              next.set(
-                                group.modelId,
-                                new Set(group.candidates.map((c) => c.provider.id))
-                              );
+                              next.add(group.modelId);
                             } else {
-                              next.set(group.modelId, new Set<string>());
+                              next.delete(group.modelId);
                             }
-                            setSelectedImports(next);
+                            setSelectedModels(next);
                           }}
                         />
                       </td>
                       <td className="px-4 py-3 text-left text-text">
                         <div className="font-medium">{group.modelId}</div>
-                        {group.existingAlias ? (
+                        {group.aliasMatches.length > 0 ? (
                           <>
                             <span className="inline-flex rounded border border-border-glass px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary">
-                              Existing Alias
+                              Existing Alias Match
                             </span>
-                            {group.matchReason && (
+                            {group.aliasMatches.length === 1 ? (
                               <div className="text-[11px] text-text-muted mt-0.5">
-                                {group.matchReason}
+                                {group.aliasMatches[0].alias.id} · {group.aliasMatches[0].reason}
                               </div>
+                            ) : (
+                              <select
+                                className="mt-1 w-full max-w-xs py-1 px-2 font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                                value={selectedAliasId}
+                                onChange={(e) => {
+                                  const next = new Map(selectedAliases);
+                                  if (e.target.value) {
+                                    next.set(group.modelId, e.target.value);
+                                  } else {
+                                    next.delete(group.modelId);
+                                  }
+                                  setSelectedAliases(next);
+                                }}
+                              >
+                                <option value="">Create new alias</option>
+                                {group.aliasMatches.map((match) => (
+                                  <option key={match.alias.id} value={match.alias.id}>
+                                    {match.alias.id} ({match.reason})
+                                  </option>
+                                ))}
+                              </select>
                             )}
                           </>
                         ) : (
@@ -166,6 +202,11 @@ export function ImportModelsModal({
                             );
                           })}
                         </div>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <Button variant="ghost" size="sm" onClick={() => onSuppress(group.modelId)}>
+                          Suppress
+                        </Button>
                       </td>
                     </tr>
                   );

--- a/packages/frontend/src/hooks/useModels.ts
+++ b/packages/frontend/src/hooks/useModels.ts
@@ -1,12 +1,25 @@
+import Fuse from 'fuse.js';
 import { useState, useEffect, useCallback } from 'react';
 import { api, Alias, Provider, Model, Cooldown } from '../lib/api';
 import { useToast } from '../contexts/ToastContext';
+
+export interface AliasMatch {
+  alias: Alias;
+  reason: string;
+}
 
 export interface OrphanGroup {
   modelId: string;
   existingAlias?: Alias;
   matchReason?: string;
+  aliasMatches: AliasMatch[];
   candidates: Array<{ provider: Provider; model: Model }>;
+}
+
+interface AliasSearchEntry {
+  alias: Alias;
+  value: string;
+  normalized: string;
 }
 
 const EMPTY_ALIAS: Alias = {
@@ -14,6 +27,133 @@ const EMPTY_ALIAS: Alias = {
   aliases: [],
   priority: 'selector',
   target_groups: [{ name: 'default', selector: 'random', targets: [] }],
+};
+
+const IMPORT_SUPPRESSIONS_STORAGE_KEY = 'plexus_suppressed_import_models';
+
+const getSuppressedImportKey = (value: string) => value.toLowerCase();
+
+const normalizeModelName = (value: string) =>
+  value
+    .toLowerCase()
+    .split('/')
+    .at(-1)!
+    .split(':')
+    .at(0)!
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const readSuppressedImportModels = () => {
+  if (typeof window === 'undefined') return new Set<string>();
+
+  try {
+    const raw = window.localStorage.getItem(IMPORT_SUPPRESSIONS_STORAGE_KEY);
+    if (!raw) return new Set<string>();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set<string>();
+    return new Set(parsed.filter((item): item is string => typeof item === 'string'));
+  } catch (error) {
+    console.warn('Failed to load suppressed import models from localStorage:', error);
+    return new Set<string>();
+  }
+};
+
+const saveSuppressedImportModels = (suppressed: Set<string>) => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(
+      IMPORT_SUPPRESSIONS_STORAGE_KEY,
+      JSON.stringify(Array.from(suppressed).sort())
+    );
+  } catch (error) {
+    console.warn('Failed to save suppressed import models to localStorage:', error);
+  }
+};
+
+const getAliasSearchEntries = (aliasList: Alias[]): AliasSearchEntry[] =>
+  aliasList.flatMap((alias) =>
+    [alias.id, ...(alias.aliases ?? [])]
+      .filter((value) => value.trim().length > 0)
+      .map((value) => ({ alias, value, normalized: normalizeModelName(value) }))
+  );
+
+const getTokenSet = (value: string) =>
+  new Set(normalizeModelName(value).split('-').filter(Boolean));
+
+const getSharedPrefixTokenCount = (leftValue: string, rightValue: string) => {
+  const left = normalizeModelName(leftValue).split('-');
+  const right = normalizeModelName(rightValue).split('-');
+  let count = 0;
+  while (left[count] && left[count] === right[count]) count += 1;
+  return count;
+};
+
+const hasStrongModelRelationship = (modelId: string, aliasValue: string) => {
+  const normalizedModel = normalizeModelName(modelId);
+  const normalizedAlias = normalizeModelName(aliasValue);
+  if (!normalizedModel || !normalizedAlias) return false;
+  if (normalizedModel === normalizedAlias) return true;
+  if (
+    normalizedModel.startsWith(`${normalizedAlias}-`) ||
+    normalizedAlias.startsWith(`${normalizedModel}-`)
+  ) {
+    return true;
+  }
+
+  const modelTokens = getTokenSet(modelId);
+  const aliasTokens = getTokenSet(aliasValue);
+  const shared = Array.from(aliasTokens).filter((token) => modelTokens.has(token));
+  const aliasCoverage = shared.length / aliasTokens.size;
+  const prefixCount = getSharedPrefixTokenCount(modelId, aliasValue);
+
+  return prefixCount >= 4 && aliasCoverage >= 0.8;
+};
+
+const getAliasMatches = (modelId: string, aliasList: Alias[]): AliasMatch[] => {
+  const entries = getAliasSearchEntries(aliasList);
+  const normalizedModel = normalizeModelName(modelId);
+  const matches = new Map<string, AliasMatch>();
+
+  const addMatch = (entry: AliasSearchEntry, reason: string) => {
+    if (!matches.has(entry.alias.id)) {
+      matches.set(entry.alias.id, { alias: entry.alias, reason });
+    }
+  };
+
+  for (const entry of entries) {
+    if (entry.normalized === normalizedModel) {
+      addMatch(
+        entry,
+        entry.value === entry.alias.id ? 'exact match' : `alias match: ${entry.value}`
+      );
+    }
+  }
+
+  for (const entry of entries) {
+    if (matches.has(entry.alias.id)) continue;
+    if (normalizedModel.startsWith(`${entry.normalized}-`)) {
+      addMatch(entry, `base alias match: ${entry.value}`);
+    } else if (entry.normalized.startsWith(`${normalizedModel}-`)) {
+      addMatch(entry, `variant alias match: ${entry.value}`);
+    }
+  }
+
+  const fuse = new Fuse(entries, {
+    keys: ['normalized'],
+    includeScore: true,
+    threshold: 0.35,
+    ignoreLocation: true,
+    minMatchCharLength: 4,
+  });
+
+  for (const result of fuse.search(normalizedModel)) {
+    const entry = result.item;
+    if (matches.has(entry.alias.id) || !hasStrongModelRelationship(modelId, entry.value)) continue;
+    addMatch(entry, `similar alias: ${entry.value}`);
+  }
+
+  return Array.from(matches.values());
 };
 
 export const useModels = () => {
@@ -49,6 +189,10 @@ export const useModels = () => {
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [orphanGroups, setOrphanGroups] = useState<OrphanGroup[]>([]);
   const [selectedImports, setSelectedImports] = useState<Map<string, Set<string>>>(new Map());
+  const [selectedImportModels, setSelectedImportModels] = useState<Set<string>>(new Set());
+  const [selectedImportAliases, setSelectedImportAliases] = useState<Map<string, string>>(
+    new Map()
+  );
   const [isImporting, setIsImporting] = useState(false);
 
   const loadData = useCallback(async () => {
@@ -232,43 +376,9 @@ export const useModels = () => {
 
   const filteredAliases = aliases.filter((a) => a.id.toLowerCase().includes(search.toLowerCase()));
 
-  const findExistingAlias = useCallback(
-    (modelId: string, aliasList: Alias[]): { alias: Alias; reason?: string } | undefined => {
-      const lowerModel = modelId.toLowerCase();
-
-      // 1. Case-insensitive exact match
-      const ciMatch = aliasList.find((a) => a.id.toLowerCase() === lowerModel);
-      if (ciMatch && ciMatch.id !== modelId) {
-        return { alias: ciMatch, reason: `case-insensitive match: ${ciMatch.id}` };
-      }
-      if (ciMatch) {
-        return { alias: ciMatch };
-      }
-
-      // 2. Suffix match
-      const modelSuffix = modelId.includes('/')
-        ? modelId.substring(modelId.lastIndexOf('/') + 1)
-        : modelId;
-      const modelSuffixLower = modelSuffix.toLowerCase();
-
-      for (const alias of aliasList) {
-        const aliasSuffix = alias.id.includes('/')
-          ? alias.id.substring(alias.id.lastIndexOf('/') + 1)
-          : alias.id;
-        const aliasSuffixLower = aliasSuffix.toLowerCase();
-
-        if (aliasSuffixLower === modelSuffixLower && alias.id !== modelId) {
-          return { alias, reason: `suffix match: ${alias.id}` };
-        }
-      }
-
-      return undefined;
-    },
-    []
-  );
-
   const handleOpenImport = useCallback(() => {
     const covered = new Set<string>();
+    const suppressedImports = readSuppressedImportModels();
     aliases.forEach((alias) => {
       alias.target_groups.forEach((g) => {
         g.targets.forEach((t) => {
@@ -282,6 +392,7 @@ export const useModels = () => {
     availableModels.forEach((model) => {
       const key = `${model.providerId}|${model.id}`;
       if (covered.has(key)) return;
+      if (suppressedImports.has(getSuppressedImportKey(model.id))) return;
 
       const groupKey = model.id.toLowerCase();
       if (!canonicalIds.has(groupKey)) {
@@ -300,39 +411,77 @@ export const useModels = () => {
     const groups: OrphanGroup[] = [];
     orphanMap.forEach((candidates, groupKey) => {
       const modelId = canonicalIds.get(groupKey) || groupKey;
-      const match = findExistingAlias(modelId, aliases);
+      const aliasMatches = getAliasMatches(modelId, aliases);
       groups.push({
         modelId,
-        existingAlias: match?.alias,
-        matchReason: match?.reason,
+        existingAlias: aliasMatches[0]?.alias,
+        matchReason: aliasMatches[0]?.reason,
+        aliasMatches,
         candidates,
       });
     });
     groups.sort((a, b) => a.modelId.localeCompare(b.modelId));
 
     const selections = new Map<string, Set<string>>();
+    const aliasSelections = new Map<string, string>();
     groups.forEach((group) => {
       selections.set(group.modelId, new Set(group.candidates.map((c) => c.provider.id)));
+      if (group.aliasMatches[0]) {
+        aliasSelections.set(group.modelId, group.aliasMatches[0].alias.id);
+      }
     });
 
     setOrphanGroups(groups);
     setSelectedImports(selections);
+    setSelectedImportModels(new Set());
+    setSelectedImportAliases(aliasSelections);
     setIsImportModalOpen(true);
-  }, [aliases, availableModels, providers, findExistingAlias]);
+  }, [aliases, availableModels, providers]);
+
+  const handleSuppressImportModel = useCallback((modelId: string) => {
+    const nextSuppressed = readSuppressedImportModels();
+    nextSuppressed.add(getSuppressedImportKey(modelId));
+    saveSuppressedImportModels(nextSuppressed);
+
+    setOrphanGroups((prev) => prev.filter((group) => group.modelId !== modelId));
+    setSelectedImports((prev) => {
+      const next = new Map(prev);
+      next.delete(modelId);
+      return next;
+    });
+    setSelectedImportModels((prev) => {
+      const next = new Set(prev);
+      next.delete(modelId);
+      return next;
+    });
+    setSelectedImportAliases((prev) => {
+      const next = new Map(prev);
+      next.delete(modelId);
+      return next;
+    });
+  }, []);
 
   const handleSaveImports = useCallback(async () => {
     setIsImporting(true);
     try {
-      for (const [modelId, providerIds] of selectedImports.entries()) {
+      for (const modelId of selectedImportModels) {
+        const providerIds = selectedImports.get(modelId) ?? new Set<string>();
         if (providerIds.size === 0) continue;
 
         const group = orphanGroups.find((g) => g.modelId === modelId);
         if (!group) continue;
 
         const selectedCandidates = group.candidates.filter((c) => providerIds.has(c.provider.id));
+        const selectedAliasId = selectedImportAliases.get(modelId);
+        const selectedAlias = selectedAliasId
+          ? group.aliasMatches.find((match) => match.alias.id === selectedAliasId)?.alias
+          : undefined;
 
-        if (group.existingAlias) {
-          const updatedAlias = JSON.parse(JSON.stringify(group.existingAlias)) as Alias;
+        if (selectedAlias) {
+          const updatedAlias = JSON.parse(JSON.stringify(selectedAlias)) as Alias;
+          if (!updatedAlias.target_groups[0]) {
+            updatedAlias.target_groups = [{ name: 'default', selector: 'random', targets: [] }];
+          }
           // Merge into the first group of the existing alias
           selectedCandidates.forEach((c) => {
             const alreadyExists = updatedAlias.target_groups[0].targets.some(
@@ -346,7 +495,7 @@ export const useModels = () => {
               });
             }
           });
-          await api.saveAlias(updatedAlias, group.existingAlias.id);
+          await api.saveAlias(updatedAlias, selectedAlias.id);
         } else {
           const newAlias: Alias = {
             ...EMPTY_ALIAS,
@@ -371,6 +520,8 @@ export const useModels = () => {
       toast.success('Imports saved successfully');
       setIsImportModalOpen(false);
       setSelectedImports(new Map());
+      setSelectedImportModels(new Set());
+      setSelectedImportAliases(new Map());
       setOrphanGroups([]);
       return true;
     } catch (e) {
@@ -380,7 +531,7 @@ export const useModels = () => {
     } finally {
       setIsImporting(false);
     }
-  }, [selectedImports, orphanGroups, loadData, toast]);
+  }, [selectedImportModels, selectedImports, selectedImportAliases, orphanGroups, loadData, toast]);
 
   return {
     aliases: filteredAliases,
@@ -413,8 +564,13 @@ export const useModels = () => {
     setOrphanGroups,
     selectedImports,
     setSelectedImports,
+    selectedImportModels,
+    setSelectedImportModels,
+    selectedImportAliases,
+    setSelectedImportAliases,
     isImporting,
     handleOpenImport,
+    handleSuppressImportModel,
     handleSaveImports,
   };
 };

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -48,8 +48,13 @@ export const Models = () => {
     orphanGroups,
     selectedImports,
     setSelectedImports,
+    selectedImportModels,
+    setSelectedImportModels,
+    selectedImportAliases,
+    setSelectedImportAliases,
     isImporting,
     handleOpenImport,
+    handleSuppressImportModel,
     handleSaveImports,
   } = useModels();
 
@@ -453,6 +458,11 @@ export const Models = () => {
           orphanGroups={orphanGroups}
           selectedImports={selectedImports}
           setSelectedImports={setSelectedImports}
+          selectedModels={selectedImportModels}
+          setSelectedModels={setSelectedImportModels}
+          selectedAliases={selectedImportAliases}
+          setSelectedAliases={setSelectedImportAliases}
+          onSuppress={handleSuppressImportModel}
           onImport={handleSaveImports}
           isImporting={isImporting}
         />


### PR DESCRIPTION
Revise the Models import flow to improve orphaned model handling.

- Add fuse.js and implement fuzzy/heuristic alias matching in useModels to produce per-orphan aliasMatches (with match reasons) for existing aliases.
- Update ImportModelsModal to:
  - Track model selection via selectedModels (checkbox per orphan model).
  - Enable “Import Selected” only when at least one orphan model is selected and has provider selections.
  - Provide an alias dropdown when multiple aliasMatches exist; preselect the best match when available.
  - Add a “Suppress” action per orphan model.
- Implement local suppression in useModels using localStorage (plexus_suppressed_import_models):
  - Suppressing a model removes it from orphanGroups and clears its selection state.
  - Suppressed models are excluded when computing orphan groups.
- Wire new selection/suppression props through Models.tsx to ImportModelsModal, and update handleSaveImports to use selectedImportModels/selectedImportAliases (saving either by merging into the chosen existing alias or creating a new alias).