### PR TITLE
Add Dependabot auto-merge workflow gated on PR Tests success

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,54 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+  workflow_run:
+    workflows: ["PR Tests"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # ── Approve Dependabot PRs immediately so they don't block on review ──
+  approve:
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Enable auto-merge only after PR Tests pass ──────────────────────────
+  merge:
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR number from workflow run
+        id: pr
+        run: |
+          PR_NUMBER=$(echo '${{ toJson(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "::notice::No PR associated with this workflow run, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.pr.outputs.skip == 'false'
+        run: |
+          AUTHOR=$(gh pr view "$PR_NUMBER" --json author -q '.author.login')
+          if [ "$AUTHOR" = "dependabot[bot]" ]; then
+            echo "Enabling auto-merge for Dependabot PR #$PR_NUMBER"
+            gh pr merge --auto --squash "$PR_NUMBER"
+          else
+            echo "Not a Dependabot PR (author: $AUTHOR), skipping"
+          fi
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -42,7 +42,15 @@ jobs:
       - name: Enable auto-merge for Dependabot PRs
         if: steps.pr.outputs.skip == 'false'
         run: |
-          AUTHOR=$(gh pr view "$PR_NUMBER" --json author -q '.author.login')
+          PR_DATA=$(gh pr view "$PR_NUMBER" --json author,headRefOid)
+          AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+          HEAD_SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
+
+          if [ "$HEAD_SHA" != "$WORKFLOW_HEAD_SHA" ]; then
+            echo "::notice::PR head changed since this workflow run ($WORKFLOW_HEAD_SHA -> $HEAD_SHA), skipping"
+            exit 0
+          fi
+
           if [ "$AUTHOR" = "dependabot[bot]" ]; then
             echo "Enabling auto-merge for Dependabot PR #$PR_NUMBER"
             gh pr merge --auto --squash "$PR_NUMBER"
@@ -51,4 +59,5 @@ jobs:
           fi
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -47,7 +47,7 @@ jobs:
           HEAD_SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
 
           if [ "$HEAD_SHA" != "$WORKFLOW_HEAD_SHA" ]; then
-            echo "::notice::PR head changed since this workflow run ($WORKFLOW_HEAD_SHA -> $HEAD_SHA), skipping"
+            echo "::notice::PR head changed since test run ($WORKFLOW_HEAD_SHA -> $HEAD_SHA), skipping"
             exit 0
           fi
 
@@ -60,4 +60,5 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **User description**
Add a GitHub Actions workflow that:

- Approves Dependabot pull requests created via `pull_request_target` so they do not require manual review.
- Waits for the `PR Tests` workflow run to complete successfully (`workflow_run` event).
- Finds the pull request associated with the completed `PR Tests` run.
- Enables auto-merge (squash) only when the PR author is `dependabot[bot]`.
- Skips auto-merge when no PR is associated with the workflow run or when the author is not Dependabot.


___

### **PR Type**
Enhancement


___

### **Description**
- Add Dependabot PR auto-approval workflow

- Gate auto-merge on passing `PR Tests`

- Enable squash auto-merge for Dependabot

- Skip missing or non-Dependabot PRs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pr["Dependabot PR"]
  approve["Auto-approve PR"]
  tests["PR Tests workflow"]
  passed["Tests passed"]
  merge["Enable squash auto-merge"]
  skip["Skip non-matching runs"]
  pr -- "pull_request_target" --> approve
  pr -- "triggers" --> tests
  tests -- "workflow_run success" --> passed
  passed -- "Dependabot author" --> merge
  passed -- "no PR or other author" --> skip
```



___

