### PR TITLE
feat(inference-v2): add native vision fallthrough for beta pi-ai path

### DIFF
--- a/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
@@ -181,3 +181,215 @@ describe('runPiAiExecutor streaming errors', () => {
     );
   });
 });
+
+describe('runPiAiExecutor vision fallthrough', () => {
+  beforeEach(() => {
+    DebugManager.getInstance().resetForTesting();
+    setConfigForTesting({
+      providers: {
+        'text-only': {
+          api_base_url: 'https://api.openai.com/v1',
+          api_key: 'sk-test',
+          pi_ai_provider: 'openai-codex',
+          models: {
+            'text-model': {
+              pricing: { source: 'simple', input: 0, output: 0 },
+              pi_ai_model_id: 'text-model',
+            },
+          },
+        },
+        descriptor: {
+          api_base_url: 'https://api.openai.com/v1',
+          api_key: 'sk-test',
+          pi_ai_provider: 'openai-codex',
+          models: {
+            'gpt-4o': {
+              pricing: { source: 'simple', input: 0, output: 0 },
+              pi_ai_model_id: 'gpt-4o',
+            },
+          },
+        },
+      },
+      models: {
+        'text-model': {
+          priority: 'selector',
+          use_image_fallthrough: true,
+          targets: [{ provider: 'text-only', model: 'text-model' }],
+        },
+        'gpt-4o': {
+          priority: 'selector',
+          targets: [{ provider: 'descriptor', model: 'gpt-4o' }],
+        },
+      },
+      vision_fallthrough: { descriptor_model: 'gpt-4o' },
+      keys: {},
+      failover: { enabled: false, retryableStatusCodes: [], retryableErrors: [] },
+      quotas: [],
+    } as any);
+  });
+
+  it('describes images before dispatching to an alias with use_image_fallthrough', async () => {
+    vi.mocked(piAi.complete)
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'A blue circle.' }],
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-4o',
+        usage: { input: 20, output: 8, cacheRead: 0, cacheWrite: 0 },
+        stopReason: 'stop',
+        timestamp: Date.now(),
+      } as any)
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'That is a blue circle.' }],
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'text-model',
+        usage: { input: 15, output: 6, cacheRead: 0, cacheWrite: 0 },
+        stopReason: 'stop',
+        timestamp: Date.now(),
+      } as any);
+
+    const usageStorage = createUsageStorage();
+    DebugManager.getInstance().setStorage(usageStorage);
+
+    const context = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is this?' },
+            {
+              type: 'image',
+              mimeType: 'image/png',
+              data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+            },
+          ],
+          timestamp: Date.now(),
+        },
+      ],
+    };
+
+    const result = await runPiAiExecutor({
+      requestId: 'req-vision-fallthrough',
+      incomingApiType: 'chat',
+      modelAlias: 'text-model',
+      context: context as any,
+      generationIntent: { reasoning: { source: 'client' } } as any,
+      streaming: false,
+      request: {
+        body: {},
+        keyName: 'beta-key',
+        attribution: 'opencode',
+        ip: '127.0.0.1',
+      } as any,
+      usageStorage,
+      serializeMessage: (msg) => msg as any,
+      serializeChunks: () => [],
+    });
+
+    // First call describes the image (descriptor model), second call is the
+    // actual text-only target dispatch — never receiving image content.
+    expect(vi.mocked(piAi.complete)).toHaveBeenCalledTimes(2);
+    const [, targetContext] = vi.mocked(piAi.complete).mock.calls[1]!;
+    const targetMessage = (targetContext as any).messages[0];
+    expect(targetMessage.content).toEqual([
+      { type: 'text', text: 'What is this?' },
+      { type: 'text', text: '[Image Description: A blue circle.]' },
+    ]);
+
+    expect(result.response).toEqual(
+      expect.objectContaining({ content: [{ type: 'text', text: 'That is a blue circle.' }] })
+    );
+
+    // Target dispatch usage record reflects the fallthrough having occurred.
+    expect(usageStorage.saveRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'req-vision-fallthrough',
+        provider: 'text-only',
+        isVisionFallthrough: true,
+        visionFallthroughModel: 'gpt-4o',
+      })
+    );
+    // Descriptor sub-call gets its own usage record.
+    expect(usageStorage.saveRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ isDescriptorRequest: true, isVisionFallthrough: false })
+    );
+  });
+
+  it('does not trigger fallthrough for aliases without use_image_fallthrough', async () => {
+    setConfigForTesting({
+      providers: {
+        'text-only': {
+          api_base_url: 'https://api.openai.com/v1',
+          api_key: 'sk-test',
+          pi_ai_provider: 'openai-codex',
+          models: {
+            'text-model': {
+              pricing: { source: 'simple', input: 0, output: 0 },
+              pi_ai_model_id: 'text-model',
+            },
+          },
+        },
+      },
+      models: {
+        'text-model': {
+          priority: 'selector',
+          targets: [{ provider: 'text-only', model: 'text-model' }],
+        },
+      },
+      keys: {},
+      failover: { enabled: false, retryableStatusCodes: [], retryableErrors: [] },
+      quotas: [],
+    } as any);
+
+    vi.mocked(piAi.complete).mockResolvedValueOnce({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'response' }],
+      api: 'openai-codex-responses',
+      provider: 'openai-codex',
+      model: 'text-model',
+      usage: { input: 15, output: 6, cacheRead: 0, cacheWrite: 0 },
+      stopReason: 'stop',
+      timestamp: Date.now(),
+    } as any);
+
+    const usageStorage = createUsageStorage();
+    DebugManager.getInstance().setStorage(usageStorage);
+
+    const context = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              mimeType: 'image/png',
+              data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+            },
+          ],
+          timestamp: Date.now(),
+        },
+      ],
+    };
+
+    await runPiAiExecutor({
+      requestId: 'req-no-fallthrough',
+      incomingApiType: 'chat',
+      modelAlias: 'text-model',
+      context: context as any,
+      generationIntent: { reasoning: { source: 'client' } } as any,
+      streaming: false,
+      request: { body: {}, keyName: 'beta-key', attribution: 'opencode', ip: '127.0.0.1' } as any,
+      usageStorage,
+      serializeMessage: (msg) => msg as any,
+      serializeChunks: () => [],
+    });
+
+    // Only one call — the target dispatch — image content was forwarded verbatim.
+    expect(vi.mocked(piAi.complete)).toHaveBeenCalledTimes(1);
+    const [, sentContext] = vi.mocked(piAi.complete).mock.calls[0]!;
+    expect((sentContext as any).messages[0].content[0].type).toBe('image');
+  });
+});

--- a/packages/backend/src/inference-v2/shared/__tests__/vision-fallthrough.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/vision-fallthrough.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as piAi from '@earendil-works/pi-ai/compat';
+import { setConfigForTesting } from '../../../config';
+import {
+  applyVisionFallthrough,
+  clearVisionFallthroughCacheForTesting,
+  contextHasImages,
+} from '../vision-fallthrough';
+import type { UsageStorageService } from '../../../services/usage-storage';
+import type { Context } from '@earendil-works/pi-ai';
+
+function createUsageStorage(): UsageStorageService {
+  return {
+    saveRequest: vi.fn(async () => undefined),
+  } as unknown as UsageStorageService;
+}
+
+const IMAGE_DATA_A =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+const IMAGE_DATA_B =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJgg1';
+
+describe('contextHasImages', () => {
+  it('detects images in user message content', () => {
+    const context: Context = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'what is this?' },
+            { type: 'image', mimeType: 'image/png', data: IMAGE_DATA_A },
+          ],
+          timestamp: Date.now(),
+        },
+      ],
+    };
+    expect(contextHasImages(context)).toBe(true);
+  });
+
+  it('returns false when there are no images', () => {
+    const context: Context = {
+      messages: [{ role: 'user', content: 'hello', timestamp: Date.now() }],
+    };
+    expect(contextHasImages(context)).toBe(false);
+  });
+
+  it('returns false for string content', () => {
+    const context: Context = {
+      messages: [{ role: 'user', content: 'plain text', timestamp: Date.now() }],
+    };
+    expect(contextHasImages(context)).toBe(false);
+  });
+});
+
+describe('applyVisionFallthrough', () => {
+  beforeEach(() => {
+    clearVisionFallthroughCacheForTesting();
+    setConfigForTesting({
+      providers: {
+        descriptor: {
+          api_base_url: 'https://api.openai.com/v1',
+          api_key: 'sk-test',
+          pi_ai_provider: 'openai-codex',
+          models: {
+            'gpt-4o': {
+              pricing: { source: 'simple', input: 0, output: 0 },
+              pi_ai_model_id: 'gpt-4o',
+            },
+          },
+        },
+      },
+      models: {
+        'gpt-4o': {
+          priority: 'selector',
+          targets: [{ provider: 'descriptor', model: 'gpt-4o' }],
+        },
+      },
+      keys: {},
+      failover: { enabled: false, retryableStatusCodes: [], retryableErrors: [] },
+      quotas: [],
+    } as any);
+  });
+
+  it('returns the same context reference when there are no images', async () => {
+    const context: Context = {
+      messages: [{ role: 'user', content: 'hello', timestamp: Date.now() }],
+    };
+    const result = await applyVisionFallthrough(context, 'gpt-4o', 'Describe this image.');
+    expect(result).toBe(context);
+  });
+
+  it('replaces image blocks with text descriptions from the descriptor model', async () => {
+    vi.mocked(piAi.complete).mockResolvedValueOnce({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'A red square.' }],
+      api: 'openai-codex-responses',
+      provider: 'openai-codex',
+      model: 'gpt-4o',
+      usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 },
+      stopReason: 'stop',
+      timestamp: Date.now(),
+    } as any);
+
+    const context: Context = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is this?' },
+            { type: 'image', mimeType: 'image/png', data: IMAGE_DATA_A },
+          ],
+          timestamp: Date.now(),
+        },
+      ],
+    };
+
+    const usageStorage = createUsageStorage();
+    const result = await applyVisionFallthrough(
+      context,
+      'gpt-4o',
+      'Describe this image.',
+      usageStorage
+    );
+
+    expect(contextHasImages(result)).toBe(false);
+    const userMsg = result.messages[0] as any;
+    expect(userMsg.content).toEqual([
+      { type: 'text', text: 'What is this?' },
+      { type: 'text', text: '[Image Description: A red square.]' },
+    ]);
+    // Original context must be untouched.
+    expect(contextHasImages(context)).toBe(true);
+    expect(usageStorage.saveRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ isDescriptorRequest: true, isVisionFallthrough: false })
+    );
+  });
+
+  it('describes multiple images concurrently, preserving order', async () => {
+    vi.mocked(piAi.complete)
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'First image.' }],
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-4o',
+        usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 },
+        stopReason: 'stop',
+        timestamp: Date.now(),
+      } as any)
+      .mockResolvedValueOnce({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Second image.' }],
+        api: 'openai-codex-responses',
+        provider: 'openai-codex',
+        model: 'gpt-4o',
+        usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 },
+        stopReason: 'stop',
+        timestamp: Date.now(),
+      } as any);
+
+    const context: Context = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'image', mimeType: 'image/png', data: IMAGE_DATA_A },
+            { type: 'text', text: 'and' },
+            { type: 'image', mimeType: 'image/png', data: IMAGE_DATA_B },
+          ],
+          timestamp: Date.now(),
+        },
+      ],
+    };
+
+    const result = await applyVisionFallthrough(context, 'gpt-4o', 'Describe this image.');
+    const userMsg = result.messages[0] as any;
+    expect(userMsg.content).toEqual([
+      { type: 'text', text: '[Image Description: First image.]' },
+      { type: 'text', text: 'and' },
+      { type: 'text', text: '[Image Description: Second image.]' },
+    ]);
+  });
+
+  it('caches descriptions by (model, image hash) across calls', async () => {
+    vi.mocked(piAi.complete).mockResolvedValueOnce({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Cached description.' }],
+      api: 'openai-codex-responses',
+      provider: 'openai-codex',
+      model: 'gpt-4o',
+      usage: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0 },
+      stopReason: 'stop',
+      timestamp: Date.now(),
+    } as any);
+
+    const makeContext = (): Context => ({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'image', mimeType: 'image/png', data: IMAGE_DATA_A }],
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    const callsBefore = vi.mocked(piAi.complete).mock.calls.length;
+    const first = await applyVisionFallthrough(makeContext(), 'gpt-4o', 'Describe this image.');
+    const second = await applyVisionFallthrough(makeContext(), 'gpt-4o', 'Describe this image.');
+
+    expect(vi.mocked(piAi.complete).mock.calls.length).toBe(callsBefore + 1);
+    expect((first.messages[0] as any).content[0].text).toBe(
+      '[Image Description: Cached description.]'
+    );
+    expect((second.messages[0] as any).content[0].text).toBe(
+      '[Image Description: Cached description.]'
+    );
+  });
+
+  it('falls back to an error placeholder when the descriptor model has no route', async () => {
+    const context: Context = {
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'image', mimeType: 'image/png', data: IMAGE_DATA_B }],
+          timestamp: Date.now(),
+        },
+      ],
+    };
+
+    const result = await applyVisionFallthrough(context, 'nonexistent-model', 'Describe.');
+    expect((result.messages[0] as any).content[0].text).toBe(
+      '[Image Description: Error generating image description.]'
+    );
+  });
+});

