### PR TITLE
Update pi-ai integration to providers/all builtin model APIs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
       "name": "plexus-backend",
       "version": "1.0.0",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.79.7",
+        "@earendil-works/pi-ai": "0.80.1",
         "@fastify/bearer-auth": "^10.1.2",
         "@fastify/cors": "^11.2.0",
         "@fastify/multipart": "^10.0.0",
@@ -178,7 +178,7 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.7", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-KTe2euBoBEmFb0W+KR05Im8Qq4coU+eo46++UgNAfT3L8OIBv3QU+/pif9EqaFQ1QUmirv8kgy4TQltvrCu7iQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-qsHmuoBRu7a6rkOis/Elwl8jEhA9T884H/mXMP3tbz1slEBI+dHaY3zJ0nlEqUl+jcTz1FJNdgOVLG4sQHOPXQ=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.5.3", "", {}, "sha512-iTTYbA5Uesrl+N7zss0J5LopT7KE4j9aymYo+EZZh+rZbARQCUQOs+n2pay64JRUpc3fCkpfrniTNJnvYzOE+g=="],
 
@@ -288,7 +288,7 @@
 
     "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -351,6 +351,8 @@
     "@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
@@ -1286,11 +1288,11 @@
 
     "@earendil-works/pi-ai/@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
+    "@earendil-works/pi-ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@fastify/ajv-compiler/ajv": ["@redocly/ajv@8.18.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA=="],
-
-    "@mistralai/mistralai/zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
 
     "@modelcontextprotocol/sdk/pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "lint:migrations": "cd ../.. && bun run scripts/lint-migrations.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.79.7",
+    "@earendil-works/pi-ai": "0.80.1",
     "@fastify/bearer-auth": "^10.1.2",
     "@fastify/cors": "^11.2.0",
     "@fastify/multipart": "^10.0.0",

