### PR TITLE
fix(inference-v2): prevent TTFB stall timeout from hanging indefinitely

### DIFF
--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -265,7 +265,13 @@ function nextWithTtfbTimeout<T>(
 ): Promise<IteratorResult<T>> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
-      onTimeout();
+      // Wrap in try/catch so a throwing callback cannot escape the setTimeout
+      // handler as an unhandled exception before reject() is called.
+      try {
+        onTimeout();
+      } catch {
+        // onTimeout must not throw; swallow and fall through to reject below.
+      }
       const stallErr = new Error(`Stream stalled: no content event within ${ttfbMs}ms`) as any;
       stallErr.isStallError = true;
       stallErr.name = 'StallError';
@@ -753,18 +759,12 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
       // ── TTFB stall detection ───────────────────────────────────────────
       let nextResult: IteratorResult<AssistantMessageEvent>;
       if (stallTtfbMs != null && !sawContentEvent) {
-        const abortCtrl = new AbortController();
         nextResult = await nextWithTtfbTimeout(
           iterator.next() as Promise<IteratorResult<AssistantMessageEvent>>,
           stallTtfbMs,
           () => {
-            // Abort the upstream via the attempt signal
-            abortCtrl.abort();
-            const stallErr = new Error(
-              `Stream stalled: no content event within ${stallTtfbMs}ms`
-            ) as any;
-            stallErr.isStallError = true;
-            throw stallErr;
+            // Side-effects only — do not throw here.
+            // nextWithTtfbTimeout creates and rejects with the StallError itself.
           }
         );
       } else {

--- a/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
+++ b/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeAll, afterEach } from 'vitest';
+import { describe, expect, test, beforeAll, afterAll } from 'vitest';
 import path from 'path';
 import { ModelMetadataManager, mergeOverrides } from '../model-metadata-manager';
 import type { NormalizedModelMetadata } from '../model-metadata-manager';
@@ -11,7 +11,7 @@ const modelsDevFixture = path.join(FIXTURES, 'models-dev-sample.json');
 const catwalkFixture = path.join(FIXTURES, 'catwalk-sample.json');
 
 // Reset the singleton between test suites so each describe block gets a fresh instance
-afterEach(() => {
+afterAll(() => {
   ModelMetadataManager.resetForTesting();
 });
 
@@ -341,7 +341,11 @@ describe('ModelMetadataManager – singleton', () => {
   test('resetForTesting creates a fresh instance', async () => {
     ModelMetadataManager.resetForTesting();
     const mgr = ModelMetadataManager.getInstance();
-    await mgr.loadAll({ openrouter: openrouterFixture });
+    await mgr.loadAll({
+      openrouter: openrouterFixture,
+      modelsDev: '/dev/null-nonexistent',
+      catwalk: '/dev/null-nonexistent',
+    });
     expect(mgr.isInitialized('openrouter')).toBe(true);
 
     ModelMetadataManager.resetForTesting();


### PR DESCRIPTION
## Summary

- **Root cause**: The `onTimeout` callback in `buildSSEGenerator` was throwing a stall error inside what becomes a `setTimeout` handler in `nextWithTtfbTimeout`. That throw escaped the Promise constructor as an unhandled exception before `reject(stallErr)` could be called, leaving the Promise permanently unsettled. Streaming requests that hit a TTFB stall hung forever, leaking a concurrency slot and debug log entry for the lifetime of the process.
- **Fix**: Wrap `onTimeout()` in try/catch inside `nextWithTtfbTimeout` so any throw cannot escape the setTimeout handler. Remove the throw and dead `abortCtrl` from the `buildSSEGenerator` callback — `nextWithTtfbTimeout` already creates and rejects with `StallError` itself.
- **Test fix**: The `model-metadata-manager` singleton test was calling `loadAll` with only an `openrouter` fixture, causing live HTTP requests to `catwalk.charm.sh` and `models.dev` for the other two sources. Added explicit `/dev/null-nonexistent` overrides to match the pattern used everywhere else in the file. Also changed top-level `afterEach` → `afterAll` to match the comment's stated intent (isolation between describe blocks, not between individual tests).

## Test plan

- [x] `bunx --bun vitest run --config vitest.config.ts src/inference-v2/shared/__tests__/pi-ai-executor.test.ts` — passes
- [x] `bunx --bun vitest run --config vitest.config.ts src/services/__tests__/model-metadata-manager.test.ts` — passes (18ms, no network)
- [x] Full pre-commit hook: 1758 tests pass, typecheck clean, lint clean