--- a/packages/backend/src/inference-v2/shared/__tests__/vision-fallthrough.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/vision-fallthrough.test.ts
@@ -232,4 +232,40 @@ describe('applyVisionFallthrough', () => {
       '[Image Description: Error generating image description.]'
     );
   });
+
+  it('caches an empty descriptor response to avoid repeated wasted calls', async () => {
+    vi.mocked(piAi.complete).mockResolvedValueOnce({
+      role: 'assistant',
+      content: [{ type: 'text', text: '' }],
+      api: 'openai-codex-responses',
+      provider: 'openai-codex',
+      model: 'gpt-4o',
+      usage: { input: 10, output: 0, cacheRead: 0, cacheWrite: 0 },
+      stopReason: 'stop',
+      timestamp: Date.now(),
+    } as any);
+
+    const makeContext = (): Context => ({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'image', mimeType: 'image/png', data: IMAGE_DATA_A }],
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    const callsBefore = vi.mocked(piAi.complete).mock.calls.length;
+    const first = await applyVisionFallthrough(makeContext(), 'gpt-4o', 'Describe this image.');
+    const second = await applyVisionFallthrough(makeContext(), 'gpt-4o', 'Describe this image.');
+
+    // Only one descriptor call — the empty result is cached, not re-fetched.
+    expect(vi.mocked(piAi.complete).mock.calls.length).toBe(callsBefore + 1);
+    expect((first.messages[0] as any).content[0].text).toBe(
+      '[Image Description: No description available.]'
+    );
+    expect((second.messages[0] as any).content[0].text).toBe(
+      '[Image Description: No description available.]'
+    );
+  });
 });

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -58,6 +58,8 @@ import { extractPiAiErrorMessage } from '../../transformers/oauth/type-mappers';
 import { enforceContextLimitForRoute } from '../../services/enforce-limits';
 import { compactContextForSend } from '../../services/compaction/compaction-service';
 import type { CompactionResult, CompactionStrategyName } from '../../services/compaction/types';
