### PR TITLE
fix: convert JS comment to JSX comment in Model Adapters section

### DIFF
--- a/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
@@ -1282,7 +1282,7 @@ export function ProviderModelsEditor({
                                 </div>
                               );
                             })()}
-                            /* reasoning_rewrite rules editor */
+                            {/* reasoning_rewrite rules editor */}
                             {(() => {
                               const modelAdapters: any[] = mCfg.adapter
                                 ? Array.isArray(mCfg.adapter)


### PR DESCRIPTION
The comment `/* reasoning_rewrite rules editor */` was rendered as visible text in the Model Adapters section because it lacked JSX curly braces. Wrapping it as `{/* ... */}` makes it a proper JSX comment that doesn't render.