### PR TITLE
feat(context): Add opt-in context compaction for inference-v2 beta routes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "plexus2",
       "devDependencies": {
-        "@biomejs/biome": "2.5.0",
-        "@redocly/cli": "^2.34.0",
-        "agent-browser": "^0.28.0",
+        "@biomejs/biome": "2.5.1",
+        "@redocly/cli": "^2.35.0",
+        "agent-browser": "^0.30.1",
         "bun-types": "1.3.14",
         "lefthook": "^2.1.9",
         "octokit": "^5.0.5",
@@ -146,23 +146,23 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg=="],
 
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
 
@@ -408,7 +408,7 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
-    "@redocly/cli": ["@redocly/cli@2.34.0", "", { "bin": { "redocly": "bin/cli.js", "openapi": "bin/cli.js" } }, "sha512-wlEy03fyf+xrEatHbSSLFGP7T8slYwyJHO6xooArvUOntiGRMPuTGivaSPhxx+f2bFhe69zDDzDy51+CsvJ/zw=="],
+    "@redocly/cli": ["@redocly/cli@2.35.0", "", { "bin": { "redocly": "bin/cli.js", "openapi": "bin/cli.js" } }, "sha512-p25TtRIN85KewtpPVdTuakmKHCcZkmV+ygQx2dJgvpXpNqZeoyjmnNThev1oyIc4t2h2mGkompan/LgPtG/u3g=="],
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
@@ -568,7 +568,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "agent-browser": ["agent-browser@0.28.0", "", { "bin": { "agent-browser": "bin/agent-browser.js" } }, "sha512-rPpFXR3AUhi9wgyhCKOPffPnceTZP29Y2qr20FzTXc6Dailv0QoHF9XfYrb8nXP7Wt8K9wmVxoKf1nVU1U8S5w=="],
+    "agent-browser": ["agent-browser@0.30.1", "", { "bin": { "agent-browser": "./bin/agent-browser.js" } }, "sha512-VMIZH90PFe5vmazizovDYUAAGrUWZ+xCqyv9ceuDOuL283a8aRqsshIQ0PY02QcdCpi1b6dwYYZOvUhoCl08Xw=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "eventsource-encoder": "^1.0.2",
         "eventsource-parser": "^3.1.0",
         "fastify": "^5.8.5",
+        "headroom-ai": "^0.22.4",
         "js-tiktoken": "^1.0.21",
         "parse-duration": "^2.1.6",
         "pkce-challenge": "^6.0.0",
@@ -817,6 +818,8 @@
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "headroom-ai": ["headroom-ai@0.22.4", "", { "peerDependencies": { "@ai-sdk/provider": ">=1.0.0", "@anthropic-ai/sdk": ">=0.30.0", "ai": ">=6.0.0", "openai": ">=4.0.0" }, "optionalPeers": ["@ai-sdk/provider", "@anthropic-ai/sdk", "ai", "openai"] }, "sha512-9a0rgB/jsWe8gs/ggyUwe6E8DYwKAuBvlUml2ApwlUjb5EfJ611X6X+WG0SiXw3nO6sdyV1/+Ah5uw9P7ecnjw=="],
 
     "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -97,7 +97,7 @@ Content-Type: application/json
 
 Per-alias or per-provider overrides use the same field names in the alias/provider config objects.
 
-> The global `PATCH` shallow-merges over the stored config, so nested objects (`native`, `headroom`) are **replaced wholesale** â€” send the complete sub-object when changing one of its fields. (The Config UI always sends the full object.)
+> The global `PATCH` field-merges nested objects (`native`, `headroom`). Send `null` for a field to clear its stored value and fall back to the default.
 
 ---
 
@@ -119,9 +119,9 @@ If the headroom proxy is unreachable, all requests still succeed via fail-open â
 
 ## Observability
 
-### Response headers (non-streaming)
+### Response headers
 
-When compaction fires on a non-streaming `/beta/` request, three response headers are set:
+When compaction fires on a `/beta/` request, three response headers are set before the response body or stream starts:
 
 | Header | Value |
 |---|---|
@@ -131,12 +131,12 @@ When compaction fires on a non-streaming `/beta/` request, three response header
 
 These headers are absent when compaction did not fire (not enabled, below threshold, or failed-open).
 
-### Streaming
+### Logs
 
-SSE headers are pre-flushed before the stream starts, so compaction headers cannot be appended. Compaction activity for streaming requests is observable via the backend log line:
+Compaction activity is also observable via the backend log line:
 
 ```
-[compaction] strategy=native tokensBefore=45000 tokensAfter=28000
+[compaction] native 45000->28000 tokens (gpt-4o)
 ```
 
 ### Usage records

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -1,0 +1,144 @@
+# Context Compaction
+
+## What it is
+
+Context compaction is an opt-in feature that automatically reduces conversation context before the upstream model send, to fit large requests under the model's context window. Compaction operates on the **request side only** (responses are never modified).
+
+**Applies to inference-v2 / `/beta/` routes only.** The legacy `/v1/...` Dispatcher path is unaffected.
+
+---
+
+## Strategies
+
+### `native` (default)
+
+Deterministic structural compaction. Truncates verbose JSON arrays and long tool-result / log text blocks, while protecting:
+- The system prompt (never compacted)
+- The most recent N messages (configurable via `protectRecent`)
+
+Configured via the `native` sub-object (`maxArrayItems`, `maxStringChars`).
+
+### `headroom`
+
+Delegates compaction to a self-hosted [headroom](https://github.com/chopratejas/headroom) proxy via the `headroom-ai` SDK's compress endpoint. Configured via the `headroom` sub-object (`baseUrl`, `apiKey`, `targetRatio`, `timeoutMs`).
+
+> **v1 caveat:** the `headroom` strategy maps the context through OpenAI chat format, which has no representation for assistant **thinking** blocks — so thinking content (and its signatures) is dropped from compacted messages. For Anthropic extended-thinking models used with tools, prefer the `native` strategy (which preserves thinking) until this is addressed. `native` is the default.
+
+---
+
+## Settings & Precedence
+
+Settings resolve in order: **alias > provider > global > default**. Nested `native`/`headroom` objects merge field-by-field (each field inherits independently).
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enable/disable compaction |
+| `strategy` | `"native"` | `"native"` or `"headroom"` |
+| `triggerRatio` | `0.8` | Fraction of `context_length`; compaction fires when estimated tokens ≥ this ratio × context window |
+| `absoluteTriggerTokens` | _(unset)_ | Fallback trigger when context_length is unknown; must be ≥ 1 if set |
+| `minTokens` | `2000` | Never compact if estimated input tokens is below this value |
+| `protectRecent` | `4` | Number of recent messages to keep verbatim (never compacted) |
+| `native.maxArrayItems` | _(strategy default)_ | Maximum items retained in JSON arrays during native compaction |
+| `native.maxStringChars` | _(strategy default)_ | Maximum characters retained in long strings during native compaction |
+| `headroom.baseUrl` | `"http://localhost:8787"` | URL of the headroom proxy or hosted endpoint |
+| `headroom.apiKey` | _(unset)_ | API key for a hosted headroom endpoint |
+| `headroom.targetRatio` | _(strategy default)_ | Target compression ratio passed to headroom |
+| `headroom.timeoutMs` | _(strategy default)_ | Timeout in ms for the headroom compress call |
+
+---
+
+## Trigger (safety-net)
+
+Compaction fires only when **all** of the following hold:
+
+1. `enabled: true` in the resolved config
+2. Estimated input tokens ≥ `triggerRatio × context_length` **or** ≥ `absoluteTriggerTokens` (when context_length is unknown)
+3. Estimated input tokens ≥ `minTokens`
+
+Conservative defaults mean only large requests trigger compaction.
+
+---
+
+## Guards
+
+- **Fail-open:** any strategy error or timeout leaves the original context unchanged — the request proceeds as if compaction was not configured.
+- **Validation guard:** if the post-compaction token estimate did not drop below the pre-compaction estimate, the original context is used instead.
+- **System prompt protection:** the system prompt is never compacted in native strategy v1.
+- **Request-side only:** the model response is never altered.
+
+---
+
+## Composition with `enforce_limits`
+
+If an alias also has `enforce_limits` configured, the processing order is **compact → enforce**. Compaction runs first and can rescue a borderline-oversized request; enforcement then validates the (now-reduced) context. This means compaction can prevent a 400 rejection that would have occurred without it.
+
+---
+
+## Configuring
+
+### Via the UI
+
+Open **Settings → Config → Context Compaction**. Global defaults are set here; per-provider and per-alias overrides are available in their respective editor panels. An empty field inherits from the parent level.
+
+### Via the API
+
+```
+PATCH /v0/management/config/compaction
+Content-Type: application/json
+
+{
+  "enabled": true,
+  "strategy": "native",
+  "triggerRatio": 0.8,
+  "minTokens": 2000,
+  "protectRecent": 4
+}
+```
+
+Per-alias or per-provider overrides use the same field names in the alias/provider config objects.
+
+> The global `PATCH` shallow-merges over the stored config, so nested objects (`native`, `headroom`) are **replaced wholesale** — send the complete sub-object when changing one of its fields. (The Config UI always sends the full object.)
+
+---
+
+## Self-Hosted Headroom Setup
+
+1. Run a headroom proxy: `headroom proxy` (default listens on `http://localhost:8787`).
+2. Set the global strategy to `"headroom"` and point `headroom.baseUrl` at the proxy:
+   ```json
+   {
+     "strategy": "headroom",
+     "headroom": { "baseUrl": "http://localhost:8787" }
+   }
+   ```
+3. For a **hosted** headroom endpoint: set `headroom.baseUrl` to the hosted URL and provide `headroom.apiKey`.
+
+If the headroom proxy is unreachable, all requests still succeed via fail-open — no compaction occurs and a warning is logged.
+
+---
+
+## Observability
+
+### Response headers (non-streaming)
+
+When compaction fires on a non-streaming `/beta/` request, three response headers are set:
+
+| Header | Value |
+|---|---|
+| `x-plexus-compaction-strategy` | The strategy that ran (`"native"` or `"headroom"`), or empty if strategy was null |
+| `x-plexus-compaction-tokens-before` | Estimated input token count before compaction |
+| `x-plexus-compaction-tokens-after` | Estimated input token count after compaction |
+
+These headers are absent when compaction did not fire (not enabled, below threshold, or failed-open).
+
+### Streaming
+
+SSE headers are pre-flushed before the stream starts, so compaction headers cannot be appended. Compaction activity for streaming requests is observable via the backend log line:
+
+```
+[compaction] strategy=native tokensBefore=45000 tokensAfter=28000
+```
+
+### Usage records
+
+The provider-reported `tokensInput` in usage records already reflects the compacted input (what was actually sent upstream). Dedicated compaction usage columns (e.g. original vs. compacted counts) are planned as a follow-up.

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "plexus2",
   "module": "index.ts",
   "devDependencies": {
-    "@biomejs/biome": "2.5.0",
-    "@redocly/cli": "^2.34.0",
-    "agent-browser": "^0.28.0",
+    "@biomejs/biome": "2.5.1",
+    "@redocly/cli": "^2.35.0",
+    "agent-browser": "^0.30.1",
     "bun-types": "1.3.14",
     "lefthook": "^2.1.9",
     "octokit": "^5.0.5",

--- a/packages/backend/drizzle/schema/postgres/model-aliases.ts
+++ b/packages/backend/drizzle/schema/postgres/model-aliases.ts
@@ -38,6 +38,7 @@ export const modelAliases = pgTable('model_aliases', {
   targetGroups: jsonb('target_groups'), // {name, selector}[]
   extraBody: jsonb('extra_body'), // Record<string, any>
   generation: jsonb('generation'), // { reasoning?, maxTokens?, verbosity?, serviceTier? }
+  compaction: jsonb('compaction'), // compaction config
   createdAt: bigint('created_at', { mode: 'number' }).notNull(),
   updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
 });

--- a/packages/backend/drizzle/schema/postgres/providers.ts
+++ b/packages/backend/drizzle/schema/postgres/providers.ts
@@ -35,6 +35,7 @@ export const providers = pgTable(
     geminiThinkingEnabled: boolean('gemini_thinking_enabled').notNull().default(false),
     headers: text('headers'), // JSON or encrypted string — text for encryption compatibility
     extraBody: text('extra_body'), // JSON — not encrypted, text for consistency
+    compaction: jsonb('compaction'), // compaction config
     quotaCheckerType: quotaCheckerTypeEnum('quota_checker_type'),
     quotaCheckerId: text('quota_checker_id'),
     quotaCheckerEnabled: boolean('quota_checker_enabled').notNull().default(true),

--- a/packages/backend/drizzle/schema/sqlite/model-aliases.ts
+++ b/packages/backend/drizzle/schema/sqlite/model-aliases.ts
@@ -20,6 +20,7 @@ export const modelAliases = sqliteTable('model_aliases', {
   targetGroups: text('target_groups'), // JSON: {name, selector}[]
   extraBody: text('extra_body'), // JSON: Record<string, any>
   generation: text('generation'), // JSON: { reasoning?, maxTokens?, verbosity?, serviceTier? }
+  compaction: text('compaction'), // JSON: compaction config
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });

--- a/packages/backend/drizzle/schema/sqlite/providers.ts
+++ b/packages/backend/drizzle/schema/sqlite/providers.ts
@@ -22,6 +22,7 @@ export const providers = sqliteTable(
     geminiThinkingEnabled: integer('gemini_thinking_enabled').notNull().default(0),
     headers: text('headers'), // JSON: Record<string, string>
     extraBody: text('extra_body'), // JSON: Record<string, any>
+    compaction: text('compaction'), // JSON: compaction config
     quotaCheckerType: text('quota_checker_type'),
     quotaCheckerId: text('quota_checker_id'),
     quotaCheckerEnabled: integer('quota_checker_enabled').notNull().default(1),

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -31,6 +31,7 @@
     "eventsource-encoder": "^1.0.2",
     "eventsource-parser": "^3.1.0",
     "fastify": "^5.8.5",
+    "headroom-ai": "^0.22.4",
     "js-tiktoken": "^1.0.21",
     "parse-duration": "^2.1.6",
     "pkce-challenge": "^6.0.0",

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -679,6 +679,29 @@ const ModelAutosyncSchema = z.object({
   intervalMinutes: z.number().int().min(1).default(60),
 });
 
+const CompactionNativeSchema = z.object({
+  maxArrayItems: z.number().int().positive().optional(),
+  maxStringChars: z.number().int().positive().optional(),
+});
+const CompactionHeadroomSchema = z.object({
+  baseUrl: z.string().url().optional(),
+  apiKey: z.string().optional(),
+  targetRatio: z.number().min(0).max(1).nullable().optional(),
+  timeoutMs: z.number().int().min(100).max(60000).optional(),
+});
+export const CompactionOverrideSchema = z.object({
+  enabled: z.boolean().optional(),
+  strategy: z.enum(['native', 'headroom']).optional(),
+  triggerRatio: z.number().min(0).max(1).optional(),
+  absoluteTriggerTokens: z.number().int().positive().nullable().optional(),
+  minTokens: z.number().int().min(0).optional(),
+  protectRecent: z.number().int().min(0).optional(),
+  native: CompactionNativeSchema.optional(),
+  headroom: CompactionHeadroomSchema.optional(),
+});
+export const CompactionConfigSchema = CompactionOverrideSchema;
+export type CompactionSettingsConfig = z.infer<typeof CompactionOverrideSchema>;
+
 export const ProviderConfigSchema = z
   .object({
     display_name: z.string().optional(),
@@ -723,6 +746,7 @@ export const ProviderConfigSchema = z
     stallWindowMs: z.number().int().min(3000).max(30000).nullable().optional(),
     stallGracePeriodMs: z.number().int().min(0).max(120000).nullable().optional(),
     pi_ai_provider: z.string().optional(),
+    compaction: CompactionOverrideSchema.optional(),
   })
   .refine((data) => !!data.api_key || isOAuthProviderConfig(data), {
     message: "'api_key' must be specified for provider",
@@ -916,6 +940,7 @@ export const ModelConfigSchema = z
           .optional(),
       })
       .optional(),
+    compaction: CompactionOverrideSchema.optional(),
   })
   .transform((data) => {
     // Normalise legacy flat format to grouped format immediately.
@@ -1037,6 +1062,7 @@ const RawPlexusConfigSchema = z
     // Workspace-level pi-ai custom provider / model registries (inference-v2).
     pi_ai_custom_providers: z.record(z.string(), PiAiCustomProviderSchema).optional(),
     pi_ai_custom_models: z.record(z.string(), PiAiCustomModelSchema).optional(),
+    compaction: CompactionOverrideSchema.optional(),
   })
   .passthrough();
 

--- a/packages/backend/src/db/__tests__/config-repository-compaction.test.ts
+++ b/packages/backend/src/db/__tests__/config-repository-compaction.test.ts
@@ -1,11 +1,5 @@
 import { beforeEach, afterEach, describe, expect, it } from 'vitest';
-import {
-  closeDatabase,
-  getDatabase,
-  getSchema,
-  initializeDatabase,
-  getCurrentDialect,
-} from '../client';
+import { closeDatabase, getDatabase, getSchema, initializeDatabase } from '../client';
 import { runMigrations } from '../migrate';
 import { ConfigRepository } from '../config-repository';
 
@@ -21,26 +15,6 @@ describe('config-repository compaction round-trips', () => {
     await runMigrations();
     db = getDatabase();
     schema = getSchema();
-    // Ensure compaction column exists in case migration isn't committed yet
-    const dialect = getCurrentDialect();
-    try {
-      const alterProviders =
-        dialect === 'postgres'
-          ? 'ALTER TABLE providers ADD COLUMN compaction jsonb'
-          : 'ALTER TABLE providers ADD COLUMN compaction text';
-      await db.run(alterProviders as any);
-    } catch {
-      // Column already exists — fine
-    }
-    try {
-      const alterAliases =
-        dialect === 'postgres'
-          ? 'ALTER TABLE model_aliases ADD COLUMN compaction jsonb'
-          : 'ALTER TABLE model_aliases ADD COLUMN compaction text';
-      await db.run(alterAliases as any);
-    } catch {
-      // Column already exists — fine
-    }
     repo = new ConfigRepository();
     // Clean slate
     await db.delete(schema.modelAliasTargets);

--- a/packages/backend/src/db/__tests__/config-repository-compaction.test.ts
+++ b/packages/backend/src/db/__tests__/config-repository-compaction.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import {
+  closeDatabase,
+  getDatabase,
+  getSchema,
+  initializeDatabase,
+  getCurrentDialect,
+} from '../client';
+import { runMigrations } from '../migrate';
+import { ConfigRepository } from '../config-repository';
+
+describe('config-repository compaction round-trips', () => {
+  let db: ReturnType<typeof getDatabase>;
+  let schema: ReturnType<typeof getSchema>;
+  let repo: ConfigRepository;
+
+  beforeEach(async () => {
+    await closeDatabase();
+    process.env.DATABASE_URL = process.env.PLEXUS_TEST_DB_URL ?? process.env.DATABASE_URL;
+    initializeDatabase(process.env.DATABASE_URL);
+    await runMigrations();
+    db = getDatabase();
+    schema = getSchema();
+    // Ensure compaction column exists in case migration isn't committed yet
+    const dialect = getCurrentDialect();
+    try {
+      const alterProviders =
+        dialect === 'postgres'
+          ? 'ALTER TABLE providers ADD COLUMN compaction jsonb'
+          : 'ALTER TABLE providers ADD COLUMN compaction text';
+      await db.run(alterProviders as any);
+    } catch {
+      // Column already exists — fine
+    }
+    try {
+      const alterAliases =
+        dialect === 'postgres'
+          ? 'ALTER TABLE model_aliases ADD COLUMN compaction jsonb'
+          : 'ALTER TABLE model_aliases ADD COLUMN compaction text';
+      await db.run(alterAliases as any);
+    } catch {
+      // Column already exists — fine
+    }
+    repo = new ConfigRepository();
+    // Clean slate
+    await db.delete(schema.modelAliasTargets);
+    await db.delete(schema.modelAliases);
+    await db.delete(schema.providers);
+    await db.delete(schema.systemSettings);
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  // 1. Provider round-trip
+  it('round-trips compaction through saveProvider and getProvider', async () => {
+    const compaction = { enabled: true, strategy: 'headroom' as const, triggerRatio: 0.7 };
+
+    await repo.saveProvider('test-provider', {
+      api_base_url: 'https://api.example.com',
+      compaction,
+    } as any);
+
+    const loaded = await repo.getProvider('test-provider');
+    expect(loaded).toBeDefined();
+    expect(loaded!.compaction).toEqual(compaction);
+  });
+
+  it('round-trips compaction via getAllProviders', async () => {
+    const compaction = { enabled: true, strategy: 'headroom' as const, triggerRatio: 0.7 };
+
+    await repo.saveProvider('all-provider', {
+      api_base_url: 'https://api.example.com',
+      compaction,
+    } as any);
+
+    const all = await repo.getAllProviders();
+    const loaded = all['all-provider'];
+    expect(loaded).toBeDefined();
+    expect(loaded!.compaction).toEqual(compaction);
+  });
+
+  // 2. Alias round-trip
+  it('round-trips compaction through saveAlias and getAlias', async () => {
+    const compaction = { enabled: true, strategy: 'native' as const, triggerRatio: 0.8 };
+
+    await repo.saveAlias('test-alias', {
+      target_groups: [
+        { name: 'default', selector: 'random', targets: [{ provider: 'p1', model: 'm1' }] },
+      ],
+      compaction,
+    } as any);
+
+    const loaded = await repo.getAlias('test-alias');
+    expect(loaded).toBeDefined();
+    expect(loaded!.compaction).toEqual(compaction);
+  });
+
+  it('round-trips compaction via getAllAliases', async () => {
+    const compaction = { enabled: false, strategy: 'headroom' as const };
+
+    await repo.saveAlias('all-alias', {
+      target_groups: [
+        { name: 'default', selector: 'random', targets: [{ provider: 'p2', model: 'm2' }] },
+      ],
+      compaction,
+    } as any);
+
+    const all = await repo.getAllAliases();
+    const loaded = all['all-alias'];
+    expect(loaded).toBeDefined();
+    expect(loaded!.compaction).toEqual(compaction);
+  });
+
+  // 3. Null/absent — compaction must not leak through as null
+  it('provider saved without compaction reloads with compaction absent (not null)', async () => {
+    await repo.saveProvider('no-compaction-provider', {
+      api_base_url: 'https://api.example.com',
+    } as any);
+
+    const loaded = await repo.getProvider('no-compaction-provider');
+    expect(loaded).toBeDefined();
+    expect(loaded!.compaction).toBeUndefined();
+    expect('compaction' in loaded!).toBe(false);
+  });
+
+  it('alias saved without compaction reloads with compaction absent (not null)', async () => {
+    await repo.saveAlias('no-compaction-alias', {
+      target_groups: [
+        { name: 'default', selector: 'random', targets: [{ provider: 'p3', model: 'm3' }] },
+      ],
+    } as any);
+
+    const loaded = await repo.getAlias('no-compaction-alias');
+    expect(loaded).toBeDefined();
+    expect(loaded!.compaction).toBeUndefined();
+    expect('compaction' in loaded!).toBe(false);
+  });
+
+  // 4. Global getter via getCompactionConfig
+  it('getCompactionConfig returns default empty object when not set', async () => {
+    const cfg = await repo.getCompactionConfig();
+    expect(cfg).toEqual({});
+  });
+
+  it('getCompactionConfig reflects value after setSetting', async () => {
+    await repo.setSetting('compaction', { enabled: true });
+    const cfg = await repo.getCompactionConfig();
+    expect(cfg).toEqual({ enabled: true });
+  });
+});

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -338,6 +338,7 @@ export class ConfigRepository {
       geminiThinkingEnabled: fromBool(config.geminiThinkingEnabled === true),
       headers: config.headers ? encryptJsonField(config.headers) : null,
       extraBody: config.extraBody ? toJson(config.extraBody) : null,
+      compaction: config.compaction ? toJson(config.compaction) : null,
       quotaCheckerType: config.quota_checker?.type ?? null,
       quotaCheckerId: config.quota_checker?.id ?? null,
       quotaCheckerEnabled: fromBool(config.quota_checker?.enabled !== false),
@@ -585,6 +586,7 @@ export class ConfigRepository {
         const eb = parseJson<Record<string, unknown>>(row.extraBody);
         return eb && typeof eb === 'object' && !Array.isArray(eb) ? { extraBody: eb } : {};
       })(),
+      ...(row.compaction ? { compaction: parseJson(row.compaction) } : {}),
       ...(quota_checker ? { quota_checker } : {}),
       model_autosync: {
         enabled: toBool(row.modelAutosyncEnabled),
@@ -822,6 +824,7 @@ export class ConfigRepository {
       piModel: config.pi_model ? toJson(config.pi_model) : null,
       extraBody: config.extraBody ? toJson(config.extraBody) : null,
       generation: null,
+      compaction: config.compaction ? toJson(config.compaction) : null,
       targetGroups:
         config.target_groups && config.target_groups.length > 0
           ? toJson(config.target_groups.map((g) => ({ name: g.name, selector: g.selector })))
@@ -964,6 +967,7 @@ export class ConfigRepository {
       ...(row.preferredApi ? { preferred_api: parseJson(row.preferredApi) } : {}),
       ...(row.piModel ? { pi_model: parseJson(row.piModel) } : {}),
       ...(row.extraBody ? { extraBody: parseJson(row.extraBody) } : {}),
+      ...(row.compaction ? { compaction: parseJson(row.compaction) } : {}),
     };
 
     if (row.metadataSource) {
@@ -1516,6 +1520,10 @@ export class ConfigRepository {
   async getTimeoutConfig(): Promise<TimeoutConfig> {
     const defaultSeconds = await this.getSetting<number>('timeout.defaultSeconds', 300);
     return { defaultSeconds };
+  }
+
+  async getCompactionConfig(): Promise<import('../config').CompactionSettingsConfig> {
+    return this.getSetting('compaction', {});
   }
 
   async getStallConfig(): Promise<import('../config').StallConfigType> {

--- a/packages/backend/src/inference-v2/index.ts
+++ b/packages/backend/src/inference-v2/index.ts
@@ -73,6 +73,20 @@ export interface BetaInferenceDeps {
   responsesStorage?: ResponsesStorageService;
 }
 
+interface CompactionHeaderMetadata {
+  strategy: string | null;
+  tokensBefore: number;
+  tokensAfter: number;
+}
+
+function applyCompactionHeaders(reply: FastifyReply, compaction?: CompactionHeaderMetadata): void {
+  if (!compaction) return;
+  reply
+    .header('x-plexus-compaction-strategy', String(compaction.strategy ?? ''))
+    .header('x-plexus-compaction-tokens-before', String(compaction.tokensBefore))
+    .header('x-plexus-compaction-tokens-after', String(compaction.tokensAfter));
+}
+
 function saveBetaErrorUsage(
   usageStorage: UsageStorageService,
   request: FastifyRequest,
@@ -193,23 +207,13 @@ export async function handleBetaChatCompletions(
 
     if (result.response != null) {
       // Non-streaming
-      if (result.compaction) {
-        reply
-          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
-          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
-          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
-      }
+      applyCompactionHeaders(reply, result.compaction);
       return reply.code(200).header('content-type', 'application/json').send(result.response);
     }
 
     if (result.stream != null) {
       // Streaming — SSE. Compaction headers must be set before the stream starts.
-      if (result.compaction) {
-        reply
-          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
-          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
-          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
-      }
+      applyCompactionHeaders(reply, result.compaction);
       reply
         .code(200)
         .header('content-type', 'text/event-stream; charset=utf-8')
@@ -356,23 +360,13 @@ export async function handleBetaMessages(
     earlyDisconnect.cleanup();
 
     if (result.response != null) {
-      if (result.compaction) {
-        reply
-          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
-          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
-          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
-      }
+      applyCompactionHeaders(reply, result.compaction);
       return reply.code(200).header('content-type', 'application/json').send(result.response);
     }
 
     if (result.stream != null) {
       // Compaction headers must be set before the stream starts.
-      if (result.compaction) {
-        reply
-          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
-          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
-          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
-      }
+      applyCompactionHeaders(reply, result.compaction);
       reply
         .code(200)
         .header('content-type', 'text/event-stream; charset=utf-8')
@@ -542,23 +536,13 @@ export async function handleBetaResponses(
     earlyDisconnect.cleanup();
 
     if (result.response != null) {
-      if (result.compaction) {
-        reply
-          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
-          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
-          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
-      }
+      applyCompactionHeaders(reply, result.compaction);
       return reply.code(200).header('content-type', 'application/json').send(result.response);
     }
 
     if (result.stream != null) {
       // Compaction headers must be set before the stream starts.
-      if (result.compaction) {
-        reply
-          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
-          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
-          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
-      }
+      applyCompactionHeaders(reply, result.compaction);
       reply
         .code(200)
         .header('content-type', 'text/event-stream; charset=utf-8')
@@ -683,17 +667,13 @@ export async function handleBetaGeminiRequest(
     earlyDisconnect.cleanup();
 
     if (result.response != null) {
-      if (result.compaction) {
-        reply
-          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
-          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
-          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
-      }
+      applyCompactionHeaders(reply, result.compaction);
       return reply.code(200).header('content-type', 'application/json').send(result.response);
     }
 
     if (result.stream != null) {
       // Gemini streamGenerateContent uses data-prefixed JSON frames.
+      applyCompactionHeaders(reply, result.compaction);
       reply
         .code(200)
         .header('content-type', 'text/event-stream')

--- a/packages/backend/src/inference-v2/index.ts
+++ b/packages/backend/src/inference-v2/index.ts
@@ -203,7 +203,13 @@ export async function handleBetaChatCompletions(
     }
 
     if (result.stream != null) {
-      // Streaming — SSE
+      // Streaming — SSE. Compaction headers must be set before the stream starts.
+      if (result.compaction) {
+        reply
+          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
+          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
+          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
+      }
       reply
         .code(200)
         .header('content-type', 'text/event-stream; charset=utf-8')
@@ -360,6 +366,13 @@ export async function handleBetaMessages(
     }
 
     if (result.stream != null) {
+      // Compaction headers must be set before the stream starts.
+      if (result.compaction) {
+        reply
+          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
+          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
+          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
+      }
       reply
         .code(200)
         .header('content-type', 'text/event-stream; charset=utf-8')
@@ -539,6 +552,13 @@ export async function handleBetaResponses(
     }
 
     if (result.stream != null) {
+      // Compaction headers must be set before the stream starts.
+      if (result.compaction) {
+        reply
+          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
+          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
+          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
+      }
       reply
         .code(200)
         .header('content-type', 'text/event-stream; charset=utf-8')

--- a/packages/backend/src/inference-v2/index.ts
+++ b/packages/backend/src/inference-v2/index.ts
@@ -193,6 +193,12 @@ export async function handleBetaChatCompletions(
 
     if (result.response != null) {
       // Non-streaming
+      if (result.compaction) {
+        reply
+          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
+          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
+          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
+      }
       return reply.code(200).header('content-type', 'application/json').send(result.response);
     }
 
@@ -344,6 +350,12 @@ export async function handleBetaMessages(
     earlyDisconnect.cleanup();
 
     if (result.response != null) {
+      if (result.compaction) {
+        reply
+          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
+          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
+          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
+      }
       return reply.code(200).header('content-type', 'application/json').send(result.response);
     }
 
@@ -517,6 +529,12 @@ export async function handleBetaResponses(
     earlyDisconnect.cleanup();
 
     if (result.response != null) {
+      if (result.compaction) {
+        reply
+          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
+          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
+          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
+      }
       return reply.code(200).header('content-type', 'application/json').send(result.response);
     }
 
@@ -645,6 +663,12 @@ export async function handleBetaGeminiRequest(
     earlyDisconnect.cleanup();
 
     if (result.response != null) {
+      if (result.compaction) {
+        reply
+          .header('x-plexus-compaction-strategy', String(result.compaction.strategy ?? ''))
+          .header('x-plexus-compaction-tokens-before', String(result.compaction.tokensBefore))
+          .header('x-plexus-compaction-tokens-after', String(result.compaction.tokensAfter));
+      }
       return reply.code(200).header('content-type', 'application/json').send(result.response);
     }
 

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -603,6 +603,16 @@ export async function runPiAiExecutor<TResponse>(
     const stallTtfbMs: number | null = (route.config as any).stallTtfbMs ?? globalStallTtfbMs;
     const stallCooldownEnabled: boolean = route.config.stall_cooldown !== false;
 
+    // Compaction metadata surfaced as x-plexus-compaction-* headers on BOTH the
+    // non-streaming and streaming paths.
+    const compactionMeta = compaction.compacted
+      ? {
+          strategy: compaction.strategy,
+          tokensBefore: compaction.tokensBefore,
+          tokensAfter: compaction.tokensAfter,
+        }
+      : undefined;
+
     try {
       if (!streaming) {
         // ── Non-streaming ────────────────────────────────────────────────
@@ -666,13 +676,7 @@ export async function runPiAiExecutor<TResponse>(
 
         return {
           response: serializeMessage(message),
-          compaction: compaction.compacted
-            ? {
-                strategy: compaction.strategy,
-                tokensBefore: compaction.tokensBefore,
-                tokensAfter: compaction.tokensAfter,
-              }
-            : undefined,
+          compaction: compactionMeta,
         };
       } else {
         // ── Streaming ────────────────────────────────────────────────────
@@ -711,7 +715,7 @@ export async function runPiAiExecutor<TResponse>(
           serializeChunks,
         });
 
-        return { stream: gen };
+        return { stream: gen, compaction: compactionMeta };
       }
     } catch (err: any) {
       const effectiveErr = attemptTimeout.isTimedOut() ? buildTimeoutError() : err;

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -56,6 +56,8 @@ import { splitReasoningSuffix } from './reasoning';
 import { consumeTtfb } from './fetch-tap';
 import { extractPiAiErrorMessage } from '../../transformers/oauth/type-mappers';
 import { enforceContextLimitForRoute } from '../../services/enforce-limits';
+import { compactContextForSend } from '../../services/compaction/compaction-service';
+import type { CompactionResult, CompactionStrategyName } from '../../services/compaction/types';
 
 // ─── AsyncLocalStorage for debug raw-capture correlation ─────────────────────
 
@@ -103,6 +105,12 @@ export interface PiAiExecutorResult<TResponse> {
   response?: TResponse;
   /** Set for streaming — async generator of wire-format frame strings */
   stream?: AsyncGenerator<string>;
+  /** Set for non-streaming when compaction actually ran and reduced tokens */
+  compaction?: {
+    strategy: CompactionStrategyName | null;
+    tokensBefore: number;
+    tokensAfter: number;
+  };
 }
 
 // ─── Attempt-timeout helper (mirrors Dispatcher.createAttemptTimeout) ─────────
@@ -457,6 +465,7 @@ export async function runPiAiExecutor<TResponse>(
   const attemptedProviders: string[] = [];
   let lastError: any = null;
   const failoverEnabled = betaCandidates.length > 1;
+  const compactionMemo = new Map<string, CompactionResult>();
 
   for (let i = 0; i < betaCandidates.length; i++) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -478,6 +487,19 @@ export async function runPiAiExecutor<TResponse>(
       continue;
     }
 
+    // ── Context compaction (opt-in per alias/provider/global) ──────────────
+    // Runs before force-limit enforcement so a borderline-oversized request can
+    // be rescued by compaction before it would be rejected. Fail-open: on any
+    // error the original context is returned. Per-candidate, memoized.
+    const compaction = await compactContextForSend(
+      context,
+      route,
+      modelAlias,
+      compactionMemo,
+      attemptTimeout.signal
+    );
+    const sendContext = compaction.compacted ? compaction.context : context;
+
     // ── Force-limit enforcement (opt-in per alias) ─────────────────────────
     // Mirrors dispatcher.ts:384-394. Checked AFTER cooldown and BEFORE
     // acquiring a concurrency slot, so a thrown ContextLengthExceededError
@@ -487,10 +509,10 @@ export async function runPiAiExecutor<TResponse>(
       : undefined;
     try {
       enforceContextLimitForRoute(
-        context,
+        sendContext,
         route,
         aliasForLimit,
-        (streamOptions as any).maxTokens,
+        generationIntent.maxTokens,
         incomingApiType
       );
     } catch (limitErr) {
@@ -585,7 +607,7 @@ export async function runPiAiExecutor<TResponse>(
       if (!streaming) {
         // ── Non-streaming ────────────────────────────────────────────────
         const message = await debugRequestIdStorage.run(requestId, () =>
-          piAiModels.complete(piModel as any, context, callOptions)
+          piAiModels.complete(piModel as any, sendContext, callOptions)
         );
 
         cooldown.markProviderSuccess(route.provider, route.model);
@@ -642,11 +664,20 @@ export async function runPiAiExecutor<TResponse>(
 
         await onSuccess?.(message);
 
-        return { response: serializeMessage(message) };
+        return {
+          response: serializeMessage(message),
+          compaction: compaction.compacted
+            ? {
+                strategy: compaction.strategy,
+                tokensBefore: compaction.tokensBefore,
+                tokensAfter: compaction.tokensAfter,
+              }
+            : undefined,
+        };
       } else {
         // ── Streaming ────────────────────────────────────────────────────
         const eventStream = await debugRequestIdStorage.run(requestId, () =>
-          piAiModels.stream(piModel as any, context, callOptions)
+          piAiModels.stream(piModel as any, sendContext, callOptions)
         );
 
         // Build and return the SSE generator — the generator owns

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -55,6 +55,7 @@ import type { GenerationIntent } from './generation';
 import { splitReasoningSuffix } from './reasoning';
 import { consumeTtfb } from './fetch-tap';
 import { extractPiAiErrorMessage } from '../../transformers/oauth/type-mappers';
+import { enforceContextLimitForRoute } from '../../services/enforce-limits';
 
 // ─── AsyncLocalStorage for debug raw-capture correlation ─────────────────────
 
@@ -475,6 +476,27 @@ export async function runPiAiExecutor<TResponse>(
       attemptTimeout.cleanup();
       appendSkippedAttempt(retryHistory, route, 'Provider in cooldown', incomingApiType);
       continue;
+    }
+
+    // ── Force-limit enforcement (opt-in per alias) ─────────────────────────
+    // Mirrors dispatcher.ts:384-394. Checked AFTER cooldown and BEFORE
+    // acquiring a concurrency slot, so a thrown ContextLengthExceededError
+    // (client-side; failover won't help) never leaks an acquired slot.
+    const aliasForLimit = route.canonicalModel
+      ? getConfig().models?.[route.canonicalModel]
+      : undefined;
+    try {
+      enforceContextLimitForRoute(
+        context,
+        route,
+        aliasForLimit,
+        (streamOptions as any).maxTokens,
+        incomingApiType
+      );
+    } catch (limitErr) {
+      attemptTimeout.cleanup();
+      appendFailureAttempt(retryHistory, route, limitErr, incomingApiType, false);
+      throw limitErr;
     }
 
     // ── Concurrency acquire ────────────────────────────────────────────────

--- a/packages/backend/src/routes/management/__tests__/config-compaction.test.ts
+++ b/packages/backend/src/routes/management/__tests__/config-compaction.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+
+const serviceState = vi.hoisted(() => {
+  const state = {
+    compaction: {} as Record<string, unknown>,
+    setSetting: vi.fn(async (key: string, value: unknown) => {
+      if (key === 'compaction') {
+        state.compaction = value as Record<string, unknown>;
+      }
+    }),
+    getCompactionConfig: vi.fn(async () => state.compaction),
+    getConfig: vi.fn(() => ({ providers: {} })),
+  };
+  return state;
+});
+
+vi.mock('../../../services/config-service', () => ({
+  ConfigService: {
+    getInstance: vi.fn(() => ({
+      setSetting: serviceState.setSetting,
+      getConfig: serviceState.getConfig,
+      getRepository: vi.fn(() => ({
+        getCompactionConfig: serviceState.getCompactionConfig,
+      })),
+    })),
+  },
+}));
+
+import { registerConfigRoutes } from '../config';
+
+describe('compaction config routes', () => {
+  let fastify: FastifyInstance;
+
+  beforeEach(async () => {
+    serviceState.compaction = {};
+    serviceState.setSetting.mockClear();
+    serviceState.getCompactionConfig.mockClear();
+    serviceState.getConfig.mockClear();
+
+    fastify = Fastify();
+    await registerConfigRoutes(fastify);
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  it('GET default: returns {} when nothing stored', async () => {
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/config/compaction',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({});
+  });
+
+  it('PATCH valid: stores and returns compaction config', async () => {
+    const payload = { enabled: true, strategy: 'native', triggerRatio: 0.7 };
+    const patchRes = await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload,
+    });
+
+    expect(patchRes.statusCode).toBe(200);
+    expect(patchRes.json()).toMatchObject(payload);
+
+    const getRes = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/config/compaction',
+    });
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json()).toMatchObject(payload);
+  });
+
+  it('PATCH invalid: triggerRatio out of range returns 400', async () => {
+    const res = await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload: { triggerRatio: 2 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(serviceState.setSetting).not.toHaveBeenCalled();
+  });
+
+  it('PATCH merge: preserves prior fields when patching new ones', async () => {
+    // Set initial value
+    await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload: { enabled: true },
+    });
+
+    // Patch with a new field
+    const mergeRes = await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload: { strategy: 'headroom' },
+    });
+
+    expect(mergeRes.statusCode).toBe(200);
+    const body = mergeRes.json();
+    expect(body.enabled).toBe(true);
+    expect(body.strategy).toBe('headroom');
+  });
+
+  it('PATCH non-object body returns 400', async () => {
+    const res = await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload: 'not-an-object',
+      headers: { 'content-type': 'application/json' },
+    });
+
+    // Fastify will likely parse-fail or we hit our guard
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/packages/backend/src/routes/management/__tests__/config-compaction.test.ts
+++ b/packages/backend/src/routes/management/__tests__/config-compaction.test.ts
@@ -108,6 +108,60 @@ describe('compaction config routes', () => {
     expect(body.strategy).toBe('headroom');
   });
 
+  it('PATCH merge: preserves nested subfields when patching one nested value', async () => {
+    await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload: {
+        strategy: 'headroom',
+        headroom: {
+          baseUrl: 'http://localhost:8787',
+          apiKey: 'secret',
+          targetRatio: 0.5,
+          timeoutMs: 5000,
+        },
+      },
+    });
+
+    const mergeRes = await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload: { headroom: { timeoutMs: 1000 } },
+    });
+
+    expect(mergeRes.statusCode).toBe(200);
+    expect(mergeRes.json().headroom).toEqual({
+      baseUrl: 'http://localhost:8787',
+      apiKey: 'secret',
+      targetRatio: 0.5,
+      timeoutMs: 1000,
+    });
+  });
+
+  it('PATCH merge: null clears persisted scalar fields', async () => {
+    await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload: {
+        triggerRatio: 0.7,
+        minTokens: 2000,
+        headroom: { baseUrl: 'http://localhost:8787', timeoutMs: 5000 },
+      },
+    });
+
+    const clearRes = await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/config/compaction',
+      payload: { triggerRatio: null, headroom: { timeoutMs: null } },
+    });
+
+    expect(clearRes.statusCode).toBe(200);
+    expect(clearRes.json()).toEqual({
+      minTokens: 2000,
+      headroom: { baseUrl: 'http://localhost:8787' },
+    });
+  });
+
   it('PATCH non-object body returns 400', async () => {
     const res = await fastify.inject({
       method: 'PATCH',

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -17,6 +17,39 @@ import { VisionDescriptorService } from '../../services/vision-descriptor-servic
 import type { GpuParams, ModelArchitecture } from '@plexus/shared';
 import { DEFAULT_GPU_PARAMS } from '@plexus/shared';
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeCompactionPatch(
+  current: Record<string, unknown>,
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...current };
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete merged[key];
+      continue;
+    }
+
+    if ((key === 'native' || key === 'headroom') && isRecord(value)) {
+      const currentNested = isRecord(merged[key]) ? (merged[key] as Record<string, unknown>) : {};
+      const nested = mergeCompactionPatch(currentNested, value);
+      if (Object.keys(nested).length === 0) {
+        delete merged[key];
+      } else {
+        merged[key] = nested;
+      }
+      continue;
+    }
+
+    merged[key] = value;
+  }
+
+  return merged;
+}
+
 /**
  * Build a map of provider slug -> resolved GpuParams from current config.
  * Used by recalculateEnergyIfChanged to pass concrete GPU params
@@ -827,7 +860,7 @@ export async function registerConfigRoutes(
     }
     try {
       const current = (await configService.getRepository().getCompactionConfig()) ?? {};
-      const merged = { ...current, ...body };
+      const merged = mergeCompactionPatch(current as Record<string, unknown>, body);
       const parsed = CompactionConfigSchema.safeParse(merged);
       if (!parsed.success) {
         return reply

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -5,6 +5,7 @@ import {
   ModelConfigSchema,
   KeyConfigSchema,
   McpServerConfigSchema,
+  CompactionConfigSchema,
 } from '../../config';
 import { ConfigService } from '../../services/config-service';
 import { isValidIpRule } from '../../utils/ip-match';
@@ -803,6 +804,40 @@ export async function registerConfigRoutes(
       return reply.send(updated);
     } catch (e: any) {
       logger.error('Failed to patch stall config', e);
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  // ─── Compaction Config ────────────────────────────────────────────
+
+  fastify.get('/v0/management/config/compaction', async (_request, reply) => {
+    try {
+      const compaction = await configService.getRepository().getCompactionConfig();
+      return reply.send(compaction ?? {});
+    } catch (e: any) {
+      logger.error('Failed to get compaction config', e);
+      return reply.code(500).send({ error: 'Internal server error' });
+    }
+  });
+
+  fastify.patch('/v0/management/config/compaction', async (request, reply) => {
+    const body = request.body as Record<string, unknown> | null;
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return reply.code(400).send({ error: 'Object body is required' });
+    }
+    try {
+      const current = (await configService.getRepository().getCompactionConfig()) ?? {};
+      const merged = { ...current, ...body };
+      const parsed = CompactionConfigSchema.safeParse(merged);
+      if (!parsed.success) {
+        return reply
+          .code(400)
+          .send({ error: 'Invalid compaction config', details: parsed.error.issues });
+      }
+      await configService.setSetting('compaction', parsed.data);
+      return reply.send(parsed.data);
+    } catch (e: any) {
+      logger.error('Failed to patch compaction config', e);
       return reply.code(500).send({ error: 'Internal server error' });
     }
   });

--- a/packages/backend/src/services/__tests__/enforce-limits-context.test.ts
+++ b/packages/backend/src/services/__tests__/enforce-limits-context.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import type { Context } from '@earendil-works/pi-ai';
+import type { ModelConfig } from '../../config';
+import {
+  ContextLengthExceededError,
+  enforceContextLimitForContext,
+  resolveContextLength,
+} from '../enforce-limits';
+import { ModelMetadataManager } from '../model-metadata-manager';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function aliasConfig(partial: Partial<ModelConfig> = {}): ModelConfig {
+  return {
+    targets: [{ provider: 'openai', model: 'gpt-4' }],
+    priority: 'selector',
+    ...partial,
+  } as ModelConfig;
+}
+
+/** Build a minimal pi-ai Context with a single user text message. */
+function makeContext(text: string): Context {
+  return {
+    messages: [
+      {
+        role: 'user' as const,
+        content: text,
+        timestamp: Date.now(),
+      },
+    ],
+  };
+}
+
+/** Build a Context with a large user message (~charCount chars). */
+function bigContext(charCount: number): Context {
+  return makeContext('x'.repeat(charCount));
+}
+
+// ---------------------------------------------------------------------------
+// resolveContextLength
+// ---------------------------------------------------------------------------
+
+describe('resolveContextLength', () => {
+  beforeEach(() => {
+    ModelMetadataManager.resetForTesting();
+  });
+
+  afterEach(() => {
+    ModelMetadataManager.resetForTesting();
+  });
+
+  test('returns undefined when aliasConfig has no metadata', () => {
+    const config = aliasConfig(); // no metadata
+    expect(resolveContextLength(config)).toBeUndefined();
+  });
+
+  test('prefers top_provider.context_length over root context_length', () => {
+    // top_provider.context_length = 4000, root context_length = 8000 → should return 4000
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 8_000,
+          top_provider: { context_length: 4_000 },
+        },
+      },
+    });
+    expect(resolveContextLength(config)).toBe(4_000);
+  });
+
+  test('falls back to root context_length when top_provider is absent', () => {
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 8_000,
+        },
+      },
+    });
+    expect(resolveContextLength(config)).toBe(8_000);
+  });
+
+  test('returns undefined when context_length is 0 or missing', () => {
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          top_provider: { max_completion_tokens: 4096 },
+          // no context_length
+        },
+      },
+    });
+    expect(resolveContextLength(config)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceContextLimitForContext
+// ---------------------------------------------------------------------------
+
+describe('enforceContextLimitForContext', () => {
+  beforeEach(() => {
+    ModelMetadataManager.resetForTesting();
+  });
+
+  afterEach(() => {
+    ModelMetadataManager.resetForTesting();
+  });
+
+  // --- over-window: throws ContextLengthExceededError ---
+
+  test('throws ContextLengthExceededError when estimate + reserved exceeds contextLength', () => {
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 100, // small window passed via metadata (but we also pass via opts below)
+          top_provider: { context_length: 100, max_completion_tokens: 50 },
+        },
+      },
+    });
+    // ~4000 chars ≈ ~1000 raw tokens * 1.1 = ~1100; way over 100-token window
+    const context = bigContext(4_000);
+    let caught: unknown;
+    try {
+      enforceContextLimitForContext(context, config, 'test-alias');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ContextLengthExceededError);
+    const err = caught as ContextLengthExceededError;
+    expect(err.routingContext.statusCode).toBe(400);
+    expect(err.routingContext.code).toBe('context_length_exceeded');
+    expect(err.routingContext.contextLength).toBe(100);
+    expect(err.routingContext.aliasSlug).toBe('test-alias');
+    expect(err.routingContext.estimatedInputTokens).toBeGreaterThan(0);
+    expect(err.routingContext.reservedOutputTokens).toBeGreaterThan(0);
+    expect(err.message).toContain('100');
+    expect(err.message).toContain('input tokens');
+  });
+
+  test('throws via opts.contextLength without relying on metadata', () => {
+    // Pass contextLength directly through opts — no metadata needed
+    const config = aliasConfig(); // no metadata
+    // ~4000 chars ≈ ~1000 raw tokens * 1.1 = ~1100; over a 200-token window
+    const context = bigContext(4_000);
+    expect(() =>
+      enforceContextLimitForContext(context, config, 'test-alias-opts', {
+        contextLength: 200,
+      })
+    ).toThrow(ContextLengthExceededError);
+  });
+
+  // --- under-window: does not throw ---
+
+  test('returns without throwing when estimate fits within context window', () => {
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 10_000,
+          top_provider: { context_length: 10_000, max_completion_tokens: 4096 },
+        },
+      },
+    });
+    // ~200 chars ≈ ~50 tokens * 1.1 = ~55; fits in 10000-token window
+    const context = bigContext(200);
+    expect(() => enforceContextLimitForContext(context, config, 'test-alias')).not.toThrow();
+  });
+
+  test('returns without throwing via opts.contextLength (under window)', () => {
+    const config = aliasConfig();
+    const context = bigContext(200);
+    expect(() =>
+      enforceContextLimitForContext(context, config, 'test-alias', {
+        contextLength: 10_000,
+      })
+    ).not.toThrow();
+  });
+
+  // --- fail-open: no context length known ---
+
+  test('fails open (no throw) when no context_length is known', () => {
+    const config = aliasConfig(); // no metadata, no opts.contextLength
+    // Even a huge context should not throw when we can't enforce
+    const context = bigContext(100_000);
+    expect(() => enforceContextLimitForContext(context, config, 'test-alias')).not.toThrow();
+  });
+
+  test('fails open when metadata exists but has no context_length', () => {
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          top_provider: { max_completion_tokens: 4096 },
+          // no context_length or top_provider.context_length
+        },
+      },
+    });
+    const context = bigContext(100_000);
+    expect(() => enforceContextLimitForContext(context, config, 'test-alias')).not.toThrow();
+  });
+
+  // --- reserved-output: opts.maxTokens smaller than metadata max_completion_tokens ---
+
+  test('uses opts.maxTokens when smaller than metadata max_completion_tokens', () => {
+    // We set up a case where:
+    //   estimate * 1.1 + metadata_max (8000) > contextLength (10000) → would throw
+    //   estimate * 1.1 + small maxTokens (10) <= contextLength (10000) → passes
+    // ~24000 chars ≈ ~6000 raw tokens * 1.1 = ~6600
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 10_000,
+          top_provider: { context_length: 10_000, max_completion_tokens: 8_000 },
+        },
+      },
+    });
+    const context = bigContext(24_000);
+
+    // Without small maxTokens: 6600 + 8000 = 14600 > 10000 → throws
+    expect(() => enforceContextLimitForContext(context, config, 'test-alias')).toThrow(
+      ContextLengthExceededError
+    );
+
+    // With maxTokens=10: reservation = min(10, 8000) = 10 → 6600 + 10 < 10000 → passes
+    expect(() =>
+      enforceContextLimitForContext(context, config, 'test-alias', { maxTokens: 10 })
+    ).not.toThrow();
+  });
+
+  test('reserved-output: asserts reservedOutputTokens in thrown error matches min(maxTokens, metadataMax)', () => {
+    // Use opts.contextLength=100 (tiny window) so that estimate + 300 reservation
+    // clearly exceeds the window. Metadata has max_completion_tokens=1000 so the
+    // effective reservation is min(300, 1000) = 300, which should appear in the error.
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          top_provider: { max_completion_tokens: 1000 },
+        },
+      },
+    });
+    // 'hello' → ~1 raw token * 1.1 ≈ 2 estimated; 2 + 300 = 302 > 100 → throws
+    const context = makeContext('hello');
+
+    // With maxTokens=300 (smaller than 1000): reservation = min(300, 1000) = 300
+    // 2 + 300 > 100 → throws; reservedOutputTokens should be 300
+    let caught: unknown;
+    try {
+      enforceContextLimitForContext(context, config, 'test-alias', {
+        contextLength: 100,
+        maxTokens: 300,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ContextLengthExceededError);
+    const err = caught as ContextLengthExceededError;
+    expect(err.routingContext.reservedOutputTokens).toBe(300);
+  });
+
+  test('uses DEFAULT_OUTPUT_RESERVATION (4096) when neither opts.maxTokens nor metadata max_completion_tokens is set', () => {
+    // contextLength=100 so even 4096 reservation causes a throw (100 << 4096+estimate)
+    const config = aliasConfig({
+      metadata: {
+        source: 'custom',
+        overrides: {
+          name: 'Test',
+          context_length: 100,
+          top_provider: { context_length: 100 }, // no max_completion_tokens
+        },
+      },
+    });
+    const context = makeContext('hello'); // tiny input
+    let caught: unknown;
+    try {
+      enforceContextLimitForContext(context, config, 'test-alias');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ContextLengthExceededError);
+    const err = caught as ContextLengthExceededError;
+    // DEFAULT_OUTPUT_RESERVATION = 4096
+    expect(err.routingContext.reservedOutputTokens).toBe(4096);
+  });
+});

--- a/packages/backend/src/services/__tests__/enforce-limits-route.test.ts
+++ b/packages/backend/src/services/__tests__/enforce-limits-route.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for enforceContextLimitForRoute — the thin bridge helper that gates
+ * the inference-v2 / beta / pi path against context-window limits.
+ *
+ * TDD: these tests were written BEFORE the implementation (RED), then the
+ * helper was added to enforce-limits.ts (GREEN).
+ */
+
+import { describe, expect, test } from 'vitest';
+import type { Context } from '@earendil-works/pi-ai';
+import type { ModelConfig } from '../../config';
+import {
+  ContextLengthExceededError,
+  enforceContextLimitForRoute,
+  type EnforceRouteInfo,
+} from '../enforce-limits';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function aliasConfig(partial: Partial<ModelConfig> = {}): ModelConfig {
+  return {
+    targets: [{ provider: 'openai', model: 'gpt-4' }],
+    priority: 'selector',
+    ...partial,
+  } as ModelConfig;
+}
+
+/** Build a minimal pi-ai Context with a single user text message. */
+function makeContext(text: string): Context {
+  return {
+    messages: [
+      {
+        role: 'user' as const,
+        content: text,
+        timestamp: Date.now(),
+      },
+    ],
+  };
+}
+
+/**
+ * Build a Context that reliably exceeds a context window of OVER_WINDOW_SIZE tokens.
+ * The window used by the over-limit tests is OVER_WINDOW_SIZE (4200), chosen so that
+ * even a ~100-token prompt tips over the limit:
+ *   estimateContextTokens ≈ 101 tokens → 101 × 1.1 + 4096 = 4208 > 4200. ✓
+ * (Verified with both the tiktoken encoder path and the heuristic fallback.)
+ */
+const OVER_WINDOW_SIZE = 4200;
+
+function overWindowContext(): Context {
+  // 'hello world ' repeated 50× ≈ 101 tokens via o200k_base / heuristic.
+  return makeContext('hello world '.repeat(50));
+}
+
+// ---------------------------------------------------------------------------
+// enforceContextLimitForRoute
+// ---------------------------------------------------------------------------
+
+describe('enforceContextLimitForRoute', () => {
+  // Case 1: aliasConfig undefined → no-op
+  test('no-ops when aliasConfig is undefined', () => {
+    const context = makeContext('hello world');
+    const route: EnforceRouteInfo = { canonicalModel: 'some-model' };
+    expect(() =>
+      enforceContextLimitForRoute(context, route, undefined, undefined, 'chat')
+    ).not.toThrow();
+  });
+
+  // Case 2: aliasConfig.enforce_limits falsy → no-op
+  test('no-ops when enforce_limits is falsy', () => {
+    const context = makeContext('hello world');
+    const route: EnforceRouteInfo = { canonicalModel: 'some-model' };
+    const config = aliasConfig({ enforce_limits: false });
+    expect(() =>
+      enforceContextLimitForRoute(context, route, config, undefined, 'chat')
+    ).not.toThrow();
+  });
+
+  test('no-ops when enforce_limits is absent', () => {
+    const context = makeContext('hello world');
+    const route: EnforceRouteInfo = { canonicalModel: 'some-model' };
+    const config = aliasConfig(); // enforce_limits not set
+    expect(() =>
+      enforceContextLimitForRoute(context, route, config, undefined, 'chat')
+    ).not.toThrow();
+  });
+
+  // Case 3: route.canonicalModel undefined (even with enforce_limits true) → no-op
+  test('no-ops when canonicalModel is undefined', () => {
+    const context = makeContext('hello world');
+    const route: EnforceRouteInfo = { canonicalModel: undefined };
+    const config = aliasConfig({ enforce_limits: true });
+    expect(() =>
+      enforceContextLimitForRoute(context, route, config, undefined, 'chat')
+    ).not.toThrow();
+  });
+
+  // Case 4: enforce_limits true + over-window → throws ContextLengthExceededError with statusCode 400
+  test('throws ContextLengthExceededError when context exceeds route.modelArchitecture.context_length', () => {
+    // Tiny window: OVER_WINDOW_SIZE tokens. No alias metadata → resolveContextLength returns undefined,
+    // so the route.modelArchitecture.context_length is used as the contextLength.
+    const context = overWindowContext();
+    const route: EnforceRouteInfo = {
+      canonicalModel: 'test-model',
+      modelArchitecture: { context_length: OVER_WINDOW_SIZE },
+    };
+    // No metadata on aliasConfig → resolveContextLength returns undefined → falls through to route architecture
+    const config = aliasConfig({ enforce_limits: true });
+
+    expect(() => enforceContextLimitForRoute(context, route, config, undefined, 'chat')).toThrow(
+      ContextLengthExceededError
+    );
+  });
+
+  test('thrown ContextLengthExceededError has routingContext.statusCode === 400', () => {
+    const context = overWindowContext();
+    const route: EnforceRouteInfo = {
+      canonicalModel: 'test-model',
+      modelArchitecture: { context_length: OVER_WINDOW_SIZE },
+    };
+    const config = aliasConfig({ enforce_limits: true });
+
+    let caught: unknown;
+    try {
+      enforceContextLimitForRoute(context, route, config, undefined, 'chat');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(ContextLengthExceededError);
+    const limitErr = caught as ContextLengthExceededError;
+    expect(limitErr.routingContext.statusCode).toBe(400);
+    expect(limitErr.routingContext.code).toBe('context_length_exceeded');
+    expect(limitErr.routingContext.aliasSlug).toBe('test-model');
+  });
+
+  // Case 5: enforce_limits true but under the window → no throw
+  test('does not throw when context is under the window', () => {
+    const contextWindowSize = 50_000;
+    const context = makeContext('Short prompt');
+    const route: EnforceRouteInfo = {
+      canonicalModel: 'test-model',
+      modelArchitecture: { context_length: contextWindowSize },
+    };
+    const config = aliasConfig({ enforce_limits: true });
+
+    expect(() =>
+      enforceContextLimitForRoute(context, route, config, undefined, 'chat')
+    ).not.toThrow();
+  });
+});

--- a/packages/backend/src/services/__tests__/enforce-limits-route.test.ts
+++ b/packages/backend/src/services/__tests__/enforce-limits-route.test.ts
@@ -6,9 +6,10 @@
  * helper was added to enforce-limits.ts (GREEN).
  */
 
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import type { Context } from '@earendil-works/pi-ai';
 import type { ModelConfig } from '../../config';
+import { ModelMetadataManager } from '../model-metadata-manager';
 import {
   ContextLengthExceededError,
   enforceContextLimitForRoute,
@@ -59,6 +60,16 @@ function overWindowContext(): Context {
 // ---------------------------------------------------------------------------
 
 describe('enforceContextLimitForRoute', () => {
+  // Reset the ModelMetadataManager singleton so alias metadata retained by an
+  // earlier test can't leak into the default gpt-4 fallback path (matches the
+  // sibling enforce-limits-context.test.ts).
+  beforeEach(() => {
+    ModelMetadataManager.resetForTesting();
+  });
+  afterEach(() => {
+    ModelMetadataManager.resetForTesting();
+  });
+
   // Case 1: aliasConfig undefined → no-op
   test('no-ops when aliasConfig is undefined', () => {
     const context = makeContext('hello world');

--- a/packages/backend/src/services/compaction/__tests__/compact-context-for-send.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/compact-context-for-send.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for compactContextForSend — the executor helper introduced in Task 5.
+ *
+ * Strategy: mock getConfig (the module at ../../../config, which compaction-service
+ * imports as '../../config') so we control alias config + model architecture, then
+ * call the real compactContextForSend and assert on the CompactionResult.
+ *
+ * We also reset CompactionService.instance between tests so each test gets a fresh
+ * singleton that picks up the new getConfig mock.
+ *
+ * Cases:
+ *  1. alias compaction:{enabled:false}  → reason='disabled'
+ *  2. alias compaction:{enabled:true, minTokens:10_000_000} + small context → reason='below-min'
+ *  3. alias compaction:{enabled:true, minTokens:0, triggerRatio:0, strategy:'native', ...}
+ *     + context with a long toolResult text → compacted:true (real native strategy)
+ */
+
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import type { Context, ToolResultMessage, UserMessage } from '@earendil-works/pi-ai';
+import type { RouteResult } from '../../router';
+
+// ---------------------------------------------------------------------------
+// Mock getConfig BEFORE importing the module under test so that both the
+// compaction-service and resolve-settings pick up the stub on first import.
+// ---------------------------------------------------------------------------
+
+const mockGetConfig = vi.fn();
+
+vi.mock('../../../config', () => ({
+  getConfig: () => mockGetConfig(),
+}));
+
+// Also mock enforce-limits (resolveContextLength uses ModelMetadataManager which
+// requires a database / file on disk; we short-circuit by returning undefined, which
+// causes compactContextForSend to fall back to route.modelArchitecture?.context_length).
+vi.mock('../../enforce-limits', () => ({
+  resolveContextLength: (_aliasConfig: unknown) => undefined,
+  enforceContextLimitForRoute: () => {},
+}));
+
+// Import AFTER mocks are registered
+import { compactContextForSend, CompactionService } from '../compaction-service';
+
+// ---------------------------------------------------------------------------
+// Reset singleton between tests so each picks up the fresh getConfig mock.
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  // Access and clear the private static instance
+  (CompactionService as any).instance = undefined;
+  mockGetConfig.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeToolResultMessage(text: string): ToolResultMessage {
+  return {
+    role: 'toolResult',
+    toolCallId: 'tc-1',
+    toolName: 'myTool',
+    content: [{ type: 'text', text }],
+    isError: false,
+    timestamp: Date.now(),
+  };
+}
+
+function makeUserMessage(text: string): UserMessage {
+  return { role: 'user', content: [{ type: 'text', text }], timestamp: Date.now() };
+}
+
+function makeRoute(canonicalModel: string, contextLength?: number): RouteResult {
+  return {
+    provider: 'openai',
+    model: 'gpt-4o',
+    config: { api_key: 'test-key' } as any,
+    modelConfig: {} as any,
+    canonicalModel,
+    modelArchitecture:
+      contextLength != null ? ({ context_length: contextLength } as any) : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('compactContextForSend', () => {
+  test('1. disabled — alias compaction:{enabled:false} → reason=disabled, compacted=false', async () => {
+    const canonicalModel = 'gpt-4o';
+    mockGetConfig.mockReturnValue({
+      models: {
+        [canonicalModel]: {
+          compaction: { enabled: false },
+        },
+      },
+    });
+
+    const context: Context = { messages: [makeUserMessage('hello')] };
+    const route = makeRoute(canonicalModel);
+    const memo = new Map();
+
+    const result = await compactContextForSend(context, route, 'my-alias', memo);
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('disabled');
+    expect(result.context).toBe(context);
+    expect(result.strategy).toBeNull();
+  });
+
+  test('2. below-min — enabled but minTokens very high → reason=below-min, compacted=false', async () => {
+    const canonicalModel = 'gpt-4o';
+    mockGetConfig.mockReturnValue({
+      models: {
+        [canonicalModel]: {
+          compaction: { enabled: true, minTokens: 10_000_000 },
+        },
+      },
+    });
+
+    const context: Context = { messages: [makeUserMessage('short message')] };
+    const route = makeRoute(canonicalModel, 128_000);
+    const memo = new Map();
+
+    const result = await compactContextForSend(context, route, 'my-alias', memo);
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('below-min');
+    expect(result.context).toBe(context);
+    expect(result.tokensBefore).toBeGreaterThan(0); // estimator ran
+    expect(result.strategy).toBeNull();
+  });
+
+  test('3. native compaction fires — triggerRatio=0, minTokens=0 with a large toolResult', async () => {
+    const canonicalModel = 'gpt-4o';
+    mockGetConfig.mockReturnValue({
+      models: {
+        [canonicalModel]: {
+          compaction: {
+            enabled: true,
+            minTokens: 0,
+            triggerRatio: 0, // always fire
+            protectRecent: 0, // every message eligible (deterministic)
+            strategy: 'native',
+            native: { maxArrayItems: 1, maxStringChars: 10 },
+          },
+        },
+      },
+    });
+
+    // Build a context with a toolResult containing a large JSON array
+    // (native compactor will truncate it → tokensAfter < tokensBefore)
+    const bigArray = Array.from({ length: 50 }, (_, i) => i);
+    const toolResult = makeToolResultMessage(JSON.stringify(bigArray));
+    // Put a user message LAST so it is "protected" (protectRecent defaults to 4)
+    // but include enough unprotected messages with heavy content
+    const heavyMessages = Array.from({ length: 5 }, () =>
+      makeToolResultMessage(JSON.stringify(bigArray))
+    );
+    const context: Context = {
+      messages: [...heavyMessages, toolResult, makeUserMessage('final')],
+    };
+    const route = makeRoute(canonicalModel, 1000);
+    const memo = new Map();
+
+    const result = await compactContextForSend(context, route, 'my-alias', memo);
+
+    // protectRecent:0 makes every heavy toolResult eligible, so the real
+    // NativeCompactor truncates the big JSON arrays and the estimate drops —
+    // a hard end-to-end assertion that compactContextForSend delegates to the
+    // native strategy and applies its reduced context.
+    expect(result.reason).toBe('ok');
+    expect(result.compacted).toBe(true);
+    expect(result.strategy).toBe('native');
+    expect(result.tokensAfter).toBeLessThan(result.tokensBefore);
+    expect(result.context).not.toBe(context); // a NEW context is returned
+  });
+});

--- a/packages/backend/src/services/compaction/__tests__/compact-context-for-send.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/compact-context-for-send.test.ts
@@ -25,6 +25,7 @@ import type { RouteResult } from '../../router';
 // ---------------------------------------------------------------------------
 
 const mockGetConfig = vi.fn();
+const mockResolveContextLength = vi.fn();
 
 vi.mock('../../../config', () => ({
   getConfig: () => mockGetConfig(),
@@ -34,7 +35,7 @@ vi.mock('../../../config', () => ({
 // requires a database / file on disk; we short-circuit by returning undefined, which
 // causes compactContextForSend to fall back to route.modelArchitecture?.context_length).
 vi.mock('../../enforce-limits', () => ({
-  resolveContextLength: (_aliasConfig: unknown) => undefined,
+  resolveContextLength: (aliasConfig: unknown) => mockResolveContextLength(aliasConfig),
   enforceContextLimitForRoute: () => {},
 }));
 
@@ -48,6 +49,8 @@ import { compactContextForSend, CompactionService } from '../compaction-service'
 beforeEach(() => {
   CompactionService.resetForTesting();
   mockGetConfig.mockReset();
+  mockResolveContextLength.mockReset();
+  mockResolveContextLength.mockReturnValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -174,5 +177,37 @@ describe('compactContextForSend', () => {
     expect(result.strategy).toBe('native');
     expect(result.tokensAfter).toBeLessThan(result.tokensBefore);
     expect(result.context).not.toBe(context); // a NEW context is returned
+  });
+
+  test('4. selected route context_length takes precedence over alias metadata', async () => {
+    const canonicalModel = 'gpt-4o';
+    mockResolveContextLength.mockReturnValue(1_000_000);
+    mockGetConfig.mockReturnValue({
+      models: {
+        [canonicalModel]: {
+          compaction: {
+            enabled: true,
+            minTokens: 0,
+            triggerRatio: 0.8,
+            protectRecent: 0,
+            strategy: 'native',
+            native: { maxArrayItems: 1, maxStringChars: 10 },
+          },
+        },
+      },
+    });
+
+    const bigArray = Array.from({ length: 50 }, (_, i) => i);
+    const context: Context = {
+      messages: Array.from({ length: 5 }, () => makeToolResultMessage(JSON.stringify(bigArray))),
+    };
+    const route = makeRoute(canonicalModel, 10);
+    const memo = new Map();
+
+    const result = await compactContextForSend(context, route, 'my-alias', memo);
+
+    expect(result.reason).toBe('ok');
+    expect(result.compacted).toBe(true);
+    expect(mockResolveContextLength).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/services/compaction/__tests__/compact-context-for-send.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/compact-context-for-send.test.ts
@@ -46,8 +46,7 @@ import { compactContextForSend, CompactionService } from '../compaction-service'
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  // Access and clear the private static instance
-  (CompactionService as any).instance = undefined;
+  CompactionService.resetForTesting();
   mockGetConfig.mockReset();
 });
 

--- a/packages/backend/src/services/compaction/__tests__/compaction-service.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/compaction-service.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { Context, UserMessage, AssistantMessage } from '@earendil-works/pi-ai';
+import { CompactionService } from '../compaction-service';
+import type {
+  CompactionResult,
+  CompactionSettings,
+  CompactionStrategy,
+  ResolvedCompactionSettings,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUserMsg(text: string): UserMessage {
+  return { role: 'user', content: [{ type: 'text', text }], timestamp: Date.now() };
+}
+
+function makeAssistantMsg(text: string): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    api: 'anthropic-messages',
+    provider: 'anthropic',
+    model: 'test-model',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp: Date.now(),
+  };
+}
+
+const originalMessages = [makeUserMsg('hello'), makeAssistantMsg('world')];
+const compactedMessages = [makeUserMsg('compact')];
+
+const baseContext: Context = { messages: [...originalMessages] };
+
+/** Resolved settings wired for "enabled, threshold will be met by a 9000-token context with 10000 contextLength". */
+const enabledSettings: CompactionSettings = {
+  enabled: true,
+  strategy: 'native',
+  triggerRatio: 0.8,
+  absoluteTriggerTokens: null,
+  minTokens: 2000,
+};
+
+/**
+ * Build a fake CompactionStrategy whose compact() returns `messages` and
+ * records how many times it was called.
+ */
+function makeFakeStrategy(
+  messages: Context['messages'],
+  throws?: Error
+): CompactionStrategy & { callCount: number } {
+  const obj = {
+    name: 'native' as const,
+    callCount: 0,
+    compact: vi.fn(async (_ctx: Context, _settings: ResolvedCompactionSettings, _stratCtx: any) => {
+      obj.callCount++;
+      if (throws) throw throws;
+      return messages;
+    }),
+  };
+  return obj;
+}
+
+/**
+ * A makeEstimate function that returns values from a queue.
+ * Each call pops the first value; last value is repeated if the queue empties.
+ */
+function makeEstimateQueue(...values: number[]): (ctx: Context) => number {
+  const queue = [...values];
+  return (_ctx: Context): number => {
+    if (queue.length > 1) return queue.shift()!;
+    return queue[0]!;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CompactionService.maybeCompact', () => {
+  test('1. disabled: returns reason=disabled, strategy NOT called', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages);
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(5000),
+      () => ({ enabled: false })
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    const result = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('disabled');
+    expect(result.context).toBe(baseContext);
+    expect(result.tokensBefore).toBe(0);
+    expect(result.tokensAfter).toBe(0);
+    expect(result.strategy).toBeNull();
+    expect(fakeStrategy.callCount).toBe(0);
+  });
+
+  test('2. below-min: estimate < minTokens, strategy NOT called', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages);
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(100), // well below minTokens:2000
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    const result = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('below-min');
+    expect(result.context).toBe(baseContext);
+    expect(result.tokensBefore).toBe(100);
+    expect(result.tokensAfter).toBe(100);
+    expect(result.strategy).toBeNull();
+    expect(fakeStrategy.callCount).toBe(0);
+  });
+
+  test('3. under-threshold: tokens >= minTokens but < triggerRatio*contextLength', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages);
+    // triggerRatio=0.8, contextLength=10000 → fire threshold = 8000; estimate = 3000
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(3000),
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    const result = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('under-threshold');
+    expect(result.context).toBe(baseContext);
+    expect(result.tokensBefore).toBe(3000);
+    expect(result.tokensAfter).toBe(3000);
+    expect(result.strategy).toBeNull();
+    expect(fakeStrategy.callCount).toBe(0);
+  });
+
+  test('4. compacted (tokens drop): strategy returns compacted messages, tokens drop', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages);
+    // before=9000 (>= 8000 threshold), after=3000 → real compaction
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(9000, 3000),
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    const result = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+
+    expect(result.compacted).toBe(true);
+    expect(result.reason).toBe('ok');
+    expect(result.tokensBefore).toBe(9000);
+    expect(result.tokensAfter).toBe(3000);
+    expect(result.context).not.toBe(baseContext);
+    expect(result.context.messages).toBe(compactedMessages);
+    expect(result.strategy).toBe('native');
+    expect(fakeStrategy.callCount).toBe(1);
+  });
+
+  test('5. no-reduction: tokensAfter >= tokensBefore, reverts to original context', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages);
+    // before=9000, after=9500 (tokens grew or no reduction)
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(9000, 9500),
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    const result = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('no-reduction');
+    expect(result.context).toBe(baseContext); // original returned
+    expect(result.tokensBefore).toBe(9000);
+    expect(result.tokensAfter).toBe(9500);
+    expect(result.strategy).toBe('native');
+    expect(fakeStrategy.callCount).toBe(1);
+  });
+
+  test('6. error (fail-open): strategy throws → reason=error, no rethrow, original context', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages, new Error('strategy exploded'));
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(9000),
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    // Must NOT throw
+    const result = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('error');
+    expect(result.context).toBe(baseContext);
+    expect(result.tokensBefore).toBe(9000);
+    expect(result.strategy).toBe('native');
+  });
+
+  test('6b. error NOT memoized: second call re-invokes strategy', async () => {
+    let callCount = 0;
+    const throwOnFirst: CompactionStrategy = {
+      name: 'native',
+      compact: async () => {
+        callCount++;
+        if (callCount === 1) throw new Error('first call fails');
+        return compactedMessages;
+      },
+    };
+    // First call: tokensBefore=9000, then throws (no tokensAfter call)
+    // Second call: tokensBefore=9000, tokensAfter=3000
+    const estimates = makeEstimateQueue(9000, 9000, 3000);
+    const service = new CompactionService(
+      { native: throwOnFirst, headroom: throwOnFirst },
+      estimates,
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    const result1 = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+    expect(result1.reason).toBe('error');
+
+    const result2 = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+    expect(result2.reason).toBe('ok');
+    expect(callCount).toBe(2);
+  });
+
+  test('7. memo: same model+contextLength → strategy called only once', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages);
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(9000, 3000, 9000, 3000),
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    const result1 = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+    const result2 = await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+
+    expect(fakeStrategy.callCount).toBe(1);
+    expect(result2).toBe(result1); // exact same object from memo
+  });
+
+  test('7b. memo key differentiates model+contextLength', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages);
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(9000, 3000, 9000, 3000),
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    // Different model → different memo key → strategy called twice
+    await service.maybeCompact(baseContext, { model: 'gpt-4', contextLength: 10000 }, memo);
+    await service.maybeCompact(baseContext, { model: 'gpt-3.5', contextLength: 10000 }, memo);
+
+    expect(fakeStrategy.callCount).toBe(2);
+  });
+
+  test('7c. memo key differentiates provider (failover candidates with different overrides recompute)', async () => {
+    const fakeStrategy = makeFakeStrategy(compactedMessages);
+    const service = new CompactionService(
+      { native: fakeStrategy, headroom: fakeStrategy },
+      makeEstimateQueue(9000, 3000, 9000, 3000),
+      () => enabledSettings
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    // Same model+contextLength but different provider → different memo key →
+    // strategy recomputes (so a per-provider override is honored on failover).
+    await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000, provider: 'openai' },
+      memo
+    );
+    await service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000, provider: 'azure' },
+      memo
+    );
+
+    expect(fakeStrategy.callCount).toBe(2);
+  });
+
+  test('singleton: getInstance() returns the same instance', () => {
+    // We do NOT reset the private static — just verify identity
+    const a = CompactionService.getInstance();
+    const b = CompactionService.getInstance();
+    expect(a).toBe(b);
+  });
+});

--- a/packages/backend/src/services/compaction/__tests__/compaction-service.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/compaction-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import type { Context, UserMessage, AssistantMessage } from '@earendil-works/pi-ai';
 import { CompactionService } from '../compaction-service';
 import type {
@@ -87,6 +87,10 @@ function makeEstimateQueue(...values: number[]): (ctx: Context) => number {
 // ---------------------------------------------------------------------------
 
 describe('CompactionService.maybeCompact', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test('1. disabled: returns reason=disabled, strategy NOT called', async () => {
     const fakeStrategy = makeFakeStrategy(compactedMessages);
     const service = new CompactionService(
@@ -333,6 +337,48 @@ describe('CompactionService.maybeCompact', () => {
     );
 
     expect(fakeStrategy.callCount).toBe(2);
+  });
+
+  test('8. timeout aborts the strategy signal before failing open', async () => {
+    vi.useFakeTimers();
+
+    const seenSignals: AbortSignal[] = [];
+    const neverFinishes: CompactionStrategy = {
+      name: 'headroom',
+      compact: async (_ctx, _settings, stratCtx) => {
+        if (stratCtx.signal) {
+          seenSignals.push(stratCtx.signal);
+        }
+        return new Promise<Context['messages']>(() => {});
+      },
+    };
+    const service = new CompactionService(
+      { native: neverFinishes, headroom: neverFinishes },
+      makeEstimateQueue(9000),
+      () => ({
+        ...enabledSettings,
+        strategy: 'headroom',
+        minTokens: 0,
+        headroom: { timeoutMs: 100 },
+      })
+    );
+    const memo = new Map<string, CompactionResult>();
+
+    const resultPromise = service.maybeCompact(
+      baseContext,
+      { model: 'gpt-4', contextLength: 10000 },
+      memo
+    );
+
+    expect(seenSignals).toHaveLength(1);
+    expect(seenSignals[0]!.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await resultPromise;
+
+    expect(result.reason).toBe('error');
+    expect(result.context).toBe(baseContext);
+    expect(seenSignals[0]!.aborted).toBe(true);
   });
 
   test('singleton: getInstance() returns the same instance', () => {

--- a/packages/backend/src/services/compaction/__tests__/headroom-compactor.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/headroom-compactor.test.ts
@@ -1,0 +1,366 @@
+/**
+ * headroom-compactor.test.ts
+ *
+ * TDD tests for HeadroomCompactor — all tests inject a fake compressFn,
+ * so no real headroom-ai server is ever contacted.
+ */
+import { describe, expect, test, vi } from 'vitest';
+import type {
+  Context,
+  AssistantMessage,
+  ToolResultMessage,
+  UserMessage,
+} from '@earendil-works/pi-ai';
+import type { CompressResult } from 'headroom-ai';
+import { HeadroomCompactor, toOpenAI, fromOpenAI } from '../headroom-compactor';
+import { COMPACTION_DEFAULTS } from '../types';
+import type { CompactionStrategyContext } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function makeAssistantMsg(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [],
+    api: 'openai-completions',
+    provider: 'openai',
+    model: 'gpt-4o',
+    usage: makeUsage(),
+    stopReason: 'stop',
+    timestamp: 1000,
+    ...overrides,
+  };
+}
+
+function makeUserMsg(content: UserMessage['content']): UserMessage {
+  return { role: 'user', content, timestamp: 1000 };
+}
+
+function makeToolResultMsg(overrides: Partial<ToolResultMessage> = {}): ToolResultMessage {
+  return {
+    role: 'toolResult',
+    toolCallId: 'call_1',
+    toolName: 'search',
+    content: [{ type: 'text', text: 'result text' }],
+    isError: false,
+    timestamp: 1000,
+    ...overrides,
+  };
+}
+
+/** Minimal CompressResult that echoes the input messages back. */
+function echoResult(messages: any[]): CompressResult {
+  return {
+    messages,
+    tokensBefore: 100,
+    tokensAfter: 80,
+    tokensSaved: 20,
+    compressionRatio: 0.8,
+    transformsApplied: [],
+    ccrHashes: [],
+    compressed: true,
+  };
+}
+
+const baseSettings = {
+  ...COMPACTION_DEFAULTS,
+  headroom: {
+    baseUrl: 'http://localhost:8787',
+    apiKey: 'test-key',
+    targetRatio: null,
+    timeoutMs: 5000,
+  },
+};
+
+const baseCtx: CompactionStrategyContext = {
+  model: 'gpt-4o',
+  contextLength: 10000,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HeadroomCompactor', () => {
+  // 1. Forward mapping
+  describe('1. forward mapping — pi-ai → OpenAI shapes sent to compressFn', () => {
+    test('user text, assistant with toolCall, toolResult map to correct OpenAI shapes', async () => {
+      const capturedArgs: { messages: any[]; options: any } = { messages: [], options: {} };
+      const fakeFn = vi.fn(async (messages: any[], options: any) => {
+        capturedArgs.messages = messages;
+        capturedArgs.options = options;
+        return echoResult(messages);
+      });
+
+      const context: Context = {
+        messages: [
+          makeUserMsg('hello world'),
+          makeAssistantMsg({
+            content: [
+              { type: 'text', text: 'I will search' },
+              { type: 'toolCall', id: 'call_1', name: 'search', arguments: { q: 'test' } },
+            ],
+          }),
+          makeToolResultMsg({
+            toolCallId: 'call_1',
+            toolName: 'search',
+            content: [{ type: 'text', text: 'result text' }],
+          }),
+        ],
+      };
+
+      const compactor = new HeadroomCompactor(fakeFn);
+      await compactor.compact(context, baseSettings, baseCtx);
+
+      expect(fakeFn).toHaveBeenCalledOnce();
+
+      const [userMsg, assistantMsg, toolMsg] = capturedArgs.messages;
+
+      // User message
+      expect(userMsg).toEqual({ role: 'user', content: 'hello world' });
+
+      // Assistant message: text joined, tool_calls array
+      expect(assistantMsg.role).toBe('assistant');
+      expect(assistantMsg.content).toBe('I will search');
+      expect(assistantMsg.tool_calls).toHaveLength(1);
+      expect(assistantMsg.tool_calls[0]).toEqual({
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'search', arguments: JSON.stringify({ q: 'test' }) },
+      });
+
+      // Tool result message
+      expect(toolMsg).toEqual({ role: 'tool', tool_call_id: 'call_1', content: 'result text' });
+    });
+
+    test('options carry model, baseUrl, numeric tokenBudget (10000-4096=5904), and timeout', async () => {
+      const capturedOptions: any = {};
+      const fakeFn = vi.fn(async (messages: any[], options: any) => {
+        Object.assign(capturedOptions, options);
+        return echoResult(messages);
+      });
+
+      const context: Context = { messages: [makeUserMsg('hi')] };
+      const compactor = new HeadroomCompactor(fakeFn);
+      await compactor.compact(context, baseSettings, baseCtx);
+
+      expect(capturedOptions.model).toBe('gpt-4o');
+      expect(capturedOptions.baseUrl).toBe('http://localhost:8787');
+      expect(capturedOptions.tokenBudget).toBe(5904); // 10000 - 4096
+      expect(typeof capturedOptions.tokenBudget).toBe('number');
+      expect(capturedOptions.timeout).toBe(5000);
+      // Must NOT have a signal or targetRatio field
+      expect(capturedOptions).not.toHaveProperty('signal');
+      expect(capturedOptions).not.toHaveProperty('targetRatio');
+    });
+  });
+
+  // 2. Reverse mapping
+  describe('2. reverse mapping — OpenAI output → pi-ai shapes', () => {
+    test('toolName restored via toolNameById; assistant maps back with required fields', async () => {
+      // compressFn returns compacted OpenAI messages
+      const compressedOpenAI = [
+        { role: 'tool', tool_call_id: 'call_1', content: 'compacted' },
+        {
+          role: 'assistant',
+          content: 'hi',
+          tool_calls: [
+            { id: 'call_2', type: 'function', function: { name: 'f', arguments: '{"a":1}' } },
+          ],
+        },
+      ];
+      const fakeFn = vi.fn(async () => echoResult(compressedOpenAI));
+
+      // Original context has toolCall id=call_1 (name='search') and id=call_2 (name='f')
+      const context: Context = {
+        messages: [
+          makeAssistantMsg({
+            content: [
+              { type: 'toolCall', id: 'call_1', name: 'search', arguments: {} },
+              { type: 'toolCall', id: 'call_2', name: 'f', arguments: {} },
+            ],
+          }),
+          makeToolResultMsg({ toolCallId: 'call_1', toolName: 'search' }),
+        ],
+      };
+
+      const compactor = new HeadroomCompactor(fakeFn);
+      const result = await compactor.compact(context, baseSettings, baseCtx);
+
+      expect(result).toHaveLength(2);
+
+      // toolResult: role, toolCallId, toolName (restored), content, isError, timestamp
+      const tr = result[0] as ToolResultMessage;
+      expect(tr.role).toBe('toolResult');
+      expect(tr.toolCallId).toBe('call_1');
+      expect(tr.toolName).toBe('search'); // restored from toolNameById
+      expect(tr.content).toEqual([{ type: 'text', text: 'compacted' }]);
+      expect(tr.isError).toBe(false);
+      expect(tr.timestamp).toBe(0);
+
+      // assistant: role, content (TextContent + ToolCall), api/provider/model/usage/stopReason/timestamp
+      const am = result[1] as AssistantMessage;
+      expect(am.role).toBe('assistant');
+      expect(am.content).toContainEqual({ type: 'text', text: 'hi' });
+      expect(am.content).toContainEqual({
+        type: 'toolCall',
+        id: 'call_2',
+        name: 'f',
+        arguments: { a: 1 },
+      });
+      expect(am.api).toBeDefined();
+      expect(am.provider).toBeDefined();
+      expect(am.model).toBeDefined();
+      expect(am.usage).toBeDefined();
+      expect(am.stopReason).toBe('stop');
+      expect(am.timestamp).toBe(0);
+    });
+
+    test('assistantTemplate taken from first AssistantMessage in original context', async () => {
+      const compressedOpenAI = [{ role: 'assistant', content: 'hello', tool_calls: undefined }];
+      const fakeFn = vi.fn(async () => echoResult(compressedOpenAI));
+
+      const context: Context = {
+        messages: [
+          makeAssistantMsg({
+            api: 'anthropic-messages',
+            provider: 'anthropic',
+            model: 'claude-3-5-sonnet',
+            content: [{ type: 'text', text: 'hi' }],
+          }),
+        ],
+      };
+
+      const compactor = new HeadroomCompactor(fakeFn);
+      const result = await compactor.compact(context, baseSettings, baseCtx);
+      const am = result[0] as AssistantMessage;
+
+      expect(am.api).toBe('anthropic-messages');
+      expect(am.provider).toBe('anthropic');
+      expect(am.model).toBe('claude-3-5-sonnet');
+    });
+
+    test('image content round-trips through data URI encoding', async () => {
+      const userWithImage: UserMessage = {
+        role: 'user',
+        content: [{ type: 'image', data: 'abc123', mimeType: 'image/png' }],
+        timestamp: 0,
+      };
+      const openaiOut = toOpenAI(userWithImage);
+      expect(openaiOut).toEqual({
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,abc123' } }],
+      });
+
+      // Round-trip back
+      const backMsg = fromOpenAI(openaiOut, new Map(), {
+        api: 'openai-completions',
+        provider: 'openai',
+        model: 'gpt-4o',
+      });
+      expect(backMsg.role).toBe('user');
+      const um = backMsg as UserMessage;
+      expect(um.content).toEqual([{ type: 'image', data: 'abc123', mimeType: 'image/png' }]);
+    });
+  });
+
+  // 3. Error propagation
+  describe('3. error propagation', () => {
+    test('compressFn throw causes compact() to reject', async () => {
+      const boom = new Error('network fail');
+      const fakeFn = vi.fn(async () => {
+        throw boom;
+      });
+      const context: Context = { messages: [makeUserMsg('hi')] };
+      const compactor = new HeadroomCompactor(fakeFn);
+      await expect(compactor.compact(context, baseSettings, baseCtx)).rejects.toThrow(
+        'network fail'
+      );
+    });
+  });
+
+  // 4. targetRatio path
+  describe('4. targetRatio overrides tokenBudget when set', () => {
+    test('targetRatio=0.5, contextLength=10000 → tokenBudget=5000', async () => {
+      const capturedOptions: any = {};
+      const fakeFn = vi.fn(async (messages: any[], options: any) => {
+        Object.assign(capturedOptions, options);
+        return echoResult(messages);
+      });
+
+      const settingsWithRatio = {
+        ...baseSettings,
+        headroom: { ...baseSettings.headroom, targetRatio: 0.5 },
+      };
+
+      const context: Context = { messages: [makeUserMsg('hi')] };
+      const compactor = new HeadroomCompactor(fakeFn);
+      await compactor.compact(context, settingsWithRatio, baseCtx);
+
+      expect(capturedOptions.tokenBudget).toBe(5000); // floor(10000 * 0.5)
+    });
+
+    test('no contextLength → tokenBudget is undefined', async () => {
+      const capturedOptions: any = {};
+      const fakeFn = vi.fn(async (messages: any[], options: any) => {
+        Object.assign(capturedOptions, options);
+        return echoResult(messages);
+      });
+
+      const context: Context = { messages: [makeUserMsg('hi')] };
+      const compactor = new HeadroomCompactor(fakeFn);
+      await compactor.compact(context, baseSettings, { model: 'gpt-4o' }); // no contextLength
+
+      expect(capturedOptions.tokenBudget).toBeUndefined();
+    });
+  });
+
+  // 5. toOpenAI edge cases (unit tests for the exported pure function)
+  describe('5. toOpenAI edge cases', () => {
+    test('assistant with only thinking blocks → content:null, no tool_calls', () => {
+      const msg = makeAssistantMsg({
+        content: [{ type: 'thinking', thinking: 'some deep thought' }],
+      });
+      const result = toOpenAI(msg);
+      expect(result).toEqual({ role: 'assistant', content: null });
+    });
+
+    test('assistant with no content blocks → content:null', () => {
+      const msg = makeAssistantMsg({ content: [] });
+      const result = toOpenAI(msg);
+      expect(result).toEqual({ role: 'assistant', content: null });
+    });
+
+    test('user with array content maps text and image blocks', () => {
+      const msg: UserMessage = {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe this' },
+          { type: 'image', data: 'base64data', mimeType: 'image/jpeg' },
+        ],
+        timestamp: 0,
+      };
+      const result = toOpenAI(msg);
+      expect(result).toEqual({
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe this' },
+          { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,base64data' } },
+        ],
+      });
+    });
+  });
+});

--- a/packages/backend/src/services/compaction/__tests__/headroom-compactor.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/headroom-compactor.test.ts
@@ -166,6 +166,21 @@ describe('HeadroomCompactor', () => {
       expect(capturedOptions).not.toHaveProperty('signal');
       expect(capturedOptions).not.toHaveProperty('targetRatio');
     });
+
+    test('options include the caller abort signal when provided', async () => {
+      const controller = new AbortController();
+      const capturedOptions: any = {};
+      const fakeFn = vi.fn(async (messages: any[], options: any) => {
+        Object.assign(capturedOptions, options);
+        return echoResult(messages);
+      });
+
+      const context: Context = { messages: [makeUserMsg('hi')] };
+      const compactor = new HeadroomCompactor(fakeFn);
+      await compactor.compact(context, baseSettings, { ...baseCtx, signal: controller.signal });
+
+      expect(capturedOptions.signal).toBe(controller.signal);
+    });
   });
 
   // 2. Reverse mapping
@@ -288,6 +303,35 @@ describe('HeadroomCompactor', () => {
       const compactor = new HeadroomCompactor(fakeFn);
       await expect(compactor.compact(context, baseSettings, baseCtx)).rejects.toThrow(
         'network fail'
+      );
+    });
+
+    test.each([
+      ['array', '[]'],
+      ['null', 'null'],
+      ['string', '"oops"'],
+    ])('non-object tool-call arguments from headroom output reject: %s', async (_name, args) => {
+      const compressedOpenAI = [
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            { id: 'call_1', type: 'function', function: { name: 'search', arguments: args } },
+          ],
+        },
+      ];
+      const fakeFn = vi.fn(async () => echoResult(compressedOpenAI));
+      const context: Context = {
+        messages: [
+          makeAssistantMsg({
+            content: [{ type: 'toolCall', id: 'call_1', name: 'search', arguments: {} }],
+          }),
+        ],
+      };
+      const compactor = new HeadroomCompactor(fakeFn);
+
+      await expect(compactor.compact(context, baseSettings, baseCtx)).rejects.toThrow(
+        'invalid tool arguments'
       );
     });
   });