+import { applyVisionFallthrough, contextHasImages } from './vision-fallthrough';
+import { DEFAULT_VISION_DESCRIPTION_PROMPT } from '../../utils/constants';
 
 // ─── AsyncLocalStorage for debug raw-capture correlation ─────────────────────
 
@@ -487,26 +489,58 @@ export async function runPiAiExecutor<TResponse>(
       continue;
     }
 
+    // ── Vision fallthrough (opt-in per alias) ──────────────────────────────
+    // Mirrors dispatcher.ts:317-365, but operates natively on the pi-ai
+    // Context (no UnifiedChatRequest detour). Runs before compaction/limit
+    // enforcement so the candidate's estimated token count and context-limit
+    // check reflect the post-fallthrough (text-only) content.
+    const aliasForRoute = route.canonicalModel
+      ? getConfig().models?.[route.canonicalModel]
+      : undefined;
+    let candidateContext = context;
+    let usedVisionFallthrough = false;
+    let visionFallthroughModel: string | null = null;
+    if (aliasForRoute?.use_image_fallthrough && contextHasImages(candidateContext)) {
+      const vfConfig = getConfig().vision_fallthrough;
+      if (vfConfig?.descriptor_model) {
+        try {
+          candidateContext = await applyVisionFallthrough(
+            candidateContext,
+            vfConfig.descriptor_model,
+            vfConfig.default_prompt || DEFAULT_VISION_DESCRIPTION_PROMPT,
+            usageStorage,
+            { sourceIp, keyName, attribution }
+          );
+          usedVisionFallthrough = true;
+          visionFallthroughModel = vfConfig.descriptor_model;
+        } catch (vfError) {
+          logger.error('[pi-ai-executor] Error in vision fallthrough:', vfError);
+        }
+      } else {
+        logger.warn(
+          `[pi-ai-executor] use_image_fallthrough enabled for alias '${modelAlias}' but 'vision_fallthrough.descriptor_model' not configured globally.`
+        );
+      }
+    }
+
     // ── Context compaction (opt-in per alias/provider/global) ──────────────
     // Runs before force-limit enforcement so a borderline-oversized request can
     // be rescued by compaction before it would be rejected. Fail-open: on any
     // error the original context is returned. Per-candidate, memoized.
     const compaction = await compactContextForSend(
-      context,
+      candidateContext,
       route,
       modelAlias,
       compactionMemo,
       attemptTimeout.signal
     );
-    const sendContext = compaction.compacted ? compaction.context : context;
+    const sendContext = compaction.compacted ? compaction.context : candidateContext;
 
     // ── Force-limit enforcement (opt-in per alias) ─────────────────────────
     // Mirrors dispatcher.ts:384-394. Checked AFTER cooldown and BEFORE
     // acquiring a concurrency slot, so a thrown ContextLengthExceededError
     // (client-side; failover won't help) never leaks an acquired slot.
