### PR TITLE
fix(inference-v2): preserve $defs/$schema/title in jsonSchemaToTypeBox

### DIFF
--- a/packages/backend/src/transformers/__tests__/oauth-type-mappers.test.ts
+++ b/packages/backend/src/transformers/__tests__/oauth-type-mappers.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, test } from 'vitest';
  * tool calls that failed Zod validation.
  */
 
-import { unifiedToContext } from '../oauth/type-mappers';
+import { jsonSchemaToTypeBox, unifiedToContext } from '../oauth/type-mappers';
 import type { UnifiedChatRequest } from '../../types/unified';
 
 // The full input_schema for OpenCode's `question` tool — the real-world trigger
@@ -434,5 +434,96 @@ describe('unifiedToContext — non-JSON tool call arguments (regression)', () =>
 
     expect(goodBlock.arguments).toEqual({ x: 1 });
     expect(badBlock.arguments).toEqual({ _raw: 'not json at all' });
+  });
+});
+
+/**
+ * Regression tests for `$defs` / `$ref` preservation in `jsonSchemaToTypeBox`.
+ *
+ * Bug: The `object` case rebuilt schemas via `Type.Object` and only carried
+ * `properties`, `required`, `additionalProperties`, and `description`. It
+ * dropped `$defs` (and `$schema`/`title`) while `$ref` pointers survived via
+ * the `Type.Unsafe` fallback. The result was a schema sent to upstream
+ * providers containing `$ref: "#/$defs/TagsInput"` with no `$defs` block —
+ * a dangling reference. Strict providers (e.g. wafer.ai / glm-5.2) reject
+ * this as `json_schema_refs_unresolved` (`400 tools[N].function.parameters
+ * .properties.tags.anyOf[0] references an unknown JSON Schema definition`).
+ *
+ * Mirrors the real-world stackydo `create_task` tool schema from trace
+ * a4b64c3c-4a46-42c6-9e65-90dbbaa4da76.
+ */
+const TAGS_TOOL_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  title: 'CreateTask',
+  type: 'object' as const,
+  properties: {
+    title: { description: 'Task title (required)', type: 'string' },
+    tags: {
+      anyOf: [{ $ref: '#/$defs/TagsInput' }, { type: 'null' }],
+      description: 'Tags: comma-separated string or JSON array',
+    },
+  },
+  required: ['title'],
+  additionalProperties: false,
+  $defs: {
+    TagsInput: {
+      anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+      description: 'Accepts tags as either a comma-separated string or a JSON array of strings.',
+    },
+  },
+};
+
+describe('jsonSchemaToTypeBox — $defs/$ref preservation (regression: json_schema_refs_unresolved)', () => {
+  test('preserves $defs on object schema so $ref pointers stay resolvable', () => {
+    const converted = jsonSchemaToTypeBox(TAGS_TOOL_SCHEMA) as any;
+
+    expect(converted.$defs).toBeDefined();
+    expect(converted.$defs.TagsInput).toBeDefined();
+    // The referenced definition is converted but structurally intact
+    expect(converted.$defs.TagsInput.anyOf).toHaveLength(2);
+    expect(converted.$defs.TagsInput.anyOf[0]).toMatchObject({ type: 'string' });
+    expect(converted.$defs.TagsInput.anyOf[1]).toMatchObject({
+      type: 'array',
+      items: { type: 'string' },
+    });
+    // description on the definition is preserved too
+    expect(converted.$defs.TagsInput.description).toBe(
+      'Accepts tags as either a comma-separated string or a JSON array of strings.'
+    );
+  });
+
+  test('preserves $schema and title on object schema', () => {
+    const converted = jsonSchemaToTypeBox(TAGS_TOOL_SCHEMA) as any;
+
+    expect(converted.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(converted.title).toBe('CreateTask');
+  });
+
+  test('$ref inside anyOf survives conversion (the dangling-ref trigger)', () => {
+    const converted = jsonSchemaToTypeBox(TAGS_TOOL_SCHEMA) as any;
+    const tags = converted.properties.tags;
+
+    expect(tags.anyOf).toHaveLength(2);
+    // The $ref must survive verbatim so it resolves against the preserved $defs.
+    // (Type.Unsafe attaches a Symbol(TypeBox.Kind) marker, so check the $ref
+    // value directly rather than deep-equal the whole object.)
+    expect(tags.anyOf[0].$ref).toBe('#/$defs/TagsInput');
+    expect(tags.anyOf[1]).toMatchObject({ type: 'null' });
+    expect(tags.description).toBe('Tags: comma-separated string or JSON array');
+  });
+
+  test('omits $defs/$schema/title keys when absent (no behavioral change for plain schemas)', () => {
+    const converted = jsonSchemaToTypeBox({
+      type: 'object',
+      properties: { q: { type: 'string' } },
+      required: ['q'],
+      additionalProperties: false,
+    }) as any;
+
+    expect(converted.$defs).toBeUndefined();
+    expect(converted.$schema).toBeUndefined();
+    expect(converted.title).toBeUndefined();
+    expect(converted.type).toBe('object');
+    expect(converted.required).toEqual(['q']);
   });
 });

--- a/packages/backend/src/transformers/oauth/type-mappers.ts
+++ b/packages/backend/src/transformers/oauth/type-mappers.ts
@@ -269,6 +269,26 @@ export function jsonSchemaToTypeBox(schema: any): any {
       if (schema.additionalProperties !== undefined) {
         obj.additionalProperties = schema.additionalProperties;
       }
+      // Preserve JSON Schema keywords that Type.Object drops. `$defs` holds the
+      // definitions that `$ref` pointers resolve against; dropping it while
+      // leaving `$ref` intact produces unresolved references, which strict
+      // providers (e.g. wafer.ai) reject as `json_schema_refs_unresolved`.
+      // Convert each definition recursively so nested schemas stay consistent
+      // with how `properties` is handled (and `$ref` targets pass through via
+      // the `Type.Unsafe` fallback without looping).
+      if (schema.$defs !== undefined && schema.$defs !== null) {
+        const convertedDefs: Record<string, any> = {};
+        for (const [key, val] of Object.entries(schema.$defs)) {
+          convertedDefs[key] = jsonSchemaToTypeBox(val);
+        }
+        obj.$defs = convertedDefs;
+      }
+      if (schema.$schema !== undefined) {
+        obj.$schema = schema.$schema;
+      }
+      if (schema.title !== undefined) {
+        obj.title = schema.title;
+      }
       return obj;
     }
     case 'array': {


### PR DESCRIPTION
### **User description**
## Problem

Requests to the `wafer` provider via the inference-v2 chat-completions path failed with a provider `400`:

```
json_schema_refs_unresolved
  tools[155].function.parameters.properties.tags.anyOf[0]
  references an unknown JSON Schema definition
```

(Trace `a4b64c3c-4a46-42c6-9e65-90dbbaa4da76` — `wafer` / `glm-5.2`.) OpenAI/Anthropic are lenient about unresolved refs, so this only surfaced on wafer.

## Root cause

`jsonSchemaToTypeBox()` (`packages/backend/src/transformers/oauth/type-mappers.ts`) rebuilds `object`-typed schemas via `Type.Object` and only carried `properties`/`required`/`additionalProperties`/`description`. It **dropped `$defs`, `$schema`, and `title`**, while `$ref` pointers survived via the `Type.Unsafe` fallback. The result: a schema sent upstream containing `{"$ref":"#/$defs/TagsInput"}` with no `$defs` block — a dangling reference.

The `wafer` provider and `GLM-5.2` model configs themselves were correct (`pi_ai_model_id: glm-5.2`, `api_base_url.chat: https://pass.wafer.ai/v1`); the issue is in the tool-schema transformation, not the provider/model definition.

All four inference-v2 entry points (`openai`, `anthropic`, `gemini`, `responses`) route tools through this converter, so they were all affected. Real-world trigger: the `stackydo_create_task` (tool 155) and `stackydo_update_task` (tool 169) tools, whose `tags` property uses `$ref`/`$defs`.

## Fix

Preserve the dropped JSON Schema keywords on `object` schemas in `jsonSchemaToTypeBox()`:

- **`$defs`** — converted recursively so nested defs stay consistent with how `properties` is handled (and `$ref` targets pass through via `Type.Unsafe` without looping).
- **`$schema`**
- **`title`**

`$ref` already survived; once `$defs` is preserved, the pointers resolve correctly.

## Tests

Added a regression suite in `oauth-type-mappers.test.ts` mirroring the real-world `stackydo create_task` schema from the trace, covering `$defs` preserved & structurally intact, `$schema`/`title` preserved, `$ref` inside `anyOf` survives verbatim, and plain schemas without those keys are unchanged.

- Targeted: 21/21 pass
- Full unit suite: 2072/2072 pass across 188 files
- LSP diagnostics clean on both changed files
- `bun run format:check` clean

## Files

- `packages/backend/src/transformers/oauth/type-mappers.ts` — the fix
- `packages/backend/src/transformers/__tests__/oauth-type-mappers.test.ts` — regression tests


___

### **Description**
- Preserve `$defs`, `$schema`, and `title` in `jsonSchemaToTypeBox`

- Recursively convert `$defs` entries to keep nested schemas consistent

- Add regression tests for `$ref`/`$defs` preservation using real-world schema


___

