### PR TITLE
fix(inference-v2): remap custom pi-ai provider ids for dispatch in 0.80

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -170,6 +170,11 @@ try {
   await configService.initialize();
   logger.debug('Configuration loaded from database');
 
+  // Register pi_ai_custom_providers with the piAiModels instance so custom
+  // providers can be dispatched directly by api type without remapping hacks.
+  const { registerCustomProvidersWithPiAi } = await import('./inference-v2/shared/pi-ai-utils');
+  await registerCustomProvidersWithPiAi();
+
   // One-time migration of legacy flat-format aliases to target groups.
   // TODO(#target-groups-cleanup): remove this after migration period.
   await configService.migrateLegacyTargetGroups();

--- a/packages/backend/src/inference-v2/shared/__tests__/resolve-pi-ai-model.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/resolve-pi-ai-model.test.ts
@@ -33,6 +33,9 @@ vi.mock('@earendil-works/pi-ai/providers/all', () => {
       getModel: (provider: string, modelId: string) => REGISTRY[provider]?.[modelId],
       getModels: (provider: string) => Object.values(REGISTRY[provider] ?? {}),
       getProviders: () => Object.keys(REGISTRY),
+      // Only returns a value for providers registered in REGISTRY — simulates
+      // builtinModels().getProvider() used by toDispatchModel().
+      getProvider: (id: string) => (REGISTRY[id] ? { id } : undefined),
     }),
     getBuiltinModel: (provider: string, modelId: string) => REGISTRY[provider]?.[modelId],
     getBuiltinProviders: () => Object.keys(REGISTRY),
@@ -41,7 +44,7 @@ vi.mock('@earendil-works/pi-ai/providers/all', () => {
 });
 
 import { setConfigForTesting } from '../../../config';
-import { resolvePiAiModel } from '../pi-ai-utils';
+import { resolvePiAiModel, toDispatchModel } from '../pi-ai-utils';
 
 function configWith(custom: { providers?: Record<string, any>; models?: Record<string, any> }) {
   setConfigForTesting({
@@ -274,5 +277,81 @@ describe('resolvePiAiModel', () => {
       expect(m.provider).toBe('provider-b');
       expect(m.id).toBe('shared-id');
     });
+  });
+});
+
+// ─── toDispatchModel ──────────────────────────────────────────────────────────
+//
+// Regression coverage for the pi-ai 0.80 upgrade regression where
+// piAiModels.stream() throws "Unknown provider: <custom>" because
+// builtinModels() only has builtin provider ids in its internal map.
+// toDispatchModel() must remap custom providers to their builtin equivalent
+// before the model is handed to piAiModels.stream() / .complete().
+
+describe('toDispatchModel', () => {
+  it('returns the model unchanged when provider is already a builtin', () => {
+    const model = {
+      id: 'gpt-5.5',
+      provider: 'openai',
+      api: 'openai-responses',
+      baseUrl: 'https://api.openai.com',
+    } as any;
+    const result = toDispatchModel(model);
+    expect(result).toBe(model); // same reference — no copy made
+    expect(result.provider).toBe('openai');
+  });
+
+  it('remaps a custom provider to the builtin openai provider for openai-completions api', () => {
+    // Regression: neuralwatt has pi_ai_provider:"neuralwatt" and
+    // api:"openai-completions". Before the fix, piAiModels.stream() threw
+    // "Unknown provider: neuralwatt" because builtinModels() only registers
+    // canonical builtin provider ids.
+    const model = {
+      id: 'glm-5.2',
+      provider: 'neuralwatt',
+      api: 'openai-completions',
+      baseUrl: 'https://api.neuralwatt.com/v1',
+    } as any;
+    const result = toDispatchModel(model);
+    expect(result.provider).toBe('openai');
+    expect(result.id).toBe('glm-5.2');
+    expect(result.api).toBe('openai-completions');
+    expect(result.baseUrl).toBe('https://api.neuralwatt.com/v1');
+  });
+
+  it('remaps a custom provider to anthropic for anthropic-messages api', () => {
+    const model = {
+      id: 'custom-claude',
+      provider: 'my-anthropic-proxy',
+      api: 'anthropic-messages',
+      baseUrl: 'https://proxy.example.com',
+    } as any;
+    const result = toDispatchModel(model);
+    expect(result.provider).toBe('anthropic');
+    expect(result.api).toBe('anthropic-messages');
+    expect(result.baseUrl).toBe('https://proxy.example.com');
+  });
+
+  it('remaps a custom provider to google for google-generative-ai api', () => {
+    const model = {
+      id: 'gemini-custom',
+      provider: 'my-google-proxy',
+      api: 'google-generative-ai',
+      baseUrl: 'https://proxy.example.com',
+    } as any;
+    const result = toDispatchModel(model);
+    expect(result.provider).toBe('google');
+  });
+
+  it('returns model unchanged when api has no known builtin mapping', () => {
+    const model = {
+      id: 'weird-model',
+      provider: 'unknown-provider',
+      api: 'unknown-api',
+      baseUrl: 'https://something.example.com',
+    } as any;
+    const result = toDispatchModel(model);
+    // Falls through — let piAiModels surface its own error
+    expect(result.provider).toBe('unknown-provider');
   });
 });

