### PR TITLE
fix(responses): populate output in response.completed snapshot

### DIFF
--- a/packages/backend/src/inference-v2/responses/__tests__/context-to-responses.test.ts
+++ b/packages/backend/src/inference-v2/responses/__tests__/context-to-responses.test.ts
@@ -158,6 +158,39 @@ describe('eventToResponsesSSE', () => {
     expect(frames.join('\n')).toContain('response.completed');
   });
 
+  it('response.completed snapshot includes the full accumulated output items (reasoning + function_call)', () => {
+    const state = makeResponsesChunkSerialiserState('gpt-4');
+    eventToResponsesSSE({ type: 'start', partial: { content: [] } } as any, state);
+    eventToResponsesSSE({ type: 'thinking_delta', delta: 'Thinking...' } as any, state);
+
+    const toolCall = { type: 'toolCall', id: 'call_1', name: 'list_files', arguments: {} };
+    eventToResponsesSSE(
+      {
+        type: 'toolcall_start',
+        contentIndex: 0,
+        partial: { content: [toolCall] },
+      } as any,
+      state
+    );
+    eventToResponsesSSE({ type: 'toolcall_delta', delta: '{"path":"/"}' } as any, state);
+
+    const message = makeMessage({ stopReason: 'toolUse', content: [toolCall as any] });
+    const frames = eventToResponsesSSE({ type: 'done', reason: 'toolUse', message } as any, state);
+
+    const completedFrame = frames.find((f) => f.includes('response.completed'));
+    expect(completedFrame).toBeDefined();
+    const payload = JSON.parse(completedFrame!.split('data: ')[1]!.trim());
+    const output = payload.response.output as any[];
+
+    expect(output.length).toBe(2);
+    expect(output.some((o) => o.type === 'reasoning')).toBe(true);
+    const fcItem = output.find((o) => o.type === 'function_call');
+    expect(fcItem).toBeDefined();
+    expect(fcItem.name).toBe('list_files');
+    expect(fcItem.call_id).toBe('call_1');
+    expect(fcItem.arguments).toBe('{"path":"/"}');
+  });
+
   it('thinking_delta emits reasoning events', () => {
     const state = makeResponsesChunkSerialiserState('gpt-4');
     eventToResponsesSSE({ type: 'start', partial: { content: [] } } as any, state);

--- a/packages/backend/src/inference-v2/responses/context-to-responses.ts
+++ b/packages/backend/src/inference-v2/responses/context-to-responses.ts
@@ -432,6 +432,12 @@ export function eventToResponsesSSE(
     }
 
     case 'done': {
+      // Accumulate the final output items, keyed by output_index, so the
+      // terminal response.completed snapshot can carry the full list
+      // (matching OpenAI's behaviour — clients treat this as the source of
+      // truth rather than re-deriving it from output_item.done events).
+      const outputItemsByIndex = new Map<number, Record<string, unknown>>();
+
       // Finalize reasoning item
       if (state.reasoningItemId !== null && state.reasoningOutputIndex !== null) {
         frames.push(
@@ -446,24 +452,26 @@ export function eventToResponsesSSE(
             state.sequenceNumber++
           )
         );
+        const reasoningItem = {
+          id: state.reasoningItemId,
+          type: 'reasoning',
+          status: 'completed',
+          content: state.reasoningText
+            ? [{ type: 'reasoning_text', text: state.reasoningText }]
+            : [],
+          summary: [],
+        };
         frames.push(
           sseEvent(
             'response.output_item.done',
             {
               output_index: state.reasoningOutputIndex,
-              item: {
-                id: state.reasoningItemId,
-                type: 'reasoning',
-                status: 'completed',
-                content: state.reasoningText
-                  ? [{ type: 'reasoning_text', text: state.reasoningText }]
-                  : [],
-                summary: [],
-              },
+              item: reasoningItem,
             },
             state.sequenceNumber++
           )
         );
+        outputItemsByIndex.set(state.reasoningOutputIndex, reasoningItem);
       }
 
       // Finalize message item
@@ -498,29 +506,31 @@ export function eventToResponsesSSE(
             state.sequenceNumber++
           )
         );
+        const messageItem = {
+          id: state.messageItemId,
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          content: [
+            {
+              type: 'output_text',
+              annotations: [],
+              logprobs: [],
+              text: state.messageText,
+            },
+          ],
+        };
         frames.push(
           sseEvent(
             'response.output_item.done',
             {
               output_index: state.messageOutputIndex,
-              item: {
-                id: state.messageItemId,
-                type: 'message',
-                status: 'completed',
-                role: 'assistant',
-                content: [
-                  {
-                    type: 'output_text',
-                    annotations: [],
-                    logprobs: [],
-                    text: state.messageText,
-                  },
-                ],
-              },
+              item: messageItem,
             },
             state.sequenceNumber++
           )
         );
+        outputItemsByIndex.set(state.messageOutputIndex, messageItem);
       }
 
       // Finalize tool items
@@ -529,24 +539,30 @@ export function eventToResponsesSSE(
         const name = state.toolNames.get(idx) ?? '';
         const callId = state.toolCallIds.get(idx) ?? '';
         const itemId = state.toolItemIds.get(idx) ?? '';
+        const toolItem = {
+          id: itemId,
+          type: 'function_call',
+          status: 'completed',
+          call_id: callId,
+          name,
+          arguments: args,
+        };
         frames.push(
           sseEvent(
             'response.output_item.done',
             {
               output_index: outputIndex,
-              item: {
-                id: itemId,
-                type: 'function_call',
-                status: 'completed',
-                call_id: callId,
-                name,
-                arguments: args,
-              },
+              item: toolItem,
             },
             state.sequenceNumber++
           )
         );
+        outputItemsByIndex.set(outputIndex, toolItem);
       }
+
+      const outputItems = Array.from(outputItemsByIndex.entries())
+        .sort(([a], [b]) => a - b)
+        .map(([, item]) => item);
 
       // response.completed
       const usage = event.message.usage;
@@ -560,7 +576,7 @@ export function eventToResponsesSSE(
               created_at: state.createdAt,
               status: 'completed',
               model: state.model,
-              output: [], // clients reconstruct from item.done events
+              output: outputItems,
               usage: mapUsage(usage),
             },
           },


