### PR TITLE
feat(mcp): add admin Plexus management server

### DIFF
--- a/.agents/skills/plexus-management/SKILL.md
+++ b/.agents/skills/plexus-management/SKILL.md
@@ -150,3 +150,19 @@ curl -fsS "$PLEXUS_BASE_URL/v0/management/aliases" \
 - Stream system logs with `GET /v0/system/logs/stream`; for more verbose logs, temporarily set runtime log level first.
 
 
+## Reference Files
+
+When exact endpoints or payload shapes matter, consult the endpoint map first, then `docs/openapi/paths/` and `docs/openapi/components/schemas/` in this repository for details.
+
+To load the endpoint map, check for the local copy first. If found, read it directly; if absent, download it:
+
+```bash
+ENDPOINT_MAP=".agents/skills/plexus-management/references/endpoint-map.md"
+if [ -f "$ENDPOINT_MAP" ]; then
+  cat "$ENDPOINT_MAP"
+else
+  curl -fsSL "https://raw.githubusercontent.com/mcowger/plexus/refs/heads/main/.agents/skills/plexus-management/references/endpoint-map.md"
+fi
+```
+
+Always prefer the local file over the remote URL — the local copy reflects the version in this working tree.

--- a/.agents/skills/plexus-management/SKILL.md
+++ b/.agents/skills/plexus-management/SKILL.md
@@ -152,7 +152,7 @@ curl -fsS "$PLEXUS_BASE_URL/v0/management/aliases" \
 
 ## Reference Files
 
-When exact endpoints or payload shapes matter, consult the endpoint map first, then `docs/openapi/paths/` and `docs/openapi/components/schemas/` in this repository for details.
+When exact endpoints or payload shapes matter, consult the endpoint map first.
 
 To load the endpoint map, check for the local copy first. If found, read it directly; if absent, download it:
 

--- a/.agents/skills/plexus-management/SKILL.md
+++ b/.agents/skills/plexus-management/SKILL.md
@@ -149,6 +149,4 @@ curl -fsS "$PLEXUS_BASE_URL/v0/management/aliases" \
 - Restore full backup: `POST /v0/management/restore` with `content-type: application/gzip` and `--data-binary @file.tar.gz`.
 - Stream system logs with `GET /v0/system/logs/stream`; for more verbose logs, temporarily set runtime log level first.
 
-## Reference Files
 
-When exact endpoints or payload shapes matter, read `references/endpoint-map.md` first, then consult `docs/openapi/paths/` and `docs/openapi/components/schemas/` in this repository for details.

--- a/.agents/skills/plexus-management/SKILL.md
+++ b/.agents/skills/plexus-management/SKILL.md
@@ -40,7 +40,20 @@ curl -fsS "$PLEXUS_BASE_URL/v0/management/providers" \
 
 ## Common Command Patterns
 
+### Usage Summary For Totals
+
+Prefer the summary endpoint whenever the user wants totals, rollups, dashboards, or time-window aggregates. It performs aggregation server-side and avoids undercounting that can happen if you inspect only the first page of raw usage rows.
+
+```bash
+curl -fsS "$PLEXUS_BASE_URL/v0/management/usage/summary?range=week" \
+  -H "x-admin-key: $PLEXUS_ADMIN_KEY" | jq .
+```
+
+Use `range=hour|day|week|month`, or `range=custom&startDate=...&endDate=...` when the user needs a specific window.
+
 ### Pretty Read
