### PR TITLE
feat(logs): add E2E throughput metric to Perf column

### DIFF
--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -1497,6 +1497,15 @@ export const Logs = () => {
                                 : null;
                           const liveDuration =
                             rawDurationMs != null ? formatMs(rawDurationMs) : '-';
+                          // End-to-end throughput: total output tokens / full request duration.
+                          // Unlike TPS (which excludes the TTFT delay), E2E includes it.
+                          const e2e =
+                            log.durationMs != null &&
+                            log.durationMs > 0 &&
+                            log.tokensOutput &&
+                            log.tokensOutput > 0
+                              ? log.tokensOutput / (log.durationMs / 1000)
+                              : null;
                           if (progress) {
                             return (
                               <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -1554,6 +1563,15 @@ export const Logs = () => {
                                 {log.tokensPerSec && log.tokensPerSec > 0
                                   ? `TPS: ${formatTPS(log.tokensPerSec)}`
                                   : ''}
+                              </span>
+                              <span
+                                style={{
+                                  color: 'var(--color-text-secondary)',
+                                  fontSize: '0.85em',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {e2e != null ? `E2E: ${formatTPS(e2e)}` : ''}
                               </span>
                             </div>
                           );


### PR DESCRIPTION
### **User description**
## Summary

Adds an **E2E** (end-to-end) throughput metric to the Perf column in the Logs table, alongside the existing TTFT and TPS rows.

## Rationale

- **TTFT** shows the time-to-first-token delay.
- **TPS** shows post-TTFT generation throughput (excludes the TTFT delay).
- **E2E** shows effective throughput from the user's perspective: `total output tokens / full request duration`, which **includes the TTFT delay**.

E2E is always ≤ TPS, and captures the real experienced throughput — useful for comparing models where a high TPS is undermined by a long startup delay.

## Implementation

In `packages/frontend/src/pages/Logs.tsx`, within the desktop table Perf cell:

```ts
const e2e =
  log.durationMs != null &&
  log.durationMs > 0 &&
  log.tokensOutput &&
  log.tokensOutput > 0
    ? log.tokensOutput / (log.durationMs / 1000)
    : null;
```

Rendered as a new `<span>` styled identically to the TTFT/TPS rows, using the existing `formatTPS` formatter. It only displays for completed requests (uses real `log.durationMs`, not the live pending fallback) and renders empty when data is missing so it stays out of the way for non-streaming/failed/pending requests.

## Verification

- [x] Type check passes — no TypeScript errors
- [x] Pre-commit hooks pass (biome format/lint, frontend build, typecheck)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds E2E throughput to Perf

- Computes tokens over completed duration

- Displays alongside TTFT and TPS


___

### Diagram Walkthrough


```mermaid
flowchart LR
  log["Log duration and output tokens"]
  calc["Compute E2E throughput"]
  perf["Render Perf column metric"]
  log -- "valid completed request" --> calc
  calc -- "format as TPS" --> perf
```



___

