### PR TITLE
fix(skills): correct debug log paths and staging env vars in plexus-management skill

### DIFF
--- a/.agents/skills/plexus-management/SKILL.md
+++ b/.agents/skills/plexus-management/SKILL.md
@@ -9,13 +9,13 @@ Use the Plexus management API through portable `curl` and `jq` commands. Do not 
 
 ## First Steps
 
-1. Require a base URL. Prefer `PLEXUS_BASE_URL`; if absent, ask the user for the Plexus URL.
-2. Require an admin key. All admin requests need `x-admin-key`; prefer `PLEXUS_ADMIN_KEY`. If absent, ask the user for it and do not proceed with admin calls until provided.
+1. Require a base URL. Prefer `PLEXUS_STAGING_URL`; if absent, ask the user for the Plexus URL and do not proceed until provided.
+2. Require an admin key. All admin requests need `x-admin-key`; prefer `PLEXUS_STAGING_ADMIN_KEY`. If absent, ask the user for it and do not proceed with admin calls until provided.
 3. Verify access before making changes:
 
 ```bash
-curl -fsS "$PLEXUS_BASE_URL/v0/management/auth/verify" \
-  -H "x-admin-key: $PLEXUS_ADMIN_KEY" | jq .
+curl -fsS "$PLEXUS_STAGING_URL/v0/management/auth/verify" \
+  -H "x-admin-key: $PLEXUS_STAGING_ADMIN_KEY" | jq .
 ```
 
 4. For read operations, use `GET` first and summarize findings. For write/delete/restore operations, inspect current state first and explain the intended change before issuing the mutating request.
@@ -23,11 +23,11 @@ curl -fsS "$PLEXUS_BASE_URL/v0/management/auth/verify" \
 Use this short helper pattern in the shell when running several commands interactively:
 
 ```bash
-: "${PLEXUS_BASE_URL:?Set PLEXUS_BASE_URL}"
-: "${PLEXUS_ADMIN_KEY:?Set PLEXUS_ADMIN_KEY}"
+: "${PLEXUS_STAGING_URL:?Set PLEXUS_STAGING_URL}"
+: "${PLEXUS_STAGING_ADMIN_KEY:?Set PLEXUS_STAGING_ADMIN_KEY}"
 
-curl -fsS "$PLEXUS_BASE_URL/v0/management/providers" \
-  -H "x-admin-key: $PLEXUS_ADMIN_KEY" | jq .
+curl -fsS "$PLEXUS_STAGING_URL/v0/management/providers" \
+  -H "x-admin-key: $PLEXUS_STAGING_ADMIN_KEY" | jq .
 ```
 
 ## Safety Rules
@@ -102,8 +102,8 @@ curl -fsS "$PLEXUS_BASE_URL/v0/management/aliases" \
 - Check state with `GET /v0/management/debug`.
 - Enable globally with `PATCH /v0/management/debug` and `{"enabled":true,"providers":null}` or set `providers` to an array of provider slugs.
 - Disable with `PATCH /v0/management/debug` and `{"enabled":false}`.
-- List captures with `GET /v0/management/debug-logs?limit=50`.
-- Fetch a full trace with `GET /v0/management/debug-logs/{requestId}`.
+- List captures with `GET /v0/management/debug/logs?limit=50`.
+- Fetch a full trace with `GET /v0/management/debug/logs/{requestId}`.
 
 ### Manage Providers And Model Targets
 

--- a/.agents/skills/plexus-management/references/endpoint-map.md
+++ b/.agents/skills/plexus-management/references/endpoint-map.md
@@ -39,10 +39,10 @@ Useful usage query params include `limit`, `offset`, `sortBy`, `sortDir`, `start
 | Get debug state | `GET` | `/v0/management/debug` |
 | Update global debug state | `PATCH` | `/v0/management/debug` |
 | Toggle current key debug | `POST` | `/v0/management/self/debug/toggle` |
-| List debug logs | `GET` | `/v0/management/debug-logs` |
-| Get one debug log | `GET` | `/v0/management/debug-logs/{requestId}` |
-| Delete one debug log | `DELETE` | `/v0/management/debug-logs/{requestId}` |
-| Delete all debug logs | `DELETE` | `/v0/management/debug-logs` |
+| List debug logs | `GET` | `/v0/management/debug/logs` |
+| Get one debug log | `GET` | `/v0/management/debug/logs/{requestId}` |
+| Delete one debug log | `DELETE` | `/v0/management/debug/logs/{requestId}` |
+| Delete all debug logs | `DELETE` | `/v0/management/debug/logs` |
 
 Debug state body examples:
 


### PR DESCRIPTION
### **User description**
## Summary

Fixes the plexus-management skill (`SKILL.md` and `endpoint-map.md`) to match the actual backend routes and staging environment conventions.

## Changes

**Debug log endpoints (path was wrong):**
- `/v0/management/debug-logs` → `/v0/management/debug/logs`
- Affects list, get-one, delete-one, and delete-all in `endpoint-map.md`
- Affects list-captures and fetch-trace paths in `SKILL.md`

Verified against the registered routes in `packages/backend/src/routes/management/debug.ts`.

**Environment variables (staging conventions):**
- `PLEXUS_BASE_URL` → `PLEXUS_STAGING_URL`
- `PLEXUS_ADMIN_KEY` → `PLEXUS_STAGING_ADMIN_KEY`
- Updated the First Steps section, `auth/verify` example, and the interactive helper pattern

## Verification
- `git grep` of all `/v0/...` routes in `packages/backend/src/routes/` cross-checked against the skill docs — no other discrepancies found.
- pre-commit hooks (biome-lint, typecheck, no-migrations) passed.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix debug log endpoint paths from `/v0/management/debug-logs` to `/v0/management/debug/logs` in `SKILL.md` and `endpoint-map.md`

- Update staging environment variables from `PLEXUS_BASE_URL` to `PLEXUS_STAGING_URL` and `PLEXUS_ADMIN_KEY` to `PLEXUS_STAGING_ADMIN_KEY`

- Update auth/verify example and interactive helper pattern in `SKILL.md` to use corrected env vars


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SKILL.md & endpoint-map.md"] -- "fix debug log paths" --> B["/v0/management/debug/logs"]
  A -- "update staging env vars" --> C["PLEXUS_STAGING_URL & PLEXUS_STAGING_ADMIN_KEY"]
```



___

