### PR TITLE
Set custom model max tokens for PR agent

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,7 @@
 [config]
 output_relevant_configurations = false
 ai_timeout = 300
+custom_model_max_tokens = 256000
 
 [pr_description]
 enable_semantic_files_types = false  # suppress the File Walkthrough section


### PR DESCRIPTION
Update `.pr_agent.toml` to set `custom_model_max_tokens = 256000` under the `[config]` section.

This increases the token limit used by the PR agent when handling custom models.