### PR TITLE
fix(quota): restore missing component declaration in ClineQuotaConfig

### DIFF
--- a/packages/frontend/src/components/quota/ClineQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/ClineQuotaConfig.tsx
@@ -6,9 +6,10 @@ export interface ClineQuotaConfigProps {
   onChange: (options: Record<string, unknown>) => void;
 }
 
-const handleChange = (key: string, value: string) => {
-  onChange({ ...options, [key]: value || undefined });
-};
+export const ClineQuotaConfig: React.FC<ClineQuotaConfigProps> = ({ options, onChange }) => {
+  const handleChange = (key: string, value: string) => {
+    onChange({ ...options, [key]: value || undefined });
+  };
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
### **User description**
## Summary

`packages/frontend/src/components/quota/ClineQuotaConfig.tsx` (added in #640) was missing its component function declaration. The body had a bare `handleChange` const followed by a dangling `return (...)` / closing `};` at module scope, which broke the frontend build:

```
error: Unexpected }
    at .../ClineQuotaConfig.tsx:30:1
```

## Fix

Wrapped the existing body in the missing `export const ClineQuotaConfig: React.FC<ClineQuotaConfigProps> = ({ options, onChange }) => { ... }` declaration, matching the pattern used by sibling components (e.g. `ApertisQuotaConfig.tsx`). No behavioral changes — just restoring the intended component export.

## Testing

- `bun run build:frontend` — builds successfully
- `bun run typecheck` — clean
- `lsp diagnostics` on the changed file — clean
- Pre-commit hooks (biome-format, biome-lint, frontend-build, typecheck, no-migrations) all passed


___

### **Description**
- Restore missing `ClineQuotaConfig` component function declaration

- Wrap `handleChange` and JSX return in `React.FC` export wrapper


___