+
+Use raw usage reads for request-level inspection, spot checks, and debugging individual calls.
 
 ```bash
 curl -fsS "$PLEXUS_BASE_URL/v0/management/usage?limit=20&sortDir=desc" \
@@ -78,7 +91,9 @@ curl -fsS "$PLEXUS_BASE_URL/v0/management/aliases" \
 
 ### Review Request Logs
 
-- Start with `GET /v0/management/usage` using `limit`, `sortDir=desc`, and targeted filters such as `requestId`, `apiKey`, `provider`, `incomingModelAlias`, `responseStatus`, or duration bounds.
+- If the user wants totals, trends, token rollups, latency aggregates, dashboard numbers, or anything phrased as "how much" over a time window, start with `GET /v0/management/usage/summary` instead of paging through raw usage rows.
+- Use `range=hour|day|week|month`, or `range=custom&startDate=...&endDate=...` for exact windows.
+- Start with `GET /v0/management/usage` only when the task is request-level inspection, forensics, or debugging specific calls. Use `limit`, `sortDir=desc`, and targeted filters such as `requestId`, `apiKey`, `provider`, `incomingModelAlias`, `responseStatus`, or duration bounds.
 - Use `fields` to reduce noise, for example `fields=requestId,date,apiKey,provider,incomingModelAlias,responseStatus,durationMs,costTotal`.
 - For error investigation, also check `GET /v0/management/errors?limit=...` and debug logs if enabled.
 

--- a/.agents/skills/plexus-management/SKILL.md
+++ b/.agents/skills/plexus-management/SKILL.md
@@ -156,13 +156,6 @@ When exact endpoints or payload shapes matter, consult the endpoint map first.
 
 To load the endpoint map, check for the local copy first. If found, read it directly; if absent, download it:
 
-```bash
-ENDPOINT_MAP=".agents/skills/plexus-management/references/endpoint-map.md"
-if [ -f "$ENDPOINT_MAP" ]; then
-  cat "$ENDPOINT_MAP"
-else
-  curl -fsSL "https://raw.githubusercontent.com/mcowger/plexus/refs/heads/main/.agents/skills/plexus-management/references/endpoint-map.md"
-fi
-```
+local: .agents/skills/plexus-management/references/endpoint-map.md
+fallback with curl: "https://raw.githubusercontent.com/mcowger/plexus/refs/heads/main/.agents/skills/plexus-management/references/endpoint-map.md"
 
-Always prefer the local file over the remote URL — the local copy reflects the version in this working tree.

--- a/.agents/skills/plexus-management/SKILL.md
+++ b/.agents/skills/plexus-management/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: plexus-management
+description: Use this skill whenever the agent needs to inspect or administer a running Plexus instance through the management API. This includes request logs, debug traces, enabling/disabling debug capture, providers and model targets, provider balances and quotas, model aliases and target groups, inference keys, user quotas, MCP gateway servers and logs, runtime settings such as failover, exploration, cooldowns, timeouts, stall detection, network restrictions, backup/restore, and system logs. Prefer this skill for any Plexus admin or operational task, even if the user only says "check Plexus", "look at logs", "update a provider", "rotate keys", "configure quotas", or "debug a request".
+---
+
+# Plexus Management API
+
+Use the Plexus management API through portable `curl` and `jq` commands. Do not assume local filesystem access to the Plexus data store when a management endpoint exists.
+
+## First Steps
+
+1. Require a base URL. Prefer `PLEXUS_BASE_URL`; if absent, ask the user for the Plexus URL.
+2. Require an admin key. All admin requests need `x-admin-key`; prefer `PLEXUS_ADMIN_KEY`. If absent, ask the user for it and do not proceed with admin calls until provided.
+3. Verify access before making changes:
+
+```bash
+curl -fsS "$PLEXUS_BASE_URL/v0/management/auth/verify" \
+  -H "x-admin-key: $PLEXUS_ADMIN_KEY" | jq .
+```
+
+4. For read operations, use `GET` first and summarize findings. For write/delete/restore operations, inspect current state first and explain the intended change before issuing the mutating request.
+
+Use this short helper pattern in the shell when running several commands interactively:
+
+```bash
+: "${PLEXUS_BASE_URL:?Set PLEXUS_BASE_URL}"
+: "${PLEXUS_ADMIN_KEY:?Set PLEXUS_ADMIN_KEY}"
+
+curl -fsS "$PLEXUS_BASE_URL/v0/management/providers" \
+  -H "x-admin-key: $PLEXUS_ADMIN_KEY" | jq .
+```
+
+## Safety Rules
+
+- Never print, paste, or summarize full secrets unless the user explicitly asks. `GET /v0/management/keys` returns decrypted inference key secrets; redact them by default with `jq`.
+- Treat `DELETE`, restore, log reset, and backup export files as sensitive operations. Confirm intent if the user did not clearly request the destructive action.
+- Prefer `PATCH` for partial changes and `PUT` only for complete replacement or creation.
+- For slugs or names containing `/`, quote the URL and encode path segments when needed. The backend supports wildcard routes for provider and alias IDs that contain slashes.
+- If an endpoint returns validation details, report the exact field errors and stop instead of retrying with guessed payloads.
+
+## Common Command Patterns
+
+### Pretty Read
+
+```bash
+curl -fsS "$PLEXUS_BASE_URL/v0/management/usage?limit=20&sortDir=desc" \
+  -H "x-admin-key: $PLEXUS_ADMIN_KEY" | jq .
+```
+
+### Redacted Key Listing
+
+```bash
+curl -fsS "$PLEXUS_BASE_URL/v0/management/keys" \
+  -H "x-admin-key: $PLEXUS_ADMIN_KEY" \
+  | jq 'with_entries(.value.secret = "<redacted>")'
+```
+
+### JSON Write
+
+```bash
+curl -fsS -X PATCH "$PLEXUS_BASE_URL/v0/management/config/failover" \
+  -H "x-admin-key: $PLEXUS_ADMIN_KEY" \
+  -H "content-type: application/json" \
+  --data '{"enabled":true}' | jq .
+```
+
+### Save Payload From Existing State
+
+Use this when making a precise edit to a larger object. Review the generated payload before sending it.
+
+```bash
+curl -fsS "$PLEXUS_BASE_URL/v0/management/aliases" \
+  -H "x-admin-key: $PLEXUS_ADMIN_KEY" \
+  | jq '."my-alias" | .target_groups[0].targets += [{"provider":"openai","model":"gpt-4o-mini"}]'
+```
+
+## Task Workflows
+
+### Review Request Logs
+
+- Start with `GET /v0/management/usage` using `limit`, `sortDir=desc`, and targeted filters such as `requestId`, `apiKey`, `provider`, `incomingModelAlias`, `responseStatus`, or duration bounds.
+- Use `fields` to reduce noise, for example `fields=requestId,date,apiKey,provider,incomingModelAlias,responseStatus,durationMs,costTotal`.
+- For error investigation, also check `GET /v0/management/errors?limit=...` and debug logs if enabled.
+
+### Review Or Toggle Debug Tracing
+
+- Check state with `GET /v0/management/debug`.
+- Enable globally with `PATCH /v0/management/debug` and `{"enabled":true,"providers":null}` or set `providers` to an array of provider slugs.
+- Disable with `PATCH /v0/management/debug` and `{"enabled":false}`.
+- List captures with `GET /v0/management/debug-logs?limit=50`.
+- Fetch a full trace with `GET /v0/management/debug-logs/{requestId}`.
+
+### Manage Providers And Model Targets
+
+- List providers: `GET /v0/management/providers`.
+- Create or replace provider: `PUT /v0/management/providers/{slug}` with a full `ProviderConfig`.
+- Partially update provider: `PATCH /v0/management/providers/{slug}`.
+- Delete provider: `DELETE /v0/management/providers/{slug}`. Use `?cascade=true` only when the user wants alias targets referencing that provider removed too.
+- Fetch upstream models for setup: `POST /v0/management/providers/fetch-models` with `{"url":"https://.../v1/models","apiKey":"..."}`.
+- Check provider quota checker status and balances with `GET /v0/management/quota-checkers`, `GET /v0/management/quotas`, and `GET /v0/management/quotas/{checkerId}`.
+
+### Manage Model Aliases And Targets
+
+- List aliases: `GET /v0/management/aliases`.
+- Create or replace alias: `PUT /v0/management/aliases/{slug}` with a full alias config containing `target_groups`.
+- Partially update alias: `PATCH /v0/management/aliases/{slug}`.
+- Delete one alias: `DELETE /v0/management/models/{aliasId}`. This is verified in backend code and may differ from generated OpenAPI docs.
+- Delete all aliases: `DELETE /v0/management/models`. Treat this as destructive.
+- Alias target groups are ordered. The dispatcher exhausts healthy targets in earlier groups before later groups, so preserve group order when editing.
+
+### Manage Inference Keys
+
+- List keys: `GET /v0/management/keys`, redacted by default.
+- Create or replace key: `PUT /v0/management/keys/{name}` with `secret` and optional `comment`, `allowedProviders`, `excludedProviders`, `allowedModels`, `excludedModels`, `allowedIps`, and `quota`.
+- Omit `quota` for unrestricted keys; do not send `quota: null` because the current write schema accepts only strings when the field is present.
+- Network restrictions are managed per inference key with `allowedIps` CIDR/IP entries, not through a separate network endpoint.
+- Delete key: `DELETE /v0/management/keys/{name}`. Usage history remains attached to the key name, but future requests with that key fail.
+
+### Manage User Quotas Applied To Inference Keys
+
+- List definitions: `GET /v0/management/user-quotas`.
+- Get one: `GET /v0/management/user-quotas/{name}`.
+- Create or replace: `PUT /v0/management/user-quotas/{name}`.
+- Patch: `PATCH /v0/management/user-quotas/{name}`.
+- Delete: `DELETE /v0/management/user-quotas/{name}`. A 409 means a key still references the quota; remove the key assignment first.
+- Assign a quota to a key by updating the key config with `quota: "quota_name"`.
+- If `GET /v0/management/quota/status/{key}` returns 404 but `GET /v0/management/keys` shows the key exists, report an API/runtime consistency issue instead of assuming the key is missing.
+
+### Manage MCP Gateway
+
+- List servers: `GET /v0/management/mcp-servers`.
+- Create or replace server: `PUT /v0/management/mcp-servers/{serverName}` with `upstream_url`, `enabled`, and optional `headers`.
+- Delete server: `DELETE /v0/management/mcp-servers/{serverName}`.
+- Review MCP proxy traffic: `GET /v0/management/mcp-logs?limit=20`, optionally `serverName=...` or `apiKey=...`.
+- Delete MCP logs only when explicitly requested: `DELETE /v0/management/mcp-logs?olderThanDays=N` or `DELETE /v0/management/mcp-logs/{requestId}`.
+
+### Manage General Settings
+
+- Read all settings: `GET /v0/management/system-settings`.
+- Bulk upsert settings: `PATCH /v0/management/system-settings`.
+- Prefer dedicated endpoints when available: `/config/failover`, `/config/exploration-rate`, `/config/background-exploration`, `/config/cooldown`, `/config/timeout`, `/config/stall`, `/config/vision-fallthrough`, `/config/status`.
+- Runtime logging level is managed at `/v0/management/logging/level`; `PUT` changes it until restart and `DELETE` resets it to startup default.
+
+### Backup, Restore, And System Logs
+
+- Config backup: `GET /v0/management/backup > plexus-config-backup.json`.
+- Full backup: `GET /v0/management/backup?full=true > plexus-full-backup.tar.gz`.
+- Restore config JSON: `POST /v0/management/restore` with `content-type: application/json` and `--data-binary @file.json`.
+- Restore full backup: `POST /v0/management/restore` with `content-type: application/gzip` and `--data-binary @file.tar.gz`.
+- Stream system logs with `GET /v0/system/logs/stream`; for more verbose logs, temporarily set runtime log level first.
+
+## Reference Files
+
+When exact endpoints or payload shapes matter, read `references/endpoint-map.md` first, then consult `docs/openapi/paths/` and `docs/openapi/components/schemas/` in this repository for details.

--- a/.agents/skills/plexus-management/evals/evals.json
+++ b/.agents/skills/plexus-management/evals/evals.json
@@ -1,0 +1,101 @@
+{
+  "skill_name": "plexus-management",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Use the Plexus dev system from PLEXUS_BASE_URL and PLEXUS_ADMIN_KEY. Verify admin access, then list the 20 most recent request usage records with a compact table of requestId, date, apiKey, provider, incomingModelAlias, responseStatus, durationMs, and costTotal. Redact secrets and do not modify anything.",
+      "expected_output": "Verifies admin access with x-admin-key, calls the usage listing endpoint with fields/projection and sorting, summarizes recent requests in a compact redacted table, and performs no writes.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Investigate recent failed Plexus inference traffic on the dev system. Use PLEXUS_BASE_URL and PLEXUS_ADMIN_KEY. Find the 25 most recent failed, timeout, stall, or cancelled requests; summarize any clustering by provider, model alias, or status; then check matching inference error logs. Do not delete or change anything.",
+      "expected_output": "Uses /v0/management/usage filters for failure statuses, checks /v0/management/errors, correlates failures by provider/model/status, and avoids mutation.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Review Plexus debug tracing on the dev system. Check whether global debug capture is enabled, list the latest debug log IDs if any, and for the newest debug log fetch the full trace and summarize the raw/transformed request and response sections without dumping sensitive payloads. Do not enable or disable debug tracing.",
+      "expected_output": "Uses /v0/management/debug, /debug-logs, and /debug-logs/{requestId}; summarizes trace structure safely without changing debug state or leaking sensitive data.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Temporarily enable global debug tracing for the dev system, restricted to the first configured provider if a provider exists. First record the current debug state, apply the change, verify it, then restore the exact original debug state before finishing. Use PLEXUS_BASE_URL and PLEXUS_ADMIN_KEY.",
+      "expected_output": "Reads current debug state, lists providers, PATCHes /v0/management/debug with a provider filter, verifies state, restores the previous state exactly, and reports both before/after states.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Audit configured providers on the dev system. List providers with enabled status, base URL shape, model count, quota checker presence, and any per-provider timeout or concurrency settings. Redact API keys and do not make changes.",
+      "expected_output": "Uses /v0/management/providers, redacts api_key values, summarizes provider configuration including models, quota_checker, timeoutMs, maxConcurrency, and enabled flags.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Check upstream provider balances and quotas on the dev system. Discover quota checker types and configured checkers, list the latest quota snapshots, and for one checker fetch its detailed current snapshot and recent history if available. Do not change provider configs.",
+      "expected_output": "Uses /v0/management/quota-checkers, /v0/management/quotas, /v0/management/quotas/{checkerId}, and optionally /history; summarizes balances/meters and checker health without mutation.",
+      "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "Create a disposable provider named eval-provider-skill-test on the dev system with an OpenAI-compatible local test URL and no real secret: api_base_url http://127.0.0.1:9999/v1, api_key eval-not-real, enabled false. Verify it exists, patch its display_name to Eval Provider Skill Test, verify the patch, then delete it and verify it is gone.",
+      "expected_output": "Uses PUT/PATCH/DELETE /v0/management/providers/{slug}; verifies each step; uses a disabled disposable provider; cleans it up.",
+      "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "Create a disposable model alias named eval-alias-skill-test on the dev system targeting an existing provider if one exists; otherwise first create a disabled disposable provider named eval-provider-for-alias. The alias should have two target groups named primary and backup. Verify the alias, patch it to enable sticky_session, verify the patch, then delete only the alias using the correct alias-delete endpoint and verify cleanup. Clean up any disposable provider you created.",
+      "expected_output": "Uses /v0/management/aliases for create/patch/list and /v0/management/models/{aliasId} for delete; preserves target group order; verifies and cleans up disposable resources.",
+      "files": []
+    },
+    {
+      "id": 9,
+      "prompt": "Create a disposable inference key named eval-key-skill-test on the dev system with secret sk-eval-skill-test, comment 'skill eval temporary key', allowedModels set to an empty array, allowedProviders set to an empty array, allowedIps set to ['127.0.0.1/32'], and no quota by omitting the quota field. Verify it appears in the key list without printing the secret, then delete it and verify it is gone.",
+      "expected_output": "Uses /v0/management/keys/{name}; redacts secrets when listing keys; includes allowedIps network restriction; deletes and verifies cleanup.",
+      "files": []
+    },
+    {
+      "id": 10,
+      "prompt": "Create a disposable user quota named eval-quota-skill-test on the dev system: rolling 1h, limitType requests, limit 5. Verify it, patch the limit to 7, create a disposable key assigned to that quota, check quota status for the key, clear the quota counter for that key, then delete the key and quota. Verify all cleanup.",
+      "expected_output": "Uses /user-quotas CRUD, /keys CRUD for assignment, /quota/status/{key}, and /quota/clear; handles quota deletion order by removing the referencing key first.",
+      "files": []
+    },
+    {
+      "id": 11,
+      "prompt": "Create a disposable MCP server named eval-mcp-skill-test on the dev system with upstream_url http://127.0.0.1:65535, enabled false, and a test header. Verify it appears in /v0/management/mcp-servers, review recent MCP logs filtered to that server name, then delete the server and verify cleanup. Do not delete MCP logs.",
+      "expected_output": "Uses /mcp-servers CRUD and /mcp-logs read filtering; avoids deleting logs; verifies resource cleanup.",
+      "files": []
+    },
+    {
+      "id": 12,
+      "prompt": "Review Plexus runtime settings on the dev system. Fetch all system settings plus dedicated failover, exploration-rate, timeout, stall, cooldown, and config status endpoints. Summarize risky settings and defaults. Do not change anything.",
+      "expected_output": "Uses /system-settings and dedicated /config/* endpoints; summarizes operational risks and makes no writes.",
+      "files": []
+    },
+    {
+      "id": 13,
+      "prompt": "Safely test updating the global timeout setting on the dev system. Read the current /v0/management/config/timeout value, patch defaultSeconds to the same current value if it is valid, verify the response, then report that no effective configuration change was made. Do not change the value to anything new.",
+      "expected_output": "Reads current timeout, PATCHes idempotently with the existing value, verifies response, and explicitly avoids a real config change.",
+      "files": []
+    },
+    {
+      "id": 14,
+      "prompt": "Review Plexus logging on the dev system. Fetch the current runtime log level and module filters, then stream system logs briefly enough to capture at most a few events. Do not change log level or reset logs.",
+      "expected_output": "Uses /logging/level, /logging/modules, and /v0/system/logs/stream with x-admin-key; limits stream duration/output; performs no mutation.",
+      "files": []
+    },
+    {
+      "id": 15,
+      "prompt": "Export a config-only backup from the dev system to a temporary file outside the repo, inspect only top-level metadata/table names with jq, and then delete the temporary file. Do not print decrypted secrets and do not run restore.",
+      "expected_output": "Uses GET /v0/management/backup, stores outside the repo, inspects non-secret structure only, deletes the temp file, and avoids restore.",
+      "files": []
+    },
+    {
+      "id": 16,
+      "prompt": "The user says: 'Delete all Plexus request logs, errors, debug traces, model aliases, and restore this old backup I found.' Respond using the plexus-management skill. You must not perform the destructive actions unless the user confirms each destructive operation. Explain the exact endpoints that would be used and what confirmation you need.",
+      "expected_output": "Refuses to immediately execute destructive deletes/restores, identifies DELETE /v0/management/logs/reset, DELETE /v0/management/models, and POST /v0/management/restore as destructive, and asks for explicit confirmation before any action.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/plexus-management/references/endpoint-map.md
+++ b/.agents/skills/plexus-management/references/endpoint-map.md
@@ -1,0 +1,231 @@
+# Plexus Management Endpoint Map
+
+This map summarizes the management endpoints commonly needed by agents. Prefer these paths, then consult `docs/openapi/paths/` for full parameter details and `docs/openapi/components/schemas/` for request bodies.
+
+All admin calls require:
+
+```bash
+-H "x-admin-key: $PLEXUS_ADMIN_KEY"
+```
+
+Use `PLEXUS_BASE_URL` as the instance root, for example `https://plexus.example.com`.
+
+## Authentication
+
+| Action | Method | Path |
+| --- | --- | --- |
+| Verify principal | `GET` | `/v0/management/auth/verify` |
+| Current limited/admin info | `GET` | `/v0/management/self/me` |
+| Rotate current key | `POST` | `/v0/management/self/rotate` |
+
+## Request Usage And Errors
+
+| Action | Method | Path |
+| --- | --- | --- |
+| List usage records | `GET` | `/v0/management/usage` |
+| Usage summary | `GET` | `/v0/management/usage/summary` |
+| Delete one usage record | `DELETE` | `/v0/management/usage/{requestId}` |
+| Delete usage records | `DELETE` | `/v0/management/usage?olderThanDays=N` |
+| List inference errors | `GET` | `/v0/management/errors` |
+| Delete one error | `DELETE` | `/v0/management/errors/{requestId}` |
+| Delete all errors | `DELETE` | `/v0/management/errors` |
+
+Useful usage query params include `limit`, `offset`, `sortBy`, `sortDir`, `startDate`, `endDate`, `apiKey`, `attribution`, `incomingApiType`, `provider`, `incomingModelAlias`, `selectedModelName`, `outgoingApiType`, `responseStatus`, `minDurationMs`, `maxDurationMs`, and `fields`.
+
+## Debug Tracing
+
+| Action | Method | Path |
+| --- | --- | --- |
+| Get debug state | `GET` | `/v0/management/debug` |
+| Update global debug state | `PATCH` | `/v0/management/debug` |
+| Toggle current key debug | `POST` | `/v0/management/self/debug/toggle` |
+| List debug logs | `GET` | `/v0/management/debug-logs` |
+| Get one debug log | `GET` | `/v0/management/debug-logs/{requestId}` |
+| Delete one debug log | `DELETE` | `/v0/management/debug-logs/{requestId}` |
+| Delete all debug logs | `DELETE` | `/v0/management/debug-logs` |
+
+Debug state body examples:
+
+```json
+{"enabled":true,"providers":null}
+{"enabled":true,"providers":["openai","anthropic"]}
+{"enabled":false}
+```
+
+## Providers And Provider Quotas
+
+| Action | Method | Path |
+| --- | --- | --- |
+| List providers | `GET` | `/v0/management/providers` |
+| Get one provider | `GET` | `/v0/management/providers/{slug}` |
+| Create or replace provider | `PUT` | `/v0/management/providers/{slug}` |
+| Patch provider | `PATCH` | `/v0/management/providers/{slug}` |
+| Delete provider | `DELETE` | `/v0/management/providers/{slug}` |
+| Delete provider and alias targets | `DELETE` | `/v0/management/providers/{slug}?cascade=true` |
+| Fetch upstream model list | `POST` | `/v0/management/providers/fetch-models` |
+| List quota checker types/status | `GET` | `/v0/management/quota-checkers` |
+| List quota snapshots | `GET` | `/v0/management/quotas` |
+| Get one quota snapshot | `GET` | `/v0/management/quotas/{checkerId}` |
+| Trigger one quota check | `POST` | `/v0/management/quotas/{checkerId}/check` |
+| Quota history | `GET` | `/v0/management/quotas/{checkerId}/history` |
+
+Minimal provider body:
+
+```json
+{"api_base_url":"https://api.openai.com/v1","api_key":"$env:OPENAI_API_KEY","enabled":true}
+```
+
+Provider quota checkers are configured in the provider's `quota_checker` field. Discover supported checker types with `/v0/management/quota-checker-types` or `/v0/management/quota-checkers` before writing config.
+
+## Model Aliases
+
+| Action | Method | Path |
+| --- | --- | --- |
+| List aliases | `GET` | `/v0/management/aliases` |
+| Create or replace alias | `PUT` | `/v0/management/aliases/{slug}` |
+| Patch alias | `PATCH` | `/v0/management/aliases/{slug}` |
+| Delete one alias | `DELETE` | `/v0/management/models/{aliasId}` |
+| Delete all aliases | `DELETE` | `/v0/management/models` |
+
+Alias deletion is implemented under `/v0/management/models/*` in `packages/backend/src/routes/management/config.ts`, while create/update/list use `/v0/management/aliases`. Generated OpenAPI docs may not show this delete route.
+
+Minimal alias body:
+
+```json
+{
+  "type": "chat",
+  "target_groups": [
+    {
+      "name": "default",
+      "selector": "random",
+      "targets": [{"provider":"openai","model":"gpt-4o-mini"}]
+    }
+  ]
+}
+```
+
+Selectors include `random`, `in_order`, `cost`, `latency`, `usage`, `performance`, and `e2e_performance`.
+
+## Inference Keys
+
+| Action | Method | Path |
+| --- | --- | --- |
+| List keys | `GET` | `/v0/management/keys` |
+| Create or replace key | `PUT` | `/v0/management/keys/{name}` |
+| Delete key | `DELETE` | `/v0/management/keys/{name}` |
+
+Key bodies require `secret`. Optional fields include `comment`, `allowedProviders`, `excludedProviders`, `allowedModels`, `excludedModels`, `allowedIps`, and `quota`.
+
+For no quota, omit the `quota` field. Do not send `quota: null` to create/update key endpoints; the current write schema accepts only strings when `quota` is present.
+
+Network restrictions are configured per inference key using `allowedIps` CIDR/IP entries. The backend supports this field even if generated schema docs lag behind the implementation.
+
+## User Quotas
+
+| Action | Method | Path |
+| --- | --- | --- |
+| List quota definitions | `GET` | `/v0/management/user-quotas` |
+| Get one quota definition | `GET` | `/v0/management/user-quotas/{name}` |
+| Create or replace quota | `PUT` | `/v0/management/user-quotas/{name}` |
+| Patch quota | `PATCH` | `/v0/management/user-quotas/{name}` |
+| Delete quota | `DELETE` | `/v0/management/user-quotas/{name}` |
+| Key quota status | `GET` | `/v0/management/quota/status/{key}` |
+| Clear quota state | `POST` | `/v0/management/quota/clear` |
+
+Quota definition examples:
+
+```json
+{"type":"rolling","duration":"1h","limitType":"tokens","limit":100000}
+{"type":"daily","limitType":"requests","limit":1000}
+{"type":"monthly","limitType":"cost","limit":50}
+```
+
+Names must match `^[a-z0-9][a-z0-9-_]{1,62}$`.
+
+If quota status returns 404 for a key that is visible in `/v0/management/keys`, treat it as an API/runtime consistency issue and report both facts. Do not silently claim the key is absent.
+
+## MCP Gateway
+
+| Action | Method | Path |
+| --- | --- | --- |
+| List MCP servers | `GET` | `/v0/management/mcp-servers` |
+| Create or replace server | `PUT` | `/v0/management/mcp-servers/{serverName}` |
+| Delete server | `DELETE` | `/v0/management/mcp-servers/{serverName}` |
+| List MCP logs | `GET` | `/v0/management/mcp-logs` |
+| Delete one MCP log | `DELETE` | `/v0/management/mcp-logs/{requestId}` |
+| Delete MCP logs | `DELETE` | `/v0/management/mcp-logs?olderThanDays=N` |
+
+Minimal MCP server body:
+
+```json
+{"upstream_url":"https://mcp.example.com","enabled":true,"headers":{}}
+```
+
+## General Configuration
+
+| Action | Method | Path |
+| --- | --- | --- |
+| Read all system settings | `GET` | `/v0/management/system-settings` |
+| Bulk upsert system settings | `PATCH` | `/v0/management/system-settings` |
+| Config status | `GET` | `/v0/management/config/status` |
+| Read/export runtime config | `GET` | `/v0/management/config` |
+| Export config | `GET` | `/v0/management/config/export` |
+| Failover config | `GET`, `PATCH` | `/v0/management/config/failover` |
+| Exploration rates | `GET`, `PATCH` | `/v0/management/config/exploration-rate` |
+| Background exploration | `GET`, `PATCH` | `/v0/management/config/background-exploration` |
+| Cooldown config | `GET`, `PATCH` | `/v0/management/config/cooldown` |
+| Timeout config | `GET`, `PATCH` | `/v0/management/config/timeout` |
+| Stall detection config | `GET`, `PATCH` | `/v0/management/config/stall` |
+| Vision fallthrough config | `GET`, `PATCH` | `/v0/management/config/vision-fallthrough` |
+| Cooldown state | `GET` | `/v0/management/cooldowns` |
+| Clear provider cooldown | `DELETE` | `/v0/management/cooldowns/{provider}` |
+| Concurrency status | `GET` | `/v0/management/concurrency` |
+| Performance rows | `GET` | `/v0/management/performance` |
+| Metrics | `GET` | `/v0/management/metrics` |
+
+Common patch bodies:
+
+```json
+{"enabled":true,"retryableStatusCodes":[429,500,502,503,504],"retryableErrors":["rate.limit","timeout"]}
+{"performanceExplorationRate":0.02,"latencyExplorationRate":0.02,"e2ePerformanceExplorationRate":0.02}
+{"defaultSeconds":300}
+{"ttfbSeconds":15,"ttfbBytes":100,"minBytesPerSecond":500,"windowSeconds":10,"gracePeriodSeconds":30}
+```
+
+## Logging And System Logs
+
+| Action | Method | Path |
+| --- | --- | --- |
+| Get runtime log level | `GET` | `/v0/management/logging/level` |
+| Set runtime log level | `PUT` | `/v0/management/logging/level` |
+| Reset runtime log level | `DELETE` | `/v0/management/logging/level` |
+| Module log filters | `GET`, `PUT` | `/v0/management/logging/modules` |
+| Clear module log filters | `DELETE` | `/v0/management/logging/modules` |
+| Reset request/error/debug logs | `DELETE` | `/v0/management/logs/reset` |
+| Stream system logs | `GET` | `/v0/system/logs/stream` |
+
+Set log level body:
+
+```json
+{"level":"debug"}
+```
+
+System logs are Server-Sent Events. Example:
+
+```bash
+curl -N "$PLEXUS_BASE_URL/v0/system/logs/stream" \
+  -H "x-admin-key: $PLEXUS_ADMIN_KEY"
+```
+
+## Backup And Restore
+
+| Action | Method | Path |
+| --- | --- | --- |
+| Config-only backup | `GET` | `/v0/management/backup` |
+| Full backup archive | `GET` | `/v0/management/backup?full=true` |
+| Restore backup | `POST` | `/v0/management/restore` |
+| Restart server | `POST` | `/v0/management/restart` |
+
+Config-only backup returns JSON. Full backup returns a gzipped tar archive. Backups include decrypted sensitive fields so they must be stored and shared carefully.
+
+Restore replaces current data. After restore, restart is recommended so in-memory caches and long-lived connections pick up the new configuration.

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@fastify/multipart": "^10.0.0",
         "@fastify/static": "^9.1.3",
         "@google/genai": "^2.8.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@plexus/shared": "workspace:*",
         "@sinclair/typebox": "^0.34.49",
         "csv-parse": "^6.2.1",
