### PR TITLE
Add model metadata refresh endpoint and UI

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -438,6 +438,8 @@ paths:
     $ref: paths/v0_management_models_{aliasId}.yaml
   /v0/management/models/huggingface/{modelId}:
     $ref: paths/v0_management_models_huggingface_{modelId}.yaml
+  /v0/management/models/metadata/refresh:
+    $ref: paths/v0_management_models_metadata_refresh.yaml
   /v0/management/keys:
     $ref: paths/v0_management_keys.yaml
   /v0/management/keys/{name}:

--- a/docs/openapi/paths/v0_management_models_metadata_refresh.yaml
+++ b/docs/openapi/paths/v0_management_models_metadata_refresh.yaml
@@ -1,0 +1,108 @@
+post:
+  tags:
+    - Management — Models
+  summary: Refresh external model metadata catalogs (admin only)
+  description: |
+    Triggers an immediate reload of external model metadata from the configured
+    catalog sources:
+
+    - OpenRouter
+    - models.dev
+    - Catwalk
+
+    Plexus also runs this refresh automatically every 60 minutes. This endpoint
+    is useful when you want newly published catalog metadata to be available
+    immediately in the admin UI and metadata lookup APIs.
+
+    The response includes per-source counts and any source-specific refresh
+    errors. A partial failure still returns `200` so callers can inspect which
+    sources succeeded.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Refresh completed (possibly with per-source errors).
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - success
+              - message
+              - trigger
+              - refreshedAt
+              - durationMs
+              - intervalMinutes
+              - hadErrors
+              - sources
+            properties:
+              success:
+                type: boolean
+              message:
+                type: string
+              trigger:
+                type: string
+                enum: [startup, scheduled, manual]
+              refreshedAt:
+                type: string
+                format: date-time
+              durationMs:
+                type: integer
+              intervalMinutes:
+                type: integer
+                minimum: 1
+              hadErrors:
+                type: boolean
+              sources:
+                type: object
+                required:
+                  - openrouter
+                  - modelsDev
+                  - catwalk
+                properties:
+                  openrouter:
+                    type: object
+                    required: [source, initialized, count]
+                    properties:
+                      source:
+                        type: string
+                        enum: [openrouter, models.dev, catwalk]
+                      initialized:
+                        type: boolean
+                      count:
+                        type: integer
+                      error:
+                        type: string
+                  modelsDev:
+                    type: object
+                    required: [source, initialized, count]
+                    properties:
+                      source:
+                        type: string
+                        enum: [openrouter, models.dev, catwalk]
+                      initialized:
+                        type: boolean
+                      count:
+                        type: integer
+                      error:
+                        type: string
+                  catwalk:
+                    type: object
+                    required: [source, initialized, count]
+                    properties:
+                      source:
+                        type: string
+                        enum: [openrouter, models.dev, catwalk]
+                      initialized:
+                        type: boolean
+                      count:
+                        type: integer
+                      error:
+                        type: string
+    '401':
+      description: Authentication required or invalid credentials.
+    '403':
+      description: Limited principals cannot access this endpoint.
+  operationId: postV0ManagementModelsMetadataRefresh

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -178,11 +178,11 @@ try {
   await OAuthAuthManager.getInstance().initialize();
   await PricingManager.getInstance().loadPricing();
   // Load model metadata from all configured sources (non-fatal on failure)
-  ModelMetadataManager.getInstance()
-    .loadAll()
-    .catch((e) => {
-      logger.error('Failed to load model metadata', e);
-    });
+  const modelMetadataManager = ModelMetadataManager.getInstance();
+  modelMetadataManager.startAutoRefresh(60);
+  modelMetadataManager.refreshAll(undefined, 'startup').catch((e) => {
+    logger.error('Failed to load model metadata', e);
+  });
   CodexVersionService.getInstance()
     .fetchVersion()
     .catch((e) => {

--- a/packages/backend/src/routes/management/__tests__/models.test.ts
+++ b/packages/backend/src/routes/management/__tests__/models.test.ts
@@ -1,0 +1,55 @@
+import Fastify from 'fastify';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { registerSpy } from '../../../../test/test-utils';
+import { registerModelRoutes } from '../models';
+import { ModelMetadataManager } from '../../../services/model-metadata-manager';
+
+describe('management model routes', () => {
+  let fastify: ReturnType<typeof Fastify>;
+
+  beforeEach(async () => {
+    ModelMetadataManager.resetForTesting();
+    fastify = Fastify();
+    await registerModelRoutes(fastify);
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+    ModelMetadataManager.resetForTesting();
+  });
+
+  test('POST /v0/management/models/metadata/refresh triggers a metadata refresh', async () => {
+    registerSpy(ModelMetadataManager.getInstance(), 'refreshAll').mockResolvedValue({
+      success: true,
+      message: 'Model metadata refresh completed successfully',
+      trigger: 'manual',
+      refreshedAt: '2026-06-10T12:00:00.000Z',
+      durationMs: 42,
+      intervalMinutes: 60,
+      hadErrors: false,
+      sources: {
+        openrouter: { source: 'openrouter', initialized: true, count: 1 },
+        modelsDev: { source: 'models.dev', initialized: true, count: 2 },
+        catwalk: { source: 'catwalk', initialized: true, count: 3 },
+      },
+    });
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/v0/management/models/metadata/refresh',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      success: true,
+      trigger: 'manual',
+      intervalMinutes: 60,
+      hadErrors: false,
+      sources: {
+        openrouter: { count: 1 },
+        modelsDev: { count: 2 },
+        catwalk: { count: 3 },
+      },
+    });
+  });
+});

--- a/packages/backend/src/routes/management/models.ts
+++ b/packages/backend/src/routes/management/models.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { logger } from '../../utils/logger';
 import { HuggingFaceModelFetcher } from '../../services/huggingface-model-fetcher';
+import { ModelMetadataManager } from '../../services/model-metadata-manager';
 import { getModels, getProviders } from '@earendil-works/pi-ai';
 
 interface FetchModelRequest {
@@ -10,6 +11,11 @@ interface FetchModelRequest {
 }
 
 export async function registerModelRoutes(fastify: FastifyInstance) {
+  fastify.post('/v0/management/models/metadata/refresh', async (_request, reply) => {
+    const result = await ModelMetadataManager.getInstance().refreshAll(undefined, 'manual');
+    return reply.send(result);
+  });
+
   // Fetch model architecture from Hugging Face
   fastify.get(
     '/v0/management/models/huggingface/:modelId',

--- a/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
@@ -9,6 +9,7 @@ import * as mcpProxyService from '../../../services/mcp-proxy/mcp-proxy-service'
 import { DebugManager } from '../../../services/debug-manager';
 import { CooldownManager } from '../../../services/cooldown-manager';
 import { BackupService } from '../../../services/backup-service';
+import { ModelMetadataManager } from '../../../services/model-metadata-manager';
 
 describe('Plexus management MCP routes', () => {
   let fastify: FastifyInstance;
@@ -376,6 +377,22 @@ describe('Plexus management MCP routes', () => {
       }
       if (method === 'POST' && path === '/v0/management/restart') {
         return json({ success: true, message: 'Server is restarting' });
+      }
+      if (method === 'POST' && path === '/v0/management/models/metadata/refresh') {
+        return json({
+          success: true,
+          message: 'Model metadata refresh completed successfully',
+          trigger: 'manual',
+          refreshedAt: '2026-06-10T12:00:00.000Z',
+          durationMs: 25,
+          intervalMinutes: 60,
+          hadErrors: false,
+          sources: {
+            openrouter: { source: 'openrouter', initialized: true, count: 10 },
+            modelsDev: { source: 'models.dev', initialized: true, count: 20 },
+            catwalk: { source: 'catwalk', initialized: true, count: 30 },
+          },
+        });
       }
 
       return json({ error: `Unhandled management route in test: ${method} ${url}` }, 404);
@@ -845,6 +862,40 @@ describe('Plexus management MCP routes', () => {
     expect(restartBody.result.structuredContent.ok).toBe(true);
     expect(restartBody.result.structuredContent.data.success).toBe(true);
     expect(restartBody.result.structuredContent.data.message).toContain('restarting');
+  });
+
+  test('implements plexus_operations refresh_metadata response', async () => {
+    registerSpy(ModelMetadataManager.getInstance(), 'refreshAll').mockResolvedValue({
+      success: true,
+      message: 'Model metadata refresh completed successfully',
+      trigger: 'manual',
+      refreshedAt: '2026-06-10T12:00:00.000Z',
+      durationMs: 25,
+      intervalMinutes: 60,
+      hadErrors: false,
+      sources: {
+        openrouter: { source: 'openrouter', initialized: true, count: 10 },
+        modelsDev: { source: 'models.dev', initialized: true, count: 20 },
+        catwalk: { source: 'catwalk', initialized: true, count: 30 },
+      },
+    });
+
+    const response = await postPlexusMcp(
+      {
+        method: 'tools/call',
+        id: 3,
+        params: {
+          name: 'plexus_operations',
+          arguments: { operation: 'refresh_metadata' },
+        },
+      },
+      adminHeaders()
+    );
+
+    const body = parseJsonRpcResponse(response);
+    expect(body.result.structuredContent.ok).toBe(true);
+    expect(body.result.structuredContent.data.message).toContain('refresh completed');
+    expect(body.result.structuredContent.data.sources.modelsDev.count).toBe(20);
   });
 
   test('implements plexus_key update through the management shim', async () => {

--- a/packages/backend/src/routes/mcp/plexus.ts
+++ b/packages/backend/src/routes/mcp/plexus.ts
@@ -30,7 +30,7 @@ Common workflows:
 - Inspect recent system logs with plexus_system_logs recent.
 - Inspect or change the runtime logging level with plexus_system_logs level, set_level, or reset_level.
 - Use plexus_debug state before enabling debug tracing.
-- Use plexus_operations backup, restore, list_cooldowns, or clear_cooldowns for operational actions.
+- Use plexus_operations backup, restore, refresh_metadata, list_cooldowns, or clear_cooldowns for operational actions.
 
 Best practices:
 - Keep changes narrow and reversible.
@@ -561,6 +561,11 @@ async function handleOperationsTool(
         input.operation,
         await callManagementRoute(shimContext, 'POST', '/v0/management/restart')
       );
+    case 'refresh_metadata':
+      return successResponse(
+        input.operation,
+        await callManagementRoute(shimContext, 'POST', '/v0/management/models/metadata/refresh')
+      );
     case 'list_cooldowns':
       return successResponse(
         input.operation,
@@ -592,6 +597,7 @@ async function handleOperationsTool(
         'backup',
         'restore',
         'restart',
+        'refresh_metadata',
         'list_cooldowns',
         'clear_cooldowns',
         'reset_logs',
@@ -1344,7 +1350,7 @@ function getToolDescription(toolName: string) {
     case 'plexus_system_logs':
       return 'Inspect recent Plexus system logs and control runtime log verbosity. Operations: recent, level, set_level, reset_level.';
     case 'plexus_operations':
-      return 'Run high-impact operational actions. Operations: backup, restore, restart, list_cooldowns, clear_cooldowns, reset_logs.';
+      return 'Run high-impact operational actions. Operations: backup, restore, restart, refresh_metadata, list_cooldowns, clear_cooldowns, reset_logs.';
     default:
       return 'Plexus management tool.';
   }

--- a/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
+++ b/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
@@ -16,6 +16,7 @@ afterAll(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -423,6 +424,64 @@ describe('ModelMetadataManager – error handling', () => {
     const mgr = ModelMetadataManager.getInstance();
     const meta = mgr.getMetadata('openrouter', 'anthropic/claude-3.5-sonnet');
     expect(meta).toBeUndefined();
+  });
+
+  test('failed refresh preserves the previously loaded metadata', async () => {
+    ModelMetadataManager.resetForTesting();
+    const mgr = ModelMetadataManager.getInstance();
+
+    await mgr.refreshAll({
+      openrouter: openrouterFixture,
+      modelsDev: '/dev/null-nonexistent',
+      catwalk: '/dev/null-nonexistent',
+    });
+
+    const before = mgr.getMetadata('openrouter', 'anthropic/claude-3.5-sonnet');
+    expect(before?.name).toBe('Anthropic: Claude 3.5 Sonnet');
+
+    const result = await mgr.refreshAll({
+      openrouter: '/nonexistent/path/openrouter.json',
+      modelsDev: '/dev/null-nonexistent',
+      catwalk: '/dev/null-nonexistent',
+    });
+
+    expect(result.hadErrors).toBe(true);
+    expect(result.sources.openrouter.initialized).toBe(true);
+    expect(result.sources.openrouter.count).toBeGreaterThan(0);
+    expect(mgr.getMetadata('openrouter', 'anthropic/claude-3.5-sonnet')).toEqual(before);
+  });
+
+  test('startAutoRefresh schedules refresh every 60 minutes', async () => {
+    vi.useFakeTimers();
+    ModelMetadataManager.resetForTesting();
+    const mgr = ModelMetadataManager.getInstance();
+
+    const fetchMock = vi.fn(async (_input: string | URL | Request) => {
+      return new Response(
+        JSON.stringify({
+          data: [{ id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini' }],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await mgr.refreshAll({
+      openrouter: 'https://example.com/openrouter.json',
+      modelsDev: 'https://example.com/models-dev.json',
+      catwalk: 'https://example.com/catwalk.json',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    mgr.startAutoRefresh(60);
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000 + 1);
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    mgr.stopAutoRefresh();
   });
 });
 

--- a/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
+++ b/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
@@ -448,7 +448,76 @@ describe('ModelMetadataManager – error handling', () => {
     expect(result.hadErrors).toBe(true);
     expect(result.sources.openrouter.initialized).toBe(true);
     expect(result.sources.openrouter.count).toBeGreaterThan(0);
+    expect(result.sources.openrouter.count).toBe(mgr.getAllIds('openrouter').length);
     expect(mgr.getMetadata('openrouter', 'anthropic/claude-3.5-sonnet')).toEqual(before);
+  });
+
+  test('empty models.dev refresh preserves the previously loaded metadata', async () => {
+    ModelMetadataManager.resetForTesting();
+    const mgr = ModelMetadataManager.getInstance();
+
+    await mgr.refreshAll({
+      openrouter: '/dev/null-nonexistent',
+      modelsDev: modelsDevFixture,
+      catwalk: '/dev/null-nonexistent',
+    });
+
+    const before = mgr.getMetadata('models.dev', 'anthropic.claude-3-5-haiku-20241022');
+    expect(before?.name).toBe('Claude Haiku 3.5');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ anthropic: { models: {} } }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+      )
+    );
+
+    const result = await mgr.refreshAll({
+      modelsDev: 'https://example.com/models-dev-empty.json',
+    });
+
+    expect(result.hadErrors).toBe(true);
+    expect(result.sources.modelsDev.initialized).toBe(true);
+    expect(result.sources.modelsDev.count).toBe(mgr.getAllIds('models.dev').length);
+    expect(mgr.getMetadata('models.dev', 'anthropic.claude-3-5-haiku-20241022')).toEqual(before);
+  });
+
+  test('empty catwalk refresh preserves the previously loaded metadata', async () => {
+    ModelMetadataManager.resetForTesting();
+    const mgr = ModelMetadataManager.getInstance();
+
+    await mgr.refreshAll({
+      openrouter: '/dev/null-nonexistent',
+      modelsDev: '/dev/null-nonexistent',
+      catwalk: catwalkFixture,
+    });
+
+    const before = mgr.getMetadata('catwalk', 'anthropic.claude-3-5-haiku-20241022');
+    expect(before?.name).toBe('Claude 3.5 Haiku');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+      )
+    );
+
+    const result = await mgr.refreshAll({
+      catwalk: 'https://example.com/catwalk-empty.json',
+    });
+
+    expect(result.hadErrors).toBe(true);
+    expect(result.sources.catwalk.initialized).toBe(true);
+    expect(result.sources.catwalk.count).toBe(mgr.getAllIds('catwalk').length);
+    expect(mgr.getMetadata('catwalk', 'anthropic.claude-3-5-haiku-20241022')).toEqual(before);
   });
 
   test('startAutoRefresh schedules refresh every 60 minutes', async () => {

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -1,6 +1,42 @@
 import { logger } from '../utils/logger';
 import type { MetadataOverrides } from '../config';
 
+type MetadataSourceId = 'openrouter' | 'models.dev' | 'catwalk';
+
+interface MetadataCatalogSources {
+  openrouter: string;
+  modelsDev: string;
+  catwalk: string;
+}
+
+export interface MetadataSourceRefreshSummary {
+  source: MetadataSourceId;
+  initialized: boolean;
+  count: number;
+  error?: string;
+}
+
+export interface ModelMetadataRefreshResult {
+  success: boolean;
+  message: string;
+  trigger: 'startup' | 'scheduled' | 'manual';
+  refreshedAt: string;
+  durationMs: number;
+  intervalMinutes: number;
+  hadErrors: boolean;
+  sources: {
+    openrouter: MetadataSourceRefreshSummary;
+    modelsDev: MetadataSourceRefreshSummary;
+    catwalk: MetadataSourceRefreshSummary;
+  };
+}
+
+const DEFAULT_METADATA_SOURCES: MetadataCatalogSources = {
+  openrouter: 'https://openrouter.ai/api/v1/models',
+  modelsDev: 'https://models.dev/api.json',
+  catwalk: 'https://catwalk.charm.sh/v2/providers',
+};
+
 // ─── Normalized model metadata (OpenRouter-style) ──────────────────────────
 // All three sources are normalized into this shape.
 
@@ -269,7 +305,11 @@ export class ModelMetadataManager {
   private modelsDevMap: Map<string, NormalizedModelMetadata> = new Map();
   private catwalkMap: Map<string, NormalizedModelMetadata> = new Map();
 
-  private initializedSources: Set<'openrouter' | 'models.dev' | 'catwalk'> = new Set();
+  private initializedSources: Set<MetadataSourceId> = new Set();
+  private sourceConfig: MetadataCatalogSources = { ...DEFAULT_METADATA_SOURCES };
+  private autoRefreshIntervalMinutes = 60;
+  private autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  private inFlightRefresh: Promise<ModelMetadataRefreshResult> | null = null;
 
   private constructor() {}
 
@@ -282,6 +322,7 @@ export class ModelMetadataManager {
 
   /** Reset the singleton (used in tests) */
   public static resetForTesting(): void {
+    ModelMetadataManager.instance?.stopAutoRefresh();
     ModelMetadataManager.instance = new ModelMetadataManager();
   }
 
@@ -289,30 +330,104 @@ export class ModelMetadataManager {
    * Load all three metadata sources. Each source is loaded independently;
    * failure of one does not prevent the others from loading.
    */
-  public async loadAll(sources?: {
-    openrouter?: string;
-    modelsDev?: string;
-    catwalk?: string;
-  }): Promise<void> {
-    const {
-      openrouter = 'https://openrouter.ai/api/v1/models',
-      modelsDev = 'https://models.dev/api.json',
-      catwalk = 'https://catwalk.charm.sh/v2/providers',
-    } = sources ?? {};
+  public async loadAll(sources?: Partial<MetadataCatalogSources>): Promise<void> {
+    await this.refreshAll(sources, 'manual');
+  }
 
-    await Promise.all([
-      this.loadOpenRouter(openrouter),
-      this.loadModelsDev(modelsDev),
-      this.loadCatwalk(catwalk),
-    ]);
+  public async refreshAll(
+    sources?: Partial<MetadataCatalogSources>,
+    trigger: 'startup' | 'scheduled' | 'manual' = 'manual'
+  ): Promise<ModelMetadataRefreshResult> {
+    if (sources) {
+      this.sourceConfig = {
+        ...this.sourceConfig,
+        ...sources,
+      };
+    }
+
+    if (this.inFlightRefresh) {
+      return this.inFlightRefresh;
+    }
+
+    this.inFlightRefresh = (async () => {
+      const startedAt = Date.now();
+      const refreshedAt = new Date(startedAt).toISOString();
+      const [openrouter, modelsDev, catwalk] = await Promise.all([
+        this.loadOpenRouter(this.sourceConfig.openrouter),
+        this.loadModelsDev(this.sourceConfig.modelsDev),
+        this.loadCatwalk(this.sourceConfig.catwalk),
+      ]);
+
+      const hadErrors = [openrouter, modelsDev, catwalk].some((source) => !!source.error);
+      const durationMs = Date.now() - startedAt;
+      const result: ModelMetadataRefreshResult = {
+        success: !hadErrors,
+        message: hadErrors
+          ? 'Model metadata refresh completed with errors'
+          : 'Model metadata refresh completed successfully',
+        trigger,
+        refreshedAt,
+        durationMs,
+        intervalMinutes: this.autoRefreshIntervalMinutes,
+        hadErrors,
+        sources: {
+          openrouter,
+          modelsDev,
+          catwalk,
+        },
+      };
+
+      if (hadErrors) {
+        logger.warn(`Model metadata refresh (${trigger}) completed with errors`, result);
+      } else {
+        logger.info(`Model metadata refresh (${trigger}) completed in ${durationMs}ms`);
+      }
+
+      return result;
+    })().finally(() => {
+      this.inFlightRefresh = null;
+    });
+
+    return this.inFlightRefresh;
+  }
+
+  public startAutoRefresh(intervalMinutes = 60, sources?: Partial<MetadataCatalogSources>): void {
+    if (sources) {
+      this.sourceConfig = {
+        ...this.sourceConfig,
+        ...sources,
+      };
+    }
+
+    this.stopAutoRefresh();
+    this.autoRefreshIntervalMinutes = Math.max(1, intervalMinutes);
+    this.autoRefreshTimer = setInterval(
+      () => {
+        this.refreshAll(undefined, 'scheduled').catch((error) => {
+          logger.error('Scheduled model metadata refresh failed', error);
+        });
+      },
+      this.autoRefreshIntervalMinutes * 60 * 1000
+    );
+
+    logger.info(
+      `Scheduled model metadata auto-refresh every ${this.autoRefreshIntervalMinutes} minutes`
+    );
+  }
+
+  public stopAutoRefresh(): void {
+    if (this.autoRefreshTimer) {
+      clearInterval(this.autoRefreshTimer);
+      this.autoRefreshTimer = null;
+    }
   }
 
   // ─── Loaders ────────────────────────────────────
 
-  private async loadOpenRouter(source: string): Promise<void> {
+  private async loadOpenRouter(source: string): Promise<MetadataSourceRefreshSummary> {
     try {
       logger.debug(`Loading OpenRouter metadata from ${source}`);
-      this.openrouterMap.clear();
+      const nextMap: Map<string, NormalizedModelMetadata> = new Map();
 
       const loadCatalog = async (
         catalogSource: string,
@@ -325,7 +440,7 @@ export class ModelMetadataManager {
         }
         for (const model of raw.data) {
           if (model.id) {
-            this.openrouterMap.set(model.id, normalizeOpenRouterModel(model, kind));
+            nextMap.set(model.id, normalizeOpenRouterModel(model, kind));
           }
         }
       };
@@ -340,25 +455,39 @@ export class ModelMetadataManager {
         }
       }
 
-      if (this.openrouterMap.size === 0) {
+      if (nextMap.size === 0) {
         logger.warn('Invalid OpenRouter response format');
-        return;
+        return this.toSourceSummary('openrouter', nextMap, 'Invalid OpenRouter response format');
       }
+
+      this.openrouterMap = nextMap;
       this.initializedSources.add('openrouter');
       logger.debug(`Loaded ${this.openrouterMap.size} OpenRouter models`);
+      return this.toSourceSummary('openrouter', this.openrouterMap);
     } catch (error) {
       logger.error('Failed to load OpenRouter metadata', error);
+      return this.toSourceSummary(
+        'openrouter',
+        this.openrouterMap,
+        error instanceof Error ? error.message : String(error)
+      );
     }
   }
-  private async loadModelsDev(source: string): Promise<void> {
+
+  private async loadModelsDev(source: string): Promise<MetadataSourceRefreshSummary> {
     try {
       logger.debug(`Loading models.dev metadata from ${source}`);
       const raw = await this.fetchOrReadJson<Record<string, ModelsDevProvider>>(source);
       if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
         logger.warn('Invalid models.dev response format');
-        return;
+        return this.toSourceSummary(
+          'models.dev',
+          this.modelsDevMap,
+          'Invalid models.dev response format'
+        );
       }
-      this.modelsDevMap.clear();
+
+      const nextMap: Map<string, NormalizedModelMetadata> = new Map();
       for (const [providerId, provider] of Object.entries(raw)) {
         const models = provider?.models;
         if (!models) continue;
@@ -367,47 +496,64 @@ export class ModelMetadataManager {
           for (const model of models) {
             if (model?.id) {
               const key = `${providerId}.${model.id}`;
-              this.modelsDevMap.set(key, normalizeModelsDevModel(providerId, model.id, model));
+              nextMap.set(key, normalizeModelsDevModel(providerId, model.id, model));
             }
           }
         } else if (typeof models === 'object') {
           for (const [modelId, model] of Object.entries(models)) {
             if (model) {
               const key = `${providerId}.${modelId}`;
-              this.modelsDevMap.set(key, normalizeModelsDevModel(providerId, modelId, model));
+              nextMap.set(key, normalizeModelsDevModel(providerId, modelId, model));
             }
           }
         }
       }
+
+      this.modelsDevMap = nextMap;
       this.initializedSources.add('models.dev');
       logger.debug(`Loaded ${this.modelsDevMap.size} models.dev models`);
+      return this.toSourceSummary('models.dev', this.modelsDevMap);
     } catch (error) {
       logger.error('Failed to load models.dev metadata', error);
+      return this.toSourceSummary(
+        'models.dev',
+        this.modelsDevMap,
+        error instanceof Error ? error.message : String(error)
+      );
     }
   }
 
-  private async loadCatwalk(source: string): Promise<void> {
+  private async loadCatwalk(source: string): Promise<MetadataSourceRefreshSummary> {
     try {
       logger.debug(`Loading Catwalk metadata from ${source}`);
       const raw = await this.fetchOrReadJson<CatwalkProvider[]>(source);
       if (!raw || !Array.isArray(raw)) {
         logger.warn('Invalid Catwalk response format');
-        return;
+        return this.toSourceSummary('catwalk', this.catwalkMap, 'Invalid Catwalk response format');
       }
-      this.catwalkMap.clear();
+
+      const nextMap: Map<string, NormalizedModelMetadata> = new Map();
       for (const provider of raw) {
         if (!provider?.id || !Array.isArray(provider.models)) continue;
         for (const model of provider.models) {
           if (model?.id) {
             const key = `${provider.id}.${model.id}`;
-            this.catwalkMap.set(key, normalizeCatwalkModel(provider.id, model));
+            nextMap.set(key, normalizeCatwalkModel(provider.id, model));
           }
         }
       }
+
+      this.catwalkMap = nextMap;
       this.initializedSources.add('catwalk');
       logger.debug(`Loaded ${this.catwalkMap.size} Catwalk models`);
+      return this.toSourceSummary('catwalk', this.catwalkMap);
     } catch (error) {
       logger.error('Failed to load Catwalk metadata', error);
+      return this.toSourceSummary(
+        'catwalk',
+        this.catwalkMap,
+        error instanceof Error ? error.message : String(error)
+      );
     }
   }
 
@@ -449,9 +595,7 @@ export class ModelMetadataManager {
     return file.json() as Promise<T>;
   }
 
-  private getMap(
-    source: 'openrouter' | 'models.dev' | 'catwalk'
-  ): Map<string, NormalizedModelMetadata> {
+  private getMap(source: MetadataSourceId): Map<string, NormalizedModelMetadata> {
     switch (source) {
       case 'openrouter':
         return this.openrouterMap;
@@ -533,6 +677,25 @@ export class ModelMetadataManager {
 
   public getAllIds(source: 'openrouter' | 'models.dev' | 'catwalk'): string[] {
     return Array.from(this.getMap(source).keys());
+  }
+
+  private toSourceSummary(
+    source: MetadataSourceId,
+    map: Map<string, NormalizedModelMetadata>,
+    error?: string
+  ): MetadataSourceRefreshSummary {
+    const initialized = map.size > 0 || this.initializedSources.has(source);
+
+    if (!initialized) {
+      this.initializedSources.delete(source);
+    }
+
+    return {
+      source,
+      initialized,
+      count: map.size,
+      ...(error ? { error } : {}),
+    };
   }
 }
 

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -457,7 +457,11 @@ export class ModelMetadataManager {
 
       if (nextMap.size === 0) {
         logger.warn('Invalid OpenRouter response format');
-        return this.toSourceSummary('openrouter', nextMap, 'Invalid OpenRouter response format');
+        return this.toSourceSummary(
+          'openrouter',
+          this.openrouterMap,
+          'Invalid OpenRouter response format'
+        );
       }
 
       this.openrouterMap = nextMap;
@@ -509,6 +513,15 @@ export class ModelMetadataManager {
         }
       }
 
+      if (nextMap.size === 0) {
+        logger.warn('Invalid models.dev response format');
+        return this.toSourceSummary(
+          'models.dev',
+          this.modelsDevMap,
+          'Invalid models.dev response format'
+        );
+      }
+
       this.modelsDevMap = nextMap;
       this.initializedSources.add('models.dev');
       logger.debug(`Loaded ${this.modelsDevMap.size} models.dev models`);
@@ -541,6 +554,11 @@ export class ModelMetadataManager {
             nextMap.set(key, normalizeCatwalkModel(provider.id, model));
           }
         }
+      }
+
+      if (nextMap.size === 0) {
+        logger.warn('Invalid Catwalk response format');
+        return this.toSourceSummary('catwalk', this.catwalkMap, 'Invalid Catwalk response format');
       }
 
       this.catwalkMap = nextMap;

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -361,6 +361,28 @@ export interface NormalizedModelMetadata {
   };
 }
 
+export interface ModelMetadataRefreshSourceSummary {
+  source: Exclude<MetadataSource, 'custom'>;
+  initialized: boolean;
+  count: number;
+  error?: string;
+}
+
+export interface ModelMetadataRefreshResult {
+  success: boolean;
+  message: string;
+  trigger: 'startup' | 'scheduled' | 'manual';
+  refreshedAt: string;
+  durationMs: number;
+  intervalMinutes: number;
+  hadErrors: boolean;
+  sources: {
+    openrouter: ModelMetadataRefreshSourceSummary;
+    modelsDev: ModelMetadataRefreshSourceSummary;
+    catwalk: ModelMetadataRefreshSourceSummary;
+  };
+}
+
 // Discriminated union mirrors backend validation: catalog-backed sources
 // must carry a non-empty source_path; 'custom' may omit it but MUST carry
 // an overrides blob with a non-empty `name` (there is no catalog fallback).
@@ -2579,6 +2601,17 @@ export const api = {
     }
     const json = (await res.json()) as { data: NormalizedModelMetadata };
     return json.data;
+  },
+
+  refreshModelMetadata: async (): Promise<ModelMetadataRefreshResult> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/models/metadata/refresh`, {
+      method: 'POST',
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to refresh model metadata');
+    }
+    return (await res.json()) as ModelMetadataRefreshResult;
   },
 
   getPiProviders: async (): Promise<string[]> => {

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -134,6 +134,7 @@ export const Config = () => {
   const [isFullBackupLoading, setIsFullBackupLoading] = useState(false);
   const [isRestoreLoading, setIsRestoreLoading] = useState(false);
   const [isResetLogsLoading, setIsResetLogsLoading] = useState(false);
+  const [isMetadataRefreshLoading, setIsMetadataRefreshLoading] = useState(false);
   const restoreInputRef = useRef<HTMLInputElement>(null);
 
   // Failover settings state
@@ -833,6 +834,22 @@ export const Config = () => {
     }
   };
 
+  const handleRefreshMetadata = async () => {
+    setIsMetadataRefreshLoading(true);
+    try {
+      const result = await api.refreshModelMetadata();
+      if (result.hadErrors) {
+        toast.warning(result.message);
+      } else {
+        toast.success(result.message);
+      }
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to refresh model metadata');
+    } finally {
+      setIsMetadataRefreshLoading(false);
+    }
+  };
+
   return (
     <div className="flex flex-col min-h-full">
       <PageHeader
@@ -1419,6 +1436,26 @@ export const Config = () => {
               </div>
             </div>
           </Disclosure>
+
+          <Card
+            title="Model Metadata"
+            extra={
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleRefreshMetadata}
+                isLoading={isMetadataRefreshLoading}
+                leftIcon={<RefreshCw size={14} />}
+              >
+                Refresh Metadata
+              </Button>
+            }
+          >
+            <p className="text-sm text-text-secondary">
+              Catalog metadata for model aliases auto-refreshes every 60 minutes. Use this to
+              trigger an immediate reload from OpenRouter, models.dev, and Catwalk.
+            </p>
+          </Card>
 
           <Card title="Backup & Restore">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
### **User description**
Add admin-only POST /v0/management/models/metadata/refresh to trigger an immediate reload of external model metadata catalogs from OpenRouter, models.dev, and Catwalk, returning per-source counts and any refresh errors.

Schedule automatic metadata refresh every 60 minutes, add plexus_operations refresh_metadata plumbing, and expose a frontend “Refresh Metadata” action in the Config page.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Adds manual metadata refresh endpoint

- Schedules hourly metadata catalog refresh

- Exposes UI and MCP refresh actions

- Documents endpoint and expands tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  startup["Backend startup"]
  timer["Hourly scheduler"]
  api["Management refresh endpoint"]
  manager["ModelMetadataManager"]
  sources["OpenRouter / models.dev / Catwalk"]
  ui["Config UI"]
  mcp["plexus_operations"]
  startup -- "startup refresh" --> manager
  timer -- "scheduled refresh" --> manager
  ui -- "manual POST" --> api
  mcp -- "refresh_metadata" --> api
  api -- "manual refresh" --> manager
  manager -- "reloads catalogs" --> sources
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Start scheduled metadata refresh on startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-2ef3cf9bf12d21de5f65f0c473654ec6d62ac76a214fbf53a4afa2d3a92e7bf3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.ts</strong><dd><code>Add metadata refresh management route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-82dd827df5d52aaa8bbe7cb8e30254e4101d2f22a14892c2dc0407ae5c0b3ae3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plexus.ts</strong><dd><code>Add `refresh_metadata` MCP operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-05736837540d6b374f8ee9f0cc8fdc561f10ed8be234df176c5dc411aac2f3ea">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>model-metadata-manager.ts</strong><dd><code>Implement refresh summaries and auto-refresh</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-91908d467a6fef34e3b7971ffe9496ed3e55c6d447a9c2e0561b98c44ca42025">+197/-34</a></td>

</tr>

<tr>
  <td><strong>api.ts</strong><dd><code>Add metadata refresh API client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-de192a0c5a6f3aadc6cd28e36145f7ba7abfb01b82cde5da92a25474e6af4c5f">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Config.tsx</strong><dd><code>Add Config refresh metadata action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-e3a23381e4585d8ddb0b1271cff13e17e7313d313b179778631136fc11579449">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>models.test.ts</strong><dd><code>Test manual metadata refresh management endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-35126211e4ddef5fc419dd53482f52afb3e8d1f87dbffc16596eb252427c99a7">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plexus-mcp-routes.test.ts</strong><dd><code>Test MCP metadata refresh operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-e22c94fc7757492a6d8772cddbd064b848fa7c8bf8584e5c019bddc5305240e4">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>model-metadata-manager.test.ts</strong><dd><code>Test refresh preservation and scheduling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-5a7fc0bd3ea06c9bb094434667d581c65a07abf96345be7e61b3385e231ae3b9">+59/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>openapi.yaml</strong><dd><code>Register metadata refresh OpenAPI path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-7f4bf89877b1b9af94cfd6b2a887cb9e0492a939f51ec62c48c1dd06cc61b7cc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>v0_management_models_metadata_refresh.yaml</strong><dd><code>Document metadata refresh endpoint contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mcowger/plexus/pull/576/files#diff-1805a136884fd4202c949a071d3d82d1fba10f9ec01297112595289d4ba48415">+108/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

model: gpt-5.5
fallback_models: []
git_provider: github
publish_output: True
publish_output_progress: True
progress_gif_url: 
progress_gif_width: 48
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
ai_timeout: 300
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
max_model_tokens: 32000
custom_model_max_tokens: -1
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: 
enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