--- a/packages/backend/src/inference-v2/shared/__tests__/resolve-pi-ai-model.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/resolve-pi-ai-model.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+// Mutable map of providers registered at runtime via setProvider().
+// Reset in beforeEach so tests don't bleed into each other.
+const registeredProviders: Record<string, any> = {};
+
 // Local pi-ai mock so getModel returns realistic models for known ids and
 // undefined for unknown ones (matching pi-ai 0.79.x behaviour).
 vi.mock('@earendil-works/pi-ai', () => ({
   clampThinkingLevel: (_m: any, l: string) => l,
   getSupportedThinkingLevels: () => ['off', 'low', 'medium', 'high'],
+  // Used by registerCustomProvidersWithPiAi to build a provider before setProvider().
+  createProvider: vi.fn((spec: any) => ({ id: spec.id, name: spec.name, api: spec.api })),
 }));
 
 vi.mock('@earendil-works/pi-ai/providers/all', () => {
@@ -32,10 +38,13 @@ vi.mock('@earendil-works/pi-ai/providers/all', () => {
       stream: vi.fn(),
       getModel: (provider: string, modelId: string) => REGISTRY[provider]?.[modelId],
       getModels: (provider: string) => Object.values(REGISTRY[provider] ?? {}),
-      getProviders: () => Object.keys(REGISTRY),
-      // Only returns a value for providers registered in REGISTRY — simulates
-      // builtinModels().getProvider() used by toDispatchModel().
-      getProvider: (id: string) => (REGISTRY[id] ? { id } : undefined),
+      getProviders: () => [...Object.keys(REGISTRY), ...Object.keys(registeredProviders)],
+      // Returns a value for builtin providers OR providers registered via setProvider().
+      getProvider: (id: string) => (REGISTRY[id] ? { id } : registeredProviders[id]),
+      // Simulates piAiModels.setProvider() — stores the provider for getProvider() lookup.
+      setProvider: (provider: any) => {
+        registeredProviders[provider.id] = provider;
+      },
     }),
     getBuiltinModel: (provider: string, modelId: string) => REGISTRY[provider]?.[modelId],
     getBuiltinProviders: () => Object.keys(REGISTRY),
@@ -43,8 +52,31 @@ vi.mock('@earendil-works/pi-ai/providers/all', () => {
   };
 });
 
+// Mock lazy API implementation modules used by registerCustomProvidersWithPiAi.
+vi.mock('@earendil-works/pi-ai/api/openai-completions.lazy', () => ({
+  openAICompletionsApi: () => ({ id: 'openai-completions' }),
+}));
+vi.mock('@earendil-works/pi-ai/api/openai-responses.lazy', () => ({
+  openAIResponsesApi: () => ({ id: 'openai-responses' }),
+}));
+vi.mock('@earendil-works/pi-ai/api/openai-codex-responses.lazy', () => ({
+  openAICodexResponsesApi: () => ({ id: 'openai-codex-responses' }),
+}));
+vi.mock('@earendil-works/pi-ai/api/anthropic-messages.lazy', () => ({
+  anthropicMessagesApi: () => ({ id: 'anthropic-messages' }),
+}));
+vi.mock('@earendil-works/pi-ai/api/google-generative-ai.lazy', () => ({
+  googleGenerativeAIApi: () => ({ id: 'google-generative-ai' }),
+}));
+vi.mock('@earendil-works/pi-ai/api/google-vertex.lazy', () => ({
+  googleVertexApi: () => ({ id: 'google-generative-ai-vertex' }),
+}));
+vi.mock('@earendil-works/pi-ai/api/azure-openai-responses.lazy', () => ({
+  azureOpenAIResponsesApi: () => ({ id: 'azure-openai-responses' }),
+}));
+
 import { setConfigForTesting } from '../../../config';
-import { resolvePiAiModel, toDispatchModel } from '../pi-ai-utils';
+import { resolvePiAiModel, toDispatchModel, registerCustomProvidersWithPiAi } from '../pi-ai-utils';
 
 function configWith(custom: { providers?: Record<string, any>; models?: Record<string, any> }) {
   setConfigForTesting({
@@ -59,7 +91,11 @@ function configWith(custom: { providers?: Record<string, any>; models?: Record<s
 }
 
 describe('resolvePiAiModel', () => {
-  beforeEach(() => configWith({}));
+  beforeEach(() => {
+    // Clear any providers registered via setProvider() between tests.
+    Object.keys(registeredProviders).forEach((k) => delete registeredProviders[k]);
+    configWith({});
+  });
 
   it('returns a built-in registry model', () => {
     const m = resolvePiAiModel('openai', 'gpt-5.5');
@@ -301,11 +337,9 @@ describe('toDispatchModel', () => {
     expect(result.provider).toBe('openai');
   });
 
-  it('remaps a custom provider to the builtin openai provider for openai-completions api', () => {
-    // Regression: neuralwatt has pi_ai_provider:"neuralwatt" and
-    // api:"openai-completions". Before the fix, piAiModels.stream() threw
-    // "Unknown provider: neuralwatt" because builtinModels() only registers
-    // canonical builtin provider ids.
+  it('remaps a custom provider to the builtin openai for openai-completions when NOT registered via setProvider', () => {
+    // When registerCustomProvidersWithPiAi has NOT been called, the old
+    // fallback remap still applies so dispatch does not throw.
     const model = {
       id: 'glm-5.2',
       provider: 'neuralwatt',
@@ -314,6 +348,33 @@ describe('toDispatchModel', () => {
     } as any;
     const result = toDispatchModel(model);
     expect(result.provider).toBe('openai');
+    expect(result.id).toBe('glm-5.2');
+    expect(result.api).toBe('openai-completions');
+    expect(result.baseUrl).toBe('https://api.neuralwatt.com/v1');
+  });
+
+  it('returns the model UNCHANGED when the custom provider has been registered via setProvider', async () => {
+    // This is the correct post-fix behaviour: once registerCustomProvidersWithPiAi
+    // has called piAiModels.setProvider(createProvider({id:'neuralwatt',...})),
+    // toDispatchModel must NOT remap the provider to 'openai' — doing so would
+    // cause piAiModels.stream() to use the openai-responses API path instead of
+    // openai-completions, hitting /responses instead of /chat/completions.
+    configWith({
+      providers: {
+        neuralwatt: { api: 'openai-completions', display_name: 'NeuralWatt' },
+      },
+    });
+    await registerCustomProvidersWithPiAi();
+
+    const model = {
+      id: 'glm-5.2',
+      provider: 'neuralwatt',
+      api: 'openai-completions',
+      baseUrl: 'https://api.neuralwatt.com/v1',
+    } as any;
+    const result = toDispatchModel(model);
+    // Provider must NOT be remapped — it is now known to piAiModels.
+    expect(result.provider).toBe('neuralwatt');
     expect(result.id).toBe('glm-5.2');
     expect(result.api).toBe('openai-completions');
     expect(result.baseUrl).toBe('https://api.neuralwatt.com/v1');
@@ -353,5 +414,77 @@ describe('toDispatchModel', () => {
     const result = toDispatchModel(model);
     // Falls through — let piAiModels surface its own error
     expect(result.provider).toBe('unknown-provider');
+  });
+});
+
+// ─── registerCustomProvidersWithPiAi ─────────────────────────────────────────
+//
+// Verifies that custom providers defined in pi_ai_custom_providers config are
+// registered with piAiModels via createProvider()+setProvider(), so that
+// toDispatchModel() can find them and avoid the api-key remap that causes
+// the wrong API path to be used (e.g. /responses instead of /chat/completions).
+
+describe('registerCustomProvidersWithPiAi', () => {
+  beforeEach(() => {
+    Object.keys(registeredProviders).forEach((k) => delete registeredProviders[k]);
+    configWith({});
+  });
+
+  it('registers each custom provider so piAiModels.getProvider() finds it', async () => {
+    configWith({
+      providers: {
+        neuralwatt: { api: 'openai-completions', display_name: 'NeuralWatt' },
+        'my-anthropic-proxy': { api: 'anthropic-messages' },
+      },
+    });
+    await registerCustomProvidersWithPiAi();
+
+    // Both providers should now be findable in piAiModels.
+    expect(registeredProviders['neuralwatt']).toBeDefined();
+    expect(registeredProviders['my-anthropic-proxy']).toBeDefined();
+  });
+
+  it('does not re-register a provider already present in piAiModels', async () => {
+    configWith({
+      providers: { neuralwatt: { api: 'openai-completions' } },
+    });
+    // Pre-populate as if already registered.
+    registeredProviders['neuralwatt'] = { id: 'neuralwatt', sentinel: true };
+
+    await registerCustomProvidersWithPiAi();
+
+    // The original sentinel object must survive — setProvider was not called again.
+    expect(registeredProviders['neuralwatt'].sentinel).toBe(true);
+  });
+
+  it('is a no-op when pi_ai_custom_providers is empty', async () => {
+    configWith({});
+    await registerCustomProvidersWithPiAi();
+    expect(Object.keys(registeredProviders)).toHaveLength(0);
+  });
+
+  it('uses the correct API implementation for the declared api type', async () => {
+    const { createProvider } = await import('@earendil-works/pi-ai');
+    const createProviderMock = vi.mocked(createProvider);
+    createProviderMock.mockClear();
+
+    configWith({
+      providers: {
+        neuralwatt: { api: 'openai-completions' },
+        'my-google': { api: 'google-generative-ai' },
+      },
+    });
+    await registerCustomProvidersWithPiAi();
+
+    expect(createProviderMock).toHaveBeenCalledTimes(2);
+
+    const neuralwattCall = createProviderMock.mock.calls.find((c) => c[0].id === 'neuralwatt');
+    expect(neuralwattCall).toBeDefined();
+    // The api passed to createProvider must be the resolved implementation, not the string.
+    expect(neuralwattCall![0].api).toEqual({ id: 'openai-completions' });
+
+    const googleCall = createProviderMock.mock.calls.find((c) => c[0].id === 'my-google');
+    expect(googleCall).toBeDefined();
+    expect(googleCall![0].api).toEqual({ id: 'google-generative-ai' });
   });
 });

--- a/packages/backend/src/inference-v2/shared/fetch-tap.ts
+++ b/packages/backend/src/inference-v2/shared/fetch-tap.ts
@@ -54,6 +54,7 @@ export function installFetchTap(): void {
     // Always record TTFB when there is an active inference-v2 request context,
     // regardless of whether debug logging is enabled.
     const requestId = debugRequestIdStorage.getStore();
+
     if (!requestId) return response;
 
     ttfbMap.set(requestId, ttfb);

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -24,7 +24,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { calculateCost } from '@earendil-works/pi-ai';
 import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
-import { piAiModels } from './pi-ai-utils';
+import { piAiModels, toDispatchModel } from './pi-ai-utils';
 import type {
   Context,
   ProviderStreamOptions,
@@ -563,7 +563,7 @@ export async function runPiAiExecutor<TResponse>(
       if (!streaming) {
         // ── Non-streaming ────────────────────────────────────────────────
         const message = await debugRequestIdStorage.run(requestId, () =>
-          piAiModels.complete(piModel as any, context, callOptions)
+          piAiModels.complete(toDispatchModel(piModel as any), context, callOptions)
         );
 
         cooldown.markProviderSuccess(route.provider, route.model);
@@ -624,7 +624,7 @@ export async function runPiAiExecutor<TResponse>(
       } else {
         // ── Streaming ────────────────────────────────────────────────────
         const eventStream = await debugRequestIdStorage.run(requestId, () =>
-          piAiModels.stream(piModel as any, context, callOptions)
+          piAiModels.stream(toDispatchModel(piModel as any), context, callOptions)
         );
 
         // Build and return the SSE generator — the generator owns

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -602,6 +602,35 @@ export function resolvePiAiModel(piAiProvider: string, piAiModelId: string): PiA
   return safeGetModel(piAiProvider, piAiModelId);
 }
 
+/**
+ * Prepare a resolved pi-ai Model for dispatch via `piAiModels.stream()` /
+ * `piAiModels.complete()`.
+ *
+ * `builtinModels()` routes by `model.provider` via a provider map that only
+ * contains the builtin provider ids (`openai`, `anthropic`, `google`, …).
+ * Custom providers (e.g. `neuralwatt`, `wafer`) are not registered in that
+ * map, so dispatching with `provider: "neuralwatt"` throws
+ * `"Unknown provider: neuralwatt"`.
+ *
+ * The pre-0.80 compat `stream()` free function dispatched by `model.api`
+ * instead, transparently handling custom providers. This helper restores that
+ * behaviour: when `model.provider` is not a registered builtin, remap it to
+ * the canonical builtin that implements the same wire API so that
+ * `piAiModels.stream()` can route to the correct provider.
+ */
+export function toDispatchModel(model: PiAiModel<any>): PiAiModel<any> {
+  if (piAiModels.getProvider(model.provider)) {
+    // Already a known builtin — no remapping needed.
+    return model;
+  }
+  const builtinProvider = API_TO_BUILTIN_PROVIDER[model.api];
+  if (!builtinProvider) {
+    // Unknown api — return as-is and let piAiModels surface the error.
+    return model;
+  }
+  return { ...model, provider: builtinProvider };
+}
+
 function applyCustomProvider(
   model: PiAiModel<any>,
   providerSpec: PiAiCustomProvider | undefined

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -8,11 +8,94 @@
  *  - buildPiAiModel: construct a call-ready pi-ai Model with base URL override applied
  */
 
-import { clampThinkingLevel, getSupportedThinkingLevels } from '@earendil-works/pi-ai';
+import {
+  clampThinkingLevel,
+  getSupportedThinkingLevels,
+  createProvider,
+} from '@earendil-works/pi-ai';
 import { getBuiltinModel, builtinModels } from '@earendil-works/pi-ai/providers/all';
 import type { Model as PiAiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
 
 export const piAiModels = builtinModels();
+
+// Lazy API implementation factories, keyed by pi-ai api id.
+// Imported here so we can instantiate the right one when registering custom providers.
+const API_IMPLEMENTATIONS: Record<string, () => any> = {
+  'openai-completions': () =>
+    import('@earendil-works/pi-ai/api/openai-completions.lazy').then((m) =>
+      m.openAICompletionsApi()
+    ),
+  'openai-responses': () =>
+    import('@earendil-works/pi-ai/api/openai-responses.lazy').then((m) => m.openAIResponsesApi()),
+  'openai-codex-responses': () =>
+    import('@earendil-works/pi-ai/api/openai-codex-responses.lazy').then((m) =>
+      m.openAICodexResponsesApi()
+    ),
+  'anthropic-messages': () =>
+    import('@earendil-works/pi-ai/api/anthropic-messages.lazy').then((m) =>
+      m.anthropicMessagesApi()
+    ),
+  'google-generative-ai': () =>
+    import('@earendil-works/pi-ai/api/google-generative-ai.lazy').then((m) =>
+      m.googleGenerativeAIApi()
+    ),
+  'google-generative-ai-vertex': () =>
+    import('@earendil-works/pi-ai/api/google-vertex.lazy').then((m) => m.googleVertexApi()),
+  'azure-openai-responses': () =>
+    import('@earendil-works/pi-ai/api/azure-openai-responses.lazy').then((m) =>
+      m.azureOpenAIResponsesApi()
+    ),
+};
+
+/**
+ * Register each pi_ai_custom_provider from Plexus config with the piAiModels
+ * instance via createProvider() + setProvider(). This must be called at startup
+ * so that toDispatchModel() can find custom providers by id and piAiModels.stream()
+ * routes to the correct API implementation instead of falling back to the openai
+ * builtin (which only supports openai-responses).
+ */
+export async function registerCustomProvidersWithPiAi(): Promise<void> {
+  let cfg: ReturnType<typeof getConfig> | undefined;
+  try {
+    cfg = getConfig();
+  } catch {
+    return;
+  }
+  const customProviders = (cfg as any)?.pi_ai_custom_providers as
+    | Record<string, PiAiCustomProvider>
+    | undefined;
+  if (!customProviders || Object.keys(customProviders).length === 0) return;
+
+  for (const [id, spec] of Object.entries(customProviders)) {
+    if (piAiModels.getProvider(id)) {
+      // Already registered (e.g. duplicate call at reload) — skip.
+      continue;
+    }
+    const apiFactory = API_IMPLEMENTATIONS[spec.api];
+    if (!apiFactory) {
+      logger.warn(
+        `[registerCustomProvidersWithPiAi] Unknown api '${spec.api}' for custom provider '${id}' — skipping`
+      );
+      continue;
+    }
+    try {
+      const apiImpl = await apiFactory();
+      const provider = createProvider({
+        id,
+        name: spec.display_name ?? id,
+        auth: { apiKey: { name: id, resolve: async () => ({ auth: {} }) } },
+        models: [],
+        api: apiImpl,
+      });
+      piAiModels.setProvider(provider);
+    } catch (e: any) {
+      logger.warn(
+        `[registerCustomProvidersWithPiAi] Failed to register custom provider '${id}': ${e.message}`
+      );
+    }
+  }
+}
+
 import {
   getConfig,
   type ProviderConfig,
@@ -25,6 +108,7 @@ import { resolveModelParams, DEFAULT_GPU_PARAMS } from '@plexus/shared';
 import type { ReasoningEffort, ReasoningIntent } from './reasoning';
 import { effortToBudget, intentToEffort } from './reasoning';
 import type { GenerationIntent } from './generation';
+import { logger } from '../../utils/logger';
 
 // ─── buildThinkingOptions ─────────────────────────────────────────────────────
 //
@@ -575,6 +659,7 @@ export function resolvePiAiModel(piAiProvider: string, piAiModelId: string): PiA
   //    then fall back to the plain key `piAiModelId` for backwards compatibility.
   const compoundKey = piAiModelId.includes(':') ? piAiModelId : `${piAiProvider}:${piAiModelId}`;
   const modelSpec = customModels?.[compoundKey] ?? customModels?.[piAiModelId];
+
   if (modelSpec && modelSpec.provider === piAiProvider) {
     const resolved = resolveCustomModel(modelSpec, piAiProvider, piAiModelId);
     if (resolved) {

--- a/packages/backend/src/routes/management/pi-ai-custom.ts
+++ b/packages/backend/src/routes/management/pi-ai-custom.ts
@@ -46,11 +46,10 @@ export async function registerPiAiCustomRoutes(fastify: FastifyInstance) {
       }
       try {
         await configService.savePiAiCustomProvider(name, result.data);
-        // Re-register with piAiModels so the new provider is available immediately
-        // without requiring a restart.
-        registerCustomProvidersWithPiAi().catch((e) =>
-          logger.warn('Failed to re-register pi-ai custom providers after save', e)
-        );
+        // Await re-registration so the provider is available in piAiModels before
+        // we respond — avoids a race where a request arrives before registration
+        // completes and toDispatchModel falls back to the wrong builtin API path.
+        await registerCustomProvidersWithPiAi();
         return reply.send({ success: true, name, definition: result.data });
       } catch (e: any) {
         logger.error('Failed to save pi-ai custom provider', e);

--- a/packages/backend/src/routes/management/pi-ai-custom.ts
+++ b/packages/backend/src/routes/management/pi-ai-custom.ts
@@ -4,6 +4,7 @@ import type { Model as PiAiModel } from '@earendil-works/pi-ai';
 import { logger } from '../../utils/logger';
 import { PiAiCustomProviderSchema, PiAiCustomModelSchema } from '../../config';
 import { ConfigService } from '../../services/config-service';
+import { registerCustomProvidersWithPiAi } from '../../inference-v2/shared/pi-ai-utils';
 
 const NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9.:\-_]{0,126}$/;
 
@@ -45,6 +46,11 @@ export async function registerPiAiCustomRoutes(fastify: FastifyInstance) {
       }
       try {
         await configService.savePiAiCustomProvider(name, result.data);
+        // Re-register with piAiModels so the new provider is available immediately
+        // without requiring a restart.
+        registerCustomProvidersWithPiAi().catch((e) =>
+          logger.warn('Failed to re-register pi-ai custom providers after save', e)
+        );
         return reply.send({ success: true, name, definition: result.data });
       } catch (e: any) {
         logger.error('Failed to save pi-ai custom provider', e);

--- a/packages/backend/test/vitest.setup.ts
+++ b/packages/backend/test/vitest.setup.ts
@@ -194,12 +194,17 @@ vi.mock('@earendil-works/pi-ai/compat', () => ({
   getProviders: mockGetProviders,
 }));
 
+const MOCK_BUILTIN_PROVIDER_IDS = new Set(['anthropic', 'openai-codex', 'openai', 'google']);
+
 const mockModels = {
   complete: mockComplete,
   stream: mockStream,
   getModel: mockGetModel,
   getModels: mockGetModels,
   getProviders: mockGetProviders,
+  // Returns a truthy stub for known builtin provider ids, undefined otherwise.
+  // Mirrors the real piAiModels.getProvider() used by toDispatchModel().
+  getProvider: (id: string) => (MOCK_BUILTIN_PROVIDER_IDS.has(id) ? { id } : undefined),
 };
 
 vi.mock('../src/utils/logger', () => ({

--- a/scripts/deploy-staging.ts
+++ b/scripts/deploy-staging.ts
@@ -448,6 +448,8 @@ docker(
     '--rm',
     '-v',
     '/var/run/docker.sock:/var/run/docker.sock',
+    '-e',
+    'DOCKER_API_VERSION=1.40',
     'containrrr/watchtower',
     '--run-once',
     '--no-pull',


### PR DESCRIPTION
### **Unknown provider**
neuralwatt


___

### **User description**
## Problem

The upgrade to `@earendil-works/pi-ai` 0.80.1 (commit `26330d3`) introduced a regression for any Plexus provider configured with a custom `pi_ai_provider` id (e.g. `neuralwatt`, `wafer`).

**Before 0.80**, the executor called the `stream()`/`complete()` free functions from `@earendil-works/pi-ai/compat`, which dispatched by **`model.api`** (e.g. `openai-completions`), transparently routing custom providers through the appropriate builtin API handler.

**After 0.80**, the executor was changed to call `piAiModels.stream()` / `piAiModels.complete()` on a `builtinModels()` instance. This collection routes by **`model.provider`** via an internal map that only contains canonical builtin ids (`openai`, `anthropic`, `google`, …). Custom provider ids are not registered, so:

```
piAiModels.stream({ provider: "neuralwatt", api: "openai-completions", ... })
  → requireProvider("neuralwatt")
  → this.providers.get("neuralwatt") === undefined
  → throw new ModelsError("provider", "Unknown provider: neuralwatt")
```

Observed in production as request `c6f583c6-a61d-45bd-a07d-9c94fff973e7` (`glm-5.2` via `neuralwatt`).

## Fix

Add a `toDispatchModel()` helper in `pi-ai-utils.ts` that remaps `model.provider` to the canonical builtin that implements the same wire API before the model is handed to `piAiModels.stream()` / `.complete()`:

- If `model.provider` is already a registered builtin → return the model unchanged (same reference).
- Otherwise, look up `API_TO_BUILTIN_PROVIDER[model.api]` (map already existed for `resolvePiAiModel`) and return a shallow copy with the remapped provider.
- If the api has no mapping → return unchanged and let `piAiModels` surface its own error.

`pi-ai-executor.ts` now wraps both call sites with `toDispatchModel()`.

## Tests

- Added `getProvider` to `builtinModels` mock in `vitest.setup.ts` and the local mock in `resolve-pi-ai-model.test.ts`.
- Added a `toDispatchModel` describe block with 5 tests, including a regression case that mirrors the exact `neuralwatt`/`glm-5.2` failure (`openai-completions` → remapped to `openai`), plus coverage for `anthropic-messages`, `google-generative-ai`, builtin passthrough, and unknown-api fallthrough.


___

