### PR TITLE
fix(quota): shorten hyper balance unit label

### DIFF
--- a/packages/backend/src/services/quota/checkers/__tests__/hyper-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/hyper-checker.test.ts
@@ -38,7 +38,7 @@ describe('hyper checker', () => {
     expect(capturedAuth).toBe('Bearer hyper-api-key');
     expect(meters).toHaveLength(1);
     expect(meters[0]?.kind).toBe('balance');
-    expect(meters[0]?.unit).toBe('hypercredits');
+    expect(meters[0]?.unit).toBe('credits');
     expect(meters[0]?.remaining).toBe(1711);
     expect(meters[0]?.label).toBe('Account balance');
   });

--- a/packages/backend/src/services/quota/checkers/hyper-checker.ts
+++ b/packages/backend/src/services/quota/checkers/hyper-checker.ts
@@ -43,7 +43,7 @@ export default defineChecker({
       ctx.balance({
         key: 'balance',
         label: 'Account balance',
-        unit: 'hypercredits',
+        unit: 'credits',
         remaining,
       }),
     ];


### PR DESCRIPTION
It's currently very long in the UI and the provider name usually ends up truncated.