-    const aliasForLimit = route.canonicalModel
-      ? getConfig().models?.[route.canonicalModel]
-      : undefined;
+    const aliasForLimit = aliasForRoute;
     try {
       enforceContextLimitForRoute(
         sendContext,
@@ -654,6 +688,8 @@ export async function runPiAiExecutor<TResponse>(
           startTime,
           costMetadata: null,
           tokensReasoning: null,
+          isVisionFallthrough: usedVisionFallthrough,
+          visionFallthroughModel,
           ...usageData,
         };
 
@@ -710,6 +746,8 @@ export async function runPiAiExecutor<TResponse>(
           toolsDefined: toolsDefined ?? null,
           messageCount: messageCount ?? null,
           parallelToolCalls: parallelToolCalls ?? null,
+          isVisionFallthrough: usedVisionFallthrough,
+          visionFallthroughModel,
           debug,
           onSuccess,
           serializeChunks,
@@ -788,6 +826,8 @@ interface SSEGeneratorParams {
   toolsDefined: number | null;
   messageCount: number | null;
   parallelToolCalls: boolean | null;
+  isVisionFallthrough: boolean;
+  visionFallthroughModel: string | null;
   debug: DebugManager;
   onSuccess?: (msg: AssistantMessage) => void | Promise<void>;
   serializeChunks: (event: AssistantMessageEvent) => string[];
@@ -818,6 +858,8 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
     toolsDefined,
     messageCount,
     parallelToolCalls,
+    isVisionFallthrough,
+    visionFallthroughModel,
     debug,
     onSuccess,
     serializeChunks,
@@ -920,6 +962,8 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
           startTime,
           costMetadata: null,
           tokensReasoning: null,
+          isVisionFallthrough,
+          visionFallthroughModel,
           ...usageData,
         };
 
@@ -986,6 +1030,8 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
           ttftMs,
           finishReason: 'error',
           toolCallsCount: null,
+          isVisionFallthrough,
+          visionFallthroughModel,
         };
 
         if (transformedStreamSnapshot) {
@@ -1055,6 +1101,8 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
       ttftMs,
       finishReason: 'error',
       toolCallsCount: null,
+      isVisionFallthrough,
+      visionFallthroughModel,
     };
 
     usageStorage.saveRequest(usageRecord as any).catch(() => {});

--- a/packages/backend/src/inference-v2/shared/vision-fallthrough.ts
+++ b/packages/backend/src/inference-v2/shared/vision-fallthrough.ts
@@ -1,0 +1,406 @@
+/**
+ * Vision fallthrough for the beta (inference-v2) pi-ai path.
+ *
+ * Converts image content blocks in a pi-ai `Context` into text descriptions
+ * produced by a configured "descriptor" model, for target models/providers
+ * that don't support vision input. This is a native pi-ai implementation —
+ * it operates directly on `Context` / `ImageContent` / `TextContent` and
+ * dispatches the descriptor sub-call straight through `piAiModels.complete()`.
+ * It does NOT go through `UnifiedChatRequest` or the legacy `Dispatcher`
+ * (see `services/vision-descriptor-service.ts` for that v1 path).
+ *
+ * Because the descriptor sub-call bypasses `runPiAiExecutor` entirely (it
+ * calls `piAiModels.complete()` directly), there is no recursion risk and no
+ * need for a `_isVisionDescriptorRequest` guard flag like the v1 path uses.
+ */
+
+import crypto from 'node:crypto';
+import { calculateCost } from '@earendil-works/pi-ai';
+import type { Context, ImageContent, Message, TextContent } from '@earendil-works/pi-ai';
+import { Router } from '../../services/router';
+import { CooldownManager } from '../../services/cooldown-manager';
+import { ConcurrencyTracker } from '../../services/concurrency-tracker';
+import type { UsageStorageService } from '../../services/usage-storage';
+import { logger } from '../../utils/logger';
+import {
+  buildPiAiModel,
+  computeKwhUsed,
+  piAiModels,
+  resolvePiAiModel,
+  toDispatchModel,
+} from './pi-ai-utils';
+
+const DESCRIPTION_CACHE_MAX = 500;
+
+// LRU cache: key = "<model>:<sha256(imageData)>", value = description string.
+// Shared module-level cache, mirroring VisionDescriptorService's cache shape.
+const descriptionCache = new Map<string, string>();
+
+function cacheKeyFor(image: ImageContent, model: string): string {
+  const hash = crypto.createHash('sha256').update(image.data).digest('hex');
+  return `${model}:${hash}`;
+}
+
+function cacheGet(key: string): string | undefined {
+  if (!descriptionCache.has(key)) return undefined;
+  const val = descriptionCache.get(key)!;
+  // Move to end (most recently used)
+  descriptionCache.delete(key);
+  descriptionCache.set(key, val);
+  return val;
+}
+
+function cacheSet(key: string, value: string): void {
+  if (descriptionCache.has(key)) {
+    descriptionCache.delete(key);
+  } else if (descriptionCache.size >= DESCRIPTION_CACHE_MAX) {
+    // Evict least recently used (first entry in Map insertion order)
+    descriptionCache.delete(descriptionCache.keys().next().value!);
+  }
+  descriptionCache.set(key, value);
+}
+
+/** Clears the in-memory description cache. Primarily useful in tests. */
+export function clearVisionFallthroughCacheForTesting(): void {
+  descriptionCache.clear();
+}
+
+function messageContentBlocks(msg: Message): (TextContent | ImageContent)[] | undefined {
+  if (msg.role === 'user' && Array.isArray(msg.content)) return msg.content;
+  if (msg.role === 'toolResult') return msg.content;
+  return undefined;
+}
+
+/** Checks whether any message in a pi-ai Context carries image content. */
+export function contextHasImages(context: Context): boolean {
+  for (const msg of context.messages) {
+    const blocks = messageContentBlocks(msg);
+    if (blocks?.some((b) => b.type === 'image')) return true;
+  }
+  return false;
+}
+
+function collectImages(messages: Message[]): ImageContent[] {
+  const images: ImageContent[] = [];
+  for (const msg of messages) {
+    const blocks = messageContentBlocks(msg);
+    if (!blocks) continue;
+    for (const block of blocks) {
+      if (block.type === 'image') images.push(block);
+    }
+  }
+  return images;
+}
+
+/** Replaces image blocks with text-description blocks, in traversal order. */
+function injectDescriptions(messages: Message[], descriptions: string[]): Message[] {
+  let descIdx = 0;
+  return messages.map((msg) => {
+    const blocks = messageContentBlocks(msg);
+    if (!blocks) return msg;
+
+    const newContent = blocks.map((block) => {
+      if (block.type === 'image') {
+        const desc = descriptions[descIdx++] ?? 'No description available.';
+        return { type: 'text', text: `[Image Description: ${desc}]` } as TextContent;
+      }
+      return block;
+    });
+
+    return { ...msg, content: newContent } as Message;
+  });
+}
+
+export interface VisionFallthroughParentMeta {
+  sourceIp?: string | null;
+  keyName?: string;
+  attribution?: string | null;
+}
+
+async function recordDescriptorUsage(
+  usageStorage: UsageStorageService,
+  route: import('../../services/router').RouteResult,
+  piModel: any,
+  message: import('@earendil-works/pi-ai').AssistantMessage,
+  startTime: number,
+  descriptorModel: string,
+  responseStatus: string,
+  parentMeta?: VisionFallthroughParentMeta
+): Promise<void> {
+  const durationMs = Date.now() - startTime;
+  const usage = message.usage;
+  const cost = calculateCost(piModel, usage);
+  const kwhUsed = computeKwhUsed(usage.input, usage.output, route);
+
+  await usageStorage
+    .saveRequest({
+      requestId: `desc-${crypto.randomUUID()}`,
+      date: new Date().toISOString(),
+      startTime,
+      durationMs,
+      createdAt: Date.now(),
+      incomingApiType: 'chat',
+      outgoingApiType: piModel.api,
+      provider: route.provider,
+      selectedModelName: route.model,
+      canonicalModelName: route.canonicalModel ?? null,
+      incomingModelAlias: descriptorModel,
+      sourceIp: parentMeta?.sourceIp ?? null,
+      apiKey: parentMeta?.keyName ?? null,
+      attribution: parentMeta?.attribution ?? null,
+      attemptCount: 1,
+      isStreamed: false,
+      isPassthrough: false,
+      responseStatus,
+      tokensInput: usage.input,
+      tokensOutput: usage.output,
+      tokensCached: usage.cacheRead,
+      tokensCacheWrite: usage.cacheWrite,
+      tokensReasoning: usage.reasoning ?? null,
+      costInput: cost?.input ?? null,
+      costOutput: cost?.output ?? null,
+      costCached: cost?.cacheRead ?? null,
+      costCacheWrite: cost?.cacheWrite ?? null,
+      costTotal: cost?.total ?? null,
+      costSource: 'pi-ai',
+      costMetadata: null,
+      kwhUsed,
+      isDescriptorRequest: true,
+      isVisionFallthrough: false,
+    } as any)
+    .catch((err) => {
+      logger.error(`[vision-fallthrough] Failed to save descriptor usage record: ${err}`);
+    });
+}
+
+async function recordDescriptorErrorUsage(
+  usageStorage: UsageStorageService,
+  descriptorModel: string,
+  startTime: number,
+  route?: import('../../services/router').RouteResult,
+  parentMeta?: VisionFallthroughParentMeta
+): Promise<void> {
+  await usageStorage
+    .saveRequest({
+      requestId: `desc-${crypto.randomUUID()}`,
+      date: new Date().toISOString(),
+      startTime,
+      durationMs: Date.now() - startTime,
+      createdAt: Date.now(),
+      incomingApiType: 'chat',
+      outgoingApiType: null,
+      provider: route?.provider ?? null,
+      selectedModelName: route?.model ?? descriptorModel,
+      canonicalModelName: route?.canonicalModel ?? null,
+      incomingModelAlias: descriptorModel,
+      sourceIp: parentMeta?.sourceIp ?? null,
+      apiKey: parentMeta?.keyName ?? null,
+      attribution: parentMeta?.attribution ?? null,
+      attemptCount: 1,
+      isStreamed: false,
+      isPassthrough: false,
+      responseStatus: 'error',
+      tokensInput: null,
+      tokensOutput: null,
+      tokensCached: null,
+      costInput: null,
+      costOutput: null,
+      costCached: null,
+      costTotal: null,
+      costSource: null,
+      costMetadata: null,
+      isDescriptorRequest: true,
+      isVisionFallthrough: false,
+    } as any)
+    .catch(() => {});
+}
+
+/**
+ * Describe a single image via the configured descriptor model, dispatching
+ * directly through pi-ai (candidate resolution → cooldown/concurrency gate →
+ * `piAiModels.complete()`), with simple sequential failover across
+ * beta-compatible candidates. Results are cached by (model, image-hash).
+ */
+async function describeImage(
+  image: ImageContent,
+  descriptorModel: string,
+  prompt: string,
+  usageStorage?: UsageStorageService,
+  parentMeta?: VisionFallthroughParentMeta
+): Promise<string> {
+  const key = cacheKeyFor(image, descriptorModel);
+  const cached = cacheGet(key);
+  if (cached !== undefined) {
+    logger.debug(`[vision-fallthrough] Cache hit for descriptor model '${descriptorModel}'`);
+    return cached;
+  }
+
+  let candidates;
+  try {
+    candidates = await Router.resolveCandidates(descriptorModel, 'chat');
+    if (candidates.length === 0) {
+      candidates = [await Router.resolve(descriptorModel, 'chat')];
+    }
+  } catch (err) {
+    logger.error(
+      `[vision-fallthrough] No route found for descriptor model '${descriptorModel}':`,
+      err
+    );
+    if (usageStorage) {
+      await recordDescriptorErrorUsage(
+        usageStorage,
+        descriptorModel,
+        Date.now(),
+        undefined,
+        parentMeta
+      );
+    }
+    return 'Error generating image description.';
+  }
+
+  const betaCandidates = candidates.filter((c) => {
+    const piAiProvider = (c.config as any).pi_ai_provider as string | undefined;
+    const piAiModelId = (c.modelConfig as any)?.pi_ai_model_id as string | undefined;
+    if (!piAiProvider || !piAiModelId) return false;
+    return resolvePiAiModel(piAiProvider, piAiModelId) != null;
+  });
+
+  if (betaCandidates.length === 0) {
+    logger.error(
+      `[vision-fallthrough] No beta-compatible candidate for descriptor model '${descriptorModel}'`
+    );
+    if (usageStorage) {
+      await recordDescriptorErrorUsage(
+        usageStorage,
+        descriptorModel,
+        Date.now(),
+        undefined,
+        parentMeta
+      );
+    }
+    return 'Error generating image description.';
+  }
+
+  const descriptorContext: Context = {
+    messages: [
+      {
+        role: 'user',
+        content: [image, { type: 'text', text: prompt } as TextContent],
+        timestamp: Date.now(),
+      },
+    ],
+  };
+
+  const cooldown = CooldownManager.getInstance();
+  const concurrency = ConcurrencyTracker.getInstance();
+
+  for (const route of betaCandidates) {
+    const healthy = await cooldown.isProviderHealthy(route.provider, route.model);
+    if (!healthy) continue;
+
+    if (!concurrency.acquire(route.provider, route.model)) continue;
+
+    const piAiProvider = (route.config as any).pi_ai_provider as string;
+    const piAiModelId = (route.modelConfig as any)?.pi_ai_model_id as string;
+    const piModel = buildPiAiModel(route.config, piAiProvider, piAiModelId, 'chat');
+    if (!piModel) {
+      concurrency.release(route.provider, route.model);
+      continue;
+    }
+
+    const startTime = Date.now();
+    try {
+      logger.debug(
+        `[vision-fallthrough] Dispatching description request to ${route.provider}/${route.model}`
+      );
+      const message = await piAiModels.complete(
+        toDispatchModel(piModel as any),
+        descriptorContext,
+        {
+          apiKey: route.config.api_key,
+          headers: route.config.headers,
+        }
+      );
+
+      cooldown.markProviderSuccess(route.provider, route.model);
+      concurrency.release(route.provider, route.model);
+
+      const textBlock = message.content.find((b) => b.type === 'text') as TextContent | undefined;
+      const description = textBlock?.text?.trim();
+
+      if (usageStorage) {
+        await recordDescriptorUsage(
+          usageStorage,
+          route,
+          piModel,
+          message,
+          startTime,
+          descriptorModel,
+          description ? 'success' : 'error',
+          parentMeta
+        );
+      }
+
+      if (!description) {
+        logger.warn(
+          `[vision-fallthrough] Model ${descriptorModel} returned empty description for image`
+        );
+        return 'No description available.';
+      }
+
+      cacheSet(key, description);
+      return description;
+    } catch (err) {
+      concurrency.release(route.provider, route.model);
+      cooldown.markProviderFailure(route.provider, route.model);
+      logger.error(
+        `[vision-fallthrough] Error describing image with ${route.provider}/${route.model}:`,
+        err
+      );
+      if (usageStorage) {
+        await recordDescriptorErrorUsage(
+          usageStorage,
+          descriptorModel,
+          startTime,
+          route,
+          parentMeta
+        );
+      }
+      // Try the next beta-compatible candidate.
+      continue;
+    }
+  }
+
+  return 'Error generating image description.';
+}
+
+/**
+ * Processes a pi-ai Context by converting image content blocks into text
+ * descriptions produced by `descriptorModel`. Returns a new Context (the
+ * input is never mutated); returns the original reference unchanged when
+ * there are no images.
+ */
+export async function applyVisionFallthrough(
+  context: Context,
+  descriptorModel: string,
+  prompt: string,
+  usageStorage?: UsageStorageService,
+  parentMeta?: VisionFallthroughParentMeta
+): Promise<Context> {
+  const images = collectImages(context.messages);
+  if (images.length === 0) return context;
+
+  logger.debug(
+    `[vision-fallthrough] Describing ${images.length} images using model '${descriptorModel}'`
+  );
+
+  const descriptions = await Promise.all(
+    images.map((image) => describeImage(image, descriptorModel, prompt, usageStorage, parentMeta))
+  );
+
+  const messages = injectDescriptions(context.messages, descriptions);
+
+  logger.debug(`[vision-fallthrough] Replaced ${images.length} images with descriptions`);
+
+  return { ...context, messages };
+}

--- a/packages/backend/src/inference-v2/shared/vision-fallthrough.ts
+++ b/packages/backend/src/inference-v2/shared/vision-fallthrough.ts
@@ -300,16 +300,27 @@ async function describeImage(
 
     if (!concurrency.acquire(route.provider, route.model)) continue;
 
-    const piAiProvider = (route.config as any).pi_ai_provider as string;
-    const piAiModelId = (route.modelConfig as any)?.pi_ai_model_id as string;
-    const piModel = buildPiAiModel(route.config, piAiProvider, piAiModelId, 'chat');
-    if (!piModel) {
+    // Guarantee the concurrency slot is released exactly once regardless of
+    // where in this block a throw occurs (buildPiAiModel, piAiModels.complete,
+    // or the usage-recording call) — mirrors the doRelease pattern used in
+    // pi-ai-executor.ts.
+    let released = false;
+    const doRelease = () => {
+      if (released) return;
+      released = true;
       concurrency.release(route.provider, route.model);
-      continue;
-    }
+    };
 
     const startTime = Date.now();
     try {
+      const piAiProvider = (route.config as any).pi_ai_provider as string;
+      const piAiModelId = (route.modelConfig as any)?.pi_ai_model_id as string;
+      const piModel = buildPiAiModel(route.config, piAiProvider, piAiModelId, 'chat');
+      if (!piModel) {
+        doRelease();
+        continue;
+      }
+
       logger.debug(
         `[vision-fallthrough] Dispatching description request to ${route.provider}/${route.model}`
       );
@@ -323,7 +334,7 @@ async function describeImage(
       );
 
       cooldown.markProviderSuccess(route.provider, route.model);
-      concurrency.release(route.provider, route.model);
+      doRelease();
 
       const textBlock = message.content.find((b) => b.type === 'text') as TextContent | undefined;
       const description = textBlock?.text?.trim();
@@ -345,13 +356,17 @@ async function describeImage(
         logger.warn(
           `[vision-fallthrough] Model ${descriptorModel} returned empty description for image`
         );
+        // Cache the negative result too: an empty descriptor response is a
+        // deterministic model output for this image, not a transient failure,
+        // so retrying on every request would just waste descriptor API calls.
+        cacheSet(key, 'No description available.');
         return 'No description available.';
       }
 
       cacheSet(key, description);
       return description;
     } catch (err) {
-      concurrency.release(route.provider, route.model);
+      doRelease();
       cooldown.markProviderFailure(route.provider, route.model);
       logger.error(
         `[vision-fallthrough] Error describing image with ${route.provider}/${route.model}:`,


### PR DESCRIPTION
### **User description**
## Summary
Implements vision fallthrough for the beta `inference-v2` (pi-ai) path, operating directly on pi-ai's `Context`/`ImageContent`/`TextContent` types — no `UnifiedChatRequest` detour through the legacy `Dispatcher`.

## Changes
- **New:** `packages/backend/src/inference-v2/shared/vision-fallthrough.ts`
  - `contextHasImages(context)` — detects image blocks in a pi-ai `Context`.
  - `applyVisionFallthrough(context, descriptorModel, prompt, usageStorage?, parentMeta?)` — describes each image concurrently via a configured descriptor model, dispatched directly through `piAiModels.complete()` (candidate resolution → cooldown/concurrency gate → sequential failover across beta-compatible candidates). Returns a new `Context` with images replaced by `[Image Description: ...]` text blocks; never mutates the input.
  - LRU description cache keyed by `(model, sha256(imageData))`.
  - Records descriptor sub-call usage (`isDescriptorRequest: true`), mirroring the v1 `VisionDescriptorService`.
- **Modified:** `packages/backend/src/inference-v2/shared/pi-ai-executor.ts`
  - Wired vision fallthrough into the per-candidate failover loop, gated on the alias's `use_image_fallthrough` and the global `vision_fallthrough.descriptor_model` config — matching `dispatcher.ts`'s v1 semantics.
  - Runs before compaction/context-limit enforcement so token estimates reflect post-fallthrough (text-only) content.
  - Threaded `isVisionFallthrough`/`visionFallthroughModel` through all non-streaming and streaming (success/error/exception) usage records.

## Tests
- `vision-fallthrough.test.ts` — unit tests for `contextHasImages`/`applyVisionFallthrough` (multi-image ordering, caching, no-route error fallback).
- Extended `pi-ai-executor.test.ts` — executor-level tests confirming fallthrough triggers only for aliases with `use_image_fallthrough`, that the descriptor call happens before the target dispatch, and that images never reach a text-only target model.

Full backend suite (2091 tests), typecheck, and format checks all pass.


___

### **Description**
- Add native vision fallthrough module for inference-v2 pi-ai path

- Wire fallthrough into `pi-ai-executor` failover loop before compaction

- Thread `isVisionFallthrough` and `visionFallthroughModel` through usage records

- Add unit and executor-level integration tests for fallthrough behavior


___

