### PR TITLE
Enhance OpenRouter metadata loading and search

### DIFF
--- a/packages/backend/src/routes/inference/__tests__/models.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/models.test.ts
@@ -440,6 +440,35 @@ describe('GET /v1/metadata/search', () => {
     expect(json.data[0]).toHaveProperty('name');
   });
 
+  it('should return OpenRouter non-chat models matched by modality or description', async () => {
+    const mgr = ModelMetadataManager.getInstance();
+    await mgr.loadAll({
+      openrouter: openrouterMetadataFixture,
+      modelsDev: '/nonexistent',
+      catwalk: '/nonexistent',
+    });
+
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+    setConfigForTesting({ models: {} } as unknown as PlexusConfig);
+
+    const audioResponse = await fastify.inject({
+      method: 'GET',
+      url: '/v1/metadata/search?source=openrouter&q=audio',
+    });
+    expect(audioResponse.statusCode).toBe(200);
+    expect(audioResponse.json().data.map((r: any) => r.id)).toContain('openai/gpt-audio');
+
+    const transcriptionResponse = await fastify.inject({
+      method: 'GET',
+      url: '/v1/metadata/search?source=openrouter&q=transcribe',
+    });
+    expect(transcriptionResponse.statusCode).toBe(200);
+    expect(transcriptionResponse.json().data.map((r: any) => r.id)).toContain(
+      'mistralai/voxtral-small-24b-2507'
+    );
+  });
+
   it('should return all models when no q param given', async () => {
     const mgr = ModelMetadataManager.getInstance();
     await mgr.loadAll({

--- a/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
+++ b/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeAll, afterAll } from 'vitest';
+import { describe, expect, test, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import path from 'path';
 import { ModelMetadataManager, mergeOverrides } from '../model-metadata-manager';
 import type { NormalizedModelMetadata } from '../model-metadata-manager';
@@ -13,6 +13,10 @@ const catwalkFixture = path.join(FIXTURES, 'catwalk-sample.json');
 // Reset the singleton between test suites so each describe block gets a fresh instance
 afterAll(() => {
   ModelMetadataManager.resetForTesting();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 // ─── OpenRouter ──────────────────────────────────────────────────
@@ -58,9 +62,18 @@ describe('ModelMetadataManager – OpenRouter source', () => {
 
   test('getMetadata returns architecture with modalities', () => {
     const meta = mgr.getMetadata('openrouter', 'openai/gpt-4.1-nano');
+    expect(meta!.architecture?.modality).toBe('text+image->text');
     expect(meta!.architecture?.input_modalities).toContain('text');
     expect(meta!.architecture?.input_modalities).toContain('image');
     expect(meta!.architecture?.output_modalities).toContain('text');
+  });
+
+  test('getMetadata preserves non-text OpenRouter modalities', () => {
+    const meta = mgr.getMetadata('openrouter', 'openai/gpt-audio');
+    expect(meta).toBeDefined();
+    expect(meta!.architecture?.modality).toBe('text+audio->text+audio');
+    expect(meta!.architecture?.input_modalities).toContain('audio');
+    expect(meta!.architecture?.output_modalities).toContain('audio');
   });
 
   test('getMetadata returns supported_parameters', () => {
@@ -96,6 +109,16 @@ describe('ModelMetadataManager – OpenRouter source', () => {
     ).toBe(true);
   });
 
+  test('search matches OpenRouter architecture modalities', () => {
+    const results = mgr.search('openrouter', 'audio');
+    expect(results.map((r) => r.id)).toContain('openai/gpt-audio');
+  });
+
+  test('search matches OpenRouter descriptions', () => {
+    const results = mgr.search('openrouter', 'transcribe');
+    expect(results.map((r) => r.id)).toContain('mistralai/voxtral-small-24b-2507');
+  });
+
   test('search is case-insensitive', () => {
     const lower = mgr.search('openrouter', 'claude');
     const upper = mgr.search('openrouter', 'CLAUDE');
@@ -122,6 +145,81 @@ describe('ModelMetadataManager – OpenRouter source', () => {
     expect(ids).toContain('anthropic/claude-3.5-sonnet');
     expect(ids).toContain('openai/gpt-4.1-nano');
     expect(ids).toContain('google/gemini-pro');
+  });
+
+  test('loadAll merges OpenRouter embeddings and videos catalog endpoints', async () => {
+    ModelMetadataManager.resetForTesting();
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/api/v1/models')) {
+        return new Response(JSON.stringify({ data: [{ id: 'openai/gpt-4o', name: 'GPT-4o' }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/api/v1/embeddings/models')) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'google/gemini-embedding-2',
+                name: 'Google: Gemini Embedding 2',
+                description: 'Multimodal embedding model',
+                context_length: 8192,
+                architecture: {
+                  modality: 'text+image+file+audio+video->embeddings',
+                  input_modalities: ['text', 'image', 'file', 'audio', 'video'],
+                  output_modalities: ['embeddings'],
+                  tokenizer: 'Gemini',
+                  instruct_type: null,
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      if (url.endsWith('/api/v1/videos/models')) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 'google/veo-3.1-fast',
+                name: 'Google: Veo 3.1 Fast',
+                description: 'Video generation model',
+                supported_frame_images: ['first_frame'],
+                generate_audio: true,
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      return new Response('{}', { status: 404, statusText: 'Not Found' });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = ModelMetadataManager.getInstance();
+    await manager.loadAll({
+      openrouter: 'https://openrouter.ai/api/v1/models',
+      modelsDev: '/dev/null-nonexistent',
+      catwalk: '/dev/null-nonexistent',
+    });
+
+    expect(manager.getAllIds('openrouter')).toEqual([
+      'openai/gpt-4o',
+      'google/gemini-embedding-2',
+      'google/veo-3.1-fast',
+    ]);
+    expect(manager.search('openrouter', 'embed').map((r) => r.id)).toContain(
+      'google/gemini-embedding-2'
+    );
+    expect(manager.search('openrouter', 'video').map((r) => r.id)).toContain('google/veo-3.1-fast');
+    expect(manager.getMetadata('openrouter', 'google/veo-3.1-fast')?.architecture).toEqual({
+      modality: 'text+image->video+audio',
+      input_modalities: ['text', 'image'],
+      output_modalities: ['video', 'audio'],
+    });
   });
 });
 

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -14,6 +14,7 @@ export interface NormalizedModelMetadata {
   /** Maximum context window in tokens */
   context_length?: number;
   architecture?: {
+    modality?: string;
     input_modalities?: string[];
     output_modalities?: string[];
     tokenizer?: string;
@@ -41,6 +42,7 @@ interface OpenRouterRawModel {
   description?: string;
   context_length?: number;
   architecture?: {
+    modality?: string;
     input_modalities?: string[];
     output_modalities?: string[];
     tokenizer?: string;
@@ -58,11 +60,15 @@ interface OpenRouterRawModel {
     context_length?: number;
     max_completion_tokens?: number;
   };
+  supported_frame_images?: string[];
+  generate_audio?: boolean | null;
 }
 
 interface OpenRouterResponse {
   data: OpenRouterRawModel[];
 }
+
+type OpenRouterCatalogKind = 'models' | 'embeddings' | 'videos';
 
 interface ModelsDevModel {
   id: string;
@@ -114,13 +120,37 @@ interface CatwalkProvider {
 }
 
 // ─── Normalizers ───────────────────────────────────────
-function normalizeOpenRouterModel(raw: OpenRouterRawModel): NormalizedModelMetadata {
+function inferOpenRouterArchitecture(
+  raw: OpenRouterRawModel,
+  kind: OpenRouterCatalogKind
+): OpenRouterRawModel['architecture'] {
+  if (raw.architecture) return raw.architecture;
+  if (kind !== 'videos') return undefined;
+
+  const inputModalities = ['text'];
+  if (raw.supported_frame_images?.length) inputModalities.push('image');
+  const outputModalities = ['video'];
+  if (raw.generate_audio) outputModalities.push('audio');
+
+  return {
+    modality: `${inputModalities.join('+')}->${outputModalities.join('+')}`,
+    input_modalities: inputModalities,
+    output_modalities: outputModalities,
+  };
+}
+
+function normalizeOpenRouterModel(
+  raw: OpenRouterRawModel,
+  kind: OpenRouterCatalogKind = 'models'
+): NormalizedModelMetadata {
+  const architecture = inferOpenRouterArchitecture(raw, kind);
+
   return {
     id: raw.id,
     name: raw.name ?? raw.id,
     description: raw.description,
     context_length: raw.context_length,
-    architecture: raw.architecture,
+    architecture,
     pricing: raw.pricing
       ? {
           prompt: raw.pricing.prompt,
@@ -152,13 +182,20 @@ function normalizeModelsDevModel(
   if (raw.reasoning) params.push('reasoning');
   if (raw.attachment) params.push('image'); // attachment support implies image input
 
+  const inputModalities = raw.modalities?.input;
+  const outputModalities = raw.modalities?.output;
+
   return {
     id: `${providerId}.${modelId}`,
     name: raw.name ?? raw.id ?? modelId,
     context_length: raw.limit?.context,
     architecture: {
-      input_modalities: raw.modalities?.input,
-      output_modalities: raw.modalities?.output,
+      modality:
+        inputModalities?.length || outputModalities?.length
+          ? `${inputModalities?.join('+') ?? ''}->${outputModalities?.join('+') ?? ''}`
+          : undefined,
+      input_modalities: inputModalities,
+      output_modalities: outputModalities,
     },
     pricing:
       raw.cost?.input != null || raw.cost?.output != null
@@ -192,14 +229,16 @@ function normalizeCatwalkModel(providerId: string, raw: CatwalkModel): Normalize
 
   const inputModalities = ['text'];
   if (raw.supports_attachments) inputModalities.push('image');
+  const outputModalities = ['text'];
 
   return {
     id: `${providerId}.${raw.id}`,
     name: raw.name ?? raw.id,
     context_length: raw.context_window,
     architecture: {
+      modality: `${inputModalities.join('+')}->${outputModalities.join('+')}`,
       input_modalities: inputModalities,
-      output_modalities: ['text'],
+      output_modalities: outputModalities,
     },
     pricing:
       raw.cost_per_1m_in != null || raw.cost_per_1m_out != null
@@ -273,16 +312,37 @@ export class ModelMetadataManager {
   private async loadOpenRouter(source: string): Promise<void> {
     try {
       logger.debug(`Loading OpenRouter metadata from ${source}`);
-      const raw = await this.fetchOrReadJson<OpenRouterResponse>(source);
-      if (!raw || !Array.isArray(raw.data)) {
+      this.openrouterMap.clear();
+
+      const loadCatalog = async (
+        catalogSource: string,
+        kind: OpenRouterCatalogKind
+      ): Promise<void> => {
+        const raw = await this.fetchOrReadJson<OpenRouterResponse>(catalogSource);
+        if (!raw || !Array.isArray(raw.data)) {
+          logger.warn(`Invalid OpenRouter ${kind} response format`);
+          return;
+        }
+        for (const model of raw.data) {
+          if (model.id) {
+            this.openrouterMap.set(model.id, normalizeOpenRouterModel(model, kind));
+          }
+        }
+      };
+
+      await loadCatalog(source, 'models');
+
+      for (const auxiliary of this.getOpenRouterAuxiliarySources(source)) {
+        try {
+          await loadCatalog(auxiliary.source, auxiliary.kind);
+        } catch (error) {
+          logger.warn(`Failed to load OpenRouter ${auxiliary.kind} metadata`, error);
+        }
+      }
+
+      if (this.openrouterMap.size === 0) {
         logger.warn('Invalid OpenRouter response format');
         return;
-      }
-      this.openrouterMap.clear();
-      for (const model of raw.data) {
-        if (model.id) {
-          this.openrouterMap.set(model.id, normalizeOpenRouterModel(model));
-        }
       }
       this.initializedSources.add('openrouter');
       logger.debug(`Loaded ${this.openrouterMap.size} OpenRouter models`);
@@ -353,6 +413,26 @@ export class ModelMetadataManager {
 
   // ─── Helpers ─────────────────────────────────────────
 
+  private getOpenRouterAuxiliarySources(
+    source: string
+  ): Array<{ source: string; kind: Exclude<OpenRouterCatalogKind, 'models'> }> {
+    if (!source.startsWith('http://') && !source.startsWith('https://')) return [];
+
+    const url = new URL(source);
+    if (!url.pathname.endsWith('/models')) return [];
+
+    const embeddings = new URL(url);
+    embeddings.pathname = url.pathname.replace(/\/models$/, '/embeddings/models');
+
+    const videos = new URL(url);
+    videos.pathname = url.pathname.replace(/\/models$/, '/videos/models');
+
+    return [
+      { source: embeddings.toString(), kind: 'embeddings' },
+      { source: videos.toString(), kind: 'videos' },
+    ];
+  }
+
   private async fetchOrReadJson<T>(source: string): Promise<T> {
     if (source.startsWith('http://') || source.startsWith('https://')) {
       const response = await fetch(source);
@@ -417,17 +497,25 @@ export class ModelMetadataManager {
     const results: Array<{ id: string; name: string }> = [];
 
     for (const [key, meta] of map) {
-      if (
-        !query ||
-        key.toLowerCase().includes(lowerQuery) ||
-        meta.name.toLowerCase().includes(lowerQuery)
-      ) {
+      const architecture = meta.architecture;
+      const searchableText = [
+        key,
+        meta.name,
+        meta.description,
+        architecture?.modality,
+        ...(architecture?.input_modalities ?? []),
+        ...(architecture?.output_modalities ?? []),
+      ]
+        .filter((value): value is string => typeof value === 'string')
+        .join(' ')
+        .toLowerCase();
+      if (!query || searchableText.includes(lowerQuery)) {
         results.push({ id: key, name: meta.name });
-        if (results.length >= limit) break;
       }
     }
 
-    // Prioritize matches that start with the query
+    // Prioritize matches that start with the query, then cap after ranking so
+    // broad searches don't hide later multimodal models due to catalog order.
     if (query) {
       results.sort((a, b) => {
         const aStarts =
@@ -440,7 +528,7 @@ export class ModelMetadataManager {
       });
     }
 
-    return results;
+    return results.slice(0, limit);
   }
 
   public getAllIds(source: 'openrouter' | 'models.dev' | 'catwalk'): string[] {

--- a/packages/backend/src/utils/__tests__/fixtures/openrouter-metadata-sample.json
+++ b/packages/backend/src/utils/__tests__/fixtures/openrouter-metadata-sample.json
@@ -78,6 +78,52 @@
         "max_completion_tokens": 8192,
         "is_moderated": false
       }
+    },
+    {
+      "id": "openai/gpt-audio",
+      "name": "OpenAI: GPT Audio",
+      "description": "GPT Audio supports audio input and output.",
+      "context_length": 128000,
+      "architecture": {
+        "modality": "text+audio->text+audio",
+        "input_modalities": ["text", "audio"],
+        "output_modalities": ["text", "audio"],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000025",
+        "completion": "0.00001"
+      },
+      "supported_parameters": ["temperature", "max_tokens"],
+      "top_provider": {
+        "context_length": 128000,
+        "max_completion_tokens": 16384,
+        "is_moderated": false
+      }
+    },
+    {
+      "id": "mistralai/voxtral-small-24b-2507",
+      "name": "Mistral: Voxtral Small 24B 2507",
+      "description": "Audio understanding model that can transcribe speech from uploaded audio files.",
+      "context_length": 32768,
+      "architecture": {
+        "modality": "text+file+audio->text",
+        "input_modalities": ["text", "audio", "file"],
+        "output_modalities": ["text"],
+        "tokenizer": "Mistral",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000001",
+        "completion": "0.0000003"
+      },
+      "supported_parameters": ["temperature", "max_tokens"],
+      "top_provider": {
+        "context_length": 32768,
+        "max_completion_tokens": 4096,
+        "is_moderated": false
+      }
     }
   ]
 }


### PR DESCRIPTION
### **User description**
Load OpenRouter models from additional catalog endpoints for embeddings and videos, normalize inferred architecture modalities for non-text outputs, and extend search matching to include modality, input modalities, and output modalities.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Load additional OpenRouter catalogs

- Preserve and infer modalities

- Search descriptions and modalities

- Add multimodal metadata tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  source["OpenRouter models endpoint"]
  aux["Embeddings and videos endpoints"]
  normalize["Normalize metadata with modalities"]
  search["Search across descriptions and modalities"]
  results["Return multimodal model results"]
  source -- "loads" --> normalize
  aux -- "merges" --> normalize
  normalize -- "indexes" --> search
  search -- "finds" --> results
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.test.ts</strong><dd><code>Test OpenRouter multimodal search route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/backend/src/routes/inference/__tests__/models.test.ts

<ul><li>Adds API search coverage for OpenRouter non-chat models.<br> <li> Verifies <code>audio</code> matches <code>openai/gpt-audio</code>.<br> <li> Verifies description query <code>transcribe</code> matches Voxtral.</ul>


</details>


  </td>
  <td><a href="https://github.com/mcowger/plexus/pull/574/files#diff-c7cb90f39ae02ee8fee96dada6eeebf2e20efd32c7b4d1ede171b2f0399fc769">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>model-metadata-manager.test.ts</strong><dd><code>Test metadata loading and modality search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/backend/src/services/__tests__/model-metadata-manager.test.ts

<ul><li>Adds <code>vi</code> cleanup after each test.<br> <li> Verifies <code>architecture.modality</code> preservation.<br> <li> Tests searching OpenRouter modalities and descriptions.<br> <li> Mocks auxiliary embeddings and videos catalog loading.</ul>


</details>


  </td>
  <td><a href="https://github.com/mcowger/plexus/pull/574/files#diff-5a7fc0bd3ea06c9bb094434667d581c65a07abf96345be7e61b3385e231ae3b9">+99/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openrouter-metadata-sample.json</strong><dd><code>Add OpenRouter audio model fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/backend/src/utils/__tests__/fixtures/openrouter-metadata-sample.json

<ul><li>Adds <code>openai/gpt-audio</code> multimodal fixture.<br> <li> Adds Voxtral audio transcription fixture.<br> <li> Includes modality, pricing, and provider metadata.</ul>


</details>


  </td>
  <td><a href="https://github.com/mcowger/plexus/pull/574/files#diff-5249abc474d4ba0d74e9f616d70841635b8c26017f3b5b38e3efb66465caa769">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-metadata-manager.ts</strong><dd><code>Expand OpenRouter catalogs and searchable modalities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/backend/src/services/model-metadata-manager.ts

<ul><li>Adds <code>modality</code> to normalized architecture metadata.<br> <li> Loads OpenRouter embeddings and videos catalog endpoints.<br> <li> Infers video model architecture from frame/audio fields.<br> <li> Expands search over descriptions and modalities.</ul>


</details>


  </td>
  <td><a href="https://github.com/mcowger/plexus/pull/574/files#diff-91908d467a6fef34e3b7971ffe9496ed3e55c6d447a9c2e0561b98c44ca42025">+109/-21</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

model: gpt-5.5
fallback_models: []
git_provider: github
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
ai_timeout: 300
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
custom_model_max_tokens: -1
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
