### PR TITLE
feat(quota): add Sakana.ai checker

### DIFF
--- a/packages/backend/drizzle/schema/postgres/enums.ts
+++ b/packages/backend/drizzle/schema/postgres/enums.ts
@@ -39,4 +39,5 @@ export const quotaCheckerTypeEnum = pgEnum('quota_checker_type', [
   'crof',
   'exedev',
   'hyper',
+  'sakana',
 ]);

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -456,6 +456,11 @@ const HyperQuotaCheckerOptionsSchema = z.object({
   endpoint: z.url().optional(),
 });
 
+const SakanaQuotaCheckerOptionsSchema = z.object({
+  sessionCookie: z.string().trim().min(1, 'Sakana session cookie is required'),
+  endpoint: z.string().url().optional(),
+});
+
 const ProviderQuotaCheckerSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('naga'),
@@ -659,6 +664,13 @@ const ProviderQuotaCheckerSchema = z.discriminatedUnion('type', [
     intervalMinutes: z.number().min(1).default(30),
     id: z.string().trim().min(1).optional(),
     options: HyperQuotaCheckerOptionsSchema.optional().default({}),
+  }),
+  z.object({
+    type: z.literal('sakana'),
+    enabled: z.boolean().default(true),
+    intervalMinutes: z.number().min(1).default(30),
+    id: z.string().trim().min(1).optional(),
+    options: SakanaQuotaCheckerOptionsSchema,
   }),
 ]);
 

--- a/packages/backend/src/services/quota/checker-registry.ts
+++ b/packages/backend/src/services/quota/checker-registry.ts
@@ -212,4 +212,5 @@ export async function loadAllCheckers(): Promise<void> {
   await import('./checkers/crof-checker');
   await import('./checkers/exedev-checker');
   await import('./checkers/hyper-checker');
+  await import('./checkers/sakana-checker');
 }