--- a/packages/backend/src/__tests__/config-pi-ai-hints.test.ts
+++ b/packages/backend/src/__tests__/config-pi-ai-hints.test.ts
@@ -93,10 +93,10 @@ describe('hydrateConfig: startup registry validation', () => {
     // Import the pi-ai module — in tests it's globally mocked as a factory.
     // We can spy on the mocked object's getModel using vi.spyOn on the module
     // to temporarily make it throw.
-    const piAiModule = await import('@earendil-works/pi-ai');
+    const piAiProvidersModule = await import('@earendil-works/pi-ai/providers/all');
 
     const getModelSpy = vi
-      .spyOn(piAiModule, 'getModel')
+      .spyOn(piAiProvidersModule, 'getBuiltinModel')
       .mockImplementationOnce((provider: string, modelId: string) => {
         if (provider === 'anthropic' && modelId === 'bogus-model-xyz') {
           throw new Error('Unknown model');

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -4,7 +4,7 @@ import { DEFAULT_VISION_DESCRIPTION_PROMPT } from './utils/constants';
 import { isValidIpRule } from './utils/ip-match';
 import { resolveGpuParams, VALID_GPU_PROFILES } from '@plexus/shared';
 import type { ModelArchitecture } from '@plexus/shared';
-import { getModel } from '@earendil-works/pi-ai';
+import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
 
 // --- Zod Schemas ---
 
@@ -1182,7 +1182,7 @@ function hydrateConfig(config: z.infer<typeof RawPlexusConfigSchema>): PlexusCon
   // mocked) for unknown pairs — treat both as "not found".
   const registryHas = (provider: string, modelId: string): boolean => {
     try {
-      return getModel(provider as any, modelId as any) != null;
+      return getBuiltinModel(provider as any, modelId as any) != null;
     } catch {
       return false;
     }

--- a/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import * as piAi from '@earendil-works/pi-ai';
+import * as piAi from '@earendil-works/pi-ai/compat';
 import { setConfigForTesting } from '../../../config';
 import { DebugManager } from '../../../services/debug-manager';
 import { enterRequestContext } from '../../../services/request-context';

--- a/packages/backend/src/inference-v2/shared/__tests__/resolve-pi-ai-model.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/resolve-pi-ai-model.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Local pi-ai mock so getModel returns realistic models for known ids and
 // undefined for unknown ones (matching pi-ai 0.79.x behaviour).
-vi.mock('@earendil-works/pi-ai', () => {
+vi.mock('@earendil-works/pi-ai', () => ({
+  clampThinkingLevel: (_m: any, l: string) => l,
+  getSupportedThinkingLevels: () => ['off', 'low', 'medium', 'high'],
+}));
+
+vi.mock('@earendil-works/pi-ai/providers/all', () => {
   const REGISTRY: Record<string, Record<string, any>> = {
     openai: {
       'gpt-5.5': {
@@ -22,11 +27,16 @@ vi.mock('@earendil-works/pi-ai', () => {
     },
   };
   return {
-    getModel: (provider: string, modelId: string) => REGISTRY[provider]?.[modelId],
-    getProviders: () => Object.keys(REGISTRY),
-    getModels: (provider: string) => Object.values(REGISTRY[provider] ?? {}),
-    clampThinkingLevel: (_m: any, l: string) => l,
-    getSupportedThinkingLevels: () => ['off', 'low', 'medium', 'high'],
+    builtinModels: () => ({
+      complete: vi.fn(),
+      stream: vi.fn(),
+      getModel: (provider: string, modelId: string) => REGISTRY[provider]?.[modelId],
+      getModels: (provider: string) => Object.values(REGISTRY[provider] ?? {}),
+      getProviders: () => Object.keys(REGISTRY),
+    }),
+    getBuiltinModel: (provider: string, modelId: string) => REGISTRY[provider]?.[modelId],
+    getBuiltinProviders: () => Object.keys(REGISTRY),
+    getBuiltinModels: (provider: string) => Object.values(REGISTRY[provider] ?? {}),
   };
 });
 

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -22,7 +22,9 @@
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { stream, complete, calculateCost, getModel } from '@earendil-works/pi-ai';
+import { calculateCost } from '@earendil-works/pi-ai';
+import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
+import { piAiModels } from './pi-ai-utils';
 import type {
   Context,
   ProviderStreamOptions,
@@ -300,7 +302,7 @@ function nextWithTtfbTimeout<T>(
 
 function buildUsageFromMessage(
   msg: AssistantMessage,
-  piModel: ReturnType<typeof getModel>,
+  piModel: ReturnType<typeof getBuiltinModel>,
   startTime: number,
   ttftMs: number | null,
   route: RouteResult
@@ -561,7 +563,7 @@ export async function runPiAiExecutor<TResponse>(
       if (!streaming) {
         // ── Non-streaming ────────────────────────────────────────────────
         const message = await debugRequestIdStorage.run(requestId, () =>
-          complete(piModel as any, context, callOptions)
+          piAiModels.complete(piModel as any, context, callOptions)
         );
 
         cooldown.markProviderSuccess(route.provider, route.model);
@@ -622,7 +624,7 @@ export async function runPiAiExecutor<TResponse>(
       } else {
         // ── Streaming ────────────────────────────────────────────────────
         const eventStream = await debugRequestIdStorage.run(requestId, () =>
-          stream(piModel as any, context, callOptions)
+          piAiModels.stream(piModel as any, context, callOptions)
         );
 
         // Build and return the SSE generator — the generator owns

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -8,8 +8,11 @@
  *  - buildPiAiModel: construct a call-ready pi-ai Model with base URL override applied
  */
 
-import { getModel, clampThinkingLevel, getSupportedThinkingLevels } from '@earendil-works/pi-ai';
+import { clampThinkingLevel, getSupportedThinkingLevels } from '@earendil-works/pi-ai';
+import { getBuiltinModel, builtinModels } from '@earendil-works/pi-ai/providers/all';
 import type { Model as PiAiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
+
+export const piAiModels = builtinModels();
 import {
   getConfig,
   type ProviderConfig,
@@ -495,7 +498,7 @@ function applyCustomModelFields(base: PiAiModel<any>, spec: PiAiCustomModel): Pi
  */
 function safeGetModel(provider: string, modelId: string): PiAiModel<any> | null {
   try {
-    return getModel(provider as any, modelId as any) ?? null;
+    return getBuiltinModel(provider as any, modelId as any) ?? null;
   } catch {
     return null;
   }

--- a/packages/backend/src/routes/inference/models.ts
+++ b/packages/backend/src/routes/inference/models.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { getConfig } from '../../config';
 import { PricingManager } from '../../services/pricing-manager';
 import { ModelMetadataManager, mergeOverrides } from '../../services/model-metadata-manager';
-import { getModel } from '@earendil-works/pi-ai';
+import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
 
 export async function registerModelsRoute(fastify: FastifyInstance) {
   /**
@@ -32,7 +32,10 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
       let piOptions: Record<string, unknown> | undefined;
       if (piModelConfig) {
         try {
-          const piModel = getModel(piModelConfig.provider as any, piModelConfig.model_id as any);
+          const piModel = getBuiltinModel(
+            piModelConfig.provider as any,
+            piModelConfig.model_id as any
+          );
           if (piModel?.compat && Object.keys(piModel.compat).length > 0) {
             piOptions = piModel.compat as Record<string, unknown>;
           }

--- a/packages/backend/src/routes/management/__tests__/pi-ai-custom.test.ts
+++ b/packages/backend/src/routes/management/__tests__/pi-ai-custom.test.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import * as piAi from '@earendil-works/pi-ai';
+import * as piAi from '@earendil-works/pi-ai/compat';
+import * as piAiProvidersAll from '@earendil-works/pi-ai/providers/all';
 import { registerPiAiCustomRoutes } from '../pi-ai-custom';
 
 // ConfigService is only touched by the custom-provider/model CRUD routes, not
@@ -67,7 +68,7 @@ describe('management pi-ai custom routes — registry-model clone', () => {
 
   test('GET /v0/management/pi/registry-model returns 404 when the base is unknown', async () => {
     // The global mock always returns a model; override it to simulate a miss.
-    vi.spyOn(piAi, 'getModel').mockReturnValue(undefined as any);
+    vi.spyOn(piAiProvidersAll, 'getBuiltinModel').mockReturnValue(undefined as any);
     const res = await fastify.inject({
       method: 'GET',
       url: '/v0/management/pi/registry-model?provider=unknown&model_id=ghost',

--- a/packages/backend/src/routes/management/models.ts
+++ b/packages/backend/src/routes/management/models.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { logger } from '../../utils/logger';
 import { HuggingFaceModelFetcher } from '../../services/huggingface-model-fetcher';
 import { ModelMetadataManager } from '../../services/model-metadata-manager';
-import { getModels, getProviders } from '@earendil-works/pi-ai';
+import { getBuiltinModels, getBuiltinProviders } from '@earendil-works/pi-ai/providers/all';
 import { ConfigService } from '../../services/config-service';
 
 interface FetchModelRequest {
@@ -82,7 +82,7 @@ export async function registerModelRoutes(fastify: FastifyInstance) {
    */
   fastify.get('/v0/management/pi/providers', async (_request, reply) => {
     // Built-in pi-ai providers plus any workspace custom providers.
-    const builtin = getProviders();
+    const builtin = getBuiltinProviders();
     let custom: string[] = [];
     try {
       custom = Object.keys(
@@ -110,9 +110,9 @@ export async function registerModelRoutes(fastify: FastifyInstance) {
     }
 
     // Built-in registry models for this provider (may be empty for a custom provider).
-    let builtin: ReturnType<typeof getModels> = [];
+    let builtin: ReturnType<typeof getBuiltinModels> = [];
     try {
-      builtin = getModels(query.provider as any) ?? [];
+      builtin = getBuiltinModels(query.provider as any) ?? [];
     } catch {
       builtin = [];
     }

--- a/packages/backend/src/routes/management/pi-ai-custom.ts
+++ b/packages/backend/src/routes/management/pi-ai-custom.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { getModel } from '@earendil-works/pi-ai';
+import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
 import type { Model as PiAiModel } from '@earendil-works/pi-ai';
 import { logger } from '../../utils/logger';
 import { PiAiCustomProviderSchema, PiAiCustomModelSchema } from '../../config';
@@ -180,7 +180,7 @@ export async function registerPiAiCustomRoutes(fastify: FastifyInstance) {
       }
       let model: PiAiModel<any> | null = null;
       try {
-        model = getModel(provider as any, model_id as any) ?? null;
+        model = getBuiltinModel(provider as any, model_id as any) ?? null;
       } catch {
         model = null;
       }

--- a/packages/backend/src/services/__tests__/dispatcher-claude-masking.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-claude-masking.test.ts
@@ -6,7 +6,7 @@ import type { UnifiedChatRequest } from '../../types/unified';
 // per-file vi.mock() call here.  With isolate: false all files share one
 // module registry and competing registrations create last-writer-wins races.
 const { Dispatcher } = await import('../dispatcher');
-import * as piAi from '@earendil-works/pi-ai';
+import * as piAi from '@earendil-works/pi-ai/compat';
 
 const fetchMock: any = vi.fn(async (): Promise<any> => {
   throw new Error('fetch should not be called in pi-ai masking path');

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -26,7 +26,7 @@ import { applyModelBehaviors } from './model-behaviors';
 import { EmbeddingsTransformerFactory } from './embeddings-transformer-factory';
 import { resolveAdapters } from './adapter-resolver';
 import type { ResolvedAdapter } from '../types/provider-adapter';
-import { getModels } from '@earendil-works/pi-ai';
+import { getBuiltinModels } from '@earendil-works/pi-ai/providers/all';
 import type { StallConfig } from './inspectors/stall-inspector';
 import { getGlobalStallConfig, resolveStallConfig } from '../utils/stall';
 import { VisionDescriptorService } from './vision-descriptor-service';
@@ -2553,7 +2553,7 @@ export class Dispatcher {
   }
 
   private assertOAuthModelSupported(oauthProvider: string, modelId: string) {
-    const supportedModels = getModels(oauthProvider as any);
+    const supportedModels = getBuiltinModels(oauthProvider as any);
     if (!supportedModels || supportedModels.length === 0) {
       throw new Error(`OAuth provider '${oauthProvider}' has no known models.`);
     }

--- a/packages/backend/src/services/provider-model-discovery.ts
+++ b/packages/backend/src/services/provider-model-discovery.ts
@@ -1,4 +1,4 @@
-import { getModels } from '@earendil-works/pi-ai';
+import { getBuiltinModels } from '@earendil-works/pi-ai/providers/all';
 import { getProviderTypes, type ProviderConfig } from '../config';
 import { logger } from '../utils/logger';
 
@@ -119,7 +119,7 @@ export async function fetchModelsFromUrl(
 }
 
 export function getOAuthProviderModels(providerId: string): DiscoveredModel[] {
-  return getModels(providerId as any).map((model) => ({
+  return getBuiltinModels(providerId as any).map((model) => ({
     id: model.id,
     name: model.name,
     context_length: model.contextWindow,

--- a/packages/backend/src/services/quota/checkers/zai-checker.ts
+++ b/packages/backend/src/services/quota/checkers/zai-checker.ts
@@ -18,7 +18,7 @@ interface ZAIQuotaResponse {
 
 export default defineChecker({
   type: 'zai',
-  displayName: 'ZAI',
+  displayName: 'ZAI Coding Plan (Global)',
   optionsSchema: z.object({
     apiKey: z.string().min(1, 'ZAI API key is required'),
     endpoint: z.string().url().optional(),

--- a/packages/backend/src/transformers/oauth/oauth-transformer.ts
+++ b/packages/backend/src/transformers/oauth/oauth-transformer.ts
@@ -4,7 +4,8 @@ import type {
   UnifiedChatResponse,
   UnifiedChatStreamChunk,
 } from '../../types/unified';
-import { getModel, stream, complete, type Model as PiAiModel } from '@earendil-works/pi-ai';
+import type { Model as PiAiModel } from '@earendil-works/pi-ai';
+import { piAiModels } from '../../inference-v2/shared/pi-ai-utils';
 import type { OAuthProvider } from '@earendil-works/pi-ai/oauth';
 import {
   applyClaudeCodeToolProxy,
@@ -105,7 +106,11 @@ export class OAuthTransformer implements Transformer {
   readonly defaultModel = 'gpt-5-mini';
 
   protected getPiAiModel(provider: OAuthProvider, modelId: string): PiAiModel<any> {
-    return getModel(provider as any, modelId);
+    const model = piAiModels.getModel(provider as any, modelId);
+    if (!model) {
+      throw new Error(`Model '${modelId}' not found for provider '${provider}'`);
+    }
+    return model;
   }
 
   private async resolveApiKey(
@@ -473,7 +478,7 @@ export class OAuthTransformer implements Transformer {
 
     if (streaming) {
       try {
-        const result = await stream(model, context, requestOptions);
+        const result = await piAiModels.stream(model, context, requestOptions);
         logger.debug(`${this.name}: OAuth stream result type`, describeStreamResult(result));
         return result;
       } catch (error: any) {
@@ -492,7 +497,7 @@ export class OAuthTransformer implements Transformer {
     }
 
     try {
-      return await complete(model, context, requestOptions);
+      return await piAiModels.complete(model, context, requestOptions);
     } catch (error: any) {
       if (error?.name === 'AbortError' || signal?.aborted) {
         const isTimeout = signal?.reason?.name === 'TimeoutError';

--- a/packages/backend/test/vitest.setup.ts
+++ b/packages/backend/test/vitest.setup.ts
@@ -87,6 +87,72 @@ const mockLogger = {
 };
 
 // ---------------------------------------------------------------------------
+const mockComplete = vi.fn(async () => ({
+  content: [{ type: 'text', text: 'ok' }],
+  stopReason: 'stop',
+  usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+  provider: 'anthropic',
+  model: 'claude-test',
+  timestamp: Date.now(),
+}));
+
+const mockStream = vi.fn(async () => ({ ok: true }));
+
+const mockGetModels = (provider: string) => {
+  if (provider === 'unknown-provider') return [];
+  if (provider === 'openai-codex') {
+    return [
+      {
+        id: 'gpt-5.4',
+        name: 'GPT-5.4',
+        contextWindow: 128000,
+        provider: 'openai-codex',
+        api: 'openai-codex-responses',
+      },
+      {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5',
+        contextWindow: 128000,
+        provider: 'openai-codex',
+        api: 'openai-codex-responses',
+      },
+    ];
+  }
+  return [
+    {
+      id: 'claude-opus-4',
+      name: 'Claude Opus 4',
+      contextWindow: 200000,
+      provider: 'anthropic',
+      api: 'anthropic-messages',
+    },
+    {
+      id: 'claude-sonnet-4',
+      name: 'Claude Sonnet 4',
+      contextWindow: 200000,
+      provider: 'anthropic',
+      api: 'anthropic-messages',
+    },
+    {
+      id: 'claude-test',
+      name: 'Claude Test',
+      contextWindow: 200000,
+      provider: 'anthropic',
+      api: 'anthropic-messages',
+    },
+  ];
+};
+
+const mockGetModel = (provider: string, modelId: string) => ({
+  id: modelId,
+  name: modelId,
+  contextWindow: 200000,
+  provider,
+  api: provider === 'openai-codex' ? 'openai-codex-responses' : 'anthropic-messages',
+});
+
+const mockGetProviders = () => ['anthropic', 'openai-codex', 'openai', 'google'];
+
 // @earendil-works/pi-ai — single authoritative mock for the whole worker.
 //
 // With isolate: false every test file shares one module registry.  Letting
@@ -102,72 +168,39 @@ const mockLogger = {
 //   • getModels returns all known test models so quota-error assertions that
 //     validate gpt-5.4/gpt-5.5 are valid for openai-codex always pass.
 //   • getModel always includes the `api` field — OAuthTransformer.executeRequest
-//     dispatches on model.api and crashes with "No API provider registered"
+//     dispatches on model.api and crashes with \"No API provider registered\"
 //     if it is missing.
 // ---------------------------------------------------------------------------
 vi.mock('@earendil-works/pi-ai', () => ({
-  getModels: (provider: string) => {
-    if (provider === 'unknown-provider') return [];
-    if (provider === 'openai-codex') {
-      return [
-        {
-          id: 'gpt-5.4',
-          name: 'GPT-5.4',
-          contextWindow: 128000,
-          provider: 'openai-codex',
-          api: 'openai-codex-responses',
-        },
-        {
-          id: 'gpt-5.5',
-          name: 'GPT-5.5',
-          contextWindow: 128000,
-          provider: 'openai-codex',
-          api: 'openai-codex-responses',
-        },
-      ];
-    }
-    return [
-      {
-        id: 'claude-opus-4',
-        name: 'Claude Opus 4',
-        contextWindow: 200000,
-        provider: 'anthropic',
-        api: 'anthropic-messages',
-      },
-      {
-        id: 'claude-sonnet-4',
-        name: 'Claude Sonnet 4',
-        contextWindow: 200000,
-        provider: 'anthropic',
-        api: 'anthropic-messages',
-      },
-      {
-        id: 'claude-test',
-        name: 'Claude Test',
-        contextWindow: 200000,
-        provider: 'anthropic',
-        api: 'anthropic-messages',
-      },
-    ];
-  },
-  getModel: (provider: string, modelId: string) => ({
-    id: modelId,
-    name: modelId,
-    contextWindow: 200000,
-    provider,
-    api: provider === 'openai-codex' ? 'openai-codex-responses' : 'anthropic-messages',
-  }),
-  complete: vi.fn(async () => ({
-    content: [{ type: 'text', text: 'ok' }],
-    stopReason: 'stop',
-    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
-    provider: 'anthropic',
-    model: 'claude-test',
-    timestamp: Date.now(),
-  })),
-  stream: vi.fn(async () => ({ ok: true })),
+  complete: mockModels.complete,
+  stream: mockModels.stream,
   calculateCost: vi.fn(() => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 })),
+  clampThinkingLevel: (_m: any, l: string) => l,
+  getSupportedThinkingLevels: () => ['off', 'low', 'medium', 'high'],
 }));
+
+vi.mock('@earendil-works/pi-ai/providers/all', () => ({
+  builtinModels: () => mockModels,
+  getBuiltinModel: mockGetModel,
+  getBuiltinModels: mockGetModels,
+  getBuiltinProviders: mockGetProviders,
+}));
+
+vi.mock('@earendil-works/pi-ai/compat', () => ({
+  complete: mockComplete,
+  stream: mockStream,
+  getModels: mockGetModels,
+  getModel: mockGetModel,
+  getProviders: mockGetProviders,
+}));
+
+const mockModels = {
+  complete: mockComplete,
+  stream: mockStream,
+  getModel: mockGetModel,
+  getModels: mockGetModels,
+  getProviders: mockGetProviders,
+};
 
 vi.mock('../src/utils/logger', () => ({
   logger: mockLogger,


### PR DESCRIPTION
### **User description**
Update the backend to use @earendil-works/pi-ai/providers/all builtin model APIs (getBuiltinModel/getBuiltinModels/getBuiltinProviders) instead of legacy getModel/getModels from @earendil-works/pi-ai.

Key changes:
- Bump @earendil-works/pi-ai to 0.80.1.
- Update inference v2 Pi AI executor and utilities to route complete/stream through a shared builtin model registry (piAiModels).
- Update inference routes and management endpoints to resolve built-in model metadata via providers/all.
- Update OAuth transformer model resolution to throw when a requested builtin model is missing.
- Rename the ZAI quota checker display name to “ZAI Coding Plan (Global)”.
- Adjust test mocks to align with the split modules (@earendil-works/pi-ai/compat and @earendil-works/pi-ai/providers/all), including shared Vitest setup mocks.


___

### **Description**
- Upgrade `@earendil-works/pi-ai` to 0.80.1 and migrate to builtin model APIs

- Replace legacy `getModel`/`getModels`/`getProviders` with `getBuiltinModel`/`getBuiltinModels`/`getBuiltinProviders` from `providers/all`

- Route inference and OAuth `complete`/`stream` calls through shared `piAiModels` registry

- Update OAuth transformer to throw when a requested builtin model is missing

- Rename ZAI quota checker display name to `ZAI Coding Plan (Global)`

- Adjust test mocks to align with split `pi-ai/compat` and `pi-ai/providers/all` modules


___

