### PR TITLE
fix(gemini,responses): preserve native fields on same-format transforms

### DIFF
--- a/packages/backend/src/transformers/__tests__/gemini-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/gemini-request-roundtrip.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { parseGeminiRequest } from '../gemini/request-parser';
+import { buildGeminiRequest } from '../gemini/request-builder';
+import type { UnifiedChatRequest } from '../../types/unified';
+
+/**
+ * Round-trip tests for the Gemini transformer.
+ *
+ * These mirror the Anthropic round-trip regression tests (PR #617). They cover
+ * the case where a same-format (gemini -> gemini) transform takes the
+ * non-pass-through path (e.g. adapter active, vision fallthrough) and would
+ * otherwise drop Gemini-native fields that the unified schema does not model:
+ *   - top-level: safetySettings, cachedContent, labels
+ *   - generationConfig extras: topP, topK, stopSequences, responseLogprobs
+ *
+ * On the common pass-through path the verbatim originalBody is sent regardless,
+ * so these only matter when pass-through is suppressed.
+ */
+
+const GEMINI_REQUEST = {
+  contents: [
+    {
+      role: 'user',
+      parts: [{ text: 'Summarize the latest news.' }],
+    },
+  ],
+  model: 'gemini-2.5-flash',
+  generationConfig: {
+    maxOutputTokens: 1024,
+    temperature: 0.7,
+    topP: 0.9,
+    topK: 40,
+    stopSequences: ['END'],
+    responseLogprobs: true,
+    logprobs: 5,
+  },
+  safetySettings: [{ category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' }],
+  cachedContent: 'cachedContents/example',
+  labels: { team: 'research', env: 'staging' },
+};
+
+describe('Gemini gemini -> gemini round-trip preserves native fields', () => {
+  it('preserves top-level safetySettings, cachedContent, labels', async () => {
+    const unified = await parseGeminiRequest(GEMINI_REQUEST);
+    const built = await buildGeminiRequest({
+      ...unified,
+      incomingApiType: 'gemini',
+      originalBody: GEMINI_REQUEST,
+    });
+
+    const builtAny = built as any;
+    expect(builtAny.safetySettings).toEqual([
+      { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
+    ]);
+    expect(builtAny.cachedContent).toBe('cachedContents/example');
+    expect(builtAny.labels).toEqual({ team: 'research', env: 'staging' });
+  });
+
+  it('preserves unmapped generationConfig keys (topP, topK, stopSequences, logprobs)', async () => {
+    const unified = await parseGeminiRequest(GEMINI_REQUEST);
+    const built = await buildGeminiRequest({
+      ...unified,
+      incomingApiType: 'gemini',
+      originalBody: GEMINI_REQUEST,
+    });
+
+    const gc = built.generationConfig as any;
+    expect(gc.topP).toBe(0.9);
+    expect(gc.topK).toBe(40);
+    expect(gc.stopSequences).toEqual(['END']);
+    expect(gc.responseLogprobs).toBe(true);
+    expect(gc.logprobs).toBe(5);
+  });
+
+  it('explicitly-mapped generationConfig fields still override originalBody', async () => {
+    const unified = await parseGeminiRequest(GEMINI_REQUEST);
+    // Simulate the unified pipeline overriding maxOutputTokens
+    const built = await buildGeminiRequest({
+      ...unified,
+      max_tokens: 2048,
+      incomingApiType: 'gemini',
+      originalBody: GEMINI_REQUEST,
+    });
+
+    const gc = built.generationConfig as any;
+    // Explicit mapping wins over originalBody
+    expect(gc.maxOutputTokens).toBe(2048);
+    // But unmapped originalBody keys are still preserved
+    expect(gc.topP).toBe(0.9);
+  });
+
+  it('does not pollute cross-format (non-gemini) transforms with originalBody fields', async () => {
+    const unified = await parseGeminiRequest(GEMINI_REQUEST);
+    // No incomingApiType/originalBody → cross-format path (e.g. chat -> gemini)
+    const built = await buildGeminiRequest(unified as UnifiedChatRequest);
+
+    const builtAny = built as any;
+    expect(builtAny.safetySettings).toBeUndefined();
+    expect(builtAny.cachedContent).toBeUndefined();
+    expect(builtAny.labels).toBeUndefined();
+  });
+});

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { ResponsesTransformer } from '../responses';
+
+/**
+ * Round-trip tests for the Responses API transformer.
+ *
+ * These mirror the Anthropic round-trip regression tests (PR #617). They cover
+ * the case where a same-format (responses -> responses) transform takes the
+ * non-pass-through path (e.g. adapter active, vision fallthrough) and would
+ * otherwise drop Responses-API-native fields that the unified schema does not
+ * model: user, store, background, service_tier, truncation, metadata, top_p,
+ * previous_response_id, conversation, stream_options, etc.
+ *
+ * On the common pass-through path the verbatim originalBody is sent regardless,
+ * so these only matter when pass-through is suppressed.
+ */
+
+const RESPONSES_REQUEST = {
+  model: 'gpt-4o',
+  input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Hello' }] }],
+  stream: true,
+  max_output_tokens: 1024,
+  temperature: 0.7,
+  top_p: 0.9,
+  top_logprobs: 3,
+  max_tool_calls: 5,
+  instructions: 'Be concise.',
+  reasoning: { effort: 'medium' },
+  include: ['reasoning.encrypted_content'],
+  prompt_cache_key: 'cache-1',
+  parallel_tool_calls: true,
+  text: { format: { type: 'text' } },
+  user: 'user-abc',
+  store: true,
+  background: false,
+  service_tier: 'auto',
+  truncation: 'auto',
+  metadata: { session: 's1' },
+  previous_response_id: 'resp_prev_1',
+  conversation: 'conv_1',
+  prompt_cache_retention: '24h',
+  safety_identifier: 'si-1',
+  stream_options: { include_obfuscation: true },
+};
+
+describe('Responses responses -> responses round-trip preserves native fields', () => {
+  it('preserves top-level user, store, background, service_tier, truncation', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+    const built = await transformer.transformRequest({
+      ...unified,
+      incomingApiType: 'responses',
+      originalBody: RESPONSES_REQUEST,
+    });
+
+    expect(built.user).toBe('user-abc');
+    expect(built.store).toBe(true);
+    expect(built.background).toBe(false);
+    expect(built.service_tier).toBe('auto');
+    expect(built.truncation).toBe('auto');
+  });
+
+  it('preserves metadata, previous_response_id, conversation, stream_options', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+    const built = await transformer.transformRequest({
+      ...unified,
+      incomingApiType: 'responses',
+      originalBody: RESPONSES_REQUEST,
+    });
+
+    expect(built.metadata).toEqual({ session: 's1' });
+    expect(built.previous_response_id).toBe('resp_prev_1');
+    expect(built.conversation).toBe('conv_1');
+    expect(built.stream_options).toEqual({ include_obfuscation: true });
+    expect(built.prompt_cache_retention).toBe('24h');
+    expect(built.safety_identifier).toBe('si-1');
+  });
+
+  it('preserves sampling params top_p, top_logprobs, max_tool_calls', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+    const built = await transformer.transformRequest({
+      ...unified,
+      incomingApiType: 'responses',
+      originalBody: RESPONSES_REQUEST,
+    });
+
+    expect(built.top_p).toBe(0.9);
+    expect(built.top_logprobs).toBe(3);
+    expect(built.max_tool_calls).toBe(5);
+  });
+
+  it('explicitly-mapped fields still override originalBody', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+    // Simulate the unified pipeline overriding max_output_tokens
+    const built = await transformer.transformRequest({
+      ...unified,
+      max_tokens: 4096,
+      incomingApiType: 'responses',
+      originalBody: RESPONSES_REQUEST,
+    });
+
+    // Explicit mapping wins over originalBody
+    expect(built.max_output_tokens).toBe(4096);
+    // But unmapped originalBody fields are still preserved
+    expect(built.user).toBe('user-abc');
+  });
+
+  it('does not pollute cross-format (non-responses) transforms with originalBody fields', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+    // Strip incomingApiType/originalBody to simulate a cross-format path
+    // (e.g. chat -> responses), where the guard must not fire.
+    const { incomingApiType, originalBody, ...rest } = unified;
+    const built = await transformer.transformRequest(rest);
+
+    expect(built.user).toBeUndefined();
+    expect(built.store).toBeUndefined();
+    expect(built.service_tier).toBeUndefined();
+    expect(built.stream_options).toBeUndefined();
+  });
+});

