### PR TITLE
ci: fix migration and openapi bundle generation workflows

### DIFF
--- a/.github/workflows/generate-migrations.yml
+++ b/.github/workflows/generate-migrations.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'packages/backend/drizzle/schema/**/*.ts'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/backend/drizzle/schema/**/*.ts'
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +25,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Bun
@@ -46,13 +52,16 @@ jobs:
           fi
 
       - name: Commit and push migrations
-        if: steps.check.outputs.has_changes == 'true'
+        if: steps.check.outputs.has_changes == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         id: push
+        env:
+          PR_REF: ${{ github.event.pull_request.head.ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add packages/backend/drizzle/migrations/ packages/backend/drizzle/migrations_pg/
           git commit --no-verify -m "chore: auto-generate migrations for schema changes"
-          git push
+          git push origin HEAD:${PR_REF:-$REF_NAME}
 
 

--- a/.github/workflows/generate-openapi-bundle.yml
+++ b/.github/workflows/generate-openapi-bundle.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'docs/openapi/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/openapi/**'
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +25,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Bun
@@ -47,10 +53,13 @@ jobs:
           fi
 
       - name: Commit and push bundle
-        if: steps.check.outputs.has_changes == 'true'
+        if: steps.check.outputs.has_changes == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+        env:
+          PR_REF: ${{ github.event.pull_request.head.ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/openapi.yaml
           git commit --no-verify -m "chore: regenerate OpenAPI bundle"
-          git push
+          git push origin HEAD:${PR_REF:-$REF_NAME}


### PR DESCRIPTION
### **User description**
This PR fixes the generate-migrations and generate-openapi-bundle workflows so that they can run on pull requests and commit/push back to the PR head branch instead of pushing directly to the protected 'main' branch (which fails with branch protection rules). It also resolves a GHA script injection security issue with the head ref by passing it as an environment variable.


___

### **Description**
- Add `pull_request` triggers to migration and OpenAPI bundle workflows

- Checkout PR head ref and repository for pull request events

- Push generated artifacts back to PR head branch instead of `main`

- Use environment variables for ref names to prevent script injection

- Skip commit and push steps on forked pull requests


___

