### PR TITLE
fix: refresh config before quota status checks

### DIFF
--- a/packages/backend/src/routes/management/__tests__/quota-enforcement.test.ts
+++ b/packages/backend/src/routes/management/__tests__/quota-enforcement.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify from 'fastify';
+
+const mockConfigService = vi.hoisted(() => ({
+  flush: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+vi.mock('../../../services/config-service', () => ({
+  ConfigService: {
+    getInstance: vi.fn(() => mockConfigService),
+  },
+}));
+
+import { registerQuotaEnforcementRoutes } from '../quota-enforcement';
+
+describe('quota enforcement management routes', () => {
+  beforeEach(() => {
+    mockConfigService.flush.mockReset();
+    mockConfigService.getConfig.mockReset();
+  });
+
+  it('flushes ConfigService before checking quota status for newly saved keys', async () => {
+    const fastify = Fastify();
+    let flushed = false;
+
+    mockConfigService.flush.mockImplementation(async () => {
+      flushed = true;
+    });
+    mockConfigService.getConfig.mockImplementation(() => ({
+      keys: flushed
+        ? {
+            'new-key': {
+              secret: 'sk-new-key',
+              quota: 'new-quota',
+            },
+          }
+        : {},
+      user_quotas: flushed
+        ? {
+            'new-quota': {
+              type: 'rolling',
+              duration: '1h',
+              limitType: 'requests',
+              limit: 10,
+            },
+          }
+        : {},
+    }));
+
+    const quotaEnforcer = {
+      checkQuota: vi.fn(async () => ({
+        quotaName: 'new-quota',
+        allowed: true,
+        currentUsage: 0,
+        limit: 10,
+        remaining: 10,
+        resetsAt: new Date('2026-01-01T00:00:00.000Z'),
+      })),
+      clearQuota: vi.fn(),
+    };
+
+    await registerQuotaEnforcementRoutes(fastify, quotaEnforcer as any);
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/quota/status/new-key',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockConfigService.flush.mock.invocationCallOrder[0]).toBeLessThan(
+      mockConfigService.getConfig.mock.invocationCallOrder[0]!
+    );
+    expect(quotaEnforcer.checkQuota).toHaveBeenCalledWith('new-key');
+    expect(res.json()).toEqual({
+      key: 'new-key',
+      quota_name: 'new-quota',
+      allowed: true,
+      current_usage: 0,
+      limit: 10,
+      remaining: 10,
+      resets_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    await fastify.close();
+  });
+});

--- a/packages/backend/src/routes/management/quota-enforcement.ts
+++ b/packages/backend/src/routes/management/quota-enforcement.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
-import { getConfig } from '../../config';
+import { ConfigService } from '../../services/config-service';
 import { logger } from '../../utils/logger';
 
 /**
@@ -10,6 +10,8 @@ export async function registerQuotaEnforcementRoutes(
   fastify: FastifyInstance,
   quotaEnforcer: QuotaEnforcer
 ) {
+  const configService = ConfigService.getInstance();
+
   /**
    * POST /v0/management/quota/clear
    * Reset quota usage for a key.
@@ -29,6 +31,7 @@ export async function registerQuotaEnforcementRoutes(
           });
         }
 
+        await configService.flush();
         await quotaEnforcer.clearQuota(body.key);
 
         return reply.send({
@@ -67,7 +70,8 @@ export async function registerQuotaEnforcementRoutes(
           });
         }
 
-        const config = getConfig();
+        await configService.flush();
+        const config = configService.getConfig();
         const keyConfig = config.keys?.[key];
 
         // Key not found


### PR DESCRIPTION
## Summary
- Update quota enforcement management routes to use ConfigService directly instead of legacy getConfig
- Flush ConfigService before quota status and quota clear operations so newly saved keys/quotas are immediately visible
- Add a regression test covering immediate quota status lookup after config refresh

## Validation
- bun run test src/routes/management/__tests__/quota-enforcement.test.ts
- bun run typecheck
- bun run format:check
- pre-commit hooks passed, including backend changed tests and workspace typecheck