### PR TITLE
fix(openai-transformer): fall back to delta.reasoning when reasoning_content absent

### DIFF
--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -142,7 +142,7 @@ export class OpenAITransformer implements Transformer {
       model: response.model,
       created: response.created,
       content: message?.content || null,
-      reasoning_content: message?.reasoning_content || null,
+      reasoning_content: message?.reasoning_content ?? message?.reasoning ?? null,
       tool_calls: message?.tool_calls,
       usage,
       finishReason: choice?.finish_reason || null,
@@ -210,7 +210,7 @@ export class OpenAITransformer implements Transformer {
                 delta: {
                   role: choice?.delta?.role,
                   content: choice?.delta?.content,
-                  reasoning_content: choice?.delta?.reasoning_content,
+                  reasoning_content: choice?.delta?.reasoning_content ?? choice?.delta?.reasoning,
                   tool_calls: choice?.delta?.tool_calls,
                 },
                 finish_reason:


### PR DESCRIPTION
### **User description**
## Problem

Providers such as kilocode/Friendli emit reasoning text in `delta.reasoning` (OpenRouter convention) rather than `delta.reasoning_content`. The OpenAI transformer only read `reasoning_content`, so all reasoning chunks were silently dropped while the token count was still recorded in usage.

This was identified via debug trace `c4d13188-3d30-4114-8c62-e32f7bb2bafe`: the raw upstream stream contained 31 reasoning-token chunks with `delta.reasoning` populated, but the transformed output showed all those chunks with empty content and no reasoning field.

## Fix

Two-line change in `packages/backend/src/transformers/openai.ts`:

- **`transformStream()`**: `choice?.delta?.reasoning_content ?? choice?.delta?.reasoning`
- **`transformResponse()`**: `message?.reasoning_content ?? message?.reasoning ?? null`

Providers that already use `reasoning_content` are unaffected (the `??` fallback only triggers when `reasoning_content` is absent/undefined).


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve OpenRouter reasoning fields

- Add streaming reasoning fallback

- Add non-streaming reasoning fallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  upstream["Upstream OpenAI-compatible response"]
  transformer["OpenAI transformer"]
  output["Unified response with reasoning_content"]
  upstream -- "reasoning_content or reasoning" --> transformer
  transformer -- "normalizes fallback" --> output
```



___

