### PR TITLE
fix(pi-ai): allow registering same custom model ID under multiple custom providers

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -1201,7 +1201,7 @@ function hydrateConfig(config: z.infer<typeof RawPlexusConfigSchema>): PlexusCon
   };
   const piPairResolves = (provider: string, modelId: string): boolean => {
     // Custom model: resolves if standalone (has api) or its inheritance base exists.
-    const cm = customModels[modelId];
+    const cm = customModels[`${provider}:${modelId}`] ?? customModels[modelId];
     if (cm && cm.provider === provider) {
       if (cm.inherits) return registryHas(cm.inherits.provider, cm.inherits.model_id);
       return cm.api != null;

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -1201,7 +1201,8 @@ function hydrateConfig(config: z.infer<typeof RawPlexusConfigSchema>): PlexusCon
   };
   const piPairResolves = (provider: string, modelId: string): boolean => {
     // Custom model: resolves if standalone (has api) or its inheritance base exists.
-    const cm = customModels[`${provider}:${modelId}`] ?? customModels[modelId];
+    const compoundKey = modelId.includes(':') ? modelId : `${provider}:${modelId}`;
+    const cm = customModels[compoundKey] ?? customModels[modelId];
     if (cm && cm.provider === provider) {
       if (cm.inherits) return registryHas(cm.inherits.provider, cm.inherits.model_id);
       return cm.api != null;

--- a/packages/backend/src/inference-v2/shared/__tests__/resolve-pi-ai-model.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/resolve-pi-ai-model.test.ts
@@ -230,4 +230,49 @@ describe('resolvePiAiModel', () => {
       expect(resolvePiAiModel('unknown-host', 'scoped')).toBeNull();
     });
   });
+
+  describe('compound key provider-scoped custom model', () => {
+    beforeEach(() =>
+      configWith({
+        providers: {
+          'provider-a': { api: 'openai-completions' },
+          'provider-b': { api: 'openai-responses' },
+        },
+        models: {
+          'provider-a:shared-id': {
+            provider: 'provider-a',
+            api: 'openai-completions',
+            contextWindow: 1000,
+            maxTokens: 500,
+          },
+          'provider-b:shared-id': {
+            provider: 'provider-b',
+            api: 'openai-responses',
+            contextWindow: 2000,
+            maxTokens: 600,
+          },
+        },
+      })
+    );
+
+    it('resolves the correct custom model for provider-a using the compound key', () => {
+      const m = resolvePiAiModel('provider-a', 'shared-id')!;
+      expect(m).not.toBeNull();
+      expect(m.api).toBe('openai-completions');
+      expect(m.contextWindow).toBe(1000);
+      expect(m.maxTokens).toBe(500);
+      expect(m.provider).toBe('provider-a');
+      expect(m.id).toBe('shared-id');
+    });
+
+    it('resolves the correct custom model for provider-b using the compound key', () => {
+      const m = resolvePiAiModel('provider-b', 'shared-id')!;
+      expect(m).not.toBeNull();
+      expect(m.api).toBe('openai-responses');
+      expect(m.contextWindow).toBe(2000);
+      expect(m.maxTokens).toBe(600);
+      expect(m.provider).toBe('provider-b');
+      expect(m.id).toBe('shared-id');
+    });
+  });
 });

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -571,7 +571,9 @@ export function resolvePiAiModel(piAiProvider: string, piAiModelId: string): PiA
 
   // 1. Custom model definition. A model is provider-scoped: it only matches
   //    when its `provider` field equals the referencing pi-ai provider.
