### PR TITLE
fix(quota-scheduler): remove duplicate log line on checker failure

### DIFF
--- a/packages/backend/src/routes/inference/__tests__/auth.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/auth.test.ts
@@ -42,6 +42,7 @@ describe('Auth Middleware', () => {
       models: {
         'gpt-4': {
           priority: 'selector',
+          sticky_session: false,
           targets: [{ provider: 'openai', model: 'gpt-4' }],
         },
       },
@@ -220,6 +221,7 @@ describe('Key Attribution', () => {
       models: {
         'gpt-4': {
           priority: 'selector',
+          sticky_session: false,
           targets: [{ provider: 'openai', model: 'gpt-4' }],
         },
       },
@@ -452,6 +454,7 @@ describe('Key Access Policy Propagation', () => {
       models: {
         'gpt-4': {
           priority: 'selector',
+          sticky_session: false,
           targets: [{ provider: 'openai', model: 'gpt-4' }],
         },
       },
@@ -561,6 +564,7 @@ describe('Key Access Policy Exclusion Propagation', () => {
       models: {
         'gpt-4': {
           priority: 'selector',
+          sticky_session: false,
           targets: [{ provider: 'openai', model: 'gpt-4' }],
         },
       },
@@ -638,6 +642,7 @@ describe('Key IP Allowlist', () => {
       models: {
         'gpt-4': {
           priority: 'selector',
+          sticky_session: false,
           targets: [{ provider: 'openai', model: 'gpt-4' }],
         },
       },
@@ -710,6 +715,7 @@ describe('Trusted Proxy Header Handling', () => {
       models: {
         'gpt-4': {
           priority: 'selector',
+          sticky_session: false,
           targets: [{ provider: 'openai', model: 'gpt-4' }],
         },
       },

--- a/packages/backend/src/routes/inference/__tests__/beta-key-routing.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/beta-key-routing.test.ts
@@ -55,6 +55,7 @@ async function createApp(): Promise<{
     models: {
       'test-model': {
         priority: 'selector',
+        sticky_session: false,
         targets: [{ provider: 'test-provider', model: 'test-model' }],
       },
     },

--- a/packages/backend/src/routes/inference/__tests__/embeddings.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/embeddings.test.ts
@@ -26,6 +26,7 @@ const EMBEDDINGS_TEST_CONFIG = {
   models: {
     'embeddings-small': {
       priority: 'selector' as const,
+      sticky_session: false,
       targets: [{ provider: 'openai', model: 'text-embedding-3-small' }],
     },
   },

--- a/packages/backend/src/routes/inference/__tests__/transcriptions-debug.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/transcriptions-debug.test.ts
@@ -114,6 +114,7 @@ describe('Transcriptions Debug Logging', () => {
         'transcription-model': {
           type: 'transcriptions',
           priority: 'selector',
+          sticky_session: false,
           targets: [{ provider: 'openai', model: 'whisper-1' }],
         },
       },

--- a/packages/backend/src/routes/inference/__tests__/transcriptions.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/transcriptions.test.ts
@@ -58,6 +58,7 @@ const TRANSCRIPTIONS_TEST_CONFIG = {
     'transcription-model': {
       type: 'transcriptions' as const,
       priority: 'selector' as const,
+      sticky_session: false,
       targets: [{ provider: 'openai', model: 'whisper-1' }],
     },
   },

--- a/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
@@ -88,6 +88,7 @@ describe('Plexus management MCP routes', () => {
       models: {
         'gpt-5': {
           priority: 'selector',
+          sticky_session: false,
           selector: 'random',
           target_groups: [
             {

--- a/packages/backend/src/services/quota/quota-scheduler.ts
+++ b/packages/backend/src/services/quota/quota-scheduler.ts
@@ -108,7 +108,6 @@ export class QuotaScheduler {
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      logger.error(`Quota checker '${checkerId}' threw an exception: ${message}`);
       result = {
         checkerId,
         checkerType: config.type,


### PR DESCRIPTION
### **User description**
When a quota checker throws an exception, it was logging two lines:
- `[error]` from the catch block
- `[warn]` from the generic `!result.success` check

The warn covers all failure cases (exceptions included), so the error log in the catch block is redundant. Removed it.

Also fixes pre-existing TypeScript errors in test fixtures where `sticky_session` was missing after it was made required in #597.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Remove duplicate quota exception logging

- Add `sticky_session` to test configs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Quota checker exception"] -- "records failure result" --> B["Generic failure warning"]
  C["Test config fixtures"] -- "explicitly set" --> D["sticky_session false"]
```



___

