### PR TITLE
fix: accept snake_case thinkingConfig fields from Gemini Python SDK

### DIFF
--- a/packages/backend/src/transformers/gemini/__tests__/request-builder.test.ts
+++ b/packages/backend/src/transformers/gemini/__tests__/request-builder.test.ts
@@ -300,6 +300,18 @@ describe('Gemini Request Builder', () => {
 
       expect(result.generationConfig?.thinkingConfig).toBeUndefined();
     });
+
+    it('should not emit thinkingConfig when reasoning.enabled is false', async () => {
+      const request: UnifiedChatRequest = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        model: 'gemini-2.5-flash',
+        reasoning: { enabled: false },
+      };
+
+      const result = await buildGeminiRequest(request);
+
+      expect(result.generationConfig?.thinkingConfig).toBeUndefined();
+    });
   });
 
   describe('Gap 5: Google built-in tools', () => {

--- a/packages/backend/src/transformers/gemini/__tests__/request-builder.test.ts
+++ b/packages/backend/src/transformers/gemini/__tests__/request-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildGeminiRequest } from '../request-builder';
+import { parseGeminiRequest } from '../request-parser';
 import type { UnifiedChatRequest, UnifiedToolConfig } from '../../../types/unified';
 
 // Helper to get first element with type narrowing
@@ -217,6 +218,87 @@ describe('Gemini Request Builder', () => {
       expect(decl.parametersJsonSchema).toBeDefined();
       // parameters is not output when parametersJsonSchema is present
       expect(decl.parameters).toBeUndefined();
+    });
+  });
+
+  describe('thinkingConfig building', () => {
+    it('should emit camelCase thinkingLevel from effort', async () => {
+      // SDK ThinkingConfig uses camelCase: includeThoughts, thinkingBudget, thinkingLevel
+      const request: UnifiedChatRequest = {
+        messages: [{ role: 'user', content: 'Think' }],
+        model: 'gemini-2.5-flash',
+        reasoning: { enabled: true, effort: 'medium' },
+      };
+
+      const result = await buildGeminiRequest(request);
+
+      expect(result.generationConfig?.thinkingConfig).toBeDefined();
+      expect(result.generationConfig?.thinkingConfig?.thinkingLevel).toBe('MEDIUM');
+      expect(result.generationConfig?.thinkingConfig?.includeThoughts).toBe(true);
+    });
+
+    it('should emit camelCase thinkingBudget from max_tokens', async () => {
+      const request: UnifiedChatRequest = {
+        messages: [{ role: 'user', content: 'Think' }],
+        model: 'gemini-2.5-flash',
+        reasoning: { enabled: true, max_tokens: 8192 },
+      };
+
+      const result = await buildGeminiRequest(request);
+
+      expect(result.generationConfig?.thinkingConfig?.thinkingBudget).toBe(8192);
+    });
+
+    it('should NOT emit snake_case thinking_budget or include_thoughts', async () => {
+      // Guards against re-introducing the snake_case bug on the outbound path
+      const request: UnifiedChatRequest = {
+        messages: [{ role: 'user', content: 'Think' }],
+        model: 'gemini-2.5-flash',
+        reasoning: { enabled: true, effort: 'high', max_tokens: 4096 },
+      };
+
+      const result = await buildGeminiRequest(request);
+      const tc = result.generationConfig?.thinkingConfig as any;
+
+      expect(tc).toBeDefined();
+      expect(tc.thinking_budget).toBeUndefined();
+      expect(tc.include_thoughts).toBeUndefined();
+      expect(tc.thinking_level).toBeUndefined();
+    });
+
+    it('should round-trip thinking config through parser then builder', async () => {
+      // Reproduces the bug from the trace: Python SDK sends snake_case thinkingConfig,
+      // parser must normalise to unified, builder must emit camelCase to the SDK.
+      const rawRequest = {
+        contents: [{ role: 'user', parts: [{ text: 'Think about this' }] }],
+        model: 'gemini-2.5-flash',
+        generationConfig: {
+          thinkingConfig: {
+            include_thoughts: true,
+            thinking_level: 'MEDIUM',
+          },
+        },
+      };
+
+      const unified = await parseGeminiRequest(rawRequest);
+      const rebuilt = await buildGeminiRequest(unified);
+
+      const tc = rebuilt.generationConfig?.thinkingConfig;
+      expect(tc).toBeDefined();
+      // Builder must emit camelCase (SDK ThinkingConfig field names)
+      expect(tc?.includeThoughts).toBe(true);
+      expect(tc?.thinkingLevel).toBe('MEDIUM');
+    });
+
+    it('should not emit thinkingConfig when reasoning is absent', async () => {
+      const request: UnifiedChatRequest = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        model: 'gemini-2.5-flash',
+      };
+
+      const result = await buildGeminiRequest(request);
+
+      expect(result.generationConfig?.thinkingConfig).toBeUndefined();
     });
   });
 

