### PR TITLE
ci: move job-level skip conditions to step level for green status checks

### DIFF
--- a/.github/workflows/check-no-migrations-in-pr.yml
+++ b/.github/workflows/check-no-migrations-in-pr.yml
@@ -10,10 +10,10 @@ jobs:
   check-migrations:
     name: Block migration files in PR
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'migrations-ok') }}
     steps:
       - name: Check author association
         id: author-check
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'migrations-ok') }}
         run: |
           ASSOC="${{ github.event.pull_request.author_association }}"
           SENDER="${{ github.event.pull_request.user.login }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,10 +13,11 @@ permissions:
 jobs:
   # ── Approve Dependabot PRs immediately so they don't block on review ──
   approve:
-    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Approve PR
+        if: github.actor == 'dependabot[bot]'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -24,11 +25,12 @@ jobs:
 
   # ── Enable auto-merge only after PR Tests pass ──────────────────────────
   merge:
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     steps:
       - name: Get PR number from workflow run
         id: pr
+        if: github.event.workflow_run.conclusion == 'success'
         run: |
           PR_NUMBER=$(echo '${{ toJson(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
@@ -40,7 +42,7 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.pr.outputs.skip == 'false'
+        if: steps.pr.conclusion == 'success' && steps.pr.outputs.skip == 'false'
         run: |
           PR_DATA=$(gh pr view "$PR_NUMBER" --json author,headRefOid)
           AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')

--- a/.github/workflows/pr-agent-review.yml
+++ b/.github/workflows/pr-agent-review.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   pr-agent:
-    if: github.event.sender.type != 'Bot' || github.event.sender.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
     env:
       PR_AGENT_LLM_API_KEY: ${{ secrets.LLM_API_KEY }}:${{ github.repository }}|${{ github.workflow }}|${{ github.job }}


### PR DESCRIPTION
### **User description**
## Problem

When workflow jobs have a job-level `if:` condition that evaluates to false, GitHub marks the entire job as **Skipped** (grey circle), not green. This makes the PR status check circle show grey even when nothing is actually wrong.

## Fix

Move conditional logic from job-level `if:` down to step-level `if:` so the job always runs and completes green. When conditions aren't met, individual steps are skipped but the job itself succeeds.

### Changes

- **`dependabot-auto-merge.yml`** — `approve` job: moved `actor == dependabot[bot]` check to step level; `merge` job: moved `conclusion == 'success'` check to step level
- **`check-no-migrations-in-pr.yml`** — moved `migrations-ok` label check from job level to the first step; all downstream steps naturally skip via their existing step-level conditions
- **`pr-agent-review.yml`** — removed redundant bot-sender job-level `if:` entirely; the preflight step already handles this filtering correctly

### Not changed

- **`pi-assistant-issue.yml` / `pi-assistant-pr.yml`** — structurally mutually exclusive (both on `issue_comment`, split by PR vs issue); one will always skip. Fixing requires merging into a single workflow.
- **`dev-release.yml`** — intentional deploy gate (main/dispatch only), should stay as-is.


___

### **PR Type**
Bug fix


___

### **Description**
- Avoid skipped workflow status checks

- Gate migration check at step level

- Gate Dependabot approve and merge steps

- Let PR Agent preflight filter bots


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Job-level conditions"]
  B["Step-level guards"]
  C["Jobs complete successfully"]
  D["Green PR status checks"]
  A -- "move filters" --> B
  B -- "skip steps only" --> C
  C -- "report" --> D
```



___