-  const modelSpec = customModels?.[piAiModelId];
+  //    First, look up via the compound key `${piAiProvider}:${piAiModelId}`,
+  //    then fall back to the plain key `piAiModelId` for backwards compatibility.
+  const modelSpec = customModels?.[`${piAiProvider}:${piAiModelId}`] ?? customModels?.[piAiModelId];
   if (modelSpec && modelSpec.provider === piAiProvider) {
     const resolved = resolveCustomModel(modelSpec, piAiProvider, piAiModelId);
     if (resolved) {

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -573,7 +573,8 @@ export function resolvePiAiModel(piAiProvider: string, piAiModelId: string): PiA
   //    when its `provider` field equals the referencing pi-ai provider.
   //    First, look up via the compound key `${piAiProvider}:${piAiModelId}`,
   //    then fall back to the plain key `piAiModelId` for backwards compatibility.
-  const modelSpec = customModels?.[`${piAiProvider}:${piAiModelId}`] ?? customModels?.[piAiModelId];
+  const compoundKey = piAiModelId.includes(':') ? piAiModelId : `${piAiProvider}:${piAiModelId}`;
+  const modelSpec = customModels?.[compoundKey] ?? customModels?.[piAiModelId];
   if (modelSpec && modelSpec.provider === piAiProvider) {
     const resolved = resolveCustomModel(modelSpec, piAiProvider, piAiModelId);
     if (resolved) {

--- a/packages/backend/src/routes/management/models.ts
+++ b/packages/backend/src/routes/management/models.ts
@@ -127,12 +127,15 @@ export async function registerModelRoutes(fastify: FastifyInstance) {
         .getAllPiAiCustomModels();
       customEntries = Object.entries(customModels)
         .filter(([, def]) => def.provider === query.provider)
-        .map(([id, def]) => ({
-          id,
-          name: (def as any).name ?? id,
-          api: (def as any).api ?? 'custom',
-          custom: true as const,
-        }));
+        .map(([id, def]) => {
+          const cleanId = id.includes(':') ? id.split(':').slice(1).join(':') : id;
+          return {
+            id: cleanId,
+            name: (def as any).name ?? cleanId,
+            api: (def as any).api ?? 'custom',
+            custom: true as const,
+          };
+        });
     } catch {
       /* non-fatal */
     }

--- a/packages/backend/src/routes/management/pi-ai-custom.ts
+++ b/packages/backend/src/routes/management/pi-ai-custom.ts
@@ -5,7 +5,7 @@ import { logger } from '../../utils/logger';
 import { PiAiCustomProviderSchema, PiAiCustomModelSchema } from '../../config';
 import { ConfigService } from '../../services/config-service';
 
-const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9.\-_]{0,126}$/;
+const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9.:\-_]{0,126}$/;
 
 /**
  * Register API endpoints for pi-ai custom provider / model registries

--- a/packages/frontend/src/pages/PiRegistry.tsx
+++ b/packages/frontend/src/pages/PiRegistry.tsx
@@ -755,12 +755,17 @@ function ProviderRow({
                     variant="secondary"
                     size="sm"
                     leftIcon={<Plus size={14} />}
-                    disabled={!draftModel.trim() || !!models[draftModel.trim()]}
+                    disabled={
+                      !draftModel.trim() ||
+                      !!models[`${name}:${draftModel.trim()}`] ||
+                      (!!models[draftModel.trim()] && models[draftModel.trim()].provider === name)
+                    }
                     onClick={async () => {
                       const id = draftModel.trim();
+                      const key = `${name}:${id}`;
                       try {
                         // Seed under this provider; user edits the rest below.
-                        await api.savePiCustomModel(id, {
+                        await api.savePiCustomModel(key, {
                           provider: name,
                           api: 'openai-completions',
                         });
@@ -810,6 +815,7 @@ function ModelRow({
   providerId: string;
   onChanged: () => void;
 }) {
+  const cleanName = name.includes(':') ? name.split(':').slice(1).join(':') : name;
   const toast = useToast();
   const [mode, setMode] = useState<'inherit' | 'standalone'>(
     def.inherits ? 'inherit' : 'standalone'
@@ -902,14 +908,14 @@ function ModelRow({
   return (
     <div className="border border-border-glass rounded-md p-3">
       <div className="flex items-center justify-between mb-2 gap-2">
-        <span className="font-mono text-[13px] text-text">{name}</span>
+        <span className="font-mono text-[13px] text-text">{cleanName}</span>
         <Button
           variant="ghost"
           size="sm"
           onClick={async () => {
             try {
               await api.deletePiCustomModel(name);
-              toast.success(`Deleted '${name}'`);
+              toast.success(`Deleted '${cleanName}'`);
               onChanged();
             } catch (e: any) {
               toast.error(e?.message ?? 'Failed to delete');
@@ -1047,7 +1053,7 @@ function ModelRow({
             Display name {mode === 'inherit' ? '(override)' : '(optional)'}
           </label>
           <Input
-            placeholder={name}
+            placeholder={cleanName}
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
           />
@@ -1182,7 +1188,7 @@ function ModelRow({
             }
             try {
               await api.savePiCustomModel(name, def);
-              toast.success(`Saved '${name}'`);
+              toast.success(`Saved '${cleanName}'`);
               onChanged();
             } catch (e: any) {
               toast.error(e?.message ?? 'Failed to save');

--- a/packages/frontend/src/pages/PiRegistry.tsx
+++ b/packages/frontend/src/pages/PiRegistry.tsx
@@ -755,11 +755,16 @@ function ProviderRow({
                     variant="secondary"
                     size="sm"
                     leftIcon={<Plus size={14} />}
-                    disabled={
-                      !draftModel.trim() ||
-                      !!models[`${name}:${draftModel.trim()}`] ||
-                      (!!models[draftModel.trim()] && models[draftModel.trim()].provider === name)
-                    }
+                    disabled={(() => {
+                      const trimmedModel = draftModel.trim();
+                      const isValidModelId = /^[a-zA-Z0-9][a-zA-Z0-9.\-_]*$/.test(trimmedModel);
+                      return (
+                        !trimmedModel ||
+                        !isValidModelId ||
+                        !!models[`${name}:${trimmedModel}`] ||
+                        (!!models[trimmedModel] && models[trimmedModel].provider === name)
+                      );
+                    })()}
                     onClick={async () => {
                       const id = draftModel.trim();
                       const key = `${name}:${id}`;


### PR DESCRIPTION
### **User description**
This PR fixes a bug where registering a custom pi-ai model under provider B with the same model ID as an existing custom model under provider A was disallowed by the UI, even if they required different configurations or parameters.

### Changes:
- **Compound Key Scoping**: Custom models are now stored using a provider-prefixed compound key format `${piAiProvider}:${piAiModelId}` (e.g., `"niche-provider:gpt-4"`) in the flat config/database registries.
- **Backward-Compatible Resolution**: Updated `resolvePiAiModel` and startup validation to check the compound key first, falling back to the plain model ID.
- **Refined API & Validation**: Adjusted `NAME_RE` to permit colons (`:`) in management routes, and stripped the compound prefix when returning model lists in `/v0/management/pi/models` for the dropdown so Plexus continues to utilize clean, simple model IDs at the routing level.
- **Frontend Refinements**: Updated the registration checks and form disabled logic on `PiRegistry.tsx` to verify uniqueness per-provider rather than globally. Improved `ModelRow` to dynamically extract and render only the clean model ID without visual clutter.
- **Unit Test Coverage**: Added tests verifying coexistence and resolution of identical model IDs under different providers.


___

### **Description**
- Support provider-scoped custom models via compound key `${provider}:${modelId}`

- Update `resolvePiAiModel` and config hydration to check compound key first

- Adjust management routes and `NAME_RE` to handle and strip compound keys

- Update frontend registry to enforce per-provider uniqueness and clean display

- Add tests for resolving identical model IDs under different providers


___

