### PR TITLE
Suppress noisy PR-agent describe/review sections

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -5,6 +5,13 @@ custom_model_max_tokens = 256000
 
 [pr_description]
 enable_semantic_files_types = false  # suppress the File Walkthrough section
+enable_pr_type = false                 # suppress the "PR Type" section
+enable_pr_diagram = false               # suppress the "Diagram Walkthrough" section
+
+[pr_reviewer]
+# Suppress the "PR Reviewer Guide" comment when there are no findings to report,
+# so we don't post a noise comment saying "No major issues detected" etc.
+publish_output_no_suggestions = false
 
 [pr_code_suggestions]
 num_code_suggestions_per_chunk = 5


### PR DESCRIPTION
### **User description**
Reduces PR-agent comment noise by tuning `.pr_agent.toml`.

## Changes

- `[pr_description]` `enable_pr_type = false` — drops the "PR Type" label section from the AI description.
- `[pr_description]` `enable_pr_diagram = false` — drops the "Diagram Walkthrough" mermaid section.
- `[pr_reviewer]` `publish_output_no_suggestions = false` — skips the "PR Reviewer Guide" comment when there are no findings, avoiding noisy "No major issues detected" comments.

## Context

Investigation of run 27806701371 / job 82287956792 (PR #624) showed the PR agent was not crashing or stopping after the reviewer guide — the improve phase ran but discarded all its suggestions via self-review scoring (both below `suggestions_score_threshold = 6`), and with `publish_output_no_suggestions = false` nothing was posted. The real source of the perceived noise was the reviewer guide posting a "no findings" table on every clean PR, plus the describe phase emitting a PR-type label and a mermaid diagram that added little value.

After this change, `/describe` posts only the user description plus the bullet summary, and `/review` only posts when it has actual findings to report.


___

### **PR Type**
Enhancement


___

### **Description**
- Disable PR Type and Diagram Walkthrough sections in `[pr_description]`

- Skip PR Reviewer Guide comment when no suggestions are found

- Reduce PR-agent comment noise by tuning `.pr_agent.toml`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Agent Config"] --> B["Disable PR Type section"]
  A --> C["Disable Diagram Walkthrough section"]
  A --> D["Skip Reviewer Guide when no findings"]
```



___

