### PR TITLE
fix: mask auth token headers

### DIFF
--- a/packages/backend/src/utils/__tests__/sanitize-headers.test.ts
+++ b/packages/backend/src/utils/__tests__/sanitize-headers.test.ts
@@ -11,6 +11,13 @@ describe('sanitizeHeaders', () => {
     expect(result['content-type']).toBe('application/json');
   });
 
+  test('masks auth token header', () => {
+    const result = sanitizeHeaders({
+      'x-auth-token': 'token-1234567890abcdef',
+    });
+    expect(result['x-auth-token']).toBe('toke...cdef');
+  });
+
   test('masks x-api-key header', () => {
     const result = sanitizeHeaders({
       'x-api-key': 'my-long-api-key-value',

--- a/packages/backend/src/utils/sanitize-headers.ts
+++ b/packages/backend/src/utils/sanitize-headers.ts
@@ -1,4 +1,11 @@
-const SENSITIVE_HEADERS = ['authorization', 'x-api-key', 'x-goog-api-key', 'api-key', 'cookie'];
+const SENSITIVE_HEADERS = [
+  'authorization',
+  'x-auth-token',
+  'x-api-key',
+  'x-goog-api-key',
+  'api-key',
+  'cookie',
+];
 
 export function sanitizeHeaders(
   headers: Record<string, string | string[] | undefined>


### PR DESCRIPTION
### **User description**
## Summary
- add x-auth-token to backend sensitive header sanitization
- add unit coverage for masking auth token headers

## Validation
- bun run test
- bun run format:check


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Mask `x-auth-token` header values

- Add unit coverage for token masking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend headers"] --> B["sanitizeHeaders"]
  B -- "detects sensitive names" --> C["Masked log output"]
  D["Unit tests"] -- "verify x-auth-token" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanitize-headers.ts</strong><dd><code>Add auth token header sanitization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/backend/src/utils/sanitize-headers.ts

<ul><li>Adds <code>x-auth-token</code> to <code>SENSITIVE_HEADERS</code>.<br> <li> Reformats the sensitive header list across multiple lines.</ul>


</details>


  </td>
  <td><a href="https://github.com/mcowger/plexus/pull/570/files#diff-bb781d252f915853be2ab3bc76de51efd4d9e63f722c7dac7ecd2c8efab3e062">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanitize-headers.test.ts</strong><dd><code>Cover auth token header masking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/backend/src/utils/__tests__/sanitize-headers.test.ts

<ul><li>Adds a test for masking <code>x-auth-token</code>.<br> <li> Verifies long token values are abbreviated safely.</ul>


</details>


  </td>
  <td><a href="https://github.com/mcowger/plexus/pull/570/files#diff-589cc52092934922abdf71b24ef55c842e6dbd1f51b15a43004005e482510aa3">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

model: gpt-5.5
fallback_models: []
git_provider: github
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
ai_timeout: 300
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
custom_model_max_tokens: -1
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