### PR DESCRIPTION
### **User description**
## Bug

When proxying a streaming `/v1/responses` request, Plexus correctly emits incremental `response.output_item.added` / `response.output_item.done` events for each output item (e.g. `reasoning`, `function_call`), but the terminal `response.completed` event carried a `response` object with an empty `output` array (`"output": []`).

Per the OpenAI Responses API spec, the `response` object in the terminal `response.completed` event must be the complete, authoritative snapshot of the final response — clients (including the official OpenAI SDK's streaming accumulator) are entitled to read `response.completed.response.output` as the source of truth instead of re-deriving it from streamed `output_item.done` events.

### Impact
Clients that read tool calls from the final snapshot (rather than accumulating streamed deltas) saw zero tool calls, so the tool was never executed and the turn produced no visible output.

## Fix

In `packages/backend/src/inference-v2/responses/context-to-responses.ts`, the `'done'` branch of `eventToResponsesSSE` now accumulates each finalized output item (reasoning, message, function_call) into a map keyed by `output_index` as it builds the corresponding `response.output_item.done` frames, then sorts by index and populates `response.completed.response.output` with the full list — mirroring the already-correct pattern in the sibling transformer `packages/backend/src/transformers/responses.ts` (`finalizeOutputItems`).

## Testing

- Added a regression test (`response.completed snapshot includes the full accumulated output items (reasoning + function_call)`) asserting the final snapshot's `output` array contains both a `reasoning` item and a `function_call` item with correct `name`, `call_id`, and `arguments`.
- `bun run test` — all 2093 tests pass.
- `bun run typecheck` — pass.
- `bun run format:check` / lint — pass.


___

### **Description**
- Populate `response.completed` snapshot with accumulated output items

- Accumulate reasoning, message, and function_call items by `output_index`

- Sort accumulated items and replace empty `output` array in final event

- Add regression test for full snapshot with reasoning and function_call


___