--- a/packages/backend/src/transformers/gemini/request-builder.ts
+++ b/packages/backend/src/transformers/gemini/request-builder.ts
@@ -225,5 +225,30 @@ export async function buildGeminiRequest(
     generationConfig,
   };
 
+  // For same-format (gemini -> gemini) requests that take the non-pass-through
+  // path (e.g. adapter active, vision fallthrough), carry through Gemini-native
+  // top-level fields that the unified schema does not model. The unified schema
+  // intentionally abstracts away provider-specific options (safetySettings,
+  // cachedContent, labels, etc.) so cross-format transforms don't drop them on
+  // the floor when the client is talking the same API type as the upstream
+  // provider. Only fields not already set by the explicit mapping above are
+  // carried through, so the unified pipeline output is never overridden.
+  if (request.incomingApiType?.toLowerCase() === 'gemini' && request.originalBody) {
+    const passthroughFields = ['safetySettings', 'cachedContent', 'labels'];
+    for (const field of passthroughFields) {
+      if (request.originalBody[field] !== undefined && (req as any)[field] === undefined) {
+        (req as any)[field] = request.originalBody[field];
+      }
+    }
+
+    // Merge unmapped generationConfig keys (e.g. topP, topK, stopSequences,
+    // responseLogprobs, logprobs) that the explicit mapping above didn't set.
+    const originalGenConfig = request.originalBody.generationConfig;
+    if (originalGenConfig && typeof originalGenConfig === 'object') {
+      const mergedGenConfig: any = { ...originalGenConfig, ...req.generationConfig };
+      req.generationConfig = mergedGenConfig;
+    }
+  }
+
   return req;
 }

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -214,6 +214,38 @@ export class ResponsesTransformer implements Transformer {
       };
     }
 