--- a/packages/backend/src/services/quota/checkers/__tests__/sakana-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/sakana-checker.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMeterContext, isCheckerRegistered } from '../../checker-registry';
+import checkerDef from '../sakana-checker';
+
+const makeCtx = (options: Record<string, unknown> = {}) =>
+  createMeterContext('sakana-test', 'sakana', {
+    sessionCookie: 'test-session-cookie',
+    ...options,
+  });
+
+function mockBillingHtml(opts: {
+  fiveHourPercent?: number;
+  fiveHourReset?: string;
+  weeklyPercent?: number;
+  weeklyReset?: string;
+  creditBalance?: number;
+}): string {
+  let usageLimitHtml = '';
+  if (opts.fiveHourPercent !== undefined) {
+    usageLimitHtml += `<div class="space-y-2"><div class="flex flex-wrap items-end justify-between gap-2"><div class="flex items-center gap-1.5"><p class="font-medium text-sm">5-hour</p><p class="text-muted-foreground text-xs tabular-nums">Resets on ${opts.fiveHourReset ?? 'June 24, 2026 at 4:47 AM'}</p></div><div aria-label="5-hour: ${opts.fiveHourPercent}% used" data-state="indeterminate" data-max="100" data-slot="progress" class="relative w-full overflow-hidden rounded-full bg-primary/20 h-2.5" role="progressbar"><div data-state="indeterminate" data-max="100" data-slot="progress-indicator" class="h-full w-full flex-1 bg-primary transition-all" style="transform:translateX(-${100 - opts.fiveHourPercent}%)"></div></div></div>`;
+  }
+  if (opts.weeklyPercent !== undefined) {
+    usageLimitHtml += `<div class="space-y-2"><div class="flex flex-wrap items-end justify-between gap-2"><div class="flex items-center gap-1.5"><p class="font-medium text-sm">Weekly</p><p class="text-muted-foreground text-xs tabular-nums">Resets on ${opts.weeklyReset ?? 'June 29, 2026 at 12:00 AM'}</p></div><div aria-label="Weekly: ${opts.weeklyPercent}% used" data-state="indeterminate" data-max="100" data-slot="progress" class="relative w-full overflow-hidden rounded-full bg-primary/20 h-2.5" role="progressbar"><div data-state="indeterminate" data-max="100" data-slot="progress-indicator" class="h-full w-full flex-1 bg-primary transition-all" style="transform:translateX(-${100 - opts.weeklyPercent}%)"></div></div></div>`;
+  }
+
+  let creditHtml = '';
+  if (opts.creditBalance !== undefined) {
+    const formatted = opts.creditBalance.toFixed(2);
+    creditHtml = `<script>self.__next_f.push([1,"35:[\\"$\\",\\"$L42\\",null,{\\"data\\":[],\\"children\\":[[\\"$\\",\\"div\\",null,{\\"children\\":[[\\"$\\",\\"h2\\",null,{\\"children\\":\\"Credit balance\\"}],[\\"$\\",\\"p\\",null,{\\"children\\":\\"$$${formatted}\\"}]]}]}]</script>`;
+  }
+
+  return `<!DOCTYPE html><html><head><title>Sakana AI Console</title></head><body><div data-slot="card"><div data-slot="card-title">Usage limit</div><div data-slot="card-content" class="px-6 space-y-5">${usageLimitHtml}</div></div>${creditHtml}</body></html>`;
+}
+
+describe('sakana checker', () => {
+  const setFetchMock = (impl: (...args: unknown[]) => Promise<Response>): void => {
+    global.fetch = vi.fn(impl) as unknown as typeof fetch;
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is registered under sakana', () => {
+    expect(isCheckerRegistered('sakana')).toBe(true);
+  });
+
+  it('returns five_hour and weekly allowance meters', async () => {
+    setFetchMock(
+      async () =>
+        new Response(mockBillingHtml({ fiveHourPercent: 15, weeklyPercent: 9 }), { status: 200 })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+    expect(meters).toHaveLength(2);
+
+    const fiveHour = meters.find((m) => m.key === 'five_hour')!;
+    expect(fiveHour.kind).toBe('allowance');
+    expect(fiveHour.unit).toBe('percentage');
+    expect(fiveHour.used).toBe(15);
+    expect(fiveHour.remaining).toBe(85);
+    expect(fiveHour.periodValue).toBe(5);
+    expect(fiveHour.periodUnit).toBe('hour');
+    expect(fiveHour.periodCycle).toBe('rolling');
+    expect(fiveHour.resetsAt).toBeDefined();
+
+    const weekly = meters.find((m) => m.key === 'weekly')!;
+    expect(weekly.kind).toBe('allowance');
+    expect(weekly.unit).toBe('percentage');
+    expect(weekly.used).toBe(9);
+    expect(weekly.remaining).toBe(91);
+    expect(weekly.periodValue).toBe(7);
+    expect(weekly.periodUnit).toBe('day');
+    expect(weekly.periodCycle).toBe('rolling');
+    expect(weekly.resetsAt).toBeDefined();
+  });
+
+  it('includes credit balance meter when balance > 0', async () => {
+    setFetchMock(
+      async () =>
+        new Response(
+          mockBillingHtml({ fiveHourPercent: 5, weeklyPercent: 3, creditBalance: 42.5 }),
+          { status: 200 }
+        )
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+    expect(meters).toHaveLength(3);
+
+    const credit = meters.find((m) => m.key === 'credit')!;
+    expect(credit.kind).toBe('balance');
+    expect(credit.unit).toBe('usd');
+    expect(credit.remaining).toBe(42.5);
+  });
+
+  it('includes credit balance meter when balance is 0', async () => {
+    setFetchMock(
+      async () =>
+        new Response(
+          mockBillingHtml({ fiveHourPercent: 10, weeklyPercent: 20, creditBalance: 0 }),
+          { status: 200 }
+        )
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+    expect(meters).toHaveLength(3);
+
+    const credit = meters.find((m) => m.key === 'credit')!;
+    expect(credit.kind).toBe('balance');
+    expect(credit.unit).toBe('usd');
+    expect(credit.remaining).toBe(0);
+  });
+
+  it('returns partial meters when only 5-hour is available', async () => {
+    setFetchMock(
+      async () => new Response(mockBillingHtml({ fiveHourPercent: 50 }), { status: 200 })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+    expect(meters).toHaveLength(1);
+    expect(meters[0]!.key).toBe('five_hour');
+    expect(meters[0]!.used).toBe(50);
+    expect(meters[0]!.remaining).toBe(50);
+  });
+
+  it('sends session cookie and user-agent header', async () => {
+    let capturedCookie: string | undefined;
+    let capturedUA: string | undefined;
+
+    setFetchMock(async (_input: unknown, init: unknown) => {
+      const headers = new Headers((init as RequestInit | undefined)?.headers);
+      capturedCookie = headers.get('Cookie') ?? undefined;
+      capturedUA = headers.get('User-Agent') ?? undefined;
+      return new Response(mockBillingHtml({ fiveHourPercent: 1, weeklyPercent: 1 }), {
+        status: 200,
+      });
+    });
+
+    await checkerDef.check(makeCtx({ sessionCookie: 'my-cookie-value' }));
+    expect(capturedCookie).toBe('__Secure-authjs.session-token=my-cookie-value');
+    expect(capturedUA).toContain('Chrome');
+  });
+
+  it('throws when no usage data can be parsed from HTML', async () => {
+    setFetchMock(
+      async () => new Response('<html><body>no data here</body></html>', { status: 200 })
+    );
+
+    await expect(checkerDef.check(makeCtx())).rejects.toThrow(
+      'Could not parse usage data from Sakana billing page'
+    );
+  });
+
+  it('throws on non-200 response', async () => {
+    setFetchMock(
+      async () => new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' })
+    );
+
+    await expect(checkerDef.check(makeCtx())).rejects.toThrow('HTTP 401: Unauthorized');
+  });
+
+  it('uses custom endpoint when configured', async () => {
+    let capturedUrl: string | undefined;
+
+    setFetchMock(async (input: unknown) => {
+      capturedUrl = typeof input === 'string' ? input : undefined;
+      return new Response(mockBillingHtml({ fiveHourPercent: 1, weeklyPercent: 1 }), {
+        status: 200,
+      });
+    });
+
+    await checkerDef.check(makeCtx({ endpoint: 'https://custom.example.com/billing' }));
+    expect(capturedUrl).toBe('https://custom.example.com/billing');
+  });
+
+  it('throws when sessionCookie option is missing', async () => {
+    const ctx = createMeterContext('sakana-test', 'sakana', {});
+    await expect(checkerDef.check(ctx)).rejects.toThrow();
+  });
+
+  it('parses reset date as UTC ISO string', async () => {
+    setFetchMock(
+      async () =>
+        new Response(
+          mockBillingHtml({
+            fiveHourPercent: 10,
+            fiveHourReset: 'June 24, 2026 at 4:47 AM',
+            weeklyPercent: 5,
+            weeklyReset: 'June 29, 2026 at 12:00 AM',
+          }),
+          { status: 200 }
+        )
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+    const fiveHour = meters.find((m) => m.key === 'five_hour')!;
+    expect(fiveHour.resetsAt).toBe('2026-06-24T04:47:00.000Z');
+
+    const weekly = meters.find((m) => m.key === 'weekly')!;
+    expect(weekly.resetsAt).toBe('2026-06-29T00:00:00.000Z');
+  });
+});

--- a/packages/backend/src/services/quota/checkers/sakana-checker.ts
+++ b/packages/backend/src/services/quota/checkers/sakana-checker.ts
@@ -1,0 +1,129 @@
+import { defineChecker } from '../checker-registry';
+import { z } from 'zod';
+import { logger } from '../../../utils/logger';
+
+const USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+
+interface UsageWindow {
+  percent: number;
+  resetsAt?: string;
+}
+
+function extractUsageWindow(html: string, label: string): UsageWindow | null {
+  const percentRe = new RegExp(`aria-label="${label}:\\s*([\\d.]+)% used"`);
+  const percentMatch = html.match(percentRe);
+  if (!percentMatch) {
+    logger.debug(`Could not find ${label} usage percent in HTML`);
+    return null;
+  }
+  const percent = parseFloat(percentMatch[1]!);
+
+  const resetRe = new RegExp(`>${label}</p>\\s*<p[^>]*>Resets on ([^<]+)<`);
+  const resetMatch = html.match(resetRe);
+  let resetsAt: string | undefined;
+  if (resetMatch) {
+    const dateStr = resetMatch[1]!.trim();
+    const normalized = dateStr.replace(' at ', ' ') + ' UTC';
+    const date = new Date(normalized);
+    if (!Number.isNaN(date.getTime())) {
+      resetsAt = date.toISOString();
+    }
+  }
+
+  logger.silly(`${label}: ${percent}% used, resets at ${resetsAt ?? 'unknown'}`);
+  return { percent, resetsAt };
+}
+
+function extractCreditBalance(html: string): number | null {
+  const match = html.match(/Credit balance[\s\S]*?\$\$(\d[\d,.]*)/);
+  if (!match) return null;
+  const amount = parseFloat(match[1]!.replace(/,/g, ''));
+  if (!Number.isFinite(amount)) return null;
+  return amount;
+}
+
+export default defineChecker({
+  type: 'sakana',
+  displayName: 'Sakana',
+  optionsSchema: z.object({
+    sessionCookie: z.string().trim().min(1, 'Sakana session cookie is required'),
+    endpoint: z.string().url().optional(),
+  }),
+  async check(ctx) {
+    const sessionCookie = ctx.requireOption<string>('sessionCookie');
+    const endpoint = ctx.getOption<string>('endpoint', 'https://console.sakana.ai/billing');
+
+    logger.debug(`Fetching ${endpoint}`);
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'text/html',
+        'Accept-Language': 'en-US,en;q=0.9',
+        Cookie: `__Secure-authjs.session-token=${sessionCookie}`,
+      },
+    });
+
+    if (response.url.includes('/login')) {
+      throw new Error('Authentication failed. The session cookie may be expired or invalid.');
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const html = await response.text();
+    const meters = [];
+
+    const fiveHour = extractUsageWindow(html, '5-hour');
+    if (fiveHour) {
+      meters.push(
+        ctx.allowance({
+          key: 'five_hour',
+          label: '5-hour usage',
+          unit: 'percentage',
+          used: fiveHour.percent,
+          remaining: Math.max(0, 100 - fiveHour.percent),
+          periodValue: 5,
+          periodUnit: 'hour',
+          periodCycle: 'rolling',
+          resetsAt: fiveHour.resetsAt,
+        })
+      );
+    }
+
+    const weekly = extractUsageWindow(html, 'Weekly');
+    if (weekly) {
+      meters.push(
+        ctx.allowance({
+          key: 'weekly',
+          label: 'Weekly usage',
+          unit: 'percentage',
+          used: weekly.percent,
+          remaining: Math.max(0, 100 - weekly.percent),
+          periodValue: 7,
+          periodUnit: 'day',
+          periodCycle: 'rolling',
+          resetsAt: weekly.resetsAt,
+        })
+      );
+    }
+
+    const credit = extractCreditBalance(html);
+    if (credit !== null) {
+      meters.push(
+        ctx.balance({
+          key: 'credit',
+          label: 'Credit balance',
+          unit: 'usd',
+          remaining: credit,
+        })
+      );
+    }
+
+    if (meters.length === 0) throw new Error('Could not parse usage data from Sakana billing page');
+
+    return meters;
+  },
+});

--- a/packages/frontend/src/components/providers/ProviderQuotaEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderQuotaEditor.tsx
@@ -25,6 +25,7 @@ import { OpenCodeGoQuotaConfig } from '../quota/OpenCodeGoQuotaConfig';
 import { CrofQuotaConfig } from '../quota/CrofQuotaConfig';
 import { ExeDevQuotaConfig } from '../quota/ExeDevQuotaConfig';
 import { HyperQuotaConfig } from '../quota/HyperQuotaConfig';
+import { SakanaQuotaConfig } from '../quota/SakanaQuotaConfig';
 
 interface Props {
   editingProvider: Provider;
@@ -69,6 +70,7 @@ const QUOTA_CONFIG_MAP: Record<
   crof: CrofQuotaConfig,
   exedev: ExeDevQuotaConfig,
   hyper: HyperQuotaConfig,
+  sakana: SakanaQuotaConfig,
 };
 
 export function ProviderQuotaEditor({

--- a/packages/frontend/src/components/quota/SakanaQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/SakanaQuotaConfig.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Input } from '../ui/Input';
+
+export interface SakanaQuotaConfigProps {
+  options: Record<string, unknown>;
+  onChange: (options: Record<string, unknown>) => void;
+}
+
+export const SakanaQuotaConfig: React.FC<SakanaQuotaConfigProps> = ({ options, onChange }) => {
+  const handleChange = (key: string, value: string) => {
+    onChange({ ...options, [key]: value });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="sakana-session-cookie"
+          className="font-body text-[13px] font-medium text-text-secondary"
+        >
+          Session Cookie <span className="text-danger">*</span>
+        </label>
+        <Input
+          id="sakana-session-cookie"
+          type="password"
+          value={(options.sessionCookie as string) ?? ''}
+          onChange={(e) => handleChange('sessionCookie', e.target.value)}
+          placeholder="Paste your __Secure-authjs.session-token cookie"
+        />
+        <span className="text-[10px] text-text-muted">
+          Required. Found in browser DevTools (F12) → Application → Cookies → console.sakana.ai →
+          copy the <span className="font-mono">__Secure-authjs.session-token</span> value. Treat it
+          like a password — it expires and must be refreshed periodically.
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="sakana-endpoint"
+          className="font-body text-[13px] font-medium text-text-secondary"
+        >
+          Endpoint (optional)
+        </label>
+        <Input
+          id="sakana-endpoint"
+          value={(options.endpoint as string) ?? ''}
+          onChange={(e) => handleChange('endpoint', e.target.value)}
+          placeholder="https://console.sakana.ai/billing"
+        />
+        <span className="text-[10px] text-text-muted">
+          Custom billing page URL. Defaults to the standard Sakana billing console.
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/src/components/quota/index.ts
+++ b/packages/frontend/src/components/quota/index.ts
@@ -6,6 +6,7 @@ export { RoutingRunQuotaConfig } from './RoutingRunQuotaConfig';
 export { CrofQuotaConfig } from './CrofQuotaConfig';
 export { ExeDevQuotaConfig } from './ExeDevQuotaConfig';
 export { HyperQuotaConfig } from './HyperQuotaConfig';
+export { SakanaQuotaConfig } from './SakanaQuotaConfig';
 export { CombinedBalancesCard } from './CombinedBalancesCard';
 export { CompactBalancesCard } from './CompactBalancesCard';
 export { CompactQuotasCard } from './CompactQuotasCard';

--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -784,6 +784,11 @@ export function useProviderForm() {
       if (!options.authCookie || !(options.authCookie as string).trim())
         return 'Auth cookie is required for OpenCode Go quota checker';
     }
+    if (
+      quotaType === 'sakana' &&
+      (!options.sessionCookie || !(options.sessionCookie as string).trim())
+    )
+      return 'Session cookie is required for Sakana quota checker';
     return null;
   };
 


### PR DESCRIPTION
### **User description**
Sakana.ai exposes no public billing/usage API. The only source of quota data is the authenticated billing console at console.sakana.ai/billing, which renders usage meters in the initial SSR HTML. This checker scrapes that page using a NextAuth session cookie, following the same pattern as the ollama and opencode-go checkers.

Extracts:
- 5-hour rolling usage window (percent used + reset timestamp)
- Weekly rolling usage window (percent used + reset timestamp)
- Pay-as-you-go credit balance (from RSC flight payload, when present)


___

### **Description**
- Add Sakana.ai quota checker scraping billing console HTML via session cookie

- Extract 5-hour and weekly rolling usage windows plus pay-as-you-go credit balance

- Register `sakana` type in backend enum, config schema, and checker registry

- Add frontend `SakanaQuotaConfig` component with session cookie and endpoint inputs

- Add comprehensive unit tests covering parsing, auth, and error scenarios


___