--- a/packages/backend/src/transformers/gemini/__tests__/request-parser.test.ts
+++ b/packages/backend/src/transformers/gemini/__tests__/request-parser.test.ts
@@ -226,6 +226,77 @@ describe('Gemini Request Parser', () => {
     });
   });
 
+  describe('thinkingConfig parsing', () => {
+    it('should parse snake_case include_thoughts and thinking_level', async () => {
+      const input = {
+        contents: [{ role: 'user', parts: [{ text: 'Think' }] }],
+        model: 'gemini-2.5-flash',
+        generationConfig: {
+          thinkingConfig: {
+            include_thoughts: true,
+            thinking_level: 'MEDIUM',
+          },
+        },
+      };
+
+      const result = await parseGeminiRequest(input);
+
+      expect(result.reasoning).toBeDefined();
+      expect(result.reasoning?.enabled).toBe(true);
+      expect(result.reasoning?.effort).toBe('medium');
+    });
+
+    it('should parse snake_case thinking_budget', async () => {
+      const input = {
+        contents: [{ role: 'user', parts: [{ text: 'Think' }] }],
+        model: 'gemini-2.5-flash',
+        generationConfig: {
+          thinkingConfig: {
+            include_thoughts: true,
+            thinking_budget: 8192,
+          },
+        },
+      };
+
+      const result = await parseGeminiRequest(input);
+
+      expect(result.reasoning).toBeDefined();
+      expect(result.reasoning?.enabled).toBe(true);
+      expect(result.reasoning?.max_tokens).toBe(8192);
+    });
+
+    it('should parse camelCase includeThoughts and thinkingBudget for backwards compatibility', async () => {
+      const input = {
+        contents: [{ role: 'user', parts: [{ text: 'Think' }] }],
+        model: 'gemini-2.5-flash',
+        generationConfig: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingBudget: 4096,
+          },
+        },
+      };
+
+      const result = await parseGeminiRequest(input);
+
+      expect(result.reasoning).toBeDefined();
+      expect(result.reasoning?.enabled).toBe(true);
+      expect(result.reasoning?.max_tokens).toBe(4096);
+    });
+
+    it('should produce no reasoning when thinkingConfig is absent', async () => {
+      const input = {
+        contents: [{ role: 'user', parts: [{ text: 'Hello' }] }],
+        model: 'gemini-2.5-flash',
+        generationConfig: {},
+      };
+
+      const result = await parseGeminiRequest(input);
+
+      expect(result.reasoning).toBeUndefined();
+    });
+  });
+
   describe('Gap 5: Google built-in tools', () => {
     it('should parse googleSearch tool', async () => {
       const input = {

--- a/packages/backend/src/transformers/gemini/request-builder.ts
+++ b/packages/backend/src/transformers/gemini/request-builder.ts
@@ -16,6 +16,7 @@ export interface GenerateContentRequest {
     thinkingConfig?: {
       includeThoughts?: boolean;
       thinkingBudget?: number;
+      thinkingLevel?: string;
     };
     [key: string]: any;
   };
@@ -203,6 +204,8 @@ export async function buildGeminiRequest(
     generationConfig.thinkingConfig = {
       includeThoughts: request.reasoning.enabled,
       thinkingBudget: request.reasoning.max_tokens,
+      // Map unified effort back to Gemini's ThinkingLevel enum values (MINIMAL/LOW/MEDIUM/HIGH)
+      thinkingLevel: request.reasoning.effort ? request.reasoning.effort.toUpperCase() : undefined,
     };
   }
 

--- a/packages/backend/src/transformers/gemini/request-builder.ts
+++ b/packages/backend/src/transformers/gemini/request-builder.ts
@@ -200,7 +200,7 @@ export async function buildGeminiRequest(
   }
 
   // Pass through thinking config
-  if (request.reasoning) {
+  if (request.reasoning && request.reasoning.enabled !== false) {
     generationConfig.thinkingConfig = {
       includeThoughts: request.reasoning.enabled,
       thinkingBudget: request.reasoning.max_tokens,

--- a/packages/backend/src/transformers/gemini/request-parser.ts
+++ b/packages/backend/src/transformers/gemini/request-parser.ts
@@ -67,11 +67,15 @@ export async function parseGeminiRequest(input: any): Promise<UnifiedChatRequest
   }
 
   // Map thinking config
+  // Accept both camelCase (includeThoughts, thinkingBudget, thinkingLevel) and
+  // snake_case (include_thoughts, thinking_budget, thinking_level) variants since
+  // some Gemini SDK clients send snake_case field names.
   if (generationConfig.thinkingConfig) {
-    const thinkingLevel = generationConfig.thinkingConfig.thinkingLevel as string | undefined;
+    const tc = generationConfig.thinkingConfig;
+    const thinkingLevel = (tc.thinkingLevel ?? tc.thinking_level) as string | undefined;
     unifiedChatRequest.reasoning = {
-      enabled: generationConfig.thinkingConfig.includeThoughts,
-      max_tokens: generationConfig.thinkingConfig.thinkingBudget,
+      enabled: tc.includeThoughts ?? tc.include_thoughts,
+      max_tokens: tc.thinkingBudget ?? tc.thinking_budget,
       // Map Gemini's thinkingLevel (NONE/LOW/MEDIUM/HIGH) to unified ThinkLevel
       effort: thinkingLevel ? (thinkingLevel.toLowerCase() as any) : undefined,
     };


### PR DESCRIPTION
### **User description**
## Problem

When a Gemini request goes through the full transform path (e.g. because an adapter like `reasoning_rewrite` is configured), the parser failed to read the thinking config fields that the Gemini Python SDK sends as snake_case over the wire (`include_thoughts`, `thinking_level`, `thinking_budget`).

The parser only read camelCase variants, so `reasoning` ended up as an all-undefined but truthy object. `buildGeminiRequest` then emitted `thinkingConfig: {}`, causing Gemini to return a 400 INVALID_ARGUMENT about a missing `thought_signature`.

## Root cause

The `reasoning_rewrite` adapter being configured for the provider causes `hasAdapters = true`, which suppresses passthrough and forces the full parse/transform path. On that path the snake_case mismatch bit.

## Fix

- **`request-parser.ts`:** Accept both snake_case and camelCase variants via `??` fallback.
- **`request-builder.ts`:** Emit camelCase field names (`includeThoughts`, `thinkingBudget`, `thinkingLevel`) matching the `@google/genai` SDK `ThinkingConfig` type, with `effort` mapped to the `ThinkingLevel` enum values.

## Tests

Added tests covering snake_case inbound parse, camelCase outbound emit, explicit assertions that wrong-casing is absent on each side, a full round-trip, and the no-reasoning case.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Accept snake_case Gemini thinking config

- Emit camelCase SDK thinking fields

- Map `reasoning.effort` to `thinkingLevel`

- Add parser, builder, round-trip tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Gemini request"] --> B["Parser accepts snake_case or camelCase"]
  B --> C["Unified reasoning fields"]
  C --> D["Builder emits camelCase thinkingConfig"]
  D --> E["Gemini SDK-compatible request"]
```



___

