### PR TITLE
fix(mcp): immediately flush reponse headers

### DIFF
--- a/packages/backend/src/routes/mcp/index.ts
+++ b/packages/backend/src/routes/mcp/index.ts
@@ -14,12 +14,11 @@ const DEFAULT_TIMEOUT_MS = 120000;
 // reply.send() buffers a streamed response head until the first body chunk,
 // which strands clients on MCP's long-lived idle SSE channels.
 async function streamUpstreamResponse(
-  request: FastifyRequest,
   reply: FastifyReply,
   status: number,
   upstreamHeaders: Record<string, string>,
   stream: ReadableStream<Uint8Array>
-): Promise<FastifyReply> {
+): Promise<void> {
   const headers: Record<string, string> = { ...upstreamHeaders };
 
   // Preserve the upstream content-type (it carries the session-bound SSE
@@ -44,7 +43,7 @@ async function streamUpstreamResponse(
   const onClose = () => {
     reader.cancel().catch(() => {});
   };
-  request.raw.on('close', onClose);
+  reply.raw.on('close', onClose);
 
   try {
     for (;;) {
@@ -59,11 +58,9 @@ async function streamUpstreamResponse(
   } catch (error) {
     logger.silly(`[mcp] Upstream stream error: ${(error as Error).message}`);
   } finally {
-    request.raw.removeListener('close', onClose);
+    reply.raw.removeListener('close', onClose);
     reply.raw.end();
   }
-
-  return reply;
 }
 
 export async function registerMcpRoutes(
@@ -235,13 +232,7 @@ export async function registerMcpRoutes(
 
         if (result.stream) {
           logger.silly(`Sending streaming response`);
-          return streamUpstreamResponse(
-            request,
-            reply,
-            result.status,
-            result.headers,
-            result.stream
-          );
+          return streamUpstreamResponse(reply, result.status, result.headers, result.stream);
         }
 
         if (result.body !== undefined) {
@@ -325,13 +316,7 @@ export async function registerMcpRoutes(
         }
 
         if (result.stream) {
-          return streamUpstreamResponse(
-            request,
-            reply,
-            result.status,
-            result.headers,
-            result.stream
-          );
+          return streamUpstreamResponse(reply, result.status, result.headers, result.stream);
         }
 
         if (result.body !== undefined) {

--- a/packages/backend/src/routes/mcp/index.ts
+++ b/packages/backend/src/routes/mcp/index.ts
@@ -9,6 +9,63 @@ import { registerPlexusMcpRoutes } from './plexus';
 
 const DEFAULT_TIMEOUT_MS = 120000;
 
+// streamUpstreamResponse proxies an upstream MCP event-stream to the client,
+// writing the head via reply.raw so it is flushed immediately. Fastify's
+// reply.send() buffers a streamed response head until the first body chunk,
+// which strands clients on MCP's long-lived idle SSE channels.
+async function streamUpstreamResponse(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  status: number,
+  upstreamHeaders: Record<string, string>,
+  stream: ReadableStream<Uint8Array>
+): Promise<FastifyReply> {
+  const headers: Record<string, string> = { ...upstreamHeaders };
+
+  // Preserve the upstream content-type (it carries the session-bound SSE
+  // framing); only default it when the upstream omitted one.
+  if (!Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')) {
+    headers['Content-Type'] = 'text/event-stream';
+  }
+  headers['Cache-Control'] = 'no-cache';
+  headers['Connection'] = 'keep-alive';
+
+  // Take over the response lifecycle so Fastify does not also try to send a
+  // reply, and write the head directly so it reaches the client immediately
+  // instead of being buffered until the first stream chunk.
+  reply.hijack();
+  reply.raw.writeHead(status, headers);
+  reply.raw.flushHeaders();
+
+  const reader = stream.getReader();
+
+  // Cancel the upstream read when the client disconnects so we do not leak the
+  // upstream fetch connection or its MCP session.
+  const onClose = () => {
+    reader.cancel().catch(() => {});
+  };
+  request.raw.on('close', onClose);
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        reply.raw.write(value);
+      }
+    }
+  } catch (error) {
+    logger.silly(`[mcp] Upstream stream error: ${(error as Error).message}`);
+  } finally {
+    request.raw.removeListener('close', onClose);
+    reply.raw.end();
+  }
+
+  return reply;
+}
+
 export async function registerMcpRoutes(
   fastify: FastifyInstance,
   mcpUsageStorage: McpUsageStorageService
@@ -178,11 +235,13 @@ export async function registerMcpRoutes(
 
         if (result.stream) {
           logger.silly(`Sending streaming response`);
-          reply.code(result.status);
-          reply.header('Content-Type', 'text/event-stream');
-          reply.header('Cache-Control', 'no-cache');
-          reply.header('Connection', 'keep-alive');
-          return reply.send(result.stream);
+          return streamUpstreamResponse(
+            request,
+            reply,
+            result.status,
+            result.headers,
+            result.stream
+          );
         }
 
         if (result.body !== undefined) {
@@ -266,11 +325,13 @@ export async function registerMcpRoutes(
         }
 
         if (result.stream) {
-          reply.code(result.status);
-          reply.header('Content-Type', 'text/event-stream');
-          reply.header('Cache-Control', 'no-cache');
-          reply.header('Connection', 'keep-alive');
-          return reply.send(result.stream);
+          return streamUpstreamResponse(
+            request,
+            reply,
+            result.status,
+            result.headers,
+            result.stream
+          );
         }
 
         if (result.body !== undefined) {


### PR DESCRIPTION
The MCP gateway proxied streaming responses with reply.send(stream). Fastify converts a web ReadableStream to a Node stream and forwards it through sendStream:

- https://github.com/fastify/fastify/blob/f15d4eaba03d86786bec2de7aed1236718c813f9/lib/reply.js#L684-L690

sendStream deliberately stages headers with res.setHeader() and defers res.writeHead() until there is data to send (so it can still emit an error status if the stream fails before producing output):

- https://github.com/fastify/fastify/blob/f15d4eaba03d86786bec2de7aed1236718c813f9/lib/reply.js#L733-L741

MCP streamable-HTTP servers open a long-lived GET SSE channel that is allowed to sit idle, sending no bytes until the server has a message to push. After writing the head, the Go SDK just blocks, writing nothing further until a message, cancellation, or close:

- https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server
- https://github.com/modelcontextprotocol/go-sdk/blob/d3fd25b68a4b966b5f788a0b49e4ddf3e6048992/mcp/streamable.go#L959-L965

With an idle upstream, that first chunk never arrives, so Fastify never writes the response head and downstream clients (e.g. the MCP Go SDK client) block awaiting headers until they time out. Stateful servers, which depend on this GET channel, become unusable through the proxy while stateless ones work fine.

Soooo stream proxied responses through reply.raw with reply.hijack() + writeHead() + flushHeaders(), forwarding chunks directly so the head reaches the client immediately regardless of upstream stream timing, and cancelling the upstream reader on client disconnect so a departed client does not leave the upstream fetch connection (and, for stateful servers, its MCP session) open indefinitely.

I (da model) didn't know of a good way to test these changes other than a script using the same approach to communicate with the server I'm seeing the issue with, which it did and which confirmed the fix fwiw.