### PR TITLE
feat(adapters): add web_search_coercion provider adapter

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -141,6 +141,7 @@ Adapters can be set at **provider level** (applied to every model under the prov
 | `reasoning_content` | Renames `reasoning` / `thinking.content` → `reasoning_content` on outbound assistant messages for providers that use Fireworks/DeepSeek field naming (e.g. Fireworks DeepSeek-R1). Fixes *"Extra inputs are not permitted, field: messages[N].reasoning"* errors. |
 | `suppress_developer_role` | Rewrites the `developer` role to `system` on outbound messages for providers that do not support the newer OpenAI `developer` role. |
 | `model_override` | Conditionally rewrites the provider model name based on request payload fields. Used for providers that expose reasoning variants as separate model names rather than respecting reasoning-related fields in the request body. See [Model Override Adapter](#model-override-adapter) below. |
+| `web_search_coercion` | Translates server-side web search tool entries to the format expected by the target provider. Clients can use any web search format; Plexus rewrites it transparently. See [Web Search Coercion Adapter](#web-search-coercion-adapter) below. |
 
 **Example — provider-level:**
 ```json
@@ -224,6 +225,73 @@ The `model_override` adapter is configured at **model level** only (not provider
 - The adapter operates on the **transformed provider payload**, so fields must survive API transformation to be matchable. For chat-to-chat requests, all fields from the original request body are preserved (including non-standard fields like `enable_thinking`, `thinking_budget`, etc.).
 - Multiple rules are evaluated in order; only the first matching rule applies.
 - The rewrite is transparent to the client — billing and usage tracking still reference the original canonical model name.
+
+### Web Search Coercion Adapter
+
+Different providers expose server-side web search under completely different tool type strings, making it impossible for a client to use a single request format across all providers. The `web_search_coercion` adapter solves this: configure the target format once on the provider, and Plexus rewrites every web search tool entry in the outgoing request automatically — regardless of which format the client sent.
+
+**Supported incoming formats** (any of these will be recognised and coerced):
+
+| Provider | Tool entry |
+|----------|-----------|
+| Anthropic | `{ "type": "web_search_20250305", "name": "web_search", "max_uses": N }` |
+| OpenAI | `{ "type": "web_search" }` |
+| OpenRouter | `{ "type": "openrouter:web_search" }` |
+| Google | `{ "googleSearch": {} }` / `{ "type": "googleSearch" }` |
+
+**Supported targets** (the format Plexus rewrites to):
+
+| `target` | Output tool entry | Provider |
+|----------|------------------|---------|
+| `anthropic` | `{ "type": "web_search_20250305", "name": "web_search" }` | Anthropic API |
+| `openai` | `{ "type": "web_search" }` | OpenAI Responses API |
+| `openrouter` | `{ "type": "openrouter:web_search" }` | OpenRouter |
+| `google` | `{ "googleSearch": {} }` | Google Gemini native API |
+
+The adapter operates transparently across **all four incoming API surfaces** (Chat Completions, Anthropic Messages, OpenAI Responses, and Gemini native) — a client using any of these APIs and any web search format will have its request correctly rewritten for the target provider.
+
+**Configuration:**
+
+Set the adapter on the provider that needs coercion. The only required option is `target`:
+
+```json
+PATCH /v0/management/providers/my-openrouter-provider
+{
+  "adapter": [
+    {
+      "name": "web_search_coercion",
+      "options": {
+        "target": "openrouter"
+      }
+    }
+  ]
+}
+```
+
+For the Anthropic target, an optional `max_uses` limits how many web searches are allowed per request:
+
+```json
+{
+  "name": "web_search_coercion",
+  "options": {
+    "target": "anthropic",
+    "max_uses": 5
+  }
+}
+```
+
+**Options:**
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `target` | `"anthropic"` \| `"openai"` \| `"openrouter"` \| `"google"` | Yes | The provider's expected web search tool format |
+| `max_uses` | integer | No | Maximum web searches per request. Anthropic target only; ignored for other targets. |
+
+**Notes:**
+- Non-web-search tools (regular function tools) in the same request are left untouched.
+- The adapter only fires when a web search tool is present; requests without web search tools have zero overhead.
+- For Google providers, web search coercion requires the **native Gemini API** endpoint (`/v1beta/models/...`). The OpenAI-compatible endpoint Google exposes does not support any web search tool format.
+- Pass-through optimisation is automatically disabled when any adapter is active.
 
 ### Provider Quota Checkers
 

--- a/docs/openapi/components/schemas/ProviderConfig.yaml
+++ b/docs/openapi/components/schemas/ProviderConfig.yaml
@@ -245,7 +245,7 @@ properties:
       Adapters can be specified as bare strings (backward compatible) or as
       objects with `{ name, options }` for adapters that require configuration.
 
-      Available adapters:
+       Available adapters:
 
       - `reasoning_content` — Renames `reasoning`/`thinking.content` →
         `reasoning_content` on outbound assistant messages. Fixes Fireworks/
@@ -271,6 +271,17 @@ properties:
         an optional `when` condition (with `op` and `value`), an array of
         `rewrites` (each with `target` and `value`), and optional `strip`
         paths to remove after rewriting.
+
+      - `web_search_coercion` — Translates server-side web search tool entries
+        to the format expected by this provider. Clients may send any known web
+        search tool format (`web_search_20250305`, `web_search`,
+        `openrouter:web_search`, or `googleSearch`); the adapter rewrites it
+        to the target provider's canonical shape. Accepts a `target` option
+        (`"anthropic"`, `"openai"`, `"openrouter"`, or `"google"`) and an
+        optional `max_uses` integer (Anthropic target only). Works transparently
+        across all four incoming API surfaces (Chat Completions, Anthropic
+        Messages, OpenAI Responses, and Gemini native).
+        See [`WebSearchCoercionAdapterOptions`](#/components/schemas/WebSearchCoercionAdapterOptions).
 
       Pass-through optimisation is automatically disabled when any adapter
       is active.

--- a/docs/openapi/components/schemas/WebSearchCoercionAdapterOptions.yaml
+++ b/docs/openapi/components/schemas/WebSearchCoercionAdapterOptions.yaml
@@ -1,0 +1,51 @@
+type: object
+description: >
+  Options for the `web_search_coercion` provider adapter.
+
+  This adapter translates server-side web search tool entries to the format
+  expected by the target provider, allowing clients to use any known web
+  search tool format regardless of which provider Plexus routes to.
+
+  **Recognised incoming formats:**
+
+  - Anthropic: `{ "type": "web_search_20250305", "name": "web_search" }`
+  - OpenAI: `{ "type": "web_search" }`
+  - OpenRouter: `{ "type": "openrouter:web_search" }`
+  - Google: `{ "googleSearch": {} }`
+
+  The adapter works across all four Plexus incoming API surfaces: Chat
+  Completions (`/v1/chat/completions`), Anthropic Messages (`/v1/messages`),
+  OpenAI Responses (`/v1/responses`), and Gemini native
+  (`/v1beta/models/{model}:generateContent`).
+required:
+  - target
+properties:
+  target:
+    type: string
+    enum:
+      - anthropic
+      - openai
+      - openrouter
+      - google
+    description: >
+      The provider's expected web search tool format.
+
+      | Value | Output tool entry | Provider |
+      |-------|------------------|---------|
+      | `anthropic` | `{ "type": "web_search_20250305", "name": "web_search" }` | Anthropic API |
+      | `openai` | `{ "type": "web_search" }` | OpenAI Responses API |
+      | `openrouter` | `{ "type": "openrouter:web_search" }` | OpenRouter |
+      | `google` | `{ "googleSearch": {} }` | Google Gemini native API |
+
+      **Note for `google`:** web search coercion requires the native Gemini
+      API endpoint. Google's OpenAI-compatible endpoint does not support any
+      web search tool format.
+  max_uses:
+    type: integer
+    minimum: 1
+    description: >
+      Maximum number of web searches allowed per request. Only honoured when
+      `target` is `"anthropic"` (maps to `max_uses` on the
+      `web_search_20250305` tool entry). Ignored for all other targets.
+example:
+  target: openrouter

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -555,6 +555,9 @@ paths:
   /register:
     $ref: paths/register.yaml
 components:
+  schemas:
+    WebSearchCoercionAdapterOptions:
+      $ref: ./components/schemas/WebSearchCoercionAdapterOptions.yaml
   securitySchemes:
     PlexusApiKey:
       type: http

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -119,6 +119,20 @@ export type ModelOverrideRule = z.infer<typeof ModelOverrideRuleSchema>;
 export type ModelOverrideOptions = z.infer<typeof ModelOverrideOptionsSchema>;
 export type AdapterEntry = z.infer<typeof AdapterEntrySchema>;
 
+// ─── Web Search Coercion Adapter Config ──────────────────────────────
+
+const WebSearchCoercionOptionsSchema = z.object({
+  /** The target provider web-search format to coerce incoming tools to. */
+  target: z.enum(['anthropic', 'openai', 'openrouter', 'google']),
+  /**
+   * Max number of web searches allowed (Anthropic only).
+   * Ignored when target is not 'anthropic'.
+   */
+  max_uses: z.number().int().positive().optional(),
+});
+
+export type WebSearchCoercionOptions = z.infer<typeof WebSearchCoercionOptionsSchema>;
+
 // ─── Reasoning Rewrite Adapter Config ────────────────────────────────
 
 const ValueTransformSchema = z.union([

--- a/packages/backend/src/transformers/adapters/__tests__/web-search-coercion.adapter.test.ts
+++ b/packages/backend/src/transformers/adapters/__tests__/web-search-coercion.adapter.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import {
+  webSearchCoercionAdapter,
+  isWebSearchTool,
+  buildTargetTool,
+} from '../web-search-coercion.adapter';
+
+// ── isWebSearchTool ────────────────────────────────────────────────────────
+
+describe('isWebSearchTool', () => {
+  it('recognises the Anthropic web search type', () => {
+    expect(isWebSearchTool({ type: 'web_search_20250305', name: 'web_search' })).toBe(true);
+  });
+
+  it('recognises the OpenAI web search type', () => {
+    expect(isWebSearchTool({ type: 'web_search' })).toBe(true);
+  });
+
+  it('recognises the OpenRouter web search type', () => {
+    expect(isWebSearchTool({ type: 'openrouter:web_search' })).toBe(true);
+  });
+
+  it('returns false for regular function tools', () => {
+    expect(
+      isWebSearchTool({ type: 'function', function: { name: 'get_weather', parameters: {} } })
+    ).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isWebSearchTool(null)).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(isWebSearchTool('web_search')).toBe(false);
+    expect(isWebSearchTool(42)).toBe(false);
+  });
+
+  it('returns false when type is missing', () => {
+    expect(isWebSearchTool({ name: 'web_search' })).toBe(false);
+  });
+});
+
+// ── buildTargetTool ────────────────────────────────────────────────────────
+
+describe('buildTargetTool', () => {
+  it('builds the Anthropic tool without max_uses', () => {
+    expect(buildTargetTool('anthropic')).toEqual({
+      type: 'web_search_20250305',
+      name: 'web_search',
+    });
+  });
+
+  it('builds the Anthropic tool with max_uses', () => {
+    expect(buildTargetTool('anthropic', 5)).toEqual({
+      type: 'web_search_20250305',
+      name: 'web_search',
+      max_uses: 5,
+    });
+  });
+
+  it('builds the OpenAI tool', () => {
+    expect(buildTargetTool('openai')).toEqual({ type: 'web_search' });
+  });
+
+  it('builds the OpenRouter tool', () => {
+    expect(buildTargetTool('openrouter')).toEqual({ type: 'openrouter:web_search' });
+  });
+});
+
+// ── webSearchCoercionAdapter.preDispatch ──────────────────────────────────
+
+describe('webSearchCoercionAdapter.preDispatch', () => {
+  // ── no-op cases ──────────────────────────────────────────────────────────
+
+  it('returns payload unchanged when options are missing', () => {
+    const payload = { model: 'gpt-4', tools: [{ type: 'web_search' }] };
+    expect(webSearchCoercionAdapter.preDispatch(payload)).toBe(payload);
+  });
+
+  it('returns payload unchanged when target is missing from options', () => {
+    const payload = { model: 'gpt-4', tools: [{ type: 'web_search' }] };
+    expect(webSearchCoercionAdapter.preDispatch(payload, { max_uses: 5 })).toBe(payload);
+  });
+
+  it('returns payload unchanged when tools array is empty', () => {
+    const payload = { model: 'gpt-4', tools: [] };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'anthropic' });
+    expect(result).toBe(payload);
+  });
+
+  it('returns payload unchanged when tools is not an array', () => {
+    const payload = { model: 'gpt-4' };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'anthropic' });
+    expect(result).toBe(payload);
+  });
+
+  it('returns payload unchanged when no web search tools are present', () => {
+    const payload = {
+      model: 'gpt-4',
+      tools: [{ type: 'function', function: { name: 'calculator', parameters: {} } }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'anthropic' });
+    expect(result).toBe(payload);
+  });
+
+  // ── coercion to anthropic ─────────────────────────────────────────────────
+
+  it('coerces OpenAI web_search → Anthropic format', () => {
+    const payload = {
+      model: 'claude-3-5-sonnet',
+      tools: [{ type: 'web_search' }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'anthropic' });
+    expect(result.tools).toEqual([{ type: 'web_search_20250305', name: 'web_search' }]);
+  });
+
+  it('coerces OpenRouter web_search → Anthropic format with max_uses', () => {
+    const payload = {
+      model: 'claude-3-5-sonnet',
+      tools: [{ type: 'openrouter:web_search' }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, {
+      target: 'anthropic',
+      max_uses: 3,
+    });
+    expect(result.tools).toEqual([
+      { type: 'web_search_20250305', name: 'web_search', max_uses: 3 },
+    ]);
+  });
+
+  it('keeps Anthropic format as-is when target is anthropic', () => {
+    const payload = {
+      model: 'claude-3-5-sonnet',
+      tools: [{ type: 'web_search_20250305', name: 'web_search', max_uses: 5 }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'anthropic' });
+    // It rewrites (since it matched), but output should be canonical Anthropic form
+    expect(result.tools).toEqual([{ type: 'web_search_20250305', name: 'web_search' }]);
+  });
+
+  // ── coercion to openai ────────────────────────────────────────────────────
+
+  it('coerces Anthropic web_search → OpenAI format', () => {
+    const payload = {
+      model: 'gpt-4o',
+      tools: [{ type: 'web_search_20250305', name: 'web_search', max_uses: 5 }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'openai' });
+    expect(result.tools).toEqual([{ type: 'web_search' }]);
+  });
+
+  it('coerces OpenRouter web_search → OpenAI format', () => {
+    const payload = {
+      model: 'gpt-4o',
+      tools: [{ type: 'openrouter:web_search' }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'openai' });
+    expect(result.tools).toEqual([{ type: 'web_search' }]);
+  });
+
+  // ── coercion to openrouter ────────────────────────────────────────────────
+
+  it('coerces Anthropic web_search → OpenRouter format', () => {
+    const payload = {
+      model: 'gpt-4o',
+      tools: [{ type: 'web_search_20250305', name: 'web_search' }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'openrouter' });
+    expect(result.tools).toEqual([{ type: 'openrouter:web_search' }]);
+  });
+
+  it('coerces OpenAI web_search → OpenRouter format', () => {
+    const payload = {
+      model: 'gpt-4o',
+      tools: [{ type: 'web_search' }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'openrouter' });
+    expect(result.tools).toEqual([{ type: 'openrouter:web_search' }]);
+  });
+
+  // ── mixed tools ───────────────────────────────────────────────────────────
+
+  it('only rewrites web-search tools, leaving other tools intact', () => {
+    const calculator = {
+      type: 'function',
+      function: { name: 'calculator', parameters: {} },
+    };
+    const payload = {
+      model: 'gpt-4o',
+      tools: [{ type: 'web_search' }, calculator],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'openrouter' });
+    expect(result.tools).toEqual([{ type: 'openrouter:web_search' }, calculator]);
+  });
+
+  it('rewrites multiple web search tools in one pass', () => {
+    const payload = {
+      model: 'gpt-4o',
+      // Unlikely in practice but the adapter should handle it
+      tools: [{ type: 'web_search' }, { type: 'openrouter:web_search' }],
+    };
+    const result = webSearchCoercionAdapter.preDispatch(payload, { target: 'anthropic' });
+    expect(result.tools).toHaveLength(2);
+    result.tools.forEach((t: any) => {
+      expect(t.type).toBe('web_search_20250305');
+    });
+  });
+
+  // ── payload immutability ──────────────────────────────────────────────────
+
+  it('does not mutate the original payload', () => {
+    const original = { model: 'gpt-4o', tools: [{ type: 'web_search' }] };
+    const copy = JSON.parse(JSON.stringify(original));
+    webSearchCoercionAdapter.preDispatch(original, { target: 'anthropic' });
+    expect(original).toEqual(copy);
+  });
+});
+
+// ── postDispatch / stream hooks ───────────────────────────────────────────
+
+describe('webSearchCoercionAdapter.postDispatch', () => {
+  it('returns the response unchanged', () => {
+    const response = { id: 'resp_123', choices: [] };
+    expect(webSearchCoercionAdapter.postDispatch(response)).toBe(response);
+  });
+});

--- a/packages/backend/src/transformers/adapters/index.ts
+++ b/packages/backend/src/transformers/adapters/index.ts
@@ -3,6 +3,7 @@ import { reasoningContentAdapter } from './reasoning-content.adapter';
 import { suppressDeveloperRoleAdapter } from './suppress-developer-role.adapter';
 import { modelOverrideAdapter } from './model-override.adapter';
 import { reasoningRewriteAdapter } from './reasoning-rewrite.adapter';
+import { webSearchCoercionAdapter } from './web-search-coercion.adapter';
 
 /**
  * Registry of all built-in provider adapters.
@@ -13,4 +14,5 @@ export const ADAPTER_REGISTRY: Record<string, ProviderAdapter> = {
   [suppressDeveloperRoleAdapter.name]: suppressDeveloperRoleAdapter,
   [modelOverrideAdapter.name]: modelOverrideAdapter,
   [reasoningRewriteAdapter.name]: reasoningRewriteAdapter,
+  [webSearchCoercionAdapter.name]: webSearchCoercionAdapter,
 };

--- a/packages/backend/src/transformers/adapters/web-search-coercion.adapter.ts
+++ b/packages/backend/src/transformers/adapters/web-search-coercion.adapter.ts
@@ -37,8 +37,17 @@ export const webSearchCoercionAdapter: ProviderAdapter = {
     if (!options?.target) return payload;
     if (!Array.isArray(payload.tools) || payload.tools.length === 0) return payload;
 
-    const target = options.target as WebSearchCoercionOptions['target'];
-    const maxUses = options.max_uses as number | undefined;
+    const target = options.target;
+    if (
+      target !== 'anthropic' &&
+      target !== 'openai' &&
+      target !== 'openrouter' &&
+      target !== 'google'
+    ) {
+      return payload;
+    }
+
+    const maxUses = typeof options.max_uses === 'number' ? options.max_uses : undefined;
 
     let didRewrite = false;
     const tools = payload.tools.map((tool: any) => {

--- a/packages/backend/src/transformers/adapters/web-search-coercion.adapter.ts
+++ b/packages/backend/src/transformers/adapters/web-search-coercion.adapter.ts
@@ -1,0 +1,106 @@
+import type { ProviderAdapter } from '../../types/provider-adapter';
+import type { WebSearchCoercionOptions } from '../../config';
+import { logger } from '../../utils/logger';
+
+/**
+ * web_search_coercion adapter
+ *
+ * Different providers expose server-side web search as differently-named tool
+ * entries in the `tools` array.  This adapter normalises any inbound web-search
+ * tool entry to the format expected by the target provider.
+ *
+ * Known formats:
+ *   - Anthropic  : { type: "web_search_20250305", name: "web_search", max_uses?: number }
+ *   - OpenAI     : { type: "web_search" }
+ *   - OpenRouter : { type: "openrouter:web_search" }
+ *   - Google     : { type: "googleSearch", googleSearch: {} }
+ *                  (used after the Gemini transformer converts unified → provider payload)
+ *
+ * Options schema (WebSearchCoercionOptions):
+ *   target: "anthropic" | "openai" | "openrouter" | "google"
+ *   max_uses?: number   (Anthropic only — ignored for other targets)
+ *
+ * Outbound (preDispatch):
+ *   - Any tool entry that matches one of the three known web-search type strings
+ *     is replaced with the target provider's canonical form.
+ *   - Non-web-search tools are left untouched.
+ *   - If no web-search tool is found, the payload is returned unchanged.
+ *
+ * Inbound (postDispatch): no-op — response shapes are not affected.
+ *
+ * Stream: no-op — tool definitions appear only in requests.
+ */
+export const webSearchCoercionAdapter: ProviderAdapter = {
+  name: 'web_search_coercion',
+
+  preDispatch(payload: Record<string, any>, options?: Record<string, any>): Record<string, any> {
+    if (!options?.target) return payload;
+    if (!Array.isArray(payload.tools) || payload.tools.length === 0) return payload;
+
+    const target = options.target as WebSearchCoercionOptions['target'];
+    const maxUses = options.max_uses as number | undefined;
+
+    let didRewrite = false;
+    const tools = payload.tools.map((tool: any) => {
+      if (!isWebSearchTool(tool)) return tool;
+
+      didRewrite = true;
+      return buildTargetTool(target, maxUses);
+    });
+
+    if (!didRewrite) return payload;
+
+    logger.debug(`web_search_coercion: rewrote web search tool(s) → target '${target}'`);
+
+    return { ...payload, tools };
+  },
+
+  postDispatch(response: Record<string, any>, _options?: Record<string, any>): Record<string, any> {
+    return response;
+  },
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** The known type strings that identify a server-side web-search tool. */
+const WEB_SEARCH_TYPES = new Set([
+  'web_search_20250305', // Anthropic
+  'web_search', // OpenAI
+  'openrouter:web_search', // OpenRouter
+  'googleSearch', // Google Gemini (post-transform unified form)
+]);
+
+/**
+ * Returns true when a tool entry represents a server-side web search tool
+ * from any of the three known providers.
+ */
+export function isWebSearchTool(tool: any): boolean {
+  if (!tool || typeof tool !== 'object') return false;
+  return WEB_SEARCH_TYPES.has(tool.type);
+}
+
+/**
+ * Build the canonical web search tool entry for the given target provider.
+ */
+export function buildTargetTool(
+  target: WebSearchCoercionOptions['target'],
+  maxUses?: number
+): Record<string, any> {
+  switch (target) {
+    case 'anthropic':
+      return {
+        type: 'web_search_20250305',
+        name: 'web_search',
+        ...(maxUses !== undefined ? { max_uses: maxUses } : {}),
+      };
+    case 'openai':
+      return { type: 'web_search' };
+    case 'openrouter':
+      return { type: 'openrouter:web_search' };
+    case 'google':
+      // The Gemini transformer converts unified googleSearch → { googleSearch: {} } in the
+      // provider payload. The adapter operates post-transform, so we emit the already-transformed
+      // Gemini REST shape directly.
+      return { googleSearch: {} };
+  }
+}

--- a/packages/backend/src/transformers/anthropic/tool-mapper.ts
+++ b/packages/backend/src/transformers/anthropic/tool-mapper.ts
@@ -5,28 +5,53 @@ import { UnifiedTool } from '../../types/unified';
  *
  * Anthropic uses: { name, description, input_schema }
  * Unified uses: { type: "function", function: { name, description, parameters } }
+ *
+ * Built-in Anthropic tools (e.g. web_search_20250305) are passed through as-is
+ * so they survive the round-trip and can be coerced by provider adapters.
  */
 export function convertAnthropicToolsToUnified(tools: any[]): UnifiedTool[] {
-  return tools.map((t) => ({
-    type: 'function',
-    function: {
-      name: t.name,
-      description: t.description,
-      parameters: t.input_schema,
-    },
-  }));
+  return tools.map((t: any) => {
+    // Pass through built-in Anthropic tool types verbatim
+    if (t.type && ANTHROPIC_BUILTIN_TOOL_TYPES.has(t.type)) {
+      return t as unknown as UnifiedTool;
+    }
+    return {
+      type: 'function' as const,
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.input_schema,
+      },
+    };
+  });
 }
+
+/**
+ * Anthropic built-in tool type strings that must be passed through as-is.
+ * These are server-side tools (e.g. web search) that Anthropic recognises by
+ * their `type` field and must NOT be mapped to the custom function schema.
+ */
+const ANTHROPIC_BUILTIN_TOOL_TYPES = new Set(['web_search_20250305']);
 
 /**
  * Converts unified tool format to Anthropic's format.
  *
  * Unified uses: { type: "function", function: { name, description, parameters }
  * Anthropic uses: { name, description, input_schema }
+ *
+ * Built-in Anthropic tools (e.g. web_search_20250305) are passed through
+ * unchanged — they are not function declarations and must not be rewritten.
  */
 export function convertUnifiedToolsToAnthropic(tools: UnifiedTool[]): any[] {
-  return tools.map((t) => ({
-    name: t.function?.name ?? '',
-    description: t.function?.description ?? '',
-    input_schema: t.function?.parameters ?? {},
-  }));
+  return tools.map((t: any) => {
+    // Pass through built-in Anthropic tool types verbatim
+    if (t.type && ANTHROPIC_BUILTIN_TOOL_TYPES.has(t.type)) {
+      return t;
+    }
+    return {
+      name: t.function?.name ?? '',
+      description: t.function?.description ?? '',
+      input_schema: t.function?.parameters ?? {},
+    };
+  });
 }

--- a/packages/backend/src/transformers/gemini/request-builder.ts
+++ b/packages/backend/src/transformers/gemini/request-builder.ts
@@ -144,8 +144,16 @@ export async function buildGeminiRequest(
         }
 
         functionDeclarations.push(funcDecl);
-      } else if (t.type === 'googleSearch') {
-        // Gap 5: Google built-in tools
+      } else if (
+        t.type === 'googleSearch' ||
+        // Coerce known cross-provider web search types to googleSearch so that
+        // clients using Anthropic/OpenAI/OpenRouter web search tool formats are
+        // transparently mapped to the Gemini built-in when routing to a Gemini provider.
+        (t as any).type === 'web_search_20250305' ||
+        (t as any).type === 'web_search' ||
+        (t as any).type === 'openrouter:web_search'
+      ) {
+        // Gap 5: Google built-in tools (including cross-provider web search coercion)
         googleSearches.push({});
       } else if (t.type === 'codeExecution') {
         codeExecutions.push({});

--- a/packages/backend/src/transformers/gemini/request-parser.ts
+++ b/packages/backend/src/transformers/gemini/request-parser.ts
@@ -120,6 +120,17 @@ export async function parseGeminiRequest(input: any): Promise<UnifiedChatRequest
       if (tool.urlContext) {
         unifiedTools.push({ type: 'urlContext' as const, urlContext: {} });
       }
+
+      // Coerce cross-provider web search types to googleSearch so clients
+      // using Anthropic/OpenAI/OpenRouter web search tool formats work transparently
+      // when routing to a Gemini provider via the native Gemini API.
+      if (
+        tool.type === 'web_search_20250305' ||
+        tool.type === 'web_search' ||
+        tool.type === 'openrouter:web_search'
+      ) {
+        unifiedTools.push({ type: 'googleSearch' as const, googleSearch: {} });
+      }
     }
 
     if (unifiedTools.length > 0) {

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -159,6 +159,9 @@ export class OpenAITransformer implements Transformer {
       content: response.content,
       reasoning_content: response.reasoning_content,
       tool_calls: response.tool_calls,
+      ...(response.annotations && response.annotations.length > 0
+        ? { annotations: response.annotations }
+        : {}),
     };
 
     return {

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -53,8 +53,9 @@ export class ResponsesTransformer implements Transformer {
       });
     }
 
-    // Convert tools (filter out built-in tools that Chat Completions doesn't support)
-    const tools = this.convertToolsForChatCompletions(input.tools || []);
+    // Convert tools — built-in server-side tools (web search etc.) are passed through
+    // so provider adapters can coerce them; only function tools are reformatted.
+    const tools = this.convertToolsForUnified(input.tools || []);
 
     return {
       requestId: input.requestId,
@@ -154,13 +155,20 @@ export class ResponsesTransformer implements Transformer {
         : JSON.stringify(systemMessage.content)
       : undefined;
 
-    // Convert tools to Responses API format
-    const tools = request.tools?.map((tool) => ({
-      type: 'function',
-      name: tool.function?.name ?? '',
-      description: tool.function?.description ?? '',
-      parameters: tool.function?.parameters ?? {},
-    }));
+    // Convert tools to Responses API format.
+    // Non-function tools (e.g. server-side web search types like "web_search",
+    // "web_search_20250305", "openrouter:web_search") are passed through as-is
+    // so that provider adapters can coerce them to the correct format before
+    // the HTTP call is made.
+    const tools = request.tools?.map((tool: any) => {
+      if (tool.type !== 'function' || !tool.function) return tool;
+      return {
+        type: 'function',
+        name: tool.function?.name ?? '',
+        description: tool.function?.description ?? '',
+        parameters: tool.function?.parameters ?? {},
+      };
+    });
 
     const payload: any = {
       model: request.model,
@@ -228,6 +236,27 @@ export class ResponsesTransformer implements Transformer {
       const messageItem = response.output?.find((item: any) => item.type === 'message');
       const content = messageItem?.content?.map((part: any) => part.text).join('\n') || null;
 
+      // Collect url_citation annotations from all output_text content parts
+      const annotations: any[] = [];
+      for (const part of messageItem?.content ?? []) {
+        if (Array.isArray(part.annotations)) {
+          for (const ann of part.annotations) {
+            if (ann.type === 'url_citation') {
+              annotations.push({
+                type: 'url_citation',
+                url_citation: {
+                  url: ann.url,
+                  title: ann.title,
+                  content: ann.text ?? ann.content,
+                  start_index: ann.start_index,
+                  end_index: ann.end_index,
+                },
+              });
+            }
+          }
+        }
+      }
+
       // Find reasoning output item
       const reasoningItem = response.output?.find((item: any) => item.type === 'reasoning');
       const reasoningParts = reasoningItem?.content?.length
@@ -241,6 +270,7 @@ export class ResponsesTransformer implements Transformer {
         created: response.created_at || Math.floor(Date.now() / 1000),
         content,
         reasoning_content,
+        annotations: annotations.length > 0 ? annotations : undefined,
         tool_calls: undefined, // TODO: Extract from function_call output items if needed
         usage,
       };
@@ -450,7 +480,8 @@ export class ResponsesTransformer implements Transformer {
   }
 
   /**
-   * Filters out built-in tools and converts function tools
+   * Filters out built-in tools and converts function tools.
+   * Used when routing Responses API → Chat Completions (outbound transform).
    */
   private convertToolsForChatCompletions(tools: any[]): any[] {
     return tools
@@ -464,6 +495,27 @@ export class ResponsesTransformer implements Transformer {
           strict: tool.strict,
         },
       }));
+  }
+
+  /**
+   * Converts incoming Responses API tools to unified format.
+   * Function tools are reformatted; non-function tools (built-in server-side
+   * tools like web_search, web_search_20250305, openrouter:web_search) are
+   * passed through as-is so provider adapters can coerce them.
+   */
+  private convertToolsForUnified(tools: any[]): any[] {
+    return tools.map((tool) => {
+      if (tool.type !== 'function') return tool;
+      return {
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+          strict: tool.strict,
+        },
+      };
+    });
   }
 
   /**

--- a/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
@@ -32,7 +32,20 @@ export const KNOWN_ADAPTERS: { value: string; label: string; description: string
     description:
       'Rewrites reasoning/thinking fields to provider-specific formats (e.g. enable_thinking, budget_tokens, thinking.type).',
   },
+  {
+    value: 'web_search_coercion',
+    label: 'Web Search Coercion',
+    description:
+      'Coerces server-side web search tool entries to the format expected by this provider (Anthropic, OpenAI, or OpenRouter).',
+  },
 ];
+
+const WEB_SEARCH_TARGETS = [
+  { value: 'anthropic', label: 'Anthropic (web_search_20250305)' },
+  { value: 'openai', label: 'OpenAI (web_search)' },
+  { value: 'openrouter', label: 'OpenRouter (openrouter:web_search)' },
+  { value: 'google', label: 'Google (googleSearch)' },
+] as const;
 
 interface Props {
   editingProvider: Provider;
@@ -183,7 +196,10 @@ export function ProviderAdvancedEditor({
                 </div>
                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px' }}>
                   {KNOWN_ADAPTERS.filter(
-                    (a) => a.value !== 'model_override' && a.value !== 'reasoning_rewrite'
+                    (a) =>
+                      a.value !== 'model_override' &&
+                      a.value !== 'reasoning_rewrite' &&
+                      a.value !== 'web_search_coercion'
                   ).map((a) => {
                     const adapterEntries: any[] = editingProvider.adapter ?? [];
                     const active = adapterEntries.some(
@@ -232,6 +248,158 @@ export function ProviderAdvancedEditor({
                     );
                   })}
                 </div>
+
+                {/* Web Search Coercion — inline options editor */}
+                {(() => {
+                  const adapterEntries: any[] = editingProvider.adapter ?? [];
+                  const entry = adapterEntries.find(
+                    (e: any) => (typeof e === 'string' ? e : e.name) === 'web_search_coercion'
+                  );
+                  const active = !!entry;
+                  const currentTarget: string = entry?.options?.target ?? '';
+                  const currentMaxUses: string =
+                    entry?.options?.max_uses != null ? String(entry.options.max_uses) : '';
+
+                  const toggleActive = () => {
+                    const current: any[] = editingProvider.adapter ?? [];
+                    const next = active
+                      ? current.filter(
+                          (e: any) => (typeof e === 'string' ? e : e.name) !== 'web_search_coercion'
+                        )
+                      : [
+                          ...current,
+                          {
+                            name: 'web_search_coercion',
+                            options: { target: 'openai' },
+                          },
+                        ];
+                    setEditingProvider({ ...editingProvider, adapter: next });
+                  };
+
+                  const updateOptions = (patch: Record<string, any>) => {
+                    const current: any[] = editingProvider.adapter ?? [];
+                    const next = current.map((e: any) => {
+                      const name = typeof e === 'string' ? e : e.name;
+                      if (name !== 'web_search_coercion') return e;
+                      return { name: 'web_search_coercion', options: { ...e.options, ...patch } };
+                    });
+                    setEditingProvider({ ...editingProvider, adapter: next });
+                  };
+
+                  return (
+                    <div
+                      style={{
+                        gridColumn: '1 / -1',
+                        padding: '4px 8px',
+                        borderRadius: 'var(--radius-sm)',
+                        border: '1px solid var(--color-border-glass)',
+                        background: active ? 'var(--color-bg-hover)' : 'var(--color-bg-glass)',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '6px',
+                      }}
+                    >
+                      {/* Header row: checkbox + label */}
+                      <label
+                        style={{
+                          display: 'flex',
+                          alignItems: 'flex-start',
+                          gap: '8px',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={active}
+                          style={{ marginTop: '2px', flexShrink: 0 }}
+                          onChange={toggleActive}
+                        />
+                        <div>
+                          <div className="font-body text-[12px] font-medium text-text">
+                            Web Search Coercion
+                          </div>
+                          <div
+                            className="font-body text-[11px] text-text-secondary"
+                            style={{ lineHeight: 1.35 }}
+                          >
+                            Coerces server-side web search tool entries to the format expected by
+                            this provider.
+                          </div>
+                        </div>
+                      </label>
+
+                      {/* Options — only shown when active */}
+                      {active && (
+                        <div
+                          style={{
+                            display: 'flex',
+                            gap: '8px',
+                            alignItems: 'flex-end',
+                            flexWrap: 'wrap',
+                          }}
+                        >
+                          {/* Target dropdown */}
+                          <div className="flex flex-col gap-0.5" style={{ flex: '1 1 160px' }}>
+                            <label className="font-body text-[11px] font-medium text-text-secondary">
+                              Target Format
+                            </label>
+                            <select
+                              className="w-full py-1 pl-2 pr-2 font-body text-[12px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                              value={currentTarget}
+                              onChange={(e) => updateOptions({ target: e.target.value })}
+                            >
+                              <option value="">— select —</option>
+                              {WEB_SEARCH_TARGETS.map((t) => (
+                                <option key={t.value} value={t.value}>
+                                  {t.label}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+
+                          {/* max_uses — only relevant for Anthropic */}
+                          {currentTarget === 'anthropic' && (
+                            <div className="flex flex-col gap-0.5" style={{ flex: '0 1 110px' }}>
+                              <label className="font-body text-[11px] font-medium text-text-secondary">
+                                Max Uses
+                                <span className="font-normal text-[10px] text-text-muted ml-1">
+                                  optional
+                                </span>
+                              </label>
+                              <input
+                                className="w-full py-1 pl-2 pr-2 font-body text-[12px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                                type="number"
+                                min="1"
+                                step="1"
+                                placeholder="No limit"
+                                value={currentMaxUses}
+                                onChange={(e) => {
+                                  const raw = e.target.value;
+                                  if (raw === '') {
+                                    // Remove max_uses from options
+                                    const current: any[] = editingProvider.adapter ?? [];
+                                    const next = current.map((e2: any) => {
+                                      const name = typeof e2 === 'string' ? e2 : e2.name;
+                                      if (name !== 'web_search_coercion') return e2;
+                                      const { max_uses: _removed, ...rest } = e2.options ?? {};
+                                      return { name: 'web_search_coercion', options: rest };
+                                    });
+                                    setEditingProvider({ ...editingProvider, adapter: next });
+                                  } else {
+                                    const num = parseInt(raw, 10);
+                                    if (Number.isFinite(num) && num >= 1) {
+                                      updateOptions({ max_uses: num });
+                                    }
+                                  }
+                                }}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
               </div>
             )}
           </div>


### PR DESCRIPTION
### **User description**
## Summary

Adds a new `web_search_coercion` provider adapter that transparently translates server-side web search tool entries to the format expected by each provider. This lets clients use any web search format and have Plexus rewrite it correctly for the target provider — without any changes to the client.

## Problem

Different providers use completely different type strings for server-side web search:

| Provider | Tool entry |
|----------|-----------|
| Anthropic | `{ "type": "web_search_20250305", "name": "web_search" }` |
| OpenAI | `{ "type": "web_search" }` |
| OpenRouter | `{ "type": "openrouter:web_search" }` |
| Google Gemini | `{ "googleSearch": {} }` |

Without coercion, a request written for one provider's format is rejected by every other provider.

## Solution

A new `web_search_coercion` adapter configured on the provider with a single `target` option (`anthropic`, `openai`, `openrouter`, or `google`). Any of the four incoming formats is recognised and rewritten to the target's canonical shape.

```json
PATCH /v0/management/providers/my-openrouter-provider
{
  "adapter": [{
    "name": "web_search_coercion",
    "options": { "target": "openrouter" }
  }]
}
```

The adapter works across **all four incoming API surfaces**: Chat Completions, Anthropic Messages, OpenAI Responses, and Gemini native.

## Changes

### New adapter
- `packages/backend/src/transformers/adapters/web-search-coercion.adapter.ts` — adapter implementation
- `packages/backend/src/transformers/adapters/__tests__/web-search-coercion.adapter.test.ts` — 27 unit tests
- `packages/backend/src/config.ts` — `WebSearchCoercionOptionsSchema` Zod schema + exported type
- `packages/backend/src/transformers/adapters/index.ts` — registered in `ADAPTER_REGISTRY`
- `packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx` — inline UI in Provider Adapters section (checkbox + target dropdown + optional max_uses)

### Transformer passthrough fixes (uncovered during testing)
- **`anthropic/tool-mapper.ts`** — both `convertAnthropicToolsToUnified` and `convertUnifiedToolsToAnthropic` now pass through built-in tool types (`web_search_20250305`) verbatim instead of mangling them as function tools
- **`responses.ts` parseRequest** — non-function tools now survive into the unified request instead of being filtered out by `convertToolsForChatCompletions`
- **`responses.ts` transformResponse** — `url_citation` annotations from Responses API output blocks are now extracted into `UnifiedChatResponse.annotations`
- **`openai.ts` formatResponse** — `annotations` now included in the `message` object when present (previously silently dropped)
- **`gemini/request-parser.ts`** — recognises `web_search_20250305`, `web_search`, and `openrouter:web_search` and coerces them to `googleSearch` in the unified form
- **`gemini/request-builder.ts`** — also recognises the three cross-provider web search types as aliases for `googleSearch` in the outbound Gemini payload

### Documentation
- `docs/CONFIGURATION.md` — new **Web Search Coercion Adapter** section with full reference
- `docs/openapi/components/schemas/ProviderConfig.yaml` — adapter description updated
- `docs/openapi/components/schemas/WebSearchCoercionAdapterOptions.yaml` — new schema component
- `docs/openapi/openapi.yaml` — schema registered in `components/schemas`

## Testing

All 1834 tests pass. End-to-end matrix tested against live providers:

| Provider / Incoming API | Result | Coerced to |
|------------------------|--------|-----------|
| anthropic / chat | OK | `web_search_20250305` |
| anthropic / messages | OK | `web_search_20250305` |
| anthropic / responses | OK | `web_search_20250305` |
| openai-s / chat | OK | `web_search` |
| openai-s / messages | OK | `web_search` |
| openai-s / responses | OK | `web_search` |
| openrouter-s / chat | OK | `openrouter:web_search` |
| openrouter-s / messages | OK | `openrouter:web_search` |
| openrouter-s / responses | OK | `openrouter:web_search` |
| google-s / gemini | OK | `{ googleSearch: {} }` |


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Add `web_search_coercion` provider adapter

- Preserve built-in tools across transformers

- Surface web citation annotations

- Add UI, docs, and tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  client["Client web-search tools"]
  transformer["API transformers"]
  adapter["web_search_coercion adapter"]
  provider["Target provider format"]
  docsui["Provider UI and docs"]
  tests["Unit tests"]
  client -- "parse and preserve" --> transformer
  transformer -- "coerce tools" --> adapter
  adapter -- "emit canonical" --> provider
  docsui -- "configure target" --> adapter
  tests -- "verify behavior" --> adapter
```



___

