### PR TITLE
feat(models): enable sticky sessions by default for new and unconfigured aliases

### DIFF
--- a/packages/backend/src/__tests__/config-sticky-session.test.ts
+++ b/packages/backend/src/__tests__/config-sticky-session.test.ts
@@ -37,11 +37,11 @@ describe('ModelConfigSchema sticky_session parsing', () => {
     expect(cfg.models?.['test-alias']?.sticky_session).toBe(false);
   });
 
-  it('defaults sticky_session to false when not provided', () => {
+  it('defaults sticky_session to true when not provided', () => {
     const cfg = validateConfig(configWithAlias({}));
-    // Schema is `.default(false).optional()` — same pattern as the sibling
-    // booleans on this schema, so missing input parses to false.
-    expect(cfg.models?.['test-alias']?.sticky_session).toBe(false);
+    // Schema is `.default(true).optional()` — missing input parses to true so
+    // sticky sessions are enabled by default for new models.
+    expect(cfg.models?.['test-alias']?.sticky_session).toBe(true);
   });
 
   it('rejects non-boolean sticky_session', () => {

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -769,7 +769,7 @@ export const ModelConfigSchema = z
     // previous turn of the same conversation (when still healthy and present
     // in the alias targets). Tracked in-memory only; see
     // services/sticky-session-manager.ts.
-    sticky_session: z.boolean().default(true).optional(),
+    sticky_session: z.boolean().default(true),
     // Advertised in GET /v1/models to inform clients of the preferred API surface(s)
     // for this alias, even if plexus can translate between them.
     preferred_api: z

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -769,7 +769,7 @@ export const ModelConfigSchema = z
     // previous turn of the same conversation (when still healthy and present
     // in the alias targets). Tracked in-memory only; see
     // services/sticky-session-manager.ts.
-    sticky_session: z.boolean().default(false).optional(),
+    sticky_session: z.boolean().default(true).optional(),
     // Advertised in GET /v1/models to inform clients of the preferred API surface(s)
     // for this alias, even if plexus can translate between them.
     preferred_api: z

--- a/packages/frontend/src/components/models/ModelBehaviorsEditor.tsx
+++ b/packages/frontend/src/components/models/ModelBehaviorsEditor.tsx
@@ -125,7 +125,7 @@ export function ModelBehaviorsEditor({ editingAlias, setEditingAlias }: Props) {
                 </p>
               </div>
               <Switch
-                checked={editingAlias.sticky_session || false}
+                checked={editingAlias.sticky_session ?? true}
                 onChange={(val) => setEditingAlias({ ...editingAlias, sticky_session: val })}
                 size="sm"
               />

--- a/packages/frontend/src/hooks/useModels.ts
+++ b/packages/frontend/src/hooks/useModels.ts
@@ -27,6 +27,7 @@ const EMPTY_ALIAS: Alias = {
   aliases: [],
   priority: 'selector',
   target_groups: [{ name: 'default', selector: 'random', targets: [] }],
+  sticky_session: true,
 };
 
 const IMPORT_SUPPRESSIONS_STORAGE_KEY = 'plexus_suppressed_import_models';

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1879,7 +1879,7 @@ export const api = {
       additional_aliases: alias.aliases,
       use_image_fallthrough: alias.use_image_fallthrough || false,
       enforce_limits: alias.enforce_limits || false,
-      sticky_session: alias.sticky_session || false,
+      sticky_session: alias.sticky_session ?? true,
       ...(alias.preferred_api &&
         alias.preferred_api.length > 0 && {
           preferred_api: alias.preferred_api,
@@ -2007,7 +2007,7 @@ export const api = {
           target_groups: targetGroups,
           use_image_fallthrough: val.use_image_fallthrough || false,
           enforce_limits: val.enforce_limits || false,
-          sticky_session: val.sticky_session || false,
+          sticky_session: val.sticky_session ?? true,
           advanced: val.advanced || [],
           metadata: val.metadata,
           model_architecture: val.model_architecture,


### PR DESCRIPTION
### **User description**
## Summary

Changes `sticky_session` to default to `true` instead of `false` for model aliases where no explicit value has been set.

## Changes

- **`packages/backend/src/config.ts`** — Zod schema default changed from `false` to `true`; config files without an explicit `sticky_session` key now parse to `true`
- **`packages/frontend/src/lib/api.ts`** — Changed `|| false` to `?? true` in `saveAlias` and alias list parsing so explicit `false` is preserved but unset values default to `true`
- **`packages/frontend/src/components/models/ModelBehaviorsEditor.tsx`** — Same `??` fix for the checkbox `checked` prop
- **`packages/frontend/src/hooks/useModels.ts`** — Added `sticky_session: true` to `EMPTY_ALIAS` so new aliases created via the UI start with sticky sessions enabled
- **`packages/backend/src/__tests__/config-sticky-session.test.ts`** — Updated default-value test to expect `true`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Default aliases enable sticky sessions

- Preserve explicit disabled sticky sessions

- Initialize new UI aliases enabled

- Update sticky-session default test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Missing sticky_session"] -- "defaults to" --> B["Enabled sticky sessions"]
  C["Explicit false"] -- "preserved by" --> D["Nullish coalescing"]
  E["New UI alias"] -- "starts with" --> B
```



___