+    // For same-format (responses -> responses) requests that take the
+    // non-pass-through path (e.g. adapter active, vision fallthrough), carry
+    // through Responses-API-native top-level fields that the explicit mapping
+    // above does not set. The unified schema intentionally abstracts away
+    // provider-specific options so cross-format transforms don't drop them on
+    // the floor when the client is talking the same API type as the upstream
+    // provider. Only fields not already set are carried through, so the
+    // unified pipeline output is never overridden.
+    if (request.incomingApiType?.toLowerCase() === 'responses' && request.originalBody) {
+      const passthroughFields = [
+        'user',
+        'store',
+        'background',
+        'service_tier',
+        'truncation',
+        'metadata',
+        'top_p',
+        'top_logprobs',
+        'max_tool_calls',
+        'previous_response_id',
+        'conversation',
+        'prompt_cache_retention',
+        'safety_identifier',
+        'stream_options',
+      ];
+      for (const field of passthroughFields) {
+        if (request.originalBody[field] !== undefined && payload[field] === undefined) {
+          payload[field] = request.originalBody[field];
+        }
+      }
+    }
+
     return payload;
   }
 


### PR DESCRIPTION
### **User description**
## Summary

Follow-up to #617. That PR added same-format (`messages → messages`) native-field preservation to the **Anthropic** transformer and fixed the dispatcher to allow pass-through even when adapters are active. This PR mirrors the same-format preservation pattern across the other two same-format-capable transformers that were missing it: **Gemini** and **Responses**.

The **OpenAI `chat`** transformer already had this pattern, so no change was needed there.

## Background

PR #617's three fixes:
1. Dispatcher no longer suppresses pass-through when adapters are active.
2. Anthropic `request-builder` carries through native top-level fields on same-format non-pass-through paths.
3. Per-block `cache_control` and tool-level extras preserved.

Fix #1 is global and already covers the **common** same-format case (`gemini → gemini`, `responses → responses`, etc.) — the verbatim `originalBody` is sent regardless of what the builder does. The transformer-level preservation is **defense-in-depth** for the non-pass-through branches:
- an adapter is active (now runs on the pass-through payload, so largely covered), or
- `_hasVisionFallthrough`, or
- `isPiAiRoute`.

The OpenAI `chat` builder already handled this explicitly (spreads `originalBody`, overlays mapped fields). Gemini and Responses did not, so on any non-pass-through same-format path they silently dropped native fields the unified schema doesn't model.

## Changes

**`gemini/request-builder.ts`**
For `incomingApiType === 'gemini' && originalBody`:
- Carry through top-level `safetySettings`, `cachedContent`, `labels` (only if not already set).
- Merge unmapped `generationConfig` keys (`topP`, `topK`, `stopSequences`, `responseLogprobs`, `logprobs`, …); the explicitly-mapped config takes precedence.

**`responses.ts`**
For `incomingApiType === 'responses' && originalBody`:
- Carry through `user`, `store`, `background`, `service_tier`, `truncation`, `metadata`, `top_p`, `top_logprobs`, `max_tool_calls`, `previous_response_id`, `conversation`, `prompt_cache_retention`, `safety_identifier`, `stream_options` (only if not already set by the explicit mapping).

## Tests

Mirroring `anthropic-request-roundtrip.test.ts`:
- New `gemini-request-roundtrip.test.ts` (4 tests)
- New `responses-request-roundtrip.test.ts` (5 tests)

Both cover: field preservation, explicit-override-wins, and the cross-format non-pollution guard.

## Verification

- `bun run typecheck` — clean
- Lefthook pre-commit: backend-tests (1850 passed), biome-format, biome-lint, typecheck all green
- No schema/migration changes


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Preserve Gemini-native fields (`safetySettings`, `cachedContent`, `labels`) on same-format transforms

- Merge unmapped `generationConfig` keys (`topP`, `topK`, `stopSequences`, `logprobs`) in Gemini request builder

- Preserve Responses-API-native fields (`user`, `store`, `service_tier`, `metadata`, `stream_options`, etc.) on same-format transforms

- Add round-trip tests for Gemini and Responses transformers covering preservation, override-wins, and cross-format non-pollution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Same-format request"] -- "non-pass-through path" --> B["Transformer"]
  B -- "Gemini builder" --> C["Carry safetySettings, cachedContent, labels, genConfig extras"]
  B -- "Responses builder" --> D["Carry user, store, service_tier, metadata, stream_options, etc."]
  C --> E["Native fields preserved"]
  D --> E
  F["Round-trip tests"] -- "verify preservation & non-pollution" --> E
```



___