--- a/packages/backend/src/services/compaction/__tests__/native-compactor.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/native-compactor.test.ts
@@ -53,6 +53,29 @@ function makeToolResultMessage(content: ToolResultMessage['content']): ToolResul
 }
 
 describe('NativeCompactor', () => {
+  test('assistant thinking blocks are preserved verbatim (never truncated)', async () => {
+    const compactor = new NativeCompactor();
+
+    // Thinking text far exceeds maxStringChars (20). Native must NOT compact it:
+    // Anthropic extended-thinking signatures bind the exact thinking text, so
+    // truncating it would invalidate them (see docs/compaction.md — native is
+    // the default precisely because it preserves thinking).
+    const longThinking = 'reasoning step '.repeat(20);
+    const assistant = makeAssistantMessage([{ type: 'thinking', thinking: longThinking }]);
+    const protected_ = makeUserMessage('keep me');
+    const context: Context = { messages: [assistant, protected_] };
+
+    const result = await compactor.compact(context, settings, ctx);
+
+    // Nothing changed → the assistant message is passed through by reference.
+    expect(result[0]).toBe(assistant);
+    const block = (result[0] as AssistantMessage).content[0] as {
+      type: 'thinking';
+      thinking: string;
+    };
+    expect(block.thinking).toBe(longThinking);
+  });
+
   test('1. toolResult with verbose JSON array is truncated with sentinel', async () => {
     const compactor = new NativeCompactor();
 

--- a/packages/backend/src/services/compaction/__tests__/native-compactor.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/native-compactor.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'vitest';
+import type {
+  Context,
+  UserMessage,
+  AssistantMessage,
+  ToolResultMessage,
+} from '@earendil-works/pi-ai';
+import { NativeCompactor } from '../native-compactor';
+import { COMPACTION_DEFAULTS } from '../types';
+
+const settings = {
+  ...COMPACTION_DEFAULTS,
+  protectRecent: 1,
+  native: { maxArrayItems: 2, maxStringChars: 20 },
+};
+
+const ctx = { model: 'test-model' };
+
+// Helper to build a minimal AssistantMessage
+function makeAssistantMessage(content: AssistantMessage['content']): AssistantMessage {
+  return {
+    role: 'assistant',
+    content,
+    api: 'anthropic-messages',
+    provider: 'anthropic',
+    model: 'claude-3-5-sonnet',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp: Date.now(),
+  };
+}
+
+function makeUserMessage(content: UserMessage['content']): UserMessage {
+  return { role: 'user', content, timestamp: Date.now() };
+}
+
+function makeToolResultMessage(content: ToolResultMessage['content']): ToolResultMessage {
+  return {
+    role: 'toolResult',
+    toolCallId: 'tc-1',
+    toolName: 'myTool',
+    content,
+    isError: false,
+    timestamp: Date.now(),
+  };
+}
+
+describe('NativeCompactor', () => {
+  test('1. toolResult with verbose JSON array is truncated with sentinel', async () => {
+    const compactor = new NativeCompactor();
+
+    const bigArray = [1, 2, 3, 4, 5];
+    const toolResult = makeToolResultMessage([{ type: 'text', text: JSON.stringify(bigArray) }]);
+    // put a dummy protected message last
+    const protected_ = makeUserMessage('keep me');
+    const context: Context = { messages: [toolResult, protected_] };
+
+    const result = await compactor.compact(context, settings, ctx);
+
+    expect(result).toHaveLength(2);
+    // protected message unchanged
+    expect(result[1]).toBe(protected_);
+
+    // compacted first message: parse the text and check
+    const compactedMsg = result[0] as ToolResultMessage;
+    const compactedText = (compactedMsg.content[0] as { type: 'text'; text: string }).text;
+    const parsed = JSON.parse(compactedText);
+    expect(parsed).toHaveLength(3); // 2 items + sentinel
+    expect(typeof parsed[2]).toBe('string');
+    expect(parsed[2]).toContain('items omitted');
+  });
+
+  test('2. protected (most-recent protectRecent) messages returned byte-identical', async () => {
+    const compactor = new NativeCompactor();
+
+    const older = makeToolResultMessage([{ type: 'text', text: 'A'.repeat(50) }]);
+    const recent = makeUserMessage('recent message');
+    const context: Context = { messages: [older, recent] };
+
+    const result = await compactor.compact(context, settings, ctx);
+
+    // recent (index 1) must be the exact same object reference
+    expect(result[result.length - 1]).toBe(recent);
+    // deep equality too
+    expect(result[result.length - 1]).toEqual(recent);
+  });
+
+  test('3. user message with long plain-text block is truncated with marker', async () => {
+    const compactor = new NativeCompactor();
+
+    const longText = 'A'.repeat(50); // > maxStringChars=20
+    const userMsg = makeUserMessage([{ type: 'text', text: longText }]);
+    const protected_ = makeUserMessage('keep');
+    const context: Context = { messages: [userMsg, protected_] };
+
+    const result = await compactor.compact(context, settings, ctx);
+
+    const compactedMsg = result[0] as UserMessage;
+    expect(Array.isArray(compactedMsg.content)).toBe(true);
+    const textBlock = (compactedMsg.content as Array<{ type: string; text?: string }>)[0];
+    expect(textBlock).toBeDefined();
+    expect(textBlock!.text).toContain('truncated');
+    expect(textBlock!.text).toContain('30 chars'); // 50-20=30
+    expect(textBlock!.text?.startsWith('A'.repeat(20))).toBe(true);
+  });
+
+  test('4. user message with string content is handled without crash', async () => {
+    const compactor = new NativeCompactor();
+
+    const longString = 'hello world this is a very long string for testing purposes';
+    const userMsg = makeUserMessage(longString);
+    const protected_ = makeUserMessage('keep');
+    const context: Context = { messages: [userMsg, protected_] };
+
+    let result: Context['messages'];
+    await expect(async () => {
+      result = await compactor.compact(context, settings, ctx);
+    }).not.toThrow();
+
+    result = await compactor.compact(context, settings, ctx);
+    const compactedMsg = result[0] as UserMessage;
+    // string content compacted via compactText
+    expect(typeof compactedMsg.content).toBe('string');
+    expect((compactedMsg.content as string).length).toBeLessThanOrEqual(
+      settings.native.maxStringChars + 50 // marker adds some chars
+    );
+    expect(compactedMsg.content as string).toContain('truncated');
+  });
+
+  test('5. input is NOT mutated', async () => {
+    const compactor = new NativeCompactor();
+
+    const bigArray = [1, 2, 3, 4, 5];
+    const toolResult = makeToolResultMessage([{ type: 'text', text: JSON.stringify(bigArray) }]);
+    const protected_ = makeUserMessage('keep me');
+    const originalMessages: Context['messages'] = [toolResult, protected_];
+    const originalText = (toolResult.content[0] as { type: 'text'; text: string }).text;
+
+    // Deep-clone snapshots before calling
+    const snapshotMessages = JSON.parse(JSON.stringify(originalMessages));
+
+    const context: Context = { messages: originalMessages };
+    await compactor.compact(context, settings, ctx);
+
+    // Original array reference still intact
+    expect(originalMessages).toHaveLength(2);
+    expect(originalMessages[0]).toBe(toolResult);
+    // Original nested block text unchanged
+    expect((toolResult.content[0] as { type: 'text'; text: string }).text).toBe(originalText);
+    // Deep equality to pre-call snapshot
+    expect(originalMessages).toEqual(snapshotMessages);
+  });
+
+  test('6. assistant toolCall with big-array arguments is compacted; id/name preserved', async () => {
+    const compactor = new NativeCompactor();
+
+    const toolCall = {
+      type: 'toolCall' as const,
+      id: 'call-abc',
+      name: 'searchFiles',
+      arguments: { paths: ['a', 'b', 'c', 'd', 'e'], limit: 10 },
+    };
+    const assistantMsg = makeAssistantMessage([toolCall]);
+    const protected_ = makeUserMessage('keep');
+    const context: Context = { messages: [assistantMsg, protected_] };
+
+    const result = await compactor.compact(context, settings, ctx);
+
+    const compactedMsg = result[0] as AssistantMessage;
+    const compactedCall = compactedMsg.content[0] as {
+      type: 'toolCall';
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+    };
+    expect(compactedCall.type).toBe('toolCall');
+    expect(compactedCall.id).toBe('call-abc');
+    expect(compactedCall.name).toBe('searchFiles');
+    // paths array was length 5 > maxArrayItems=2, should now be 3 (2 + sentinel)
+    expect(Array.isArray(compactedCall.arguments.paths)).toBe(true);
+    const paths = compactedCall.arguments.paths as unknown[];
+    expect(paths).toHaveLength(3);
+    expect(typeof paths[2]).toBe('string');
+    expect(paths[2] as string).toContain('items omitted');
+    // limit (scalar) preserved
+    expect(compactedCall.arguments.limit).toBe(10);
+    // arguments object is a new reference (not mutated original)
+    expect(compactedCall.arguments).not.toBe(toolCall.arguments);
+  });
+});

--- a/packages/backend/src/services/compaction/__tests__/resolve-settings.test.ts
+++ b/packages/backend/src/services/compaction/__tests__/resolve-settings.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+import { resolveCompactionSettings } from '../resolve-settings';
+import { COMPACTION_DEFAULTS } from '../types';
+
+describe('resolveCompactionSettings', () => {
+  test('empty call returns COMPACTION_DEFAULTS', () => {
+    const result = resolveCompactionSettings();
+    expect(result).toEqual(COMPACTION_DEFAULTS);
+  });
+
+  test('alias > provider > global precedence for scalar fields', () => {
+    // alias: enabled=true, strategy unset
+    // provider: strategy='headroom', enabled unset
+    // global: enabled=false, strategy='native'
+    const result = resolveCompactionSettings(
+      { enabled: false, strategy: 'native' }, // global
+      { strategy: 'headroom' }, // provider
+      { enabled: true } // alias
+    );
+    expect(result.enabled).toBe(true); // alias wins
+    expect(result.strategy).toBe('headroom'); // provider beats global
+  });
+
+  test('nested native fields merged field-by-field across layers', () => {
+    // global provides maxArrayItems=10
+    // provider provides maxStringChars=999
+    // alias provides nothing for native
+    const result = resolveCompactionSettings(
+      { native: { maxArrayItems: 10 } }, // global
+      { native: { maxStringChars: 999 } }, // provider
+      {} // alias (empty)
+    );
+    expect(result.native.maxArrayItems).toBe(10); // from global
+    expect(result.native.maxStringChars).toBe(999); // from provider
+  });
+
+  test('nested headroom fields merged field-by-field across layers', () => {
+    // global provides baseUrl
+    // alias provides timeoutMs
+    const result = resolveCompactionSettings(
+      { headroom: { baseUrl: 'http://x' } }, // global
+      undefined, // provider unset
+      { headroom: { timeoutMs: 1234 } } // alias
+    );
+    expect(result.headroom.baseUrl).toBe('http://x');
+    expect(result.headroom.timeoutMs).toBe(1234);
+    expect(result.headroom.targetRatio).toBeNull(); // default
+    expect(result.headroom.apiKey).toBeUndefined(); // no default
+  });
+});

--- a/packages/backend/src/services/compaction/compaction-service.ts
+++ b/packages/backend/src/services/compaction/compaction-service.ts
@@ -37,10 +37,13 @@ type GetGlobalFn = () => CompactionSettings | undefined;
 // Helpers
 // ---------------------------------------------------------------------------
 
-function runWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+function runWithTimeout<T>(promise: Promise<T>, ms: number, onTimeout?: () => void): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<T>((_, rej) => {
-    timer = setTimeout(() => rej(new Error('compaction timeout')), ms);
+    timer = setTimeout(() => {
+      onTimeout?.();
+      rej(new Error('compaction timeout'));
+    }, ms);
     // Allow Node/Bun process to exit even if this timeout is still pending
     if (typeof timer === 'object' && timer !== null && typeof (timer as any).unref === 'function') {
       (timer as any).unref();
@@ -51,6 +54,27 @@ function runWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([promise, timeout]).finally(() => {
     if (timer) clearTimeout(timer);
   });
+}
+
+function createScopedAbortSignal(parent?: AbortSignal): {
+  signal: AbortSignal;
+  abort: (reason?: unknown) => void;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const abortFromParent = () => controller.abort(parent?.reason);
+
+  if (parent?.aborted) {
+    abortFromParent();
+  } else {
+    parent?.addEventListener('abort', abortFromParent, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    abort: (reason?: unknown) => controller.abort(reason),
+    cleanup: () => parent?.removeEventListener('abort', abortFromParent),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -150,14 +174,16 @@ export class CompactionService {
     // 7. Run strategy with timeout (fail-open)
     const strategy = this.strategies[settings.strategy];
     let newMessages: Context['messages'];
+    const strategyAbort = createScopedAbortSignal(opts.signal);
     try {
       newMessages = await runWithTimeout(
         strategy.compact(context, settings, {
           model: opts.model,
           contextLength,
-          signal: opts.signal,
+          signal: strategyAbort.signal,
         }),
-        settings.headroom.timeoutMs
+        settings.headroom.timeoutMs,
+        () => strategyAbort.abort(new Error('compaction timeout'))
       );
     } catch (err) {
       logger.warn(
@@ -172,6 +198,8 @@ export class CompactionService {
         strategy: settings.strategy,
         reason: 'error',
       };
+    } finally {
+      strategyAbort.cleanup();
     }
 
     // 8. Build new context and re-estimate
@@ -222,8 +250,8 @@ export async function compactContextForSend(
 ): Promise<CompactionResult> {
   const aliasConfig = getConfig().models?.[route.canonicalModel ?? modelAlias];
   const contextLength =
-    (aliasConfig ? resolveContextLength(aliasConfig) : undefined) ??
-    route.modelArchitecture?.context_length;
+    route.modelArchitecture?.context_length ??
+    (aliasConfig ? resolveContextLength(aliasConfig) : undefined);
   return CompactionService.getInstance().maybeCompact(
     context,
     {

--- a/packages/backend/src/services/compaction/compaction-service.ts
+++ b/packages/backend/src/services/compaction/compaction-service.ts
@@ -77,6 +77,11 @@ export class CompactionService {
     return this.instance;
   }
 
+  /** Test-only: drop the cached singleton so each test builds a fresh instance. */
+  static resetForTesting(): void {
+    this.instance = undefined;
+  }
+
   async maybeCompact(
     context: Context,
     opts: MaybeCompactOpts,

--- a/packages/backend/src/services/compaction/compaction-service.ts
+++ b/packages/backend/src/services/compaction/compaction-service.ts
@@ -1,0 +1,234 @@
+import type { Context } from '@earendil-works/pi-ai';
+import { logger } from '../../utils/logger';
+import { getConfig, type ModelConfig } from '../../config';
+import { resolveContextLength } from '../enforce-limits';
+import { estimateContextTokens } from '../../utils/estimate-tokens';
+import type { RouteResult } from '../router';
+import { NativeCompactor } from './native-compactor';
+import { HeadroomCompactor } from './headroom-compactor';
+import { resolveCompactionSettings } from './resolve-settings';
+import type {
+  CompactionResult,
+  CompactionSettings,
+  CompactionStrategy,
+  CompactionStrategyName,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MaybeCompactOpts {
+  aliasConfig?: ModelConfig;
+  providerCompaction?: CompactionSettings;
+  /** Resolved provider id — part of the memo key so failover candidates with
+   *  different per-provider compaction overrides don't reuse each other's result. */
+  provider?: string;
+  model: string;
+  contextLength?: number;
+  signal?: AbortSignal;
+}
+
+type Strategies = Record<CompactionStrategyName, CompactionStrategy>;
+type EstimateFn = (context: Context) => number;
+type GetGlobalFn = () => CompactionSettings | undefined;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function runWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<T>((_, rej) => {
+    timer = setTimeout(() => rej(new Error('compaction timeout')), ms);
+    // Allow Node/Bun process to exit even if this timeout is still pending
+    if (typeof timer === 'object' && timer !== null && typeof (timer as any).unref === 'function') {
+      (timer as any).unref();
+    }
+  });
+  // Clear the timer once either side settles so a winning strategy doesn't leave
+  // a live timeout dangling for the full `ms` window.
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// CompactionService
+// ---------------------------------------------------------------------------
+
+export class CompactionService {
+  private static instance: CompactionService | undefined;
+
+  constructor(
+    private strategies: Strategies,
+    private estimateFn: EstimateFn,
+    private getGlobal: GetGlobalFn
+  ) {}
+
+  static getInstance(): CompactionService {
+    if (!this.instance) {
+      this.instance = new CompactionService(
+        { native: new NativeCompactor(), headroom: new HeadroomCompactor() },
+        (ctx) => estimateContextTokens(ctx),
+        () => getConfig().compaction
+      );
+    }
+    return this.instance;
+  }
+
+  async maybeCompact(
+    context: Context,
+    opts: MaybeCompactOpts,
+    memo: Map<string, CompactionResult>
+  ): Promise<CompactionResult> {
+    // 1. Resolve settings
+    const settings = resolveCompactionSettings(
+      this.getGlobal(),
+      opts.providerCompaction,
+      opts.aliasConfig?.compaction
+    );
+
+    // 2. Disabled fast-path
+    if (!settings.enabled) {
+      return {
+        compacted: false,
+        context,
+        tokensBefore: 0,
+        tokensAfter: 0,
+        strategy: null,
+        reason: 'disabled',
+      };
+    }
+
+    // 3. Estimate tokens; check below-min
+    const tokensBefore = this.estimateFn(context);
+    if (tokensBefore < settings.minTokens) {
+      return {
+        compacted: false,
+        context,
+        tokensBefore,
+        tokensAfter: tokensBefore,
+        strategy: null,
+        reason: 'below-min',
+      };
+    }
+
+    // 4. Resolve contextLength
+    const contextLength =
+      opts.contextLength ?? (opts.aliasConfig ? resolveContextLength(opts.aliasConfig) : undefined);
+
+    // 5. Trigger check
+    const fire =
+      (contextLength != null && tokensBefore >= settings.triggerRatio * contextLength) ||
+      (settings.absoluteTriggerTokens != null && tokensBefore >= settings.absoluteTriggerTokens);
+
+    if (!fire) {
+      return {
+        compacted: false,
+        context,
+        tokensBefore,
+        tokensAfter: tokensBefore,
+        strategy: null,
+        reason: 'under-threshold',
+      };
+    }
+
+    // 6. Memo check — keyed by provider+model+contextLength so a failover
+    // candidate with a different per-provider compaction override recomputes
+    // instead of reusing the prior candidate's result.
+    const key = `${opts.provider ?? ''}:${opts.model}:${contextLength ?? 'na'}`;
+    if (memo.has(key)) {
+      return memo.get(key)!;
+    }
+
+    // 7. Run strategy with timeout (fail-open)
+    const strategy = this.strategies[settings.strategy];
+    let newMessages: Context['messages'];
+    try {
+      newMessages = await runWithTimeout(
+        strategy.compact(context, settings, {
+          model: opts.model,
+          contextLength,
+          signal: opts.signal,
+        }),
+        settings.headroom.timeoutMs
+      );
+    } catch (err) {
+      logger.warn(
+        `[compaction] strategy '${settings.strategy}' failed (fail-open): ${(err as Error)?.message}`
+      );
+      // Do NOT memo errors
+      return {
+        compacted: false,
+        context,
+        tokensBefore,
+        tokensAfter: tokensBefore,
+        strategy: settings.strategy,
+        reason: 'error',
+      };
+    }
+
+    // 8. Build new context and re-estimate
+    const newContext: Context = { ...context, messages: newMessages };
+    const tokensAfter = this.estimateFn(newContext);
+
+    // 9. Validation guard
+    let result: CompactionResult;
+    if (tokensAfter >= tokensBefore) {
+      result = {
+        compacted: false,
+        context, // revert to original
+        tokensBefore,
+        tokensAfter,
+        strategy: settings.strategy,
+        reason: 'no-reduction',
+      };
+    } else {
+      result = {
+        compacted: true,
+        context: newContext,
+        tokensBefore,
+        tokensAfter,
+        strategy: settings.strategy,
+        reason: 'ok',
+      };
+      logger.info(
+        `[compaction] ${settings.strategy} ${tokensBefore}→${tokensAfter} tokens (${opts.model})`
+      );
+    }
+
+    // 10. Memo and return
+    memo.set(key, result);
+    return result;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// compactContextForSend (executor helper — used by Task 5)
+// ---------------------------------------------------------------------------
+
+export async function compactContextForSend(
+  context: Context,
+  route: RouteResult,
+  modelAlias: string,
+  memo: Map<string, CompactionResult>,
+  signal?: AbortSignal
+): Promise<CompactionResult> {
+  const aliasConfig = getConfig().models?.[route.canonicalModel ?? modelAlias];
+  const contextLength =
+    (aliasConfig ? resolveContextLength(aliasConfig) : undefined) ??
+    route.modelArchitecture?.context_length;
+  return CompactionService.getInstance().maybeCompact(
+    context,
+    {
+      aliasConfig,
+      providerCompaction: route.config.compaction,
+      provider: route.provider,
+      model: route.canonicalModel ?? modelAlias,
+      contextLength,
+      signal,
+    },
+    memo
+  );
+}

--- a/packages/backend/src/services/compaction/headroom-compactor.ts
+++ b/packages/backend/src/services/compaction/headroom-compactor.ts
@@ -128,9 +128,10 @@ export function toOpenAI(msg: Message): OAIMessage {
 
   if (msg.role === 'toolResult') {
     const m = msg as ToolResultMessage;
+    // OpenAI 'tool' messages only carry string content. Keep text blocks and
+    // mark any non-text blocks (e.g. images) so they aren't silently dropped.
     const content = (m.content as (TextContent | ImageContent)[])
-      .filter((b): b is TextContent => b.type === 'text')
-      .map((b) => b.text)
+      .map((b) => (b.type === 'text' ? b.text : `[${b.type} content omitted]`))
       .join('');
     return { role: 'tool', tool_call_id: m.toolCallId, content };
   }
@@ -142,15 +143,6 @@ export function toOpenAI(msg: Message): OAIMessage {
 // ---------------------------------------------------------------------------
 // fromOpenAI — OpenAI message → pi-ai Message
 // ---------------------------------------------------------------------------
-
-/** Try JSON.parse; return {} on failure. */
-function safeJsonParse(s: string): Record<string, unknown> {
-  try {
-    return JSON.parse(s) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
 
 /**
  * Map a single OpenAI-format message back to a pi-ai Message.
@@ -198,11 +190,13 @@ export function fromOpenAI(
     }
 
     for (const tc of m.tool_calls ?? []) {
+      // Malformed argument JSON throws → CompactionService fails open (the
+      // original context with intact arguments is used) instead of emitting {}.
       contentBlocks.push({
         type: 'toolCall',
         id: tc.id,
         name: tc.function.name,
-        arguments: safeJsonParse(tc.function.arguments),
+        arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
       });
     }
 

--- a/packages/backend/src/services/compaction/headroom-compactor.ts
+++ b/packages/backend/src/services/compaction/headroom-compactor.ts
@@ -74,6 +74,14 @@ const ZERO_USAGE: Usage = {
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
+function parseToolArguments(raw: string): Record<string, unknown> {
+  const parsed = JSON.parse(raw);
+  if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  throw new Error('HeadroomCompactor: invalid tool arguments in headroom output');
+}
+
 // ---------------------------------------------------------------------------
 // toOpenAI — pi-ai message → OpenAI message
 // ---------------------------------------------------------------------------
@@ -190,13 +198,13 @@ export function fromOpenAI(
     }
 
     for (const tc of m.tool_calls ?? []) {
-      // Malformed argument JSON throws → CompactionService fails open (the
-      // original context with intact arguments is used) instead of emitting {}.
+      // Malformed or non-object argument JSON throws → CompactionService fails
+      // open instead of rebuilding a structurally invalid tool call.
       contentBlocks.push({
         type: 'toolCall',
         id: tc.id,
         name: tc.function.name,
-        arguments: JSON.parse(tc.function.arguments) as Record<string, unknown>,
+        arguments: parseToolArguments(tc.function.arguments),
       });
     }
 
@@ -296,13 +304,15 @@ export class HeadroomCompactor implements CompactionStrategy {
     }
 
     // 5. Call compressFn. Errors propagate.
-    const result = await this.compressFn(openaiMessages, {
+    const compressOptions: CompressOptions & { signal?: AbortSignal } = {
       model: ctx.model,
       baseUrl: settings.headroom.baseUrl,
       apiKey: settings.headroom.apiKey,
       tokenBudget,
       timeout: settings.headroom.timeoutMs,
-    });
+      ...(ctx.signal ? { signal: ctx.signal } : {}),
+    };
+    const result = await this.compressFn(openaiMessages, compressOptions);
 
     // 6. Map result.messages back to pi-ai.
     return result.messages.map((m: OAIMessage) => fromOpenAI(m, toolNameById, assistantTemplate));

--- a/packages/backend/src/services/compaction/headroom-compactor.ts
+++ b/packages/backend/src/services/compaction/headroom-compactor.ts
@@ -1,0 +1,316 @@
+/**
+ * headroom-compactor.ts
+ *
+ * Compaction strategy that uses the headroom-ai SDK to compress context.
+ * Maps pi-ai messages → OpenAI format, calls compress(), maps back to pi-ai.
+ *
+ * Design notes:
+ * - systemPrompt is NOT forwarded (protected from compression).
+ * - toolName cannot be represented in OpenAI format; we restore it via
+ *   a toolCallId→toolName map built from the original context.
+ * - thinking/timestamp/usage are dropped on the way to OpenAI; reconstructed
+ *   with zero/placeholder values on the way back.
+ * - Any error from compressFn propagates — the CompactionService fails open.
+ */
+import { compress as sdkCompress } from 'headroom-ai';
+import type { CompressOptions, CompressResult } from 'headroom-ai';
+import type {
+  Context,
+  UserMessage,
+  AssistantMessage,
+  ToolResultMessage,
+  TextContent,
+  ImageContent,
+  ToolCall,
+  Message,
+  Usage,
+} from '@earendil-works/pi-ai';
+import type {
+  CompactionStrategy,
+  CompactionStrategyContext,
+  ResolvedCompactionSettings,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CompressFn = (messages: any[], options?: CompressOptions) => Promise<CompressResult>;
+
+/** Minimal OpenAI message shapes (mirrors headroom-ai's OpenAIMessage union). */
+type OAISystem = { role: 'system'; content: string };
+type OAIUser = { role: 'user'; content: string | OAIContentPart[] };
+type OAIAssistant = { role: 'assistant'; content: string | null; tool_calls?: OAIToolCall[] };
+type OAITool = { role: 'tool'; content: string; tool_call_id: string };
+type OAIMessage = OAISystem | OAIUser | OAIAssistant | OAITool;
+
+type OAIContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } };
+
+type OAIToolCall = {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+};
+
+/** Template used to reconstruct pi-ai AssistantMessage required fields. */
+interface AssistantTemplate {
+  api: string;
+  provider: string;
+  model: string;
+}
+
+// ---------------------------------------------------------------------------
+// Zero values
+// ---------------------------------------------------------------------------
+
+const ZERO_USAGE: Usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+// ---------------------------------------------------------------------------
+// toOpenAI — pi-ai message → OpenAI message
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a single pi-ai Message to an OpenAI-format message object.
+ * Exported for unit testing.
+ */
+export function toOpenAI(msg: Message): OAIMessage {
+  if (msg.role === 'user') {
+    const m = msg as UserMessage;
+    if (typeof m.content === 'string') {
+      return { role: 'user', content: m.content };
+    }
+    // Array of TextContent | ImageContent
+    const parts: OAIContentPart[] = (m.content as (TextContent | ImageContent)[]).map((block) => {
+      if (block.type === 'text') {
+        return { type: 'text', text: block.text };
+      }
+      // image → image_url with data URI
+      return {
+        type: 'image_url',
+        image_url: { url: `data:${block.mimeType};base64,${block.data}` },
+      };
+    });
+    return { role: 'user', content: parts };
+  }
+
+  if (msg.role === 'assistant') {
+    const m = msg as AssistantMessage;
+    const textBlocks = (m.content as (TextContent | { type: string })[]).filter(
+      (b): b is TextContent => b.type === 'text'
+    );
+    const toolCallBlocks = (m.content as { type: string }[]).filter(
+      (b): b is ToolCall => b.type === 'toolCall'
+    );
+
+    const content: string | null =
+      textBlocks.length > 0 ? textBlocks.map((b) => b.text).join('') : null;
+
+    const tool_calls: OAIToolCall[] = toolCallBlocks.map((tc) => ({
+      id: tc.id,
+      type: 'function',
+      function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },
+    }));
+
+    if (tool_calls.length > 0) {
+      return { role: 'assistant', content, tool_calls };
+    }
+    return { role: 'assistant', content };
+  }
+
+  if (msg.role === 'toolResult') {
+    const m = msg as ToolResultMessage;
+    const content = (m.content as (TextContent | ImageContent)[])
+      .filter((b): b is TextContent => b.type === 'text')
+      .map((b) => b.text)
+      .join('');
+    return { role: 'tool', tool_call_id: m.toolCallId, content };
+  }
+
+  // Unreachable for valid pi-ai Messages, but satisfy TS exhaustiveness.
+  throw new Error(`HeadroomCompactor: unknown pi-ai message role: ${(msg as any).role}`);
+}
+
+// ---------------------------------------------------------------------------
+// fromOpenAI — OpenAI message → pi-ai Message
+// ---------------------------------------------------------------------------
+
+/** Try JSON.parse; return {} on failure. */
+function safeJsonParse(s: string): Record<string, unknown> {
+  try {
+    return JSON.parse(s) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Map a single OpenAI-format message back to a pi-ai Message.
+ * Exported for unit testing.
+ *
+ * @param msg           - The OpenAI-format message from headroom's CompressResult.
+ * @param toolNameById  - Map of toolCallId → toolName (built from original context).
+ * @param template      - api/provider/model to use for reconstructed AssistantMessages.
+ */
+export function fromOpenAI(
+  msg: OAIMessage,
+  toolNameById: Map<string, string>,
+  template: AssistantTemplate
+): Message {
+  if (msg.role === 'user') {
+    const m = msg as OAIUser;
+    if (typeof m.content === 'string') {
+      const um: UserMessage = { role: 'user', content: m.content, timestamp: 0 };
+      return um;
+    }
+    // ContentPart[] → pi-ai (TextContent | ImageContent)[]
+    const content: (TextContent | ImageContent)[] = (m.content as OAIContentPart[]).map((part) => {
+      if (part.type === 'text') {
+        return { type: 'text', text: part.text } satisfies TextContent;
+      }
+      // image_url → ImageContent: split "data:<mime>;base64,<data>"
+      const url = part.image_url.url;
+      const match = url.match(/^data:([^;]+);base64,(.+)$/);
+      if (match && match[1] !== undefined && match[2] !== undefined) {
+        return { type: 'image', mimeType: match[1], data: match[2] } satisfies ImageContent;
+      }
+      // Non-data-URI image URL: store as a text block with the URL (best effort).
+      return { type: 'text', text: url } satisfies TextContent;
+    });
+    const um: UserMessage = { role: 'user', content, timestamp: 0 };
+    return um;
+  }
+
+  if (msg.role === 'assistant') {
+    const m = msg as OAIAssistant;
+    const contentBlocks: (TextContent | ToolCall)[] = [];
+
+    if (m.content !== null) {
+      contentBlocks.push({ type: 'text', text: m.content });
+    }
+
+    for (const tc of m.tool_calls ?? []) {
+      contentBlocks.push({
+        type: 'toolCall',
+        id: tc.id,
+        name: tc.function.name,
+        arguments: safeJsonParse(tc.function.arguments),
+      });
+    }
+
+    const am: AssistantMessage = {
+      role: 'assistant',
+      content: contentBlocks,
+      api: template.api,
+      provider: template.provider,
+      model: template.model,
+      usage: ZERO_USAGE,
+      stopReason: 'stop',
+      timestamp: 0,
+    };
+    return am;
+  }
+
+  if (msg.role === 'tool') {
+    const m = msg as OAITool;
+    const tr: ToolResultMessage = {
+      role: 'toolResult',
+      toolCallId: m.tool_call_id,
+      toolName: toolNameById.get(m.tool_call_id) ?? '',
+      content: [{ type: 'text', text: m.content }],
+      isError: false,
+      timestamp: 0,
+    };
+    return tr;
+  }
+
+  if (msg.role === 'system') {
+    // We never forward system messages to headroom; if one appears in the
+    // result something is wrong — throw so the service fails open.
+    throw new Error('HeadroomCompactor: unexpected system message in headroom output');
+  }
+
+  throw new Error(`HeadroomCompactor: unknown OpenAI message role: ${(msg as any).role}`);
+}
+
+// ---------------------------------------------------------------------------
+// HeadroomCompactor
+// ---------------------------------------------------------------------------
+
+export class HeadroomCompactor implements CompactionStrategy {
+  readonly name = 'headroom' as const;
+
+  constructor(private readonly compressFn: CompressFn = sdkCompress) {}
+
+  async compact(
+    context: Context,
+    settings: ResolvedCompactionSettings,
+    ctx: CompactionStrategyContext
+  ): Promise<Context['messages']> {
+    // 1. Build toolCallId → toolName map from original context.
+    const toolNameById = new Map<string, string>();
+    for (const msg of context.messages) {
+      if (msg.role === 'assistant') {
+        const am = msg as AssistantMessage;
+        for (const block of am.content) {
+          if (block.type === 'toolCall') {
+            const tc = block as ToolCall;
+            toolNameById.set(tc.id, tc.name);
+          }
+        }
+      }
+      if (msg.role === 'toolResult') {
+        const tr = msg as ToolResultMessage;
+        toolNameById.set(tr.toolCallId, tr.toolName);
+      }
+    }
+
+    // 2. Build assistantTemplate from first AssistantMessage, or use fallback.
+    let assistantTemplate: AssistantTemplate = {
+      api: 'openai-completions',
+      provider: 'openai',
+      model: ctx.model,
+    };
+    for (const msg of context.messages) {
+      if (msg.role === 'assistant') {
+        const am = msg as AssistantMessage;
+        assistantTemplate = { api: am.api, provider: am.provider, model: am.model };
+        break;
+      }
+    }
+
+    // 3. Map pi-ai messages to OpenAI format. systemPrompt is NOT included.
+    const openaiMessages = context.messages.map(toOpenAI);
+
+    // 4. Compute tokenBudget.
+    let tokenBudget: number | undefined;
+    if (ctx.contextLength !== undefined) {
+      if (settings.headroom.targetRatio != null) {
+        // targetRatio takes precedence when contextLength is known.
+        tokenBudget = Math.floor(ctx.contextLength * settings.headroom.targetRatio);
+      } else {
+        tokenBudget = Math.max(0, ctx.contextLength - 4096);
+      }
+    }
+
+    // 5. Call compressFn. Errors propagate.
+    const result = await this.compressFn(openaiMessages, {
+      model: ctx.model,
+      baseUrl: settings.headroom.baseUrl,
+      apiKey: settings.headroom.apiKey,
+      tokenBudget,
+      timeout: settings.headroom.timeoutMs,
+    });
+
+    // 6. Map result.messages back to pi-ai.
+    return result.messages.map((m: OAIMessage) => fromOpenAI(m, toolNameById, assistantTemplate));
+  }
+}

--- a/packages/backend/src/services/compaction/native-compactor.ts
+++ b/packages/backend/src/services/compaction/native-compactor.ts
@@ -1,0 +1,182 @@
+import type {
+  Context,
+  UserMessage,
+  AssistantMessage,
+  ToolResultMessage,
+  TextContent,
+  ImageContent,
+  ThinkingContent,
+  ToolCall,
+} from '@earendil-works/pi-ai';
+import type {
+  CompactionStrategy,
+  CompactionStrategyContext,
+  ResolvedCompactionSettings,
+} from './types';
+
+/** Recursively compact a JSON value. Never mutates the input. */
+function compactJsonValue(value: unknown, maxArrayItems: number): unknown {
+  if (Array.isArray(value)) {
+    if (value.length > maxArrayItems) {
+      const compacted = value
+        .slice(0, maxArrayItems)
+        .map((v) => compactJsonValue(v, maxArrayItems));
+      compacted.push(`…[${value.length - maxArrayItems} items omitted]`);
+      return compacted;
+    }
+    return value.map((v) => compactJsonValue(v, maxArrayItems));
+  }
+  if (value !== null && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = compactJsonValue(v, maxArrayItems);
+    }
+    return result;
+  }
+  // primitives: string, number, boolean, null
+  return value;
+}
+
+/** Compact a text string: JSON-compact if parseable, else truncate if too long. */
+function compactText(text: string, maxArrayItems: number, maxStringChars: number): string {
+  // 1. Try to parse as JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = undefined;
+  }
+
+  if (typeof parsed === 'object' && parsed !== null) {
+    return JSON.stringify(compactJsonValue(parsed, maxArrayItems));
+  }
+
+  // 2. Truncate if too long
+  if (text.length > maxStringChars) {
+    const excess = text.length - maxStringChars;
+    return `${text.slice(0, maxStringChars)}…[truncated ${excess} chars]`;
+  }
+
+  // 3. Return unchanged
+  return text;
+}
+
+function compactUserMessage(
+  msg: UserMessage,
+  maxArrayItems: number,
+  maxStringChars: number
+): UserMessage {
+  if (typeof msg.content === 'string') {
+    const compacted = compactText(msg.content, maxArrayItems, maxStringChars);
+    if (compacted === msg.content) return msg;
+    return { ...msg, content: compacted };
+  }
+
+  // content is (TextContent | ImageContent)[]
+  const newBlocks = (msg.content as (TextContent | ImageContent)[]).map(
+    (block): TextContent | ImageContent => {
+      if (block.type === 'text') {
+        const newText = compactText(block.text, maxArrayItems, maxStringChars);
+        if (newText === block.text) return block;
+        return { ...block, text: newText };
+      }
+      // image — pass through
+      return block;
+    }
+  );
+
+  // check if anything actually changed
+  const changed = newBlocks.some(
+    (b, i) => b !== (msg.content as Array<TextContent | ImageContent>)[i]
+  );
+  if (!changed) return msg;
+  return { ...msg, content: newBlocks };
+}
+
+function compactAssistantMessage(
+  msg: AssistantMessage,
+  maxArrayItems: number,
+  maxStringChars: number
+): AssistantMessage {
+  const newBlocks = (msg.content as (TextContent | ThinkingContent | ToolCall)[]).map(
+    (block): TextContent | ThinkingContent | ToolCall => {
+      if (block.type === 'text') {
+        const newText = compactText(block.text, maxArrayItems, maxStringChars);
+        if (newText === block.text) return block;
+        return { ...block, text: newText };
+      }
+      if (block.type === 'toolCall') {
+        const newArgs = compactJsonValue(block.arguments, maxArrayItems) as Record<string, unknown>;
+        // compactJsonValue always returns a new object for object inputs, but
+        // if no items were truncated the values are reference-equal; we still
+        // replace so the result is always a fresh object (no mutation guarantee).
+        return { ...block, arguments: newArgs };
+      }
+      // thinking or unknown — pass through
+      return block;
+    }
+  );
+
+  const changed = newBlocks.some(
+    (b, i) => b !== (msg.content as Array<TextContent | ThinkingContent | ToolCall>)[i]
+  );
+  if (!changed) return msg;
+  return { ...msg, content: newBlocks };
+}
+
+function compactToolResultMessage(
+  msg: ToolResultMessage,
+  maxArrayItems: number,
+  maxStringChars: number
+): ToolResultMessage {
+  const newBlocks = (msg.content as (TextContent | ImageContent)[]).map(
+    (block): TextContent | ImageContent => {
+      if (block.type === 'text') {
+        const newText = compactText(block.text, maxArrayItems, maxStringChars);
+        if (newText === block.text) return block;
+        return { ...block, text: newText };
+      }
+      return block;
+    }
+  );
+
+  const changed = newBlocks.some(
+    (b, i) => b !== (msg.content as Array<TextContent | ImageContent>)[i]
+  );
+  if (!changed) return msg;
+  return { ...msg, content: newBlocks };
+}
+
+export class NativeCompactor implements CompactionStrategy {
+  readonly name = 'native' as const;
+
+  async compact(
+    context: Context,
+    settings: ResolvedCompactionSettings,
+    _ctx: CompactionStrategyContext
+  ): Promise<Context['messages']> {
+    const messages = context.messages;
+    const { protectRecent } = settings;
+    const { maxArrayItems, maxStringChars } = settings.native;
+
+    const cutoff = Math.max(0, messages.length - protectRecent);
+    const toCompact = messages.slice(0, cutoff);
+    const protected_ = messages.slice(cutoff);
+
+    const compacted = toCompact.map((msg) => {
+      if (msg.role === 'user') {
+        return compactUserMessage(msg as UserMessage, maxArrayItems, maxStringChars);
+      }
+      if (msg.role === 'assistant') {
+        return compactAssistantMessage(msg as AssistantMessage, maxArrayItems, maxStringChars);
+      }
+      if (msg.role === 'toolResult') {
+        return compactToolResultMessage(msg as ToolResultMessage, maxArrayItems, maxStringChars);
+      }
+      // unknown role — pass through unchanged
+      return msg;
+    });
+
+    return [...compacted, ...protected_];
+  }
+}

--- a/packages/backend/src/services/compaction/resolve-settings.ts
+++ b/packages/backend/src/services/compaction/resolve-settings.ts
@@ -1,0 +1,97 @@
+import {
+  COMPACTION_DEFAULTS,
+  type CompactionSettings,
+  type ResolvedCompactionSettings,
+} from './types';
+
+/**
+ * Returns the first non-null, non-undefined value from the provided list.
+ * Used to implement alias > provider > global precedence.
+ */
+function pick<T>(...vals: (T | null | undefined)[]): T | undefined {
+  for (const v of vals) {
+    if (v !== null && v !== undefined) return v;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve compaction settings by merging three override layers with field-level
+ * precedence: alias > provider > global > COMPACTION_DEFAULTS.
+ *
+ * Nested objects (native, headroom) are merged field-by-field — a layer only
+ * contributes the specific sub-fields it defines, leaving the rest to lower
+ * layers or defaults.
+ */
+export function resolveCompactionSettings(
+  global?: CompactionSettings,
+  provider?: CompactionSettings,
+  alias?: CompactionSettings
+): ResolvedCompactionSettings {
+  return {
+    enabled:
+      pick(alias?.enabled, provider?.enabled, global?.enabled) ?? COMPACTION_DEFAULTS.enabled,
+
+    strategy:
+      pick(alias?.strategy, provider?.strategy, global?.strategy) ?? COMPACTION_DEFAULTS.strategy,
+
+    triggerRatio:
+      pick(alias?.triggerRatio, provider?.triggerRatio, global?.triggerRatio) ??
+      COMPACTION_DEFAULTS.triggerRatio,
+
+    absoluteTriggerTokens:
+      pick(
+        alias?.absoluteTriggerTokens,
+        provider?.absoluteTriggerTokens,
+        global?.absoluteTriggerTokens
+      ) ?? COMPACTION_DEFAULTS.absoluteTriggerTokens,
+
+    minTokens:
+      pick(alias?.minTokens, provider?.minTokens, global?.minTokens) ??
+      COMPACTION_DEFAULTS.minTokens,
+
+    protectRecent:
+      pick(alias?.protectRecent, provider?.protectRecent, global?.protectRecent) ??
+      COMPACTION_DEFAULTS.protectRecent,
+
+    native: {
+      maxArrayItems:
+        pick(
+          alias?.native?.maxArrayItems,
+          provider?.native?.maxArrayItems,
+          global?.native?.maxArrayItems
+        ) ?? COMPACTION_DEFAULTS.native.maxArrayItems,
+
+      maxStringChars:
+        pick(
+          alias?.native?.maxStringChars,
+          provider?.native?.maxStringChars,
+          global?.native?.maxStringChars
+        ) ?? COMPACTION_DEFAULTS.native.maxStringChars,
+    },
+
+    headroom: {
+      baseUrl:
+        pick(alias?.headroom?.baseUrl, provider?.headroom?.baseUrl, global?.headroom?.baseUrl) ??
+        COMPACTION_DEFAULTS.headroom.baseUrl,
+
+      apiKey:
+        pick(alias?.headroom?.apiKey, provider?.headroom?.apiKey, global?.headroom?.apiKey) ??
+        COMPACTION_DEFAULTS.headroom.apiKey,
+
+      targetRatio:
+        pick(
+          alias?.headroom?.targetRatio,
+          provider?.headroom?.targetRatio,
+          global?.headroom?.targetRatio
+        ) ?? COMPACTION_DEFAULTS.headroom.targetRatio,
+
+      timeoutMs:
+        pick(
+          alias?.headroom?.timeoutMs,
+          provider?.headroom?.timeoutMs,
+          global?.headroom?.timeoutMs
+        ) ?? COMPACTION_DEFAULTS.headroom.timeoutMs,
+    },
+  };
+}

--- a/packages/backend/src/services/compaction/types.ts
+++ b/packages/backend/src/services/compaction/types.ts
@@ -1,0 +1,67 @@
+import type { Context } from '@earendil-works/pi-ai';
+
+export type CompactionStrategyName = 'native' | 'headroom';
+
+export interface CompactionSettings {
+  // partial override (provider/alias/global)
+  enabled?: boolean;
+  strategy?: CompactionStrategyName;
+  triggerRatio?: number; // 0..1 of context_length
+  absoluteTriggerTokens?: number | null; // fallback when context_length unknown
+  minTokens?: number; // never compact below this estimate
+  protectRecent?: number; // keep most recent N messages untouched
+  native?: { maxArrayItems?: number; maxStringChars?: number };
+  headroom?: { baseUrl?: string; apiKey?: string; targetRatio?: number | null; timeoutMs?: number };
+}
+
+export interface ResolvedCompactionSettings {
+  enabled: boolean;
+  strategy: CompactionStrategyName;
+  triggerRatio: number;
+  absoluteTriggerTokens: number | null;
+  minTokens: number;
+  protectRecent: number;
+  native: { maxArrayItems: number; maxStringChars: number };
+  headroom: { baseUrl: string; apiKey?: string; targetRatio: number | null; timeoutMs: number };
+}
+
+export interface CompactionResult {
+  compacted: boolean;
+  context: Context; // new context to send (or the original)
+  tokensBefore: number;
+  tokensAfter: number;
+  strategy: CompactionStrategyName | null;
+  reason: 'disabled' | 'below-min' | 'under-threshold' | 'no-reduction' | 'error' | 'ok';
+}
+
+export interface CompactionStrategyContext {
+  model: string;
+  contextLength?: number;
+  signal?: AbortSignal;
+}
+
+export interface CompactionStrategy {
+  readonly name: CompactionStrategyName;
+  /** Compact context.messages; return NEW messages (never mutate input). May throw (service fails open). */
+  compact(
+    context: Context,
+    settings: ResolvedCompactionSettings,
+    ctx: CompactionStrategyContext
+  ): Promise<Context['messages']>;
+}
+
+export const COMPACTION_DEFAULTS: ResolvedCompactionSettings = {
+  enabled: false,
+  strategy: 'native',
+  triggerRatio: 0.8,
+  absoluteTriggerTokens: null,
+  minTokens: 2000,
+  protectRecent: 4,
+  native: { maxArrayItems: 50, maxStringChars: 4000 },
+  headroom: {
+    baseUrl: 'http://localhost:8787',
+    apiKey: undefined,
+    targetRatio: null,
+    timeoutMs: 5000,
+  },
+};

--- a/packages/backend/src/services/enforce-limits.ts
+++ b/packages/backend/src/services/enforce-limits.ts
@@ -162,7 +162,7 @@ export function enforceContextLimitForRoute(
 ): void {
   if (!aliasConfig?.enforce_limits || !route.canonicalModel) return;
   enforceContextLimitForContext(context, aliasConfig, route.canonicalModel, {
-    contextLength: resolveContextLength(aliasConfig) ?? route.modelArchitecture?.context_length,
+    contextLength: route.modelArchitecture?.context_length ?? resolveContextLength(aliasConfig),
     maxTokens,
     apiType,
   });

--- a/packages/backend/src/services/enforce-limits.ts
+++ b/packages/backend/src/services/enforce-limits.ts
@@ -1,6 +1,7 @@
+import type { Context } from '@earendil-works/pi-ai';
 import type { ModelConfig } from '../config';
 import type { UnifiedChatRequest } from '../types/unified';
-import { estimateInputTokens } from '../utils/estimate-tokens';
+import { estimateContextTokens, estimateInputTokens } from '../utils/estimate-tokens';
 import { logger } from '../utils/logger';
 import { ModelMetadataManager, mergeOverrides } from './model-metadata-manager';
 
@@ -103,6 +104,103 @@ export function enforceContextLimit(
   const bodyForEstimate = request.originalBody ?? { messages: request.messages };
   const rawEstimate = estimateInputTokens(bodyForEstimate, apiType);
   const estimated = Math.ceil(rawEstimate * ESTIMATE_SAFETY_MULTIPLIER);
+
+  if (estimated + reservedOutput > contextLength) {
+    const message =
+      `This model's context window is ${contextLength} tokens. ` +
+      `Your request is estimated at ~${estimated} input tokens with ${reservedOutput} reserved for the response, ` +
+      `which exceeds the limit. Please shorten the prompt or lower max_tokens.`;
+    throw new ContextLengthExceededError(message, {
+      statusCode: 400,
+      code: 'context_length_exceeded',
+      estimatedInputTokens: estimated,
+      reservedOutputTokens: reservedOutput,
+      contextLength,
+      aliasSlug,
+    });
+  }
+}
+
+/**
+ * Convenience export: resolve the effective context window for an alias.
+ * Returns undefined when no context_length is known — callers should fail open.
+ * The executor (Task 3) uses this to resolve the per-candidate context window.
+ */
+export function resolveContextLength(aliasConfig: ModelConfig): number | undefined {
+  const merged = resolveMetadata(aliasConfig);
+  const ctx = merged?.top_provider?.context_length ?? merged?.context_length;
+  return ctx && ctx > 0 ? ctx : undefined;
+}
+
+export interface ContextLimitOptions {
+  /** Resolved context window from the caller (e.g. route.modelArchitecture). Falls back to alias metadata when omitted. */
+  contextLength?: number;
+  /** Requested max output tokens (e.g. streamOptions.maxTokens). */
+  maxTokens?: number;
+  /** apiType for image-token formula parity with v1 (e.g. 'chat' | 'messages' | 'gemini' | 'responses'). */
+  apiType?: string;
+}
+
+/** Minimal structural view of a RouteResult — avoids importing inference types here. */
+export interface EnforceRouteInfo {
+  canonicalModel?: string;
+  modelArchitecture?: { context_length?: number };
+}
+
+/**
+ * Gate + bridge for the v2/beta path: enforce the context limit for one routing
+ * candidate. No-op unless the alias has `enforce_limits` AND the candidate has a
+ * canonicalModel (mirrors dispatcher.ts:392). Throws ContextLengthExceededError
+ * on violation; the caller catches it (no failover on context-length).
+ */
+export function enforceContextLimitForRoute(
+  context: Context,
+  route: EnforceRouteInfo,
+  aliasConfig: ModelConfig | undefined,
+  maxTokens: number | undefined,
+  apiType: string
+): void {
+  if (!aliasConfig?.enforce_limits || !route.canonicalModel) return;
+  enforceContextLimitForContext(context, aliasConfig, route.canonicalModel, {
+    contextLength: resolveContextLength(aliasConfig) ?? route.modelArchitecture?.context_length,
+    maxTokens,
+    apiType,
+  });
+}
+
+/**
+ * Inference-v2 (pi path) analogue of enforceContextLimit. Counts tokens from a
+ * pi-ai Context (the v2 path has no originalBody) and throws
+ * ContextLengthExceededError when estimate + reserved output exceeds the
+ * resolved context window. Fail-open when no context length is known.
+ */
+export function enforceContextLimitForContext(
+  context: Context,
+  aliasConfig: ModelConfig,
+  aliasSlug: string,
+  opts: ContextLimitOptions = {}
+): void {
+  const merged = resolveMetadata(aliasConfig);
+  const contextLength =
+    opts.contextLength ?? merged?.top_provider?.context_length ?? merged?.context_length;
+  if (!contextLength || contextLength <= 0) {
+    logger.debug(`[enforce-limits:v2] Skipping '${aliasSlug}': no context_length known.`);
+    return; // fail open — we can't enforce what we don't know
+  }
+
+  const metadataMaxOutput = merged?.top_provider?.max_completion_tokens;
+  const requestedMaxTokens =
+    typeof opts.maxTokens === 'number' && opts.maxTokens > 0 ? opts.maxTokens : undefined;
+  let reservedOutput: number;
+  if (requestedMaxTokens !== undefined && metadataMaxOutput !== undefined) {
+    reservedOutput = Math.min(requestedMaxTokens, metadataMaxOutput);
+  } else {
+    reservedOutput = requestedMaxTokens ?? metadataMaxOutput ?? DEFAULT_OUTPUT_RESERVATION;
+  }
+
+  const estimated = Math.ceil(
+    estimateContextTokens(context, opts.apiType) * ESTIMATE_SAFETY_MULTIPLIER
+  );
 
   if (estimated + reservedOutput > contextLength) {
     const message =

--- a/packages/backend/src/utils/__tests__/estimate-tokens.test.ts
+++ b/packages/backend/src/utils/__tests__/estimate-tokens.test.ts
@@ -3,6 +3,7 @@ import {
   estimateTokens,
   estimateInputTokens,
   estimateTokensFromReconstructed,
+  estimateContextTokens,
 } from '../estimate-tokens';
 
 describe('estimateTokens', () => {
@@ -206,5 +207,178 @@ describe('estimateTokensFromReconstructed', () => {
     const { output, reasoning } = estimateTokensFromReconstructed(reconstructed, 'unknown');
     expect(output).toBe(0);
     expect(reasoning).toBe(0);
+  });
+});
+
+describe('estimateContextTokens', () => {
+  // Test 1: Empty context → 0 (or ~0)
+  test('empty context returns 0', () => {
+    expect(estimateContextTokens({ messages: [] })).toBe(0);
+  });
+
+  // Test 2: systemPrompt contributes tokens
+  test('systemPrompt contributes tokens', () => {
+    const withPrompt = estimateContextTokens({
+      systemPrompt: 'You are a helpful assistant.',
+      messages: [],
+    });
+    const withoutPrompt = estimateContextTokens({
+      systemPrompt: '',
+      messages: [],
+    });
+    expect(withPrompt).toBeGreaterThan(0);
+    expect(withPrompt).toBeGreaterThan(withoutPrompt);
+  });
+
+  // Test 3: User message with string content == equivalent single text-block array
+  test('user message string content and text-block array produce same estimate', () => {
+    const text = 'Hello, how are you doing today?';
+    const withString = estimateContextTokens({
+      messages: [{ role: 'user', content: text, timestamp: 0 }],
+    });
+    const withArray = estimateContextTokens({
+      messages: [{ role: 'user', content: [{ type: 'text', text }], timestamp: 0 }],
+    });
+    expect(withString).toEqual(withArray);
+  });
+
+  // Test 4: More/larger text → strictly larger estimate
+  test('larger text block produces strictly larger estimate', () => {
+    const shortContext = estimateContextTokens({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Hi.' }], timestamp: 0 }],
+    });
+    const longContext = estimateContextTokens({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'This is a much longer message with a lot more content to count tokens for, which should produce a higher estimate than a short message.',
+            },
+          ],
+          timestamp: 0,
+        },
+      ],
+    });
+    expect(longContext).toBeGreaterThan(shortContext);
+  });
+
+  // Test 5: assistant message with toolCall block contributes > 0
+  test('assistant message with toolCall block contributes tokens', () => {
+    const result = estimateContextTokens({
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'toolCall',
+              id: 'call_123',
+              name: 'get_weather',
+              arguments: { location: 'San Francisco', unit: 'celsius' },
+            },
+          ],
+          api: 'anthropic-messages',
+          provider: 'anthropic',
+          model: 'claude-opus-4-5',
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: 'toolUse',
+          timestamp: 0,
+        },
+      ],
+    });
+    expect(result).toBeGreaterThan(0);
+  });
+
+  // Test 6: toolResult message with text block contributes > 0
+  test('toolResult message with text block contributes tokens', () => {
+    const result = estimateContextTokens({
+      messages: [
+        {
+          role: 'toolResult',
+          toolCallId: 'call_123',
+          toolName: 'get_weather',
+          content: [{ type: 'text', text: 'The weather in San Francisco is 18°C and sunny.' }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    });
+    expect(result).toBeGreaterThan(0);
+  });
+
+  // Test 7: Image block adds positive cost
+  test('user message with image block estimates more than without image', () => {
+    // A tiny 1×1 pixel PNG in base64 (raw, no data: prefix)
+    const tiny1x1PngBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    const withoutImage = estimateContextTokens({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'What do you see?' }],
+          timestamp: 0,
+        },
+      ],
+    });
+    const withImage = estimateContextTokens({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What do you see?' },
+            { type: 'image', data: tiny1x1PngBase64, mimeType: 'image/png' },
+          ],
+          timestamp: 0,
+        },
+      ],
+    });
+    expect(withImage).toBeGreaterThan(withoutImage);
+  });
+
+  // Test 8: context.tools increases the estimate (FIX 1 parity test)
+  test('context with tools array estimates more than context without tools', () => {
+    const tools = [
+      {
+        name: 'get_weather',
+        description: 'Get the weather for a city',
+        parameters: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+        },
+      },
+    ];
+    const baseMessages = [{ role: 'user' as const, content: 'What is the weather?', timestamp: 0 }];
+    const withTools = estimateContextTokens({ messages: baseMessages, tools });
+    const withoutTools = estimateContextTokens({ messages: baseMessages });
+    expect(withTools).toBeGreaterThan(withoutTools);
+  });
+
+  // Test 9: apiType changes image cost (gemini 258/image < messages 1600/image)
+  test('apiType changes image cost: gemini estimate < messages estimate', () => {
+    // A short non-image base64 string — won't decode to real dimensions,
+    // so both paths fall back to per-provider defaults (gemini=258, messages=1600).
+    const fakeBase64 = Buffer.from('x'.repeat(40)).toString('base64');
+    const ctx = {
+      messages: [
+        {
+          role: 'user' as const,
+          content: [{ type: 'image' as const, data: fakeBase64, mimeType: 'image/png' as const }],
+          timestamp: 0,
+        },
+      ],
+    };
+    const geminiEstimate = estimateContextTokens(ctx, 'gemini');
+    const messagesEstimate = estimateContextTokens(ctx, 'messages');
+    expect(geminiEstimate).toBeLessThan(messagesEstimate);
   });
 });

--- a/packages/backend/src/utils/estimate-tokens.ts
+++ b/packages/backend/src/utils/estimate-tokens.ts
@@ -1,4 +1,5 @@
 import { getEncoding, type Tiktoken } from 'js-tiktoken';
+import type { Context } from '@earendil-works/pi-ai';
 import { logger } from './logger';
 
 // ---------------------------------------------------------------------------
@@ -611,6 +612,88 @@ export function estimateInputTokens(originalBody: any, apiType: string): number 
       return Number.MAX_SAFE_INTEGER;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// pi-ai Context token estimator
+// ---------------------------------------------------------------------------
+
+/**
+ * Estimate the input-token count of a pi-ai `Context`. This is the
+ * Context-shaped equivalent of `estimateInputTokens` for the v2/beta
+ * inference path, which parses every wire format into a single `Context`
+ * (no `originalBody` available there).
+ *
+ * Counting strategy (intentionally errs toward over-counting for enforcement):
+ *  - systemPrompt via estimateTokens
+ *  - user messages: string content via estimateTokens; array content: text
+ *    blocks via estimateTokens, image blocks via estimateImageTokens
+ *  - assistant messages: text via estimateTokens, thinking via estimateTokens,
+ *    toolCall arguments via tokensForStringOrJson
+ *  - toolResult messages: text via estimateTokens, image via estimateImageTokens
+ *
+ * @param context  The pi-ai Context to estimate.
+ * @param apiType  Optional API type string forwarded to `estimateImageTokens`
+ *                 for per-provider image-cost formulas. Omitting (or passing
+ *                 an unknown value) falls back to the conservative Claude
+ *                 default (1600 tokens), which is the right direction for
+ *                 enforcement — err toward rejecting.
+ */
+export function estimateContextTokens(context: Context, apiType?: string): number {
+  let total = 0;
+
+  // 1. System prompt
+  total += estimateTokens(context.systemPrompt ?? '');
+
+  // 2. Messages
+  for (const message of context.messages) {
+    if (message.role === 'user') {
+      const { content } = message;
+      if (typeof content === 'string') {
+        total += estimateTokens(content);
+      } else {
+        for (const block of content) {
+          if (block.type === 'text') {
+            total += estimateTokens(block.text);
+          } else if (block.type === 'image') {
+            total += estimateImageTokens(
+              { base64: block.data, mediaType: block.mimeType },
+              apiType ?? ''
+            );
+          }
+        }
+      }
+    } else if (message.role === 'assistant') {
+      for (const block of message.content) {
+        if (block.type === 'text') {
+          total += estimateTokens(block.text);
+        } else if (block.type === 'thinking') {
+          total += estimateTokens(block.thinking);
+        } else if (block.type === 'toolCall') {
+          total += tokensForStringOrJson(block.arguments);
+        }
+      }
+    } else if (message.role === 'toolResult') {
+      for (const block of message.content) {
+        if (block.type === 'text') {
+          total += estimateTokens(block.text);
+        } else if (block.type === 'image') {
+          total += estimateImageTokens(
+            { base64: block.data, mediaType: block.mimeType },
+            apiType ?? ''
+          );
+        }
+      }
+    }
+  }
+
+  // Tool definitions are sent to the provider and consume input tokens; mirror
+  // v1's estimateInputTokens, which counts originalBody.tools for every format.
+  if (context.tools) {
+    total += tokensForStringOrJson(context.tools);
+  }
+
+  return total;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/backend/src/utils/estimate-tokens.ts
+++ b/packages/backend/src/utils/estimate-tokens.ts
@@ -670,10 +670,16 @@ export function estimateContextTokens(context: Context, apiType?: string): numbe
         } else if (block.type === 'thinking') {
           total += estimateTokens(block.thinking);
         } else if (block.type === 'toolCall') {
+          // The tool name and call id are serialized on the wire too.
+          total += estimateTokens(block.name);
+          total += estimateTokens(block.id);
           total += tokensForStringOrJson(block.arguments);
         }
       }
     } else if (message.role === 'toolResult') {
+      // The tool_call_id and tool name are serialized on the wire too.
+      total += estimateTokens(message.toolCallId);
+      total += estimateTokens(message.toolName);
       for (const block of message.content) {
         if (block.type === 'text') {
           total += estimateTokens(block.text);

--- a/packages/frontend/src/components/models/ModelBehaviorsEditor.tsx
+++ b/packages/frontend/src/components/models/ModelBehaviorsEditor.tsx
@@ -149,24 +149,26 @@ export function ModelBehaviorsEditor({ editingAlias, setEditingAlias }: Props) {
 
           {/* ── Compaction Override ── */}
           <div>
-            <div
-              className="flex items-center gap-2 cursor-pointer mb-1"
+            <button
+              type="button"
+              className="flex items-center gap-2 cursor-pointer mb-1 w-full border-0 bg-transparent p-0 text-left"
               onClick={() => setIsCompactionOpen(!isCompactionOpen)}
+              aria-expanded={isCompactionOpen}
             >
               {isCompactionOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-              <label
-                className="font-body text-[13px] font-medium text-text-secondary cursor-pointer"
+              <span
+                className="font-body text-[13px] font-medium text-text-secondary"
                 style={{ marginBottom: 0 }}
               >
                 Compaction Override
-              </label>
+              </span>
               {editingAlias.compaction &&
                 Object.values(editingAlias.compaction).some((v) => v != null) && (
                   <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
                     Custom
                   </Badge>
                 )}
-            </div>
+            </button>
             {isCompactionOpen && (
               <div
                 className="border border-border-glass rounded-md"

--- a/packages/frontend/src/components/models/ModelBehaviorsEditor.tsx
+++ b/packages/frontend/src/components/models/ModelBehaviorsEditor.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
 import { Switch } from '../ui/Switch';
+import { Badge } from '../ui/Badge';
+import { DebouncedInput } from '../ui/DebouncedInput';
 import { ModelArchitectureEditor } from './ModelArchitectureEditor';
 import { AliasExtraBodyEditor } from './AliasExtraBodyEditor';
-import type { Alias, AliasBehavior } from '../../lib/api';
+import type { Alias, AliasBehavior, CompactionSettings } from '../../lib/api';
 
 interface Props {
   editingAlias: Alias;
@@ -12,6 +14,7 @@ interface Props {
 
 export function ModelBehaviorsEditor({ editingAlias, setEditingAlias }: Props) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isCompactionOpen, setIsCompactionOpen] = useState(false);
 
   const getBehavior = (type: AliasBehavior['type']): boolean => {
     return (editingAlias.advanced ?? []).some((b) => b.type === type && b.enabled !== false);
@@ -141,6 +144,232 @@ export function ModelBehaviorsEditor({ editingAlias, setEditingAlias }: Props) {
 
           {/* ── Extra Body Fields ── */}
           <AliasExtraBodyEditor editingAlias={editingAlias} setEditingAlias={setEditingAlias} />
+
+          <div className="h-px bg-border-glass"></div>
+
+          {/* ── Compaction Override ── */}
+          <div>
+            <div
+              className="flex items-center gap-2 cursor-pointer mb-1"
+              onClick={() => setIsCompactionOpen(!isCompactionOpen)}
+            >
+              {isCompactionOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              <label
+                className="font-body text-[13px] font-medium text-text-secondary cursor-pointer"
+                style={{ marginBottom: 0 }}
+              >
+                Compaction Override
+              </label>
+              {editingAlias.compaction &&
+                Object.values(editingAlias.compaction).some((v) => v != null) && (
+                  <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
+                    Custom
+                  </Badge>
+                )}
+            </div>
+            {isCompactionOpen && (
+              <div
+                className="border border-border-glass rounded-md"
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '6px',
+                  padding: '8px',
+                  background: 'var(--color-bg-subtle)',
+                }}
+              >
+                <div
+                  className="font-body text-[11px] text-text-secondary"
+                  style={{ lineHeight: 1.35 }}
+                >
+                  Override global context-compaction for this alias. Empty = inherit (alias
+                  overrides provider overrides global). Nested native/headroom settings are
+                  configurable on the global Config page only (v1).
+                </div>
+                {/* enabled tri-state */}
+                <div className="flex flex-col gap-0.5">
+                  <label className="font-body text-[11px] font-medium text-text-secondary">
+                    Enabled
+                    <span className="font-normal text-[10px] text-text-muted ml-1">
+                      Inherit / On / Off
+                    </span>
+                  </label>
+                  <select
+                    className="w-full py-1 pl-2 pr-2 font-body text-[12px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    value={
+                      editingAlias.compaction?.enabled == null
+                        ? ''
+                        : editingAlias.compaction.enabled
+                          ? 'true'
+                          : 'false'
+                    }
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const enabled: boolean | undefined = raw === '' ? undefined : raw === 'true';
+                      setEditingAlias({
+                        ...editingAlias,
+                        compaction: {
+                          ...editingAlias.compaction,
+                          enabled,
+                        } as CompactionSettings,
+                      });
+                    }}
+                  >
+                    <option value="">Inherit</option>
+                    <option value="true">On</option>
+                    <option value="false">Off</option>
+                  </select>
+                </div>
+                {/* strategy */}
+                <div className="flex flex-col gap-0.5">
+                  <label className="font-body text-[11px] font-medium text-text-secondary">
+                    Strategy
+                    <span className="font-normal text-[10px] text-text-muted ml-1">
+                      native | headroom
+                    </span>
+                  </label>
+                  <select
+                    className="w-full py-1 pl-2 pr-2 font-body text-[12px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    value={editingAlias.compaction?.strategy ?? ''}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const strategy = (raw || undefined) as CompactionSettings['strategy'];
+                      setEditingAlias({
+                        ...editingAlias,
+                        compaction: {
+                          ...editingAlias.compaction,
+                          strategy,
+                        } as CompactionSettings,
+                      });
+                    }}
+                  >
+                    <option value="">Inherit</option>
+                    <option value="native">native</option>
+                    <option value="headroom">headroom</option>
+                  </select>
+                </div>
+                {/* numeric fields — two-column grid */}
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '6px' }}>
+                  {/* triggerRatio */}
+                  <div>
+                    <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                      Trigger Ratio
+                      <span className="font-normal text-[10px] text-text-muted ml-1">0–1</span>
+                    </label>
+                    <DebouncedInput
+                      type="number"
+                      placeholder="Inherit"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      value={
+                        editingAlias.compaction?.triggerRatio != null
+                          ? String(editingAlias.compaction.triggerRatio)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        const triggerRatio = val === '' || !Number.isFinite(num) ? undefined : num;
+                        setEditingAlias({
+                          ...editingAlias,
+                          compaction: {
+                            ...editingAlias.compaction,
+                            triggerRatio,
+                          } as CompactionSettings,
+                        });
+                      }}
+                    />
+                  </div>
+                  {/* absoluteTriggerTokens */}
+                  <div>
+                    <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                      Abs. Trigger Tokens
+                      <span className="font-normal text-[10px] text-text-muted ml-1">optional</span>
+                    </label>
+                    <DebouncedInput
+                      type="number"
+                      placeholder="Inherit"
+                      min={0}
+                      step={1}
+                      value={
+                        editingAlias.compaction?.absoluteTriggerTokens != null
+                          ? String(editingAlias.compaction.absoluteTriggerTokens)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        const absoluteTriggerTokens =
+                          val === '' || !Number.isFinite(num) ? undefined : num;
+                        setEditingAlias({
+                          ...editingAlias,
+                          compaction: {
+                            ...editingAlias.compaction,
+                            absoluteTriggerTokens,
+                          } as CompactionSettings,
+                        });
+                      }}
+                    />
+                  </div>
+                  {/* minTokens */}
+                  <div>
+                    <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                      Min Tokens
+                    </label>
+                    <DebouncedInput
+                      type="number"
+                      placeholder="Inherit"
+                      min={0}
+                      step={1}
+                      value={
+                        editingAlias.compaction?.minTokens != null
+                          ? String(editingAlias.compaction.minTokens)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        const minTokens = val === '' || !Number.isFinite(num) ? undefined : num;
+                        setEditingAlias({
+                          ...editingAlias,
+                          compaction: {
+                            ...editingAlias.compaction,
+                            minTokens,
+                          } as CompactionSettings,
+                        });
+                      }}
+                    />
+                  </div>
+                  {/* protectRecent */}
+                  <div>
+                    <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                      Protect Recent
+                    </label>
+                    <DebouncedInput
+                      type="number"
+                      placeholder="Inherit"
+                      min={0}
+                      step={1}
+                      value={
+                        editingAlias.compaction?.protectRecent != null
+                          ? String(editingAlias.compaction.protectRecent)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        const protectRecent = val === '' || !Number.isFinite(num) ? undefined : num;
+                        setEditingAlias({
+                          ...editingAlias,
+                          compaction: {
+                            ...editingAlias.compaction,
+                            protectRecent,
+                          } as CompactionSettings,
+                        });
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
@@ -597,24 +597,26 @@ export function ProviderAdvancedEditor({
 
           {/* Compaction Override */}
           <div className="border border-border-glass rounded-md overflow-hidden">
-            <div
-              className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover hover:bg-bg-glass"
+            <button
+              type="button"
+              className="w-full p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover hover:bg-bg-glass border-0 text-left"
               onClick={() => setIsCompactionOpen(!isCompactionOpen)}
+              aria-expanded={isCompactionOpen}
             >
               {isCompactionOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-              <label
+              <span
                 className="font-body text-[12px] font-medium text-text-secondary"
                 style={{ marginBottom: 0, flex: 1 }}
               >
                 Compaction Override
-              </label>
+              </span>
               {editingProvider.compaction &&
                 Object.values(editingProvider.compaction).some((v) => v != null) && (
                   <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
                     Custom
                   </Badge>
                 )}
-            </div>
+            </button>
             {isCompactionOpen && (
               <div
                 style={{

--- a/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
@@ -5,7 +5,7 @@ import { DebouncedInput } from '../ui/DebouncedInput';
 import { Switch } from '../ui/Switch';
 import { Badge } from '../ui/Badge';
 import { GPU_PROFILE_OPTIONS, resolveGpuParams } from '@plexus/shared';
-import type { Provider } from '../../lib/api';
+import type { Provider, CompactionSettings } from '../../lib/api';
 import { api } from '../../lib/api';
 
 export const KNOWN_ADAPTERS: { value: string; label: string; description: string }[] = [
@@ -67,6 +67,7 @@ export function ProviderAdvancedEditor({
   const [isHeadersOpen, setIsHeadersOpen] = useState(false);
   const [isExtraBodyOpen, setIsExtraBodyOpen] = useState(false);
   const [isStallOpen, setIsStallOpen] = useState(false);
+  const [isCompactionOpen, setIsCompactionOpen] = useState(false);
 
   // pi-ai provider dropdown
   const [piProviders, setPiProviders] = useState<string[]>([]);
@@ -586,6 +587,229 @@ export function ProviderAdvancedEditor({
                             stallGracePeriodMs: num * 1000,
                           });
                         }
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Compaction Override */}
+          <div className="border border-border-glass rounded-md overflow-hidden">
+            <div
+              className="p-2 px-3 flex items-center gap-2 cursor-pointer bg-bg-hover hover:bg-bg-glass"
+              onClick={() => setIsCompactionOpen(!isCompactionOpen)}
+            >
+              {isCompactionOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              <label
+                className="font-body text-[12px] font-medium text-text-secondary"
+                style={{ marginBottom: 0, flex: 1 }}
+              >
+                Compaction Override
+              </label>
+              {editingProvider.compaction &&
+                Object.values(editingProvider.compaction).some((v) => v != null) && (
+                  <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
+                    Custom
+                  </Badge>
+                )}
+            </div>
+            {isCompactionOpen && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '6px',
+                  padding: '8px',
+                  borderTop: '1px solid var(--color-border-glass)',
+                  background: 'var(--color-bg-subtle)',
+                }}
+              >
+                <div
+                  className="font-body text-[11px] text-text-secondary"
+                  style={{ lineHeight: 1.35 }}
+                >
+                  Override global context-compaction for this provider. Empty = inherit. Nested
+                  native/headroom settings are configurable on the global Config page only (v1).
+                </div>
+                {/* enabled tri-state: Inherit | On | Off */}
+                <div className="flex flex-col gap-0.5">
+                  <label className="font-body text-[11px] font-medium text-text-secondary">
+                    Enabled
+                    <span className="font-normal text-[10px] text-text-muted ml-1">
+                      Inherit / On / Off
+                    </span>
+                  </label>
+                  <select
+                    className="w-full py-1 pl-2 pr-2 font-body text-[12px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    value={
+                      editingProvider.compaction?.enabled == null
+                        ? ''
+                        : editingProvider.compaction.enabled
+                          ? 'true'
+                          : 'false'
+                    }
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const enabled: boolean | undefined = raw === '' ? undefined : raw === 'true';
+                      setEditingProvider({
+                        ...editingProvider,
+                        compaction: {
+                          ...editingProvider.compaction,
+                          enabled,
+                        } as CompactionSettings,
+                      });
+                    }}
+                  >
+                    <option value="">Inherit</option>
+                    <option value="true">On</option>
+                    <option value="false">Off</option>
+                  </select>
+                </div>
+                {/* strategy */}
+                <div className="flex flex-col gap-0.5">
+                  <label className="font-body text-[11px] font-medium text-text-secondary">
+                    Strategy
+                    <span className="font-normal text-[10px] text-text-muted ml-1">
+                      native | headroom
+                    </span>
+                  </label>
+                  <select
+                    className="w-full py-1 pl-2 pr-2 font-body text-[12px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                    value={editingProvider.compaction?.strategy ?? ''}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const strategy = (raw || undefined) as CompactionSettings['strategy'];
+                      setEditingProvider({
+                        ...editingProvider,
+                        compaction: {
+                          ...editingProvider.compaction,
+                          strategy,
+                        } as CompactionSettings,
+                      });
+                    }}
+                  >
+                    <option value="">Inherit</option>
+                    <option value="native">native</option>
+                    <option value="headroom">headroom</option>
+                  </select>
+                </div>
+                {/* numeric fields — two-column grid */}
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '6px' }}>
+                  {/* triggerRatio */}
+                  <div>
+                    <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                      Trigger Ratio
+                      <span className="font-normal text-[10px] text-text-muted ml-1">0–1</span>
+                    </label>
+                    <DebouncedInput
+                      type="number"
+                      placeholder="Inherit"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      value={
+                        editingProvider.compaction?.triggerRatio != null
+                          ? String(editingProvider.compaction.triggerRatio)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        const triggerRatio = val === '' || !Number.isFinite(num) ? undefined : num;
+                        setEditingProvider({
+                          ...editingProvider,
+                          compaction: {
+                            ...editingProvider.compaction,
+                            triggerRatio,
+                          } as CompactionSettings,
+                        });
+                      }}
+                    />
+                  </div>
+                  {/* absoluteTriggerTokens */}
+                  <div>
+                    <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                      Abs. Trigger Tokens
+                      <span className="font-normal text-[10px] text-text-muted ml-1">optional</span>
+                    </label>
+                    <DebouncedInput
+                      type="number"
+                      placeholder="Inherit"
+                      min={0}
+                      step={1}
+                      value={
+                        editingProvider.compaction?.absoluteTriggerTokens != null
+                          ? String(editingProvider.compaction.absoluteTriggerTokens)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        const absoluteTriggerTokens =
+                          val === '' || !Number.isFinite(num) ? undefined : num;
+                        setEditingProvider({
+                          ...editingProvider,
+                          compaction: {
+                            ...editingProvider.compaction,
+                            absoluteTriggerTokens,
+                          } as CompactionSettings,
+                        });
+                      }}
+                    />
+                  </div>
+                  {/* minTokens */}
+                  <div>
+                    <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                      Min Tokens
+                    </label>
+                    <DebouncedInput
+                      type="number"
+                      placeholder="Inherit"
+                      min={0}
+                      step={1}
+                      value={
+                        editingProvider.compaction?.minTokens != null
+                          ? String(editingProvider.compaction.minTokens)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        const minTokens = val === '' || !Number.isFinite(num) ? undefined : num;
+                        setEditingProvider({
+                          ...editingProvider,
+                          compaction: {
+                            ...editingProvider.compaction,
+                            minTokens,
+                          } as CompactionSettings,
+                        });
+                      }}
+                    />
+                  </div>
+                  {/* protectRecent */}
+                  <div>
+                    <label className="font-body text-[11px] font-medium text-text-secondary block mb-1">
+                      Protect Recent
+                    </label>
+                    <DebouncedInput
+                      type="number"
+                      placeholder="Inherit"
+                      min={0}
+                      step={1}
+                      value={
+                        editingProvider.compaction?.protectRecent != null
+                          ? String(editingProvider.compaction.protectRecent)
+                          : ''
+                      }
+                      onChange={(val: string) => {
+                        const num = Number(val);
+                        const protectRecent = val === '' || !Number.isFinite(num) ? undefined : num;
+                        setEditingProvider({
+                          ...editingProvider,
+                          compaction: {
+                            ...editingProvider.compaction,
+                            protectRecent,
+                          } as CompactionSettings,
+                        });
                       }}
                     />
                   </div>

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -251,6 +251,7 @@ export interface Provider {
   stallWindowMs?: number | null;
   stallGracePeriodMs?: number | null;
   pi_ai_provider?: string;
+  compaction?: CompactionSettings;
 }
 
 export type McpServer = RemoteMcpServer | LocalMcpServer;
@@ -489,6 +490,7 @@ export interface Alias {
   preferred_api?: Array<PreferredApiValue>;
   pi_model?: { provider: string; model_id: string };
   extraBody?: Record<string, any>;
+  compaction?: CompactionSettings;
 }
 
 export interface InferenceError {
@@ -1063,6 +1065,17 @@ export const STAT_LABELS = {
   TOKENS: 'Total Tokens',
   DURATION: 'Avg. Duration',
 } as const;
+
+export interface CompactionSettings {
+  enabled?: boolean;
+  strategy?: 'native' | 'headroom';
+  triggerRatio?: number;
+  absoluteTriggerTokens?: number | null;
+  minTokens?: number;
+  protectRecent?: number;
+  native?: { maxArrayItems?: number; maxStringChars?: number };
+  headroom?: { baseUrl?: string; apiKey?: string; targetRatio?: number | null; timeoutMs?: number };
+}
 
 export const api = {
   getCooldowns: async (): Promise<Cooldown[]> => {
@@ -3454,6 +3467,26 @@ export const api = {
       body: JSON.stringify(updates),
     });
     if (!res.ok) throw new Error('Failed to update timeout settings');
+    return res.json();
+  },
+
+  // ─── Compaction Settings ─────────────────────────────────────────
+
+  /** Fetch current compaction settings. */
+  getCompactionConfig: async (): Promise<CompactionSettings> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/compaction`);
+    if (!res.ok) throw new Error('Failed to fetch compaction settings');
+    return res.json();
+  },
+
+  /** Patch compaction settings. */
+  patchCompactionConfig: async (updates: CompactionSettings): Promise<CompactionSettings> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/config/compaction`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    });
+    if (!res.ok) throw new Error('Failed to update compaction settings');
     return res.json();
   },
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -3484,7 +3484,7 @@ export const api = {
     const res = await fetchWithAuth(`${API_BASE}/v0/management/config/compaction`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(updates),
+      body: JSON.stringify(updates, (_key, value) => (value === undefined ? null : value)),
     });
     if (!res.ok) throw new Error('Failed to update compaction settings');
     return res.json();

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -16,6 +16,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { api } from '../lib/api';
+import type { CompactionSettings } from '../lib/api';
 import { formatMinutesToMinSec } from '@plexus/shared';
 import { useToast } from '../contexts/ToastContext';
 import { Card } from '../components/ui/Card';
@@ -114,6 +115,8 @@ const DEFAULT_BACKGROUND_EXPLORATION: BackgroundExplorationConfig = {
   workerConcurrency: 2,
 };
 
+const DEFAULT_COMPACTION_CONFIG: CompactionSettings = { enabled: false, strategy: 'native' };
+
 const DEFAULT_FAILOVER_POLICY: FailoverPolicy = {
   enabled: true,
   retryableStatusCodes: [],
@@ -189,6 +192,12 @@ export const Config = () => {
   const [stallMinBpsInput, setStallMinBpsInput] = useState('');
   const [stallWindowInput, setStallWindowInput] = useState('');
   const [stallGraceInput, setStallGraceInput] = useState('');
+
+  // Context Compaction settings state
+  const [compactionConfig, setCompactionConfig] =
+    useState<CompactionSettings>(DEFAULT_COMPACTION_CONFIG);
+  const [compactionLoaded, setCompactionLoaded] = useState(false);
+  const [compactionSaving, setCompactionSaving] = useState(false);
 
   // Validate timeout input
   const validateTimeoutInput = (
@@ -485,6 +494,17 @@ export const Config = () => {
     }
   }, [toast]);
 
+  const loadCompactionConfig = useCallback(async () => {
+    try {
+      const cfg = await api.getCompactionConfig();
+      setCompactionConfig(cfg);
+      setCompactionLoaded(true);
+    } catch (e) {
+      console.error('Failed to load compaction config:', e);
+      toast.error('Failed to load compaction settings');
+    }
+  }, [toast]);
+
   const handleSaveTimeout = async () => {
     if (!timeoutDefaultValidation.valid) return;
     setTimeoutSaving(true);
@@ -553,6 +573,19 @@ export const Config = () => {
       toast.error((e as Error).message, 'Failed to save stall detection settings');
     } finally {
       setStallSaving(false);
+    }
+  };
+
+  const handleSaveCompaction = async () => {
+    setCompactionSaving(true);
+    try {
+      const updated = await api.patchCompactionConfig(compactionConfig);
+      setCompactionConfig(updated);
+      toast.success('Compaction settings saved');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to save compaction settings');
+    } finally {
+      setCompactionSaving(false);
     }
   };
 
@@ -633,6 +666,7 @@ export const Config = () => {
     loadTrustedProxies();
     loadTimeoutConfig();
     loadStallConfig();
+    loadCompactionConfig();
     loadExplorationRates();
     loadBackgroundExploration();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1217,6 +1251,326 @@ export const Config = () => {
                   )}
                 </div>
               </div>
+            </div>
+          </Disclosure>
+
+          {/* ─── Context Compaction Settings ────────────────────────────── */}
+          <Disclosure
+            title="Context Compaction"
+            defaultOpen={false}
+            extra={
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleSaveCompaction}
+                isLoading={compactionSaving}
+                disabled={!compactionLoaded}
+                leftIcon={<Save size={14} />}
+              >
+                Save
+              </Button>
+            }
+          >
+            <div className="flex flex-col gap-3">
+              <p className="font-body text-[11px] text-text-muted">
+                Applies to <code>/beta/</code> (inference-v2) routes.
+              </p>
+
+              {/* enabled toggle */}
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="font-body text-[12px] font-medium text-text">Enabled</p>
+                  <p className="font-body text-[11px] text-text-muted">
+                    Automatically compact context when the trigger threshold is reached.
+                  </p>
+                </div>
+                <Switch
+                  checked={compactionConfig.enabled ?? false}
+                  onChange={(checked) =>
+                    setCompactionConfig({ ...compactionConfig, enabled: checked })
+                  }
+                  aria-label="Toggle context compaction on/off"
+                />
+              </div>
+
+              {/* strategy */}
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="compactionStrategy"
+                  className="font-body text-[12px] font-medium text-text"
+                >
+                  Strategy
+                </label>
+                <select
+                  id="compactionStrategy"
+                  value={compactionConfig.strategy ?? 'native'}
+                  onChange={(e) =>
+                    setCompactionConfig({
+                      ...compactionConfig,
+                      strategy: e.target.value as 'native' | 'headroom',
+                    })
+                  }
+                  className="w-48 h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary"
+                >
+                  <option value="native">native</option>
+                  <option value="headroom">headroom</option>
+                </select>
+              </div>
+
+              {/* trigger ratio + absoluteTriggerTokens */}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="compactionTriggerRatio"
+                    className="font-body text-[12px] font-medium text-text"
+                  >
+                    Trigger Ratio{' '}
+                    <span className="text-text-muted font-normal">— fraction 0–1</span>
+                  </label>
+                  <input
+                    id="compactionTriggerRatio"
+                    type="number"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    placeholder="e.g. 0.8"
+                    value={compactionConfig.triggerRatio ?? ''}
+                    onChange={(e) => {
+                      const v = e.target.value === '' ? undefined : Number(e.target.value);
+                      setCompactionConfig({ ...compactionConfig, triggerRatio: v });
+                    }}
+                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="compactionAbsoluteTrigger"
+                    className="font-body text-[12px] font-medium text-text"
+                  >
+                    Absolute Trigger Tokens{' '}
+                    <span className="text-text-muted font-normal">— empty = off</span>
+                  </label>
+                  <input
+                    id="compactionAbsoluteTrigger"
+                    type="number"
+                    min={0}
+                    step={1}
+                    placeholder="Disabled"
+                    value={compactionConfig.absoluteTriggerTokens ?? ''}
+                    onChange={(e) => {
+                      const v = e.target.value === '' ? null : Number(e.target.value);
+                      setCompactionConfig({ ...compactionConfig, absoluteTriggerTokens: v });
+                    }}
+                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="compactionMinTokens"
+                    className="font-body text-[12px] font-medium text-text"
+                  >
+                    Min Tokens
+                  </label>
+                  <input
+                    id="compactionMinTokens"
+                    type="number"
+                    min={0}
+                    step={1}
+                    placeholder="e.g. 1000"
+                    value={compactionConfig.minTokens ?? ''}
+                    onChange={(e) => {
+                      const v = e.target.value === '' ? undefined : Number(e.target.value);
+                      setCompactionConfig({ ...compactionConfig, minTokens: v });
+                    }}
+                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="compactionProtectRecent"
+                    className="font-body text-[12px] font-medium text-text"
+                  >
+                    Protect Recent (tokens)
+                  </label>
+                  <input
+                    id="compactionProtectRecent"
+                    type="number"
+                    min={0}
+                    step={1}
+                    placeholder="e.g. 500"
+                    value={compactionConfig.protectRecent ?? ''}
+                    onChange={(e) => {
+                      const v = e.target.value === '' ? undefined : Number(e.target.value);
+                      setCompactionConfig({ ...compactionConfig, protectRecent: v });
+                    }}
+                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                  />
+                </div>
+              </div>
+
+              {/* native sub-settings */}
+              {compactionConfig.strategy === 'native' && (
+                <div className="flex flex-col gap-2">
+                  <p className="font-body text-[12px] font-medium text-text">Native Settings</p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1">
+                      <label
+                        htmlFor="compactionNativeMaxArrayItems"
+                        className="font-body text-[12px] font-medium text-text"
+                      >
+                        Max Array Items
+                      </label>
+                      <input
+                        id="compactionNativeMaxArrayItems"
+                        type="number"
+                        min={1}
+                        step={1}
+                        placeholder="e.g. 20"
+                        value={compactionConfig.native?.maxArrayItems ?? ''}
+                        onChange={(e) => {
+                          const v = e.target.value === '' ? undefined : Number(e.target.value);
+                          setCompactionConfig({
+                            ...compactionConfig,
+                            native: { ...compactionConfig.native, maxArrayItems: v },
+                          });
+                        }}
+                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label
+                        htmlFor="compactionNativeMaxStringChars"
+                        className="font-body text-[12px] font-medium text-text"
+                      >
+                        Max String Chars
+                      </label>
+                      <input
+                        id="compactionNativeMaxStringChars"
+                        type="number"
+                        min={1}
+                        step={1}
+                        placeholder="e.g. 500"
+                        value={compactionConfig.native?.maxStringChars ?? ''}
+                        onChange={(e) => {
+                          const v = e.target.value === '' ? undefined : Number(e.target.value);
+                          setCompactionConfig({
+                            ...compactionConfig,
+                            native: { ...compactionConfig.native, maxStringChars: v },
+                          });
+                        }}
+                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* headroom sub-settings */}
+              {compactionConfig.strategy === 'headroom' && (
+                <div className="flex flex-col gap-2">
+                  <p className="font-body text-[12px] font-medium text-text">Headroom Settings</p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1 col-span-2">
+                      <label
+                        htmlFor="compactionHeadroomBaseUrl"
+                        className="font-body text-[12px] font-medium text-text"
+                      >
+                        Base URL
+                      </label>
+                      <input
+                        id="compactionHeadroomBaseUrl"
+                        type="text"
+                        placeholder="http://localhost:8787"
+                        value={compactionConfig.headroom?.baseUrl ?? ''}
+                        onChange={(e) =>
+                          setCompactionConfig({
+                            ...compactionConfig,
+                            headroom: {
+                              ...compactionConfig.headroom,
+                              baseUrl: e.target.value || undefined,
+                            },
+                          })
+                        }
+                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1 col-span-2">
+                      <label
+                        htmlFor="compactionHeadroomApiKey"
+                        className="font-body text-[12px] font-medium text-text"
+                      >
+                        API Key
+                      </label>
+                      <input
+                        id="compactionHeadroomApiKey"
+                        type="password"
+                        placeholder="••••••••"
+                        value={compactionConfig.headroom?.apiKey ?? ''}
+                        onChange={(e) =>
+                          setCompactionConfig({
+                            ...compactionConfig,
+                            headroom: {
+                              ...compactionConfig.headroom,
+                              apiKey: e.target.value || undefined,
+                            },
+                          })
+                        }
+                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label
+                        htmlFor="compactionHeadroomTargetRatio"
+                        className="font-body text-[12px] font-medium text-text"
+                      >
+                        Target Ratio{' '}
+                        <span className="text-text-muted font-normal">— 0–1, empty = off</span>
+                      </label>
+                      <input
+                        id="compactionHeadroomTargetRatio"
+                        type="number"
+                        min={0}
+                        max={1}
+                        step={0.01}
+                        placeholder="Disabled"
+                        value={compactionConfig.headroom?.targetRatio ?? ''}
+                        onChange={(e) => {
+                          const v = e.target.value === '' ? null : Number(e.target.value);
+                          setCompactionConfig({
+                            ...compactionConfig,
+                            headroom: { ...compactionConfig.headroom, targetRatio: v },
+                          });
+                        }}
+                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label
+                        htmlFor="compactionHeadroomTimeoutMs"
+                        className="font-body text-[12px] font-medium text-text"
+                      >
+                        Timeout (ms)
+                      </label>
+                      <input
+                        id="compactionHeadroomTimeoutMs"
+                        type="number"
+                        min={0}
+                        step={1}
+                        placeholder="e.g. 30000"
+                        value={compactionConfig.headroom?.timeoutMs ?? ''}
+                        onChange={(e) => {
+                          const v = e.target.value === '' ? undefined : Number(e.target.value);
+                          setCompactionConfig({
+                            ...compactionConfig,
+                            headroom: { ...compactionConfig.headroom, timeoutMs: v },
+                          });
+                        }}
+                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           </Disclosure>
 

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -1392,14 +1392,14 @@ export const Config = () => {
                     htmlFor="compactionProtectRecent"
                     className="font-body text-[12px] font-medium text-text"
                   >
-                    Protect Recent (tokens)
+                    Protect Recent (messages)
                   </label>
                   <input
                     id="compactionProtectRecent"
                     type="number"
                     min={0}
                     step={1}
-                    placeholder="e.g. 500"
+                    placeholder="e.g. 4"
                     value={compactionConfig.protectRecent ?? ''}
                     onChange={(e) => {
                       const v = e.target.value === '' ? undefined : Number(e.target.value);

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -497,7 +497,9 @@ export const Config = () => {
   const loadCompactionConfig = useCallback(async () => {
     try {
       const cfg = await api.getCompactionConfig();
-      setCompactionConfig(cfg);
+      // Merge over defaults so the UI state always has a complete shape
+      // (e.g. strategy defined) even when the backend returns {}.
+      setCompactionConfig({ ...DEFAULT_COMPACTION_CONFIG, ...cfg });
       setCompactionLoaded(true);
     } catch (e) {
       console.error('Failed to load compaction config:', e);


### PR DESCRIPTION
### **User description**
This PR adds request-side context compaction for /beta/ inference-v2 routes so oversized prompts can be reduced before provider dispatch. It introduces global, provider, and model/alias compaction settings with precedence-based resolution, plus native and headroom compaction strategies.

It also adds management API and frontend controls for compaction settings, emits compaction metadata headers on beta responses, and extends context-limit enforcement for the pi-ai path. The implementation is fail-open: compaction errors or non-reducing results fall back to the original context.

Tests cover settings resolution, repository/API round trips, native/headroom strategy behavior, context-limit enforcement, timeout/fail-open behavior, and beta route integration.


___

### **Description**
- Add opt-in context compaction for beta routes
  - Supports `native` and `headroom` compression strategies
  - Resolves settings hierarchically (alias > provider > global)

- Enforce context limits on inference-v2 path
  - Rejects over-window requests with 400 errors
  - Implements image- and tools-aware token estimation

- Introduce management API and frontend controls
  - Allows configuring compaction overrides in UI

- Add comprehensive test suite and documentation


___

