### PR TITLE
chore: update pi-ai to 0.80.3 for Claude Sonnet 5 support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
       "name": "plexus-backend",
       "version": "1.0.0",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.80.1",
+        "@earendil-works/pi-ai": "0.80.3",
         "@fastify/bearer-auth": "^10.1.2",
         "@fastify/cors": "^11.2.0",
         "@fastify/multipart": "^10.0.0",
@@ -179,7 +179,7 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.1", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-qsHmuoBRu7a6rkOis/Elwl8jEhA9T884H/mXMP3tbz1slEBI+dHaY3zJ0nlEqUl+jcTz1FJNdgOVLG4sQHOPXQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.5.3", "", {}, "sha512-iTTYbA5Uesrl+N7zss0J5LopT7KE4j9aymYo+EZZh+rZbARQCUQOs+n2pay64JRUpc3fCkpfrniTNJnvYzOE+g=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "lint:migrations": "cd ../.. && bun run scripts/lint-migrations.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.80.1",
+    "@earendil-works/pi-ai": "0.80.3",
     "@fastify/bearer-auth": "^10.1.2",
     "@fastify/cors": "^11.2.0",
     "@fastify/multipart": "^10.0.0",

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -158,7 +158,8 @@ export function buildThinkingOptions(
       modelId?.includes('opus-4-6') ||
       modelId?.includes('opus-4.6') ||
       modelId?.includes('sonnet-4-6') ||
-      modelId?.includes('sonnet-4.6');
+      modelId?.includes('sonnet-4.6') ||
+      modelId?.includes('sonnet-5');
 
     base.thinkingEnabled = true;
     if (isAdaptive) {

--- a/packages/shared/src/model-params.ts
+++ b/packages/shared/src/model-params.ts
@@ -290,6 +290,19 @@ export function estimateActiveParams(options: EstimateActiveParamsOptions): numb
 // specifies a different dtype.
 
 export const PROPRIETARY_MODEL_HEURISTICS: Record<string, ModelParamsWithDtype> = {
+  // Claude Sonnet 5 (Released 2026): 1M Context + Adaptive Thinking
+  'claude-sonnet-5': {
+    total_params: 1500,
+    active_params: 120, // 15B base * ~8x output price premium
+    layers: 100,
+    heads: 80,
+    kv_lora_rank: 128,
+    qk_rope_head_dim: 96,
+    context_length: 1000000,
+    dtype_size: resolveDtypeSize('fp8'),
+    dtype: 'fp8',
+  },
+
   // Anthropic Claude 4 Series (Frontier Reasoning)
   // Claude 4.6 (Released Feb 2026): 1M Context + Adaptive Thinking
   'claude-4-6-opus': {


### PR DESCRIPTION
### **User description**
## Summary

Bumps `@earendil-works/pi-ai` from `0.80.1` to `0.80.3`, which adds `claude-sonnet-5` to the Anthropic model registry.

pi-ai's capability-aware reasoning path (`buildReasoningOptionsForModel`) already reads `model.compat.forceAdaptiveThinking` directly from the registry, so Sonnet 5 gets correct adaptive-thinking support automatically with no Plexus code change required there.

However, two places with hardcoded model-string matching needed updates for the new model:

1. **`packages/backend/src/inference-v2/shared/pi-ai-utils.ts`** — the legacy `buildThinkingOptions` (used by the OAuth transformer) string-matches model IDs to decide adaptive vs. budget-based thinking. Added `sonnet-5` to the adaptive-thinking match list so OAuth-based requests use adaptive `effort` instead of falling back to (now-invalid) `thinkingBudgetTokens`.
2. **`packages/shared/src/model-params.ts`** — added a `claude-sonnet-5` entry to `PROPRIETARY_MODEL_HEURISTICS` so the energy-estimation fetcher has architecture estimates for the new model instead of falling through to defaults.

## Testing

- `bun run typecheck` — passed across all workspaces
- `bun run test` — 2081 tests passed (189 files)
- `bun run format:check` — clean
- Pre-commit hooks (tests, format, lint, typecheck) all passed


___

### **Description**
- Bump `@earendil-works/pi-ai` from `0.80.1` to `0.80.3`

- Add `sonnet-5` to adaptive-thinking match list in `buildThinkingOptions`

- Add `claude-sonnet-5` entry to `PROPRIETARY_MODEL_HEURISTICS`


___