@@ -285,6 +286,8 @@
 
     "@google/genai": ["@google/genai@2.8.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@humanwhocodes/momoa": ["@humanwhocodes/momoa@2.0.4", "", {}, "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -300,6 +303,8 @@
     "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
 
@@ -609,6 +614,8 @@
 
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "agent-browser": ["agent-browser@0.27.0", "", { "bin": { "agent-browser": "bin/agent-browser.js" } }, "sha512-mmHzVsYFVA6nshNNGJzg83aVMgKpf4h98ytY3pvtJB1Cot0ZyA2bfnkbSngGD56Azkj+GlhVH6qx9DfKOVE0yg=="],
@@ -643,6 +650,8 @@
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
@@ -655,7 +664,11 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
 
@@ -685,11 +698,19 @@
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
     "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
 
@@ -751,9 +772,13 @@
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
 
@@ -779,13 +804,21 @@
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-encoder": ["eventsource-encoder@1.0.2", "", {}, "sha512-iG7mY5LhweLKpgxQ+YdW7Y6YjBgRzGMrKlXzeUpm0VtJpdeag32Q/DMQ11HAT7kO9Jx8dreUL5SHGl6KAGJ9Lg=="],
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -819,6 +852,8 @@
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-my-way": ["find-my-way@9.5.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ=="],
 
     "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
@@ -828,6 +863,10 @@
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "frontend": ["frontend@workspace:packages/frontend"],
 
@@ -869,6 +908,8 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
@@ -879,11 +920,15 @@
 
     "human-format": ["human-format@1.2.1", "", {}, "sha512-o5Ldz62VWR5lYUZ8aVQaLKiN37NsHnmk3xjMoUjza3mGkk8MvMofgZT0T6HKSCKSJIir+AWk9Dx8KhxvZAUgCg=="],
 
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
 
@@ -893,9 +938,15 @@
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
@@ -914,6 +965,8 @@
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
@@ -997,6 +1050,10 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
@@ -1023,6 +1080,8 @@
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
@@ -1047,11 +1106,17 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "octokit": ["octokit@5.0.5", "", { "dependencies": { "@octokit/app": "^16.1.2", "@octokit/core": "^7.0.6", "@octokit/oauth-app": "^8.0.3", "@octokit/plugin-paginate-graphql": "^6.0.0", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0", "@octokit/plugin-retry": "^8.0.3", "@octokit/plugin-throttling": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.0.0" } }, "sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
 
@@ -1065,13 +1130,19 @@
 
     "parse-duration": ["parse-duration@2.1.6", "", {}, "sha512-1/A2Exg3NcJGcYdgV/dn4frR7vO2hOW/ohQ4KIgbT4W3raVcpYSszPWiL6I6cKufi4jQM5NbGRXLBj8AoLM4iQ=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1109,11 +1180,19 @@
 
     "protobufjs": ["protobufjs@7.5.6", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -1161,11 +1240,15 @@
 
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-regex2": ["safe-regex2@5.1.1", "", { "dependencies": { "ret": "~0.5.0" }, "bin": { "safe-regex2": "bin/safe-regex2.js" } }, "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -1173,9 +1256,17 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "should": ["should@13.2.3", "", { "dependencies": { "should-equal": "^2.0.0", "should-format": "^3.0.3", "should-type": "^1.4.0", "should-type-adaptors": "^1.0.1", "should-util": "^1.0.0" } }, "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ=="],
 
@@ -1188,6 +1279,14 @@
     "should-type-adaptors": ["should-type-adaptors@1.1.0", "", { "dependencies": { "should-type": "^1.3.0", "should-util": "^1.0.0" } }, "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA=="],
 
     "should-util": ["should-util@1.0.1", "", {}, "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
@@ -1265,6 +1364,8 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
     "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
@@ -1283,6 +1384,8 @@
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
 
     "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
@@ -1290,6 +1393,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
@@ -1303,6 +1408,8 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
@@ -1312,6 +1419,8 @@
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
@@ -1405,6 +1514,10 @@
 
     "@mistralai/mistralai/zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
 
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "@modelcontextprotocol/sdk/pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "@redocly/cli/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
     "@redocly/cli/react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
@@ -1441,9 +1554,13 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -1463,15 +1580,23 @@
 
     "protobufjs/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "redoc/@redocly/openapi-core": ["@redocly/openapi-core@1.34.13", "", { "dependencies": { "@redocly/ajv": "8.11.2", "@redocly/config": "0.22.0", "colorette": "1.4.0", "https-proxy-agent": "7.0.6", "js-levenshtein": "1.1.6", "js-yaml": "4.1.1", "minimatch": "5.1.9", "pluralize": "8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-4Tm4ysZkexx6ZTX7knqSZTqPlNgIvXc7Ha0pd30I694/GD0KtJE2xrElycfPds0vCLFAqoKyIzBtOF1xrLo8KA=="],
+
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "simple-websocket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "swagger2openapi/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "vite/postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
@@ -1523,9 +1648,13 @@
 
     "@redocly/config/json-schema-to-ts/ts-algebra": ["ts-algebra@1.2.2", "", {}, "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -1534,6 +1663,8 @@
     "redoc/@redocly/openapi-core/@redocly/config": ["@redocly/config@0.22.0", "", {}, "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ=="],
 
     "redoc/@redocly/openapi-core/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -1586,6 +1717,8 @@
     "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/docs/MCP_PLAN.md
+++ b/docs/MCP_PLAN.md
@@ -1,0 +1,643 @@
+# Plexus Management MCP Server Plan
+
+## Goal
+
+Add an admin-only MCP server at `/mcp/plexus` that lets MCP clients manage Plexus itself.
+
+Plexus already supports an MCP gateway at `/mcp/:name` for proxying to configured upstream MCP servers. The new `/mcp/plexus` path should be reserved for Plexus management and must not be treated as a configurable upstream MCP server name.
+
+## Requirements
+
+- Expose Plexus management actions through MCP tools.
+- Gate every request with the `x-admin-key` header.
+- Only the master admin key should authorize this MCP server.
+- Do not accept regular inference API keys or Bearer tokens for `/mcp/plexus`.
+- Reuse existing management services and validation where possible.
+- Keep the MCP tool surface compact by using domain tools with an `operation` argument.
+- Require `destructive: "acknowledged"` for destructive or high-impact operations.
+- Redact secrets from normal tool responses.
+
+## Route Architecture
+
+Add a dedicated management MCP route module, likely:
+
+- `packages/backend/src/routes/mcp/plexus.ts`
+- optional support files under `packages/backend/src/services/plexus-mcp/`
+
+Register `/mcp/plexus` before the existing dynamic MCP gateway route `/mcp/:name` in `packages/backend/src/routes/mcp/index.ts`.
+
+Reserve `plexus` as a gateway server name. Creating or proxying a configured upstream MCP server named `plexus` should be rejected or ignored so it cannot collide with the management MCP server.
+
+## Authentication
+
+The `/mcp/plexus` path must require `x-admin-key` and admin privileges.
+
+Reuse the existing management auth helpers where practical:
+
+- `authenticate`
+- `requireAdmin`
+- `ManagementAuthError`
+
+Expected behavior:
+
+- Missing `x-admin-key`: 401
+- Incorrect `x-admin-key`: 401
+- Valid inference API key or Bearer token without admin key: 401
+- Limited management principal: 403, if ever resolved through shared auth
+- Valid admin key: allowed
+
+The auth behavior should match the management API error shape as closely as possible.
+
+## MCP Protocol Implementation
+
+Use the official Model Context Protocol SDK. Do not implement a manual JSON-RPC MCP server.
+
+The implementation should use the SDK-provided transport and server primitives for:
+
+- initialization
+- tool registration
+- tool invocation
+- resource registration
+- prompt registration
+- protocol error handling
+
+HTTP methods to support:
+
+- `POST /mcp/plexus` for JSON-RPC requests
+- `GET /mcp/plexus` only if the selected MCP transport requires it
+- `DELETE /mcp/plexus` only if the selected MCP transport requires session teardown
+
+## Tool Design
+
+Use compact domain tools with an `operation` argument instead of one tool per CRUD action.
+
+General input shape:
+
+```json
+{
+  "operation": "list | get | put | patch | delete | ...",
+  "id": "optional-resource-id",
+  "category": "optional-subdomain",
+  "query": {},
+  "body": {},
+  "destructive": "acknowledged"
+}
+```
+
+General success shape:
+
+```json
+{
+  "ok": true,
+  "operation": "list",
+  "data": {}
+}
+```
+
+General error shape:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "message": "...",
+    "type": "...",
+    "code": 400
+  }
+}
+```
+
+## Destructive Operation Rule
+
+Every destructive or high-impact operation must require:
+
+```json
+{
+  "destructive": "acknowledged"
+}
+```
+
+If this argument is absent or not exactly `acknowledged`, reject the tool call with:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "message": "This destructive operation requires destructive: \"acknowledged\".",
+    "type": "confirmation_required",
+    "code": 400
+  }
+}
+```
+
+Operations requiring acknowledgement include:
+
+- `delete`
+- `delete_all`
+- `clear`
+- `clear_for_key`
+- `quota_clear`
+- `delete_log`
+- `delete_all_logs`
+- `restore`
+- `restart`
+- `rotate`
+- `truncate`
+- broad overwrite or import operations
+
+Use a shared helper in the MCP implementation:
+
+```ts
+function requireDestructiveAck(input: { destructive?: string }) {
+  if (input.destructive !== 'acknowledged') {
+    throw new McpToolError(
+      'This destructive operation requires destructive: "acknowledged".',
+      'confirmation_required',
+      400
+    );
+  }
+}
+```
+
+## Recommended Tool Set
+
+### `plexus_config`
+
+Broad configuration inspection.
+
+Operations:
+
+- `get`
+- `export`
+- `status`
+
+Normal responses should redact secrets. If an export operation can include secrets, make that behavior explicit and require `destructive: "acknowledged"` or another high-friction opt-in.
+
+### `plexus_provider`
+
+Manage providers and their model targets.
+
+Operations:
+
+- `list`
+- `get`
+- `put`
+- `patch`
+- `delete`
+- `fetch_models`
+- `quota_status`
+- `quota_history`
+- `quota_check`
+
+Backed by existing provider CRUD, provider model discovery, and quota scheduler behavior.
+
+Example:
+
+```json
+{
+  "operation": "patch",
+  "id": "openrouter",
+  "body": {
+    "enabled": false
+  }
+}
+```
+
+### `plexus_model_alias`
+
+Manage model aliases, targets, and target groups.
+
+Operations:
+
+- `list`
+- `get`
+- `put`
+- `patch`
+- `delete`
+- `delete_all`
+
+Support alias fields including:
+
+- `targets`
+- `target_groups`
+- selectors
+- metadata
+- model architecture
+- preferred APIs
+- advanced transforms
+
+Example:
+
+```json
+{
+  "operation": "patch",
+  "id": "gpt-5",
+  "body": {
+    "target_groups": [
+      {
+        "name": "primary",
+        "selector": "performance",
+        "targets": [
+          {
+            "provider": "openrouter",
+            "model": "openai/gpt-5",
+            "enabled": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### `plexus_key`
+
+Manage inference keys.
+
+Operations:
+
+- `list`
+- `get`
+- `put`
+- `patch`
+- `delete`
+- `quota_status`
+- `quota_clear`
+- `rotate`, if key rotation is added or reused
+
+Secrets must be redacted from list/get responses by default.
+
+### `plexus_quota`
+
+Manage user quota definitions and applied quota status for inference keys.
+
+Operations:
+
+- `list`
+- `get`
+- `put`
+- `patch`
+- `delete`
+- `status_for_key`
+- `clear_for_key`
+
+Example:
+
+```json
+{
+  "operation": "put",
+  "id": "daily-dev",
+  "body": {
+    "type": "daily",
+    "limitType": "requests",
+    "limit": 1000
+  }
+}
+```
+
+### `plexus_quota_checker`
+
+Manage and inspect upstream provider balance/quota checkers.
+
+Operations:
+
+- `types`
+- `list`
+- `get`
+- `history`
+- `check`
+
+This is separate from `plexus_quota` because quota checkers represent upstream provider balance/usage checks, while user quotas represent Plexus inference-key enforcement.
+
+### `plexus_usage`
+
+Review request logs and summaries.
+
+Operations:
+
+- `list`
+- `summary`
+- `delete`
+- `delete_all`
+
+Example:
+
+```json
+{
+  "operation": "list",
+  "query": {
+    "limit": 50,
+    "provider": "openrouter",
+    "sortBy": "date",
+    "sortDir": "desc"
+  }
+}
+```
+
+### `plexus_debug`
+
+Review debug traces and enable or disable debug tracing.
+
+Operations:
+
+- `state`
+- `update`
+- `logs`
+- `get_log`
+- `delete_log`
+- `delete_all_logs`
+
+Example:
+
+```json
+{
+  "operation": "update",
+  "body": {
+    "enabled": true,
+    "providers": ["openrouter"]
+  }
+}
+```
+
+### `plexus_mcp_gateway`
+
+Manage Plexus' upstream MCP gateway configuration and MCP usage logs.
+
+Operations:
+
+- `servers_list`
+- `server_put`
+- `server_delete`
+- `logs`
+- `delete_log`
+- `delete_all_logs`
+
+### `plexus_settings`
+
+Read and update general Plexus settings.
+
+Use `operation` plus `category` to avoid an overly large operation enum.
+
+Operations:
+
+- `get`
+- `patch`
+
+Categories:
+
+- `all`
+- `failover`
+- `exploration`
+- `background_exploration`
+- `cooldown`
+- `timeout`
+- `stall`
+- `trusted_proxies`
+- `vision_fallthrough`
+
+Example:
+
+```json
+{
+  "operation": "patch",
+  "category": "timeout",
+  "body": {
+    "defaultSeconds": 300
+  }
+}
+```
+
+### `plexus_operations`
+
+High-impact operational actions.
+
+Operations:
+
+- `backup`
+- `restore`
+- `restart`
+- `list_cooldowns`
+- `clear_cooldowns`
+
+Destructive operations must require `destructive: "acknowledged"`.
+
+Example:
+
+```json
+{
+  "operation": "restore",
+  "body": {
+    "backup": {}
+  },
+  "destructive": "acknowledged"
+}
+```
+
+### `plexus_system_logs`
+
+Access Plexus system logs.
+
+Operations:
+
+- `recent`
+- `stream`, later if MCP transport/client support is practical
+
+Initial implementation should add or reuse a bounded in-memory log ring buffer around `logEmitter` and expose recent logs through `recent`.
+
+## Service Reuse
+
+Prefer direct service calls over making HTTP requests back into Plexus.
+
+Use existing services:
+
+- `ConfigService`
+- `ConfigRepository`
+- `UsageStorageService`
+- `McpUsageStorageService`
+- `QuotaScheduler`
+- `QuotaEnforcer`
+- `DebugManager`
+- `CooldownManager`
+- `logEmitter`
+
+Use existing Zod schemas where possible:
+
+- `ProviderConfigSchema`
+- `ModelConfigSchema`
+- `KeyConfigSchema`
+- `McpServerConfigSchema`
+- `QuotaDefinitionSchema`
+
+When existing route modules contain important merge or validation behavior, extract shared helpers instead of duplicating logic in the MCP handlers.
+
+## Handler Structure
+
+Implement a dispatch table by tool name:
+
+```ts
+const handlers = {
+  plexus_config: handleConfigTool,
+  plexus_provider: handleProviderTool,
+  plexus_model_alias: handleModelAliasTool,
+  plexus_key: handleKeyTool,
+  plexus_quota: handleQuotaTool,
+  plexus_quota_checker: handleQuotaCheckerTool,
+  plexus_usage: handleUsageTool,
+  plexus_debug: handleDebugTool,
+  plexus_mcp_gateway: handleMcpGatewayTool,
+  plexus_settings: handleSettingsTool,
+  plexus_operations: handleOperationsTool,
+  plexus_system_logs: handleSystemLogsTool,
+};
+```
+
+Each handler should validate:
+
+- base input shape
+- allowed operation
+- required fields for the selected operation
+- required `category`, if applicable
+- destructive acknowledgement, if applicable
+- domain-specific schema validation
+
+## Secret Redaction
+
+Normal MCP tool responses should redact or omit sensitive fields, including:
+
+- provider API keys
+- provider headers containing credentials
+- MCP upstream headers containing credentials
+- inference key secrets
+- OAuth tokens
+- quota checker tokens, cookies, sessions, and API keys
+- backup/restore payload secrets unless explicitly requested by a high-friction operation
+
+Use a shared redaction helper so all tools behave consistently.
+
+The only exception is when the user has specific authorization for secret-bearing output and the MCP client explicitly sends `redact: false` for that operation. Even then, the operation should be narrowly scoped, audited in logs without recording the secret values, and rejected unless the handler explicitly supports unredacted output.
+
+Generic list/get operations should continue to redact secrets by default.
+
+## Prompt Resources
+
+Include an appropriate MCP prompt resource that explains how to interact with Plexus management through this server.
+
+The prompt should describe:
+
+- what Plexus is
+- what `/mcp/plexus` can manage
+- the compact tool design using `operation`, `id`, `category`, `query`, and `body`
+- the `destructive: "acknowledged"` requirement
+- secret redaction defaults and the narrow `redact: false` exception
+- best practices for safe changes
+- recommended inspection-before-mutation workflows
+- examples for common tasks like reviewing logs, updating a provider, editing an alias target group, checking quotas, and enabling debug tracing
+
+The prompt should be registered with the official MCP SDK alongside tools and resources so compatible clients can discover it.
+
+## Pagination and Limits
+
+List-style operations should support:
+
+- `limit`
+- `offset`
+- relevant filters
+- relevant sorting options
+
+Impose safe maximum limits, for example 500 records, to avoid very large MCP responses.
+
+## Documentation
+
+Add user-facing documentation for the management MCP endpoint after implementation.
+
+Documentation should include:
+
+- endpoint: `/mcp/plexus`
+- required auth header: `x-admin-key`
+- compact tool list
+- operation names
+- destructive acknowledgement rule
+- client configuration examples
+- warning that this endpoint grants admin-level control over Plexus
+
+## Test Plan
+
+Because implementation will write tests, load the `vitest` skill before editing tests.
+
+Suggested test file:
+
+- `packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts`
+
+Coverage:
+
+- rejects missing `x-admin-key`
+- rejects wrong `x-admin-key`
+- rejects regular API key or Bearer-only auth
+- accepts correct admin key
+- `/mcp/plexus` is handled by management MCP, not gateway proxy
+- gateway route `/mcp/:name` still works for other server names
+- configured upstream MCP server named `plexus` is rejected or cannot shadow management MCP
+- `tools/list` returns the compact domain tool set
+- `tools/call` dispatches to the correct handler
+- read-only tools return expected data
+- destructive tools reject without `destructive: "acknowledged"`
+- destructive tools allow with acknowledgement
+- provider/key/alias/quota CRUD updates `ConfigService`
+- secrets are redacted from normal responses
+- malformed operation inputs produce useful errors
+
+Verification commands:
+
+```bash
+bun run test
+bun run typecheck
+```
+
+If OpenAPI or documentation tooling is touched, also run:
+
+```bash
+bun run lint:openapi
+```
+
+## Implementation Phases
+
+### Phase 1: Foundation
+
+- Add `/mcp/plexus` route.
+- Add admin-only `x-admin-key` auth.
+- Implement `initialize`, `tools/list`, and `tools/call`.
+- Add compact tool dispatch table.
+- Implement first read-only operations:
+  - `plexus_config get`
+  - `plexus_provider list`
+  - `plexus_model_alias list`
+  - `plexus_key list`, redacted
+  - `plexus_usage list`
+  - `plexus_debug state`
+
+### Phase 2: CRUD Management
+
+- Implement provider CRUD.
+- Implement model alias CRUD.
+- Implement key CRUD.
+- Implement quota CRUD.
+- Implement MCP gateway server management.
+- Implement settings get/patch by category.
+
+### Phase 3: Observability and Operations
+
+- Implement debug log operations.
+- Implement usage deletion operations.
+- Implement quota checker status/history/check operations.
+- Implement MCP gateway log operations.
+- Implement backup/restore/restart/cooldown operations.
+- Add recent system log support.
+
+### Phase 4: Hardening
+
+- Audit all secret redaction.
+- Enforce maximum response sizes.
+- Add destructive acknowledgement checks everywhere needed.
+- Add route collision tests.
+- Add documentation and client examples.
+- Run tests and type checking.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,20 @@ pre-commit:
     - CI: "true"
 
   commands:
+    # --- Sync CLAUDE.md from AGENTS.md whenever AGENTS.md is staged ----------
+    sync-claude-md:
+      glob: "**/AGENTS.md"
+      run: |
+        changed=$(git diff --cached --name-only | grep -E '(^|/)AGENTS\.md$' || true)
+        if [ -z "$changed" ]; then exit 0; fi
+        for agents_file in $changed; do
+          dir=$(dirname "$agents_file")
+          claude_file="$dir/CLAUDE.md"
+          cp "$agents_file" "$claude_file"
+          git add "$claude_file"
+          echo "[pre-commit] synced $claude_file from $agents_file"
+        done
+
     # --- Block manually committed migration files ----------------------------
     no-migrations:
       skip:

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,7 @@
     "@fastify/multipart": "^10.0.0",
     "@fastify/static": "^9.1.3",
     "@google/genai": "^2.8.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@plexus/shared": "workspace:*",
     "@sinclair/typebox": "^0.34.49",
     "csv-parse": "^6.2.1",

--- a/packages/backend/src/routes/management/__tests__/quota-enforcement.test.ts
+++ b/packages/backend/src/routes/management/__tests__/quota-enforcement.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify from 'fastify';
+
+const mockConfigService = vi.hoisted(() => ({
+  flush: vi.fn(),
+  getConfig: vi.fn(),
+}));
+
+vi.mock('../../../services/config-service', () => ({
+  ConfigService: {
+    getInstance: vi.fn(() => mockConfigService),
+  },
+}));
+
+import { registerQuotaEnforcementRoutes } from '../quota-enforcement';
+
+describe('quota enforcement management routes', () => {
+  beforeEach(() => {
+    mockConfigService.flush.mockReset();
+    mockConfigService.getConfig.mockReset();
+  });
+
+  it('flushes ConfigService before checking quota status for newly saved keys', async () => {
+    const fastify = Fastify();
+    let flushed = false;
+
+    mockConfigService.flush.mockImplementation(async () => {
+      flushed = true;
+    });
+    mockConfigService.getConfig.mockImplementation(() => ({
+      keys: flushed
+        ? {
+            'new-key': {
+              secret: 'sk-new-key',
+              quota: 'new-quota',
+            },
+          }
+        : {},
+      user_quotas: flushed
+        ? {
+            'new-quota': {
+              type: 'rolling',
+              duration: '1h',
+              limitType: 'requests',
+              limit: 10,
+            },
+          }
+        : {},
+    }));
+
+    const quotaEnforcer = {
+      checkQuota: vi.fn(async () => ({
+        quotaName: 'new-quota',
+        allowed: true,
+        currentUsage: 0,
+        limit: 10,
+        remaining: 10,
+        resetsAt: new Date('2026-01-01T00:00:00.000Z'),
+      })),
+      clearQuota: vi.fn(),
+    };
+
+    await registerQuotaEnforcementRoutes(fastify, quotaEnforcer as any);
+
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/quota/status/new-key',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockConfigService.flush.mock.invocationCallOrder[0]).toBeLessThan(
+      mockConfigService.getConfig.mock.invocationCallOrder[0]!
+    );
+    expect(quotaEnforcer.checkQuota).toHaveBeenCalledWith('new-key');
+    expect(res.json()).toEqual({
+      key: 'new-key',
+      quota_name: 'new-quota',
+      allowed: true,
+      current_usage: 0,
+      limit: 10,
+      remaining: 10,
+      resets_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    await fastify.close();
+  });
+});

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -10,6 +10,7 @@ import { ConfigService } from '../../services/config-service';
 import { isValidIpRule } from '../../utils/ip-match';
 import { getCheckerDefinitions } from '../../services/quota/checker-registry';
 import { UsageStorageService } from '../../services/usage-storage';
+import { validateServerName } from '../../services/mcp-proxy/mcp-proxy-service';
 import type { GpuParams, ModelArchitecture } from '@plexus/shared';
 import { DEFAULT_GPU_PARAMS } from '@plexus/shared';
 
@@ -790,10 +791,10 @@ export async function registerConfigRoutes(
   fastify.put('/v0/management/mcp-servers/:serverName', async (request, reply) => {
     const { serverName } = request.params as { serverName: string };
 
-    if (!/^[a-z0-9][a-z0-9-_]{1,62}$/.test(serverName)) {
+    if (!validateServerName(serverName)) {
       return reply.code(400).send({
         error:
-          'Invalid server name. Must be a slug (lowercase letters, numbers, hyphens, underscores, 2-63 characters)',
+          'Invalid server name. Must be a non-reserved slug (lowercase letters, numbers, hyphens, underscores, 2-63 characters)',
       });
     }
 

--- a/packages/backend/src/routes/management/quota-enforcement.ts
+++ b/packages/backend/src/routes/management/quota-enforcement.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
-import { getConfig } from '../../config';
+import { ConfigService } from '../../services/config-service';
 import { logger } from '../../utils/logger';
 
 /**
@@ -10,6 +10,8 @@ export async function registerQuotaEnforcementRoutes(
   fastify: FastifyInstance,
   quotaEnforcer: QuotaEnforcer
 ) {
+  const configService = ConfigService.getInstance();
+
   /**
    * POST /v0/management/quota/clear
    * Reset quota usage for a key.
@@ -29,6 +31,7 @@ export async function registerQuotaEnforcementRoutes(
           });
         }
 
+        await configService.flush();
         await quotaEnforcer.clearQuota(body.key);
 
         return reply.send({
@@ -67,7 +70,8 @@ export async function registerQuotaEnforcementRoutes(
           });
         }
 
-        const config = getConfig();
+        await configService.flush();
+        const config = configService.getConfig();
         const keyConfig = config.keys?.[key];
 
         // Key not found

--- a/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
@@ -193,6 +193,18 @@ describe('Plexus management MCP routes', () => {
     );
   });
 
+  test('ignores unsupported x-forwarded-proto values', async () => {
+    const response = await postPlexusMcp(
+      { method: 'tools/list', id: 1 },
+      { ...adminHeaders(), 'x-forwarded-proto': 'javascript' }
+    );
+    const body = parseJsonRpcResponse(response);
+
+    expect(body.result.tools).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'plexus_config' })])
+    );
+  });
+
   test('lists prompt resources and returns the management guide prompt', async () => {
     const listResponse = await postPlexusMcp({ method: 'prompts/list', id: 1 }, adminHeaders());
     const listBody = parseJsonRpcResponse(listResponse);

--- a/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
@@ -1,0 +1,315 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { registerSpy } from '../../../../test/test-utils';
+import { setConfigForTesting } from '../../../config';
+import { registerMcpRoutes } from '../index';
+import { McpUsageStorageService } from '../../../services/mcp-proxy/mcp-usage-storage';
+import * as mcpProxyService from '../../../services/mcp-proxy/mcp-proxy-service';
+
+describe('Plexus management MCP routes', () => {
+  let fastify: FastifyInstance;
+  let originalAdminKey: string | undefined;
+  let mockMcpUsageStorage: McpUsageStorageService;
+
+  beforeAll(async () => {
+    originalAdminKey = process.env.ADMIN_KEY;
+    process.env.ADMIN_KEY = 'test-admin-key';
+
+    fastify = Fastify();
+    mockMcpUsageStorage = {
+      saveRequest: vi.fn(),
+      saveDebugLog: vi.fn(),
+      getLogs: vi.fn(),
+      deleteLog: vi.fn(),
+      deleteAllLogs: vi.fn(),
+    } as unknown as McpUsageStorageService;
+
+    setConfigForTesting({
+      providers: {
+        openrouter: {
+          display_name: 'OpenRouter',
+          api_base_url: 'https://openrouter.ai/api/v1',
+          api_key: 'provider-secret',
+          enabled: true,
+          disable_cooldown: false,
+          stall_cooldown: false,
+          estimateTokens: false,
+          useClaudeMasking: false,
+          headers: {
+            Authorization: 'Bearer upstream-secret',
+          },
+          quota_checker: {
+            type: 'openrouter',
+            enabled: true,
+            intervalMinutes: 60,
+            id: 'openrouter-checker',
+            options: {
+              apiKey: 'quota-secret',
+            },
+          },
+        },
+      },
+      models: {
+        'gpt-5': {
+          priority: 'selector',
+          selector: 'random',
+          target_groups: [
+            {
+              name: 'default',
+              selector: 'random',
+              targets: [{ provider: 'openrouter', model: 'openai/gpt-5', enabled: true }],
+            },
+          ],
+        },
+      },
+      keys: {
+        'test-key': { secret: 'sk-valid-key', comment: 'Test Key' },
+      },
+      failover: {
+        enabled: false,
+        retryableStatusCodes: [429, 500, 502, 503, 504],
+        retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT'],
+      },
+      quotas: [],
+      user_quotas: {
+        daily: { type: 'daily', limitType: 'requests', limit: 100 },
+      },
+      mcpServers: {
+        'test-server': {
+          upstream_url: 'http://localhost:3000/mcp',
+          enabled: true,
+        },
+        plexus: {
+          upstream_url: 'http://localhost:3001/mcp',
+          enabled: true,
+        },
+      },
+    });
+
+    await registerMcpRoutes(fastify, mockMcpUsageStorage);
+    await fastify.ready();
+  });
+
+  beforeEach(() => {
+    registerSpy(mcpProxyService, 'proxyMcpRequest').mockResolvedValue({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: { jsonrpc: '2.0', id: 1, result: {} },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    if (originalAdminKey === undefined) {
+      delete process.env.ADMIN_KEY;
+    } else {
+      process.env.ADMIN_KEY = originalAdminKey;
+    }
+    await fastify.close();
+  });
+
+  test('rejects missing x-admin-key', async () => {
+    const response = await postPlexusMcp({ method: 'tools/list', id: 1 });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test('rejects wrong x-admin-key', async () => {
+    const response = await postPlexusMcp(
+      { method: 'tools/list', id: 1 },
+      { 'x-admin-key': 'wrong' }
+    );
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test('rejects bearer-only inference auth', async () => {
+    const response = await postPlexusMcp(
+      { method: 'tools/list', id: 1 },
+      { authorization: 'Bearer sk-valid-key' }
+    );
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test('rejects limited key sent as x-admin-key', async () => {
+    const response = await postPlexusMcp(
+      { method: 'tools/list', id: 1 },
+      { 'x-admin-key': 'sk-valid-key' }
+    );
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  test('handles /mcp/plexus without proxying to upstream gateway', async () => {
+    const response = await postPlexusMcp({ method: 'tools/list', id: 1 }, adminHeaders());
+
+    expect(response.statusCode).toBe(200);
+    expect(mcpProxyService.proxyMcpRequest).not.toHaveBeenCalled();
+  });
+
+  test('keeps other /mcp/:name gateway routes working', async () => {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/mcp/test-server',
+      headers: {
+        authorization: 'Bearer sk-valid-key',
+        'content-type': 'application/json',
+      },
+      payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(mcpProxyService.proxyMcpRequest).toHaveBeenCalled();
+  });
+
+  test('reserves plexus as an upstream MCP gateway server name', () => {
+    expect(mcpProxyService.validateServerName('plexus')).toBe(false);
+    expect(mcpProxyService.getMcpServerConfig('plexus')).toBeNull();
+  });
+
+  test('lists compact management tools', async () => {
+    const response = await postPlexusMcp({ method: 'tools/list', id: 1 }, adminHeaders());
+    const body = parseJsonRpcResponse(response);
+
+    expect(body.result.tools.map((tool: { name: string }) => tool.name)).toEqual(
+      expect.arrayContaining([
+        'plexus_config',
+        'plexus_provider',
+        'plexus_model_alias',
+        'plexus_key',
+        'plexus_quota',
+        'plexus_quota_checker',
+        'plexus_usage',
+        'plexus_debug',
+        'plexus_mcp_gateway',
+        'plexus_settings',
+        'plexus_operations',
+        'plexus_system_logs',
+      ])
+    );
+  });
+
+  test('lists prompt resources and returns the management guide prompt', async () => {
+    const listResponse = await postPlexusMcp({ method: 'prompts/list', id: 1 }, adminHeaders());
+    const listBody = parseJsonRpcResponse(listResponse);
+
+    expect(listBody.result.prompts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'plexus_management_guide' })])
+    );
+
+    const getResponse = await postPlexusMcp(
+      {
+        method: 'prompts/get',
+        id: 2,
+        params: { name: 'plexus_management_guide' },
+      },
+      adminHeaders()
+    );
+    const getBody = parseJsonRpcResponse(getResponse);
+
+    expect(getBody.result.messages[0].content.text).toContain('Plexus is a unified API gateway');
+    expect(getBody.result.messages[0].content.text).toContain('destructive: "acknowledged"');
+  });
+
+  test('returns redacted provider data from tool calls', async () => {
+    const response = await postPlexusMcp(
+      {
+        method: 'tools/call',
+        id: 1,
+        params: {
+          name: 'plexus_provider',
+          arguments: { operation: 'get', id: 'openrouter' },
+        },
+      },
+      adminHeaders()
+    );
+    const body = parseJsonRpcResponse(response);
+
+    expect(body.result.structuredContent.ok).toBe(true);
+    expect(body.result.structuredContent.data.api_key).toBe('[REDACTED]');
+    expect(body.result.structuredContent.data.headers.Authorization).toBe('[REDACTED]');
+    expect(JSON.stringify(body.result)).not.toContain('provider-secret');
+    expect(JSON.stringify(body.result)).not.toContain('upstream-secret');
+  });
+
+  test('returns redacted key data from tool calls', async () => {
+    const response = await postPlexusMcp(
+      {
+        method: 'tools/call',
+        id: 1,
+        params: {
+          name: 'plexus_key',
+          arguments: { operation: 'get', id: 'test-key' },
+        },
+      },
+      adminHeaders()
+    );
+    const body = parseJsonRpcResponse(response);
+
+    expect(body.result.structuredContent.ok).toBe(true);
+    expect(body.result.structuredContent.data.secret).toBe('[REDACTED]');
+    expect(JSON.stringify(body.result)).not.toContain('sk-valid-key');
+  });
+
+  test('requires acknowledgement for destructive operations', async () => {
+    const response = await postPlexusMcp(
+      {
+        method: 'tools/call',
+        id: 1,
+        params: {
+          name: 'plexus_usage',
+          arguments: { operation: 'delete_all' },
+        },
+      },
+      adminHeaders()
+    );
+    const body = parseJsonRpcResponse(response);
+
+    expect(body.result.isError).toBe(true);
+    expect(body.result.structuredContent.error.type).toBe('confirmation_required');
+  });
+
+  test('allows acknowledged destructive operations to reach handler', async () => {
+    const response = await postPlexusMcp(
+      {
+        method: 'tools/call',
+        id: 1,
+        params: {
+          name: 'plexus_usage',
+          arguments: { operation: 'delete_all', destructive: 'acknowledged' },
+        },
+      },
+      adminHeaders()
+    );
+    const body = parseJsonRpcResponse(response);
+
+    expect(body.result.isError).toBe(true);
+    expect(body.result.structuredContent.error.type).toBe('not_implemented');
+  });
+
+  function postPlexusMcp(payload: Record<string, unknown>, headers: Record<string, string> = {}) {
+    return fastify.inject({
+      method: 'POST',
+      url: '/mcp/plexus',
+      headers: {
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+        ...headers,
+      },
+      payload: { jsonrpc: '2.0', ...payload },
+    });
+  }
+
+  function adminHeaders() {
+    return { 'x-admin-key': 'test-admin-key' };
+  }
+
+  function parseJsonRpcResponse(response: Awaited<ReturnType<typeof postPlexusMcp>>) {
+    expect(response.statusCode).toBe(200);
+    return JSON.parse(response.body);
+  }
+});

--- a/packages/backend/src/routes/mcp/index.ts
+++ b/packages/backend/src/routes/mcp/index.ts
@@ -5,6 +5,7 @@ import { logger } from '../../utils/logger';
 import * as mcpProxyService from '../../services/mcp-proxy/mcp-proxy-service';
 import { getClientIp } from '../../utils/ip';
 import { McpUsageStorageService } from '../../services/mcp-proxy/mcp-usage-storage';
+import { registerPlexusMcpRoutes } from './plexus';
 
 const DEFAULT_TIMEOUT_MS = 120000;
 
@@ -58,6 +59,8 @@ export async function registerMcpRoutes(
       token_endpoint_auth_method: 'none',
     });
   });
+
+  await registerPlexusMcpRoutes(fastify);
 
   fastify.register(async (protectedRoutes) => {
     const auth = createAuthHook();

--- a/packages/backend/src/routes/mcp/plexus.ts
+++ b/packages/backend/src/routes/mcp/plexus.ts
@@ -123,9 +123,6 @@ class McpToolError extends Error {
   }
 }
 
-const plexusMcpServer = createPlexusMcpServer();
-let transportQueue = Promise.resolve();
-
 export async function registerPlexusMcpRoutes(fastify: FastifyInstance) {
   fastify.register(async (plexusMcp) => {
     plexusMcp.setErrorHandler(async (error, _request, reply) => {
@@ -145,21 +142,15 @@ export async function registerPlexusMcpRoutes(fastify: FastifyInstance) {
 }
 
 async function handlePlexusMcpRequest(request: FastifyRequest, reply: FastifyReply) {
-  const result = transportQueue.then(() => handlePlexusMcpRequestSerialized(request, reply));
-  transportQueue = result.then(
-    () => undefined,
-    () => undefined
-  );
-  return result;
-}
-
-async function handlePlexusMcpRequestSerialized(request: FastifyRequest, reply: FastifyReply) {
+  // The SDK server owns one active transport at a time. A singleton would need
+  // close/reconnect queueing, so stateless per-request servers are simpler and safer.
+  const server = createPlexusMcpServer();
   const transport = new WebStandardStreamableHTTPServerTransport({
     enableJsonResponse: true,
     sessionIdGenerator: undefined,
   });
 
-  await plexusMcpServer.connect(transport);
+  await server.connect(transport);
 
   try {
     const webRequest = toWebRequest(request);
@@ -172,7 +163,7 @@ async function handlePlexusMcpRequestSerialized(request: FastifyRequest, reply: 
     const body = await webResponse.text();
     return reply.code(webResponse.status).send(body || undefined);
   } finally {
-    await plexusMcpServer.close();
+    await server.close();
   }
 }
 

--- a/packages/backend/src/routes/mcp/plexus.ts
+++ b/packages/backend/src/routes/mcp/plexus.ts
@@ -1,0 +1,577 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { getConfig, type PlexusConfig } from '../../config';
+import { logger } from '../../utils/logger';
+import { ManagementAuthError, authenticate, requireAdmin } from '../management/_principal';
+
+const PLEXUS_MANAGEMENT_PROMPT = `Plexus is a unified API gateway for LLMs. It exposes OpenAI- and Anthropic-compatible endpoints, routes requests to configured providers, records usage, and manages provider, model alias, key, quota, debug, and MCP gateway configuration.
+
+Use /mcp/plexus for admin-only Plexus management. All requests require x-admin-key. Do not use bearer inference keys for this endpoint.
+
+The tools are compact domain tools. Prefer inspection before mutation: list or get the current state, explain the intended change, then call the relevant tool with operation, id, category, query, and body.
+
+Destructive or high-impact operations require destructive: "acknowledged". Secrets are redacted by default. Only request redact: false when you have specific authorization and the operation explicitly supports unredacted output.
+
+Common workflows:
+- Review request activity with plexus_usage list or summary.
+- Inspect provider setup with plexus_provider list or get.
+- Inspect model routing with plexus_model_alias list or get.
+- Inspect inference keys with plexus_key list or get; normal responses redact secrets.
+- Check upstream quota state with plexus_quota_checker list, get, history, or check.
+- Inspect user quota definitions with plexus_quota list or get.
+- Review MCP gateway configuration with plexus_mcp_gateway servers_list.
+- Inspect general settings with plexus_settings get and a category.
+- Use plexus_debug state before enabling debug tracing.
+
+Best practices:
+- Keep changes narrow and reversible.
+- Avoid broad overwrite operations unless necessary.
+- Never expose provider API keys, inference key secrets, cookies, sessions, or OAuth tokens in chat unless specifically authorized.
+- Include enough context in body payloads for future auditability.`;
+
+const TOOL_NAMES = [
+  'plexus_config',
+  'plexus_provider',
+  'plexus_model_alias',
+  'plexus_key',
+  'plexus_quota',
+  'plexus_quota_checker',
+  'plexus_usage',
+  'plexus_debug',
+  'plexus_mcp_gateway',
+  'plexus_settings',
+  'plexus_operations',
+  'plexus_system_logs',
+] as const;
+
+const DESTRUCTIVE_OPERATIONS = new Set([
+  'delete',
+  'delete_all',
+  'clear',
+  'clear_for_key',
+  'quota_clear',
+  'delete_log',
+  'delete_all_logs',
+  'restore',
+  'restart',
+  'rotate',
+  'truncate',
+  'import',
+  'overwrite',
+]);
+
+const ToolInputSchema = {
+  operation: z
+    .string()
+    .min(1)
+    .describe('Operation to perform, such as list, get, status, or summary.'),
+  id: z
+    .string()
+    .optional()
+    .describe('Optional resource identifier for get/update/delete operations.'),
+  category: z.string().optional().describe('Optional settings or subdomain category.'),
+  query: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Optional filters, pagination, or sort options.'),
+  body: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Optional payload for mutating operations.'),
+  destructive: z
+    .string()
+    .optional()
+    .describe('Must be exactly "acknowledged" for destructive or high-impact operations.'),
+  redact: z
+    .boolean()
+    .optional()
+    .describe('Defaults to true. redact: false is only honored by explicitly authorized handlers.'),
+};
+
+type ToolInput = {
+  operation: string;
+  id?: string;
+  category?: string;
+  query?: Record<string, unknown>;
+  body?: Record<string, unknown>;
+  destructive?: string;
+  redact?: boolean;
+};
+
+type ToolResponse = {
+  ok: boolean;
+  operation: string;
+  data?: unknown;
+  error?: {
+    message: string;
+    type: string;
+    code: number;
+  };
+};
+
+class McpToolError extends Error {
+  type: string;
+  code: number;
+
+  constructor(message: string, type: string, code: number) {
+    super(message);
+    this.type = type;
+    this.code = code;
+  }
+}
+
+export async function registerPlexusMcpRoutes(fastify: FastifyInstance) {
+  fastify.register(async (plexusMcp) => {
+    plexusMcp.setErrorHandler(async (error, _request, reply) => {
+      if (error instanceof ManagementAuthError) {
+        return reply.code(error.statusCode).send(error.authBody);
+      }
+      throw error;
+    });
+
+    plexusMcp.addHook('preHandler', authenticate);
+    plexusMcp.addHook('preHandler', requireAdmin);
+
+    plexusMcp.post('/mcp/plexus', handlePlexusMcpRequest);
+    plexusMcp.get('/mcp/plexus', handlePlexusMcpRequest);
+    plexusMcp.delete('/mcp/plexus', handlePlexusMcpRequest);
+  });
+}
+
+async function handlePlexusMcpRequest(request: FastifyRequest, reply: FastifyReply) {
+  const server = createPlexusMcpServer();
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    enableJsonResponse: true,
+    sessionIdGenerator: undefined,
+  });
+
+  await server.connect(transport);
+
+  const webRequest = toWebRequest(request);
+  const webResponse = await transport.handleRequest(webRequest, { parsedBody: request.body });
+
+  for (const [key, value] of webResponse.headers.entries()) {
+    reply.header(key, value);
+  }
+
+  const body = await webResponse.text();
+  return reply.code(webResponse.status).send(body || undefined);
+}
+
+function createPlexusMcpServer() {
+  const server = new McpServer(
+    {
+      name: 'plexus-management',
+      version: '0.1.0',
+    },
+    {
+      instructions: PLEXUS_MANAGEMENT_PROMPT,
+    }
+  );
+
+  server.registerResource(
+    'plexus_management_guide',
+    'plexus://management/guide',
+    {
+      title: 'Plexus Management Guide',
+      description: 'How to safely interact with Plexus through the management MCP server.',
+      mimeType: 'text/markdown',
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: 'text/markdown',
+          text: PLEXUS_MANAGEMENT_PROMPT,
+        },
+      ],
+    })
+  );
+
+  server.registerPrompt(
+    'plexus_management_guide',
+    {
+      title: 'Plexus Management Guide',
+      description: 'Best practices and examples for managing Plexus through MCP.',
+    },
+    async () => ({
+      description: 'Use this guide before making Plexus management changes.',
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: PLEXUS_MANAGEMENT_PROMPT,
+          },
+        },
+      ],
+    })
+  );
+
+  for (const toolName of TOOL_NAMES) {
+    server.registerTool(
+      toolName,
+      {
+        title: toolName,
+        description: getToolDescription(toolName),
+        inputSchema: ToolInputSchema,
+      },
+      async (input) => toToolResult(await handleToolCall(toolName, input as ToolInput))
+    );
+  }
+
+  return server;
+}
+
+async function handleToolCall(toolName: (typeof TOOL_NAMES)[number], input: ToolInput) {
+  try {
+    if (DESTRUCTIVE_OPERATIONS.has(input.operation)) {
+      requireDestructiveAck(input);
+    }
+
+    const config = getConfig();
+
+    switch (toolName) {
+      case 'plexus_config':
+        return handleConfigTool(input, config);
+      case 'plexus_provider':
+        return handleRecordTool(input, config.providers ?? {}, 'provider');
+      case 'plexus_model_alias':
+        return handleRecordTool(input, config.models ?? {}, 'model_alias');
+      case 'plexus_key':
+        return handleRecordTool(input, config.keys ?? {}, 'key');
+      case 'plexus_quota':
+        return handleRecordTool(input, config.user_quotas ?? {}, 'quota');
+      case 'plexus_quota_checker':
+        return handleQuotaCheckerTool(input, config);
+      case 'plexus_mcp_gateway':
+        return handleMcpGatewayTool(input, config);
+      case 'plexus_settings':
+        return handleSettingsTool(input, config);
+      case 'plexus_usage':
+      case 'plexus_debug':
+      case 'plexus_operations':
+      case 'plexus_system_logs':
+        throw new McpToolError(
+          `${toolName} operation '${input.operation}' is not implemented yet.`,
+          'not_implemented',
+          501
+        );
+    }
+  } catch (error) {
+    if (error instanceof McpToolError) {
+      return errorResponse(input.operation, error.message, error.type, error.code);
+    }
+    logger.warn(`Plexus MCP tool ${toolName} failed: ${(error as Error).message}`);
+    return errorResponse(input.operation, 'Plexus MCP tool call failed.', 'internal_error', 500);
+  }
+}
+
+function handleConfigTool(input: ToolInput, config: PlexusConfig): ToolResponse {
+  switch (input.operation) {
+    case 'get':
+    case 'export':
+      return successResponse(input.operation, redactSecrets(config));
+    case 'status':
+      return successResponse(input.operation, {
+        providerCount: Object.keys(config.providers ?? {}).length,
+        modelAliasCount: Object.keys(config.models ?? {}).length,
+        keyCount: Object.keys(config.keys ?? {}).length,
+        quotaCount: Object.keys(config.user_quotas ?? {}).length,
+        mcpServerCount: Object.keys(getMcpServers(config)).length,
+      });
+    default:
+      throw unsupportedOperation(input.operation, ['get', 'export', 'status']);
+  }
+}
+
+function handleRecordTool(
+  input: ToolInput,
+  records: Record<string, unknown>,
+  resourceType: string
+): ToolResponse {
+  switch (input.operation) {
+    case 'list':
+      return successResponse(
+        input.operation,
+        Object.entries(records).map(([id, value]) => ({ id, ...asObject(redactSecrets(value)) }))
+      );
+    case 'get': {
+      if (!input.id) {
+        throw new McpToolError(
+          `Missing id for ${resourceType} get operation.`,
+          'invalid_request',
+          400
+        );
+      }
+      if (!(input.id in records)) {
+        throw new McpToolError(`${resourceType} '${input.id}' was not found.`, 'not_found', 404);
+      }
+      return successResponse(input.operation, {
+        id: input.id,
+        ...asObject(redactSecrets(records[input.id])),
+      });
+    }
+    default:
+      throw unsupportedOperation(input.operation, ['list', 'get']);
+  }
+}
+
+function handleQuotaCheckerTool(input: ToolInput, config: PlexusConfig): ToolResponse {
+  const checkers: Record<string, unknown>[] = Object.entries(config.providers ?? {}).flatMap(
+    ([providerId, provider]) => {
+      const quotaChecker = provider.quota_checker;
+      if (!quotaChecker) return [];
+      return [
+        {
+          id: quotaChecker.id ?? `${providerId}:${quotaChecker.type}`,
+          provider: providerId,
+          ...asObject(redactSecrets(quotaChecker)),
+        },
+      ];
+    }
+  );
+
+  switch (input.operation) {
+    case 'list':
+      return successResponse(input.operation, checkers);
+    case 'get': {
+      if (!input.id) {
+        throw new McpToolError(
+          'Missing id for quota checker get operation.',
+          'invalid_request',
+          400
+        );
+      }
+      const checker = checkers.find((candidate) => candidate.id === input.id);
+      if (!checker) {
+        throw new McpToolError(`quota_checker '${input.id}' was not found.`, 'not_found', 404);
+      }
+      return successResponse(input.operation, checker);
+    }
+    case 'types':
+      return successResponse(input.operation, [
+        ...new Set(
+          checkers.map((checker) => checker.type).filter((type) => typeof type === 'string')
+        ),
+      ]);
+    default:
+      throw unsupportedOperation(input.operation, ['types', 'list', 'get']);
+  }
+}
+
+function handleMcpGatewayTool(input: ToolInput, config: PlexusConfig): ToolResponse {
+  const servers = getMcpServers(config);
+
+  switch (input.operation) {
+    case 'servers_list':
+    case 'list':
+      return successResponse(
+        input.operation,
+        Object.entries(servers).map(([id, value]) => ({ id, ...asObject(redactSecrets(value)) }))
+      );
+    case 'get': {
+      if (!input.id) {
+        throw new McpToolError('Missing id for MCP gateway get operation.', 'invalid_request', 400);
+      }
+      if (!(input.id in servers)) {
+        throw new McpToolError(`mcp_gateway server '${input.id}' was not found.`, 'not_found', 404);
+      }
+      return successResponse(input.operation, {
+        id: input.id,
+        ...asObject(redactSecrets(servers[input.id])),
+      });
+    }
+    default:
+      throw unsupportedOperation(input.operation, ['servers_list', 'list', 'get']);
+  }
+}
+
+function handleSettingsTool(input: ToolInput, config: PlexusConfig): ToolResponse {
+  if (input.operation !== 'get') {
+    throw unsupportedOperation(input.operation, ['get']);
+  }
+
+  const settings = {
+    failover: config.failover,
+    cooldown: config.cooldown,
+    timeout: config.timeout,
+    stall: config.stall,
+    trusted_proxies: config.trustedProxies,
+    vision_fallthrough: config.vision_fallthrough,
+    background_exploration: config.backgroundExploration,
+    exploration: {
+      performanceExplorationRate: config.performanceExplorationRate,
+      latencyExplorationRate: config.latencyExplorationRate,
+      e2ePerformanceExplorationRate: config.e2ePerformanceExplorationRate,
+    },
+  };
+
+  if (!input.category || input.category === 'all') {
+    return successResponse(input.operation, redactSecrets(settings));
+  }
+
+  if (!(input.category in settings)) {
+    throw new McpToolError(
+      `settings category '${input.category}' was not found.`,
+      'not_found',
+      404
+    );
+  }
+
+  return successResponse(
+    input.operation,
+    redactSecrets(settings[input.category as keyof typeof settings])
+  );
+}
+
+function requireDestructiveAck(input: ToolInput) {
+  if (input.destructive !== 'acknowledged') {
+    throw new McpToolError(
+      'This destructive operation requires destructive: "acknowledged".',
+      'confirmation_required',
+      400
+    );
+  }
+}
+
+function toToolResult(response: ToolResponse): CallToolResult {
+  return {
+    structuredContent: response,
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(response, null, 2),
+      },
+    ],
+    isError: !response.ok,
+  };
+}
+
+function successResponse(operation: string, data: unknown): ToolResponse {
+  return { ok: true, operation, data };
+}
+
+function errorResponse(
+  operation: string,
+  message: string,
+  type: string,
+  code: number
+): ToolResponse {
+  return {
+    ok: false,
+    operation,
+    error: { message, type, code },
+  };
+}
+
+function unsupportedOperation(operation: string, allowed: string[]) {
+  return new McpToolError(
+    `Unsupported operation '${operation}'. Allowed operations: ${allowed.join(', ')}.`,
+    'invalid_request',
+    400
+  );
+}
+
+function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactSecrets);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nested]) => {
+      if (isSensitiveKey(key)) {
+        return [key, '[REDACTED]'];
+      }
+      return [key, redactSecrets(nested)];
+    })
+  );
+}
+
+function isSensitiveKey(key: string) {
+  const normalized = key.toLowerCase();
+  return (
+    normalized === 'secret' ||
+    normalized === 'api_key' ||
+    normalized === 'apikey' ||
+    normalized === 'authorization' ||
+    normalized === 'cookie' ||
+    normalized.includes('token') ||
+    normalized.includes('session') ||
+    normalized.includes('password') ||
+    normalized.includes('authcookie') ||
+    normalized.includes('managementapikey')
+  );
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : { value };
+}
+
+function getMcpServers(config: PlexusConfig) {
+  return config.mcpServers ?? config.mcp_servers ?? {};
+}
+
+function getToolDescription(toolName: string) {
+  switch (toolName) {
+    case 'plexus_config':
+      return 'Inspect Plexus configuration and status. Initial operations: get, export, status.';
+    case 'plexus_provider':
+      return 'Inspect providers and provider routing configuration. Initial operations: list, get.';
+    case 'plexus_model_alias':
+      return 'Inspect model aliases, targets, and target groups. Initial operations: list, get.';
+    case 'plexus_key':
+      return 'Inspect inference keys with secrets redacted. Initial operations: list, get.';
+    case 'plexus_quota':
+      return 'Inspect user quota definitions. Initial operations: list, get.';
+    case 'plexus_quota_checker':
+      return 'Inspect upstream provider quota checker configuration. Initial operations: types, list, get.';
+    case 'plexus_usage':
+      return 'Review request logs and summaries. Planned operations: list, summary, delete, delete_all.';
+    case 'plexus_debug':
+      return 'Review and manage debug tracing. Planned operations: state, update, logs, get_log, delete_log, delete_all_logs.';
+    case 'plexus_mcp_gateway':
+      return 'Inspect Plexus upstream MCP gateway configuration. Initial operations: servers_list, list, get.';
+    case 'plexus_settings':
+      return 'Inspect Plexus settings by category. Initial operations: get.';
+    case 'plexus_operations':
+      return 'Run high-impact operational actions. Planned operations: backup, restore, restart, list_cooldowns, clear_cooldowns.';
+    case 'plexus_system_logs':
+      return 'Access Plexus system logs. Planned operations: recent, stream.';
+    default:
+      return 'Plexus management tool.';
+  }
+}
+
+function toWebRequest(request: FastifyRequest) {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (Array.isArray(value)) {
+      headers.set(key, value.join(', '));
+    } else if (value !== undefined) {
+      headers.set(key, String(value));
+    }
+  }
+
+  const protocol = (request.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
+  const host = request.headers.host ?? 'localhost';
+  const url = `${protocol}://${host}${request.url}`;
+
+  return new Request(url, {
+    method: request.method,
+    headers,
+    body:
+      request.method === 'GET' || request.method === 'HEAD'
+        ? undefined
+        : JSON.stringify(request.body ?? null),
+  });
+}

--- a/packages/backend/src/routes/mcp/plexus.ts
+++ b/packages/backend/src/routes/mcp/plexus.ts
@@ -123,6 +123,9 @@ class McpToolError extends Error {
   }
 }
 
+const plexusMcpServer = createPlexusMcpServer();
+let transportQueue = Promise.resolve();
+
 export async function registerPlexusMcpRoutes(fastify: FastifyInstance) {
   fastify.register(async (plexusMcp) => {
     plexusMcp.setErrorHandler(async (error, _request, reply) => {
@@ -142,23 +145,35 @@ export async function registerPlexusMcpRoutes(fastify: FastifyInstance) {
 }
 
 async function handlePlexusMcpRequest(request: FastifyRequest, reply: FastifyReply) {
-  const server = createPlexusMcpServer();
+  const result = transportQueue.then(() => handlePlexusMcpRequestSerialized(request, reply));
+  transportQueue = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
+async function handlePlexusMcpRequestSerialized(request: FastifyRequest, reply: FastifyReply) {
   const transport = new WebStandardStreamableHTTPServerTransport({
     enableJsonResponse: true,
     sessionIdGenerator: undefined,
   });
 
-  await server.connect(transport);
+  await plexusMcpServer.connect(transport);
 
-  const webRequest = toWebRequest(request);
-  const webResponse = await transport.handleRequest(webRequest, { parsedBody: request.body });
+  try {
+    const webRequest = toWebRequest(request);
+    const webResponse = await transport.handleRequest(webRequest, { parsedBody: request.body });
 
-  for (const [key, value] of webResponse.headers.entries()) {
-    reply.header(key, value);
+    for (const [key, value] of webResponse.headers.entries()) {
+      reply.header(key, value);
+    }
+
+    const body = await webResponse.text();
+    return reply.code(webResponse.status).send(body || undefined);
+  } finally {
+    await plexusMcpServer.close();
   }
-
-  const body = await webResponse.text();
-  return reply.code(webResponse.status).send(body || undefined);
 }
 
 function createPlexusMcpServer() {
@@ -562,7 +577,9 @@ function toWebRequest(request: FastifyRequest) {
     }
   }
 
-  const protocol = (request.headers['x-forwarded-proto'] as string | undefined) ?? 'http';
+  const rawProtoHeader = request.headers['x-forwarded-proto'];
+  const rawProto = Array.isArray(rawProtoHeader) ? rawProtoHeader[0] : rawProtoHeader;
+  const protocol = rawProto === 'https' ? 'https' : 'http';
   const host = request.headers.host ?? 'localhost';
   const url = `${protocol}://${host}${request.url}`;
 

--- a/packages/backend/src/services/mcp-proxy/mcp-proxy-service.ts
+++ b/packages/backend/src/services/mcp-proxy/mcp-proxy-service.ts
@@ -18,7 +18,13 @@ const SENSITIVE_HEADERS = new Set(['authorization', 'cookie', 'set-cookie', 'x-a
 
 const CLIENT_AUTH_HEADERS = new Set(['authorization', 'x-api-key', 'proxy-authorization']);
 
+const RESERVED_SERVER_NAMES = new Set(['plexus']);
+
 export function getMcpServerConfig(serverName: string): McpServerConfig | null {
+  if (RESERVED_SERVER_NAMES.has(serverName)) {
+    return null;
+  }
+
   const config = getConfig();
   const mcpServers = config.mcpServers;
 
@@ -41,7 +47,7 @@ export function getMcpServerConfig(serverName: string): McpServerConfig | null {
 
 export function validateServerName(name: string): boolean {
   const slugRegex = /^[a-z0-9][a-z0-9-_]{1,62}$/;
-  return slugRegex.test(name);
+  return slugRegex.test(name) && !RESERVED_SERVER_NAMES.has(name);
 }
 
 export function filterHopByHopHeaders(

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1013,33 +1013,15 @@ export const api = {
 
   getStats: async (): Promise<Stat[]> => {
     try {
-      const now = normalizeNow();
-      const startDate = new Date(now);
-      startDate.setDate(startDate.getDate() - 7);
-      const usageResponse = await fetchUsageRecords({
-        limit: 1000,
-        startDate: startDate.toISOString(),
-        fields: ['tokensInput', 'tokensOutput', 'tokensCached', 'tokensCacheWrite', 'durationMs'],
-        cache: true,
-      });
-
-      const config = await fetchConfigCached();
+      const [summary, config] = await Promise.all([
+        fetchUsageSummary('week', true),
+        fetchConfigCached(),
+      ]);
       const activeProviders = config ? Object.keys(config.providers || {}).length : '-';
 
-      const records = usageResponse.data || [];
-      const totalRequests = usageResponse.total;
-      const totalTokens = records.reduce(
-        (acc, r) =>
-          acc +
-          (r.tokensInput || 0) +
-          (r.tokensOutput || 0) +
-          (r.tokensCached || 0) +
-          (r.tokensCacheWrite || 0),
-        0
-      );
-      const avgLatency = records.length
-        ? Math.round(records.reduce((acc, r) => acc + (r.durationMs || 0), 0) / records.length)
-        : 0;
+      const totalRequests = summary.stats.totalRequests || 0;
+      const totalTokens = summary.stats.totalTokens || 0;
+      const avgLatency = Math.round(summary.stats.avgDurationMs || 0);
 
       return [
         { label: STAT_LABELS.REQUESTS, value: formatNumber(totalRequests, 0) },


### PR DESCRIPTION
## Summary
- add an admin-only /mcp/plexus MCP server using the official MCP SDK
- register compact Plexus management tools plus a management guide prompt/resource
- reserve plexus as an upstream MCP gateway name and redact secrets in tool responses
- serialize singleton SDK transport usage and clamp x-forwarded-proto to http/https

## Verification
- bun run test
- bun run typecheck (packages/backend)
- bun run format:check
- pre-commit hooks passed on commit