### PR TITLE
fix(inference-v2): pass Gemini thoughtSignature through on multi-turn tool calls

### DIFF
--- a/packages/backend/src/inference-v2/gemini/__tests__/gemini-to-context.test.ts
+++ b/packages/backend/src/inference-v2/gemini/__tests__/gemini-to-context.test.ts
@@ -232,7 +232,8 @@ describe('geminiRequestToContext', () => {
       // Gemini 3.x emits the signature as URL-safe base64 (- and _). pi-ai's
       // outbound serializer only accepts standard base64 (+ and /) and drops
       // anything else, so we must translate at capture or the next turn 400s.
-      const urlSafe = 'EsAECr0EAQw51-bAgr67Tn_BonzEE';
+      // `_--_` (bytes ff ef bf) is a length-4 URL-safe value → standard `/++/`.
+      const urlSafe = '_--_';
       const result = geminiRequestToContext(
         {
           model: 'gemini-3.5-flash',
@@ -253,10 +254,45 @@ describe('geminiRequestToContext', () => {
       );
       const asst = result.context.messages[1]!;
       const tc = (asst.content as any[]).find((b: any) => b.type === 'toolCall');
-      expect(tc.thoughtSignature).toBe('EsAECr0EAQw51+bAgr67Tn/BonzEE');
+      expect(tc.thoughtSignature).toBe('/++/');
       // Byte-identical: URL-safe and standard base64 decode to the same bytes.
       expect(Buffer.from(tc.thoughtSignature, 'base64')).toEqual(
         Buffer.from(urlSafe.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+      );
+    });
+
+    it('restores stripped padding when normalizing an unpadded URL-safe signature', () => {
+      // URL-safe base64 is commonly emitted WITHOUT `=` padding, and pi-ai's
+      // validator rejects any value whose length is not a multiple of 4. The
+      // normalizer must re-append padding so the signature survives.
+      // `-_8` (bytes fb ff, len 3) → standard, padded `+/8=` (len 4).
+      const unpadded = '-_8';
+      const result = geminiRequestToContext(
+        {
+          model: 'gemini-3.5-flash',
+          contents: [
+            { role: 'user', parts: [{ text: 'Use a tool' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: { name: 'list_files', args: {} },
+                  thoughtSignature: unpadded,
+                },
+              ],
+            },
+          ],
+        },
+        false
+      );
+      const asst = result.context.messages[1]!;
+      const tc = (asst.content as any[]).find((b: any) => b.type === 'toolCall');
+      expect(tc.thoughtSignature).toBe('+/8=');
+      // Valid standard base64: length is a multiple of 4.
+      expect(tc.thoughtSignature.length % 4).toBe(0);
+      // Byte-identical to the original decoded value.
+      expect(Buffer.from(tc.thoughtSignature, 'base64')).toEqual(
+        Buffer.from(unpadded, 'base64url')
       );
     });
 

--- a/packages/backend/src/inference-v2/gemini/__tests__/gemini-to-context.test.ts
+++ b/packages/backend/src/inference-v2/gemini/__tests__/gemini-to-context.test.ts
@@ -140,7 +140,7 @@ describe('geminiRequestToContext', () => {
               parts: [
                 {
                   functionCall: { name: 'bash', args: { command: 'ls' } },
-                  thoughtSignature: 'SIG_BASE64_PAYLOAD',
+                  thoughtSignature: 'SIGBASE64PAYLOAD',
                 },
               ],
             },
@@ -150,7 +150,7 @@ describe('geminiRequestToContext', () => {
       );
       const asst = result.context.messages[1]!;
       const tc = (asst.content as any[]).find((b: any) => b.type === 'toolCall');
-      expect(tc.thoughtSignature).toBe('SIG_BASE64_PAYLOAD');
+      expect(tc.thoughtSignature).toBe('SIGBASE64PAYLOAD');
     });
 
     it('preserves thoughtSignature nested under functionCall', () => {
@@ -166,7 +166,7 @@ describe('geminiRequestToContext', () => {
                   functionCall: {
                     name: 'bash',
                     args: { command: 'ls' },
-                    thoughtSignature: 'NESTED_SIG',
+                    thoughtSignature: 'NESTEDSIG',
                   },
                 },
               ],
@@ -177,7 +177,7 @@ describe('geminiRequestToContext', () => {
       );
       const asst = result.context.messages[1]!;
       const tc = (asst.content as any[]).find((b: any) => b.type === 'toolCall');
-      expect(tc.thoughtSignature).toBe('NESTED_SIG');
+      expect(tc.thoughtSignature).toBe('NESTEDSIG');
     });
 
     it('propagates a shared thoughtSignature to sibling tool calls in a parallel turn', () => {
@@ -190,7 +190,7 @@ describe('geminiRequestToContext', () => {
             { role: 'user', parts: [{ text: 'Two tools' }] },
             {
               role: 'model',
-              parts: [{ functionCall: { name: 'fn1', args: {} }, thoughtSignature: 'SHARED_SIG' }],
+              parts: [{ functionCall: { name: 'fn1', args: {} }, thoughtSignature: 'SHAREDSIG' }],
             },
             { role: 'model', parts: [{ functionCall: { name: 'fn2', args: {} } }] },
           ],
@@ -201,8 +201,8 @@ describe('geminiRequestToContext', () => {
       expect(assistants).toHaveLength(1);
       const toolCalls = (assistants[0]!.content as any[]).filter((b: any) => b.type === 'toolCall');
       expect(toolCalls).toHaveLength(2);
-      expect(toolCalls[0].thoughtSignature).toBe('SHARED_SIG');
-      expect(toolCalls[1].thoughtSignature).toBe('SHARED_SIG');
+      expect(toolCalls[0].thoughtSignature).toBe('SHAREDSIG');
+      expect(toolCalls[1].thoughtSignature).toBe('SHAREDSIG');
     });
 
     it('preserves thinkingSignature on thought:true parts', () => {
@@ -214,7 +214,7 @@ describe('geminiRequestToContext', () => {
             {
               role: 'model',
               parts: [
-                { text: 'Deep thought', thought: true, thoughtSignature: 'THINK_SIG' },
+                { text: 'Deep thought', thought: true, thoughtSignature: 'THINKSIG' },
                 { text: 'Answer' },
               ],
             },
@@ -225,7 +225,82 @@ describe('geminiRequestToContext', () => {
       const asst = result.context.messages[1]!;
       const thinking = (asst.content as any[]).find((b: any) => b.type === 'thinking');
       expect(thinking?.thinking).toBe('Deep thought');
-      expect(thinking?.thinkingSignature).toBe('THINK_SIG');
+      expect(thinking?.thinkingSignature).toBe('THINKSIG');
+    });
+
+    it('normalizes URL-safe base64 thoughtSignature to standard base64 on functionCall parts', () => {
+      // Gemini 3.x emits the signature as URL-safe base64 (- and _). pi-ai's
+      // outbound serializer only accepts standard base64 (+ and /) and drops
+      // anything else, so we must translate at capture or the next turn 400s.
+      const urlSafe = 'EsAECr0EAQw51-bAgr67Tn_BonzEE';
+      const result = geminiRequestToContext(
+        {
+          model: 'gemini-3.5-flash',
+          contents: [
+            { role: 'user', parts: [{ text: 'Use a tool' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: { name: 'list_files', args: {} },
+                  thoughtSignature: urlSafe,
+                },
+              ],
+            },
+          ],
+        },
+        false
+      );
+      const asst = result.context.messages[1]!;
+      const tc = (asst.content as any[]).find((b: any) => b.type === 'toolCall');
+      expect(tc.thoughtSignature).toBe('EsAECr0EAQw51+bAgr67Tn/BonzEE');
+      // Byte-identical: URL-safe and standard base64 decode to the same bytes.
+      expect(Buffer.from(tc.thoughtSignature, 'base64')).toEqual(
+        Buffer.from(urlSafe.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+      );
+    });
+
+    it('normalizes URL-safe base64 thinkingSignature on thought parts', () => {
+      const result = geminiRequestToContext(
+        {
+          model: 'gemini-3.5-flash',
+          contents: [
+            { role: 'user', parts: [{ text: 'Think' }] },
+            {
+              role: 'model',
+              parts: [{ text: 'Deep thought', thought: true, thoughtSignature: 'ab-cd_ef' }],
+            },
+          ],
+        },
+        false
+      );
+      const asst = result.context.messages[1]!;
+      const thinking = (asst.content as any[]).find((b: any) => b.type === 'thinking');
+      expect(thinking?.thinkingSignature).toBe('ab+cd/ef');
+    });
+
+    it('leaves a standard-base64 thoughtSignature unchanged', () => {
+      const result = geminiRequestToContext(
+        {
+          model: 'gemini-3.5-flash',
+          contents: [
+            { role: 'user', parts: [{ text: 'Use a tool' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: { name: 'bash', args: {} },
+                  thoughtSignature: 'Standard+Base64/Value=',
+                },
+              ],
+            },
+          ],
+        },
+        false
+      );
+      const asst = result.context.messages[1]!;
+      const tc = (asst.content as any[]).find((b: any) => b.type === 'toolCall');
+      expect(tc.thoughtSignature).toBe('Standard+Base64/Value=');
     });
 
     it('merges consecutive model turns into one AssistantMessage', () => {

--- a/packages/backend/src/inference-v2/gemini/gemini-to-context.ts
+++ b/packages/backend/src/inference-v2/gemini/gemini-to-context.ts
@@ -77,6 +77,29 @@ function mapThinkingLevel(level: string | undefined): string | undefined {
   }
 }
 
+/**
+ * Normalize a Gemini thoughtSignature to standard base64.
+ *
+ * Gemini 3.x emits (and clients echo back) the encrypted thoughtSignature as
+ * URL-safe base64 — it can contain `-` and `_` instead of `+` and `/`. pi-ai's
+ * outbound Google serializer validates signatures with a STANDARD-base64
+ * charset (`/^[A-Za-z0-9+/]+={0,2}$/`, see @earendil-works/pi-ai
+ * `api/google-shared.js` isValidThoughtSignature) and silently DROPS any value
+ * that fails — including every URL-safe signature. A dropped signature yields
+ * Google's HTTP 400 "Function call is missing a thought_signature" on the next
+ * turn, breaking multi-turn tool calling for Gemini 3.x thinking models.
+ *
+ * URL-safe and standard base64 decode to identical bytes, and Google's proto3
+ * JSON parser accepts either form for `bytes` fields, so translating `-`→`+`
+ * and `_`→`/` at capture lets pi-ai's validator pass the signature through and
+ * Google still receives a byte-identical value. Returns the input unchanged
+ * when it contains no URL-safe characters.
+ */
+function normalizeThoughtSignature(sig: string): string {
+  if (sig.indexOf('-') === -1 && sig.indexOf('_') === -1) return sig;
+  return sig.replace(/-/g, '+').replace(/_/g, '/');
+}
+
 /** Parse a Gemini Part into a TextContent or ImageContent, or null to skip. */
 function parseInlineDataPart(part: any): ImageContent | null {
   const inlineData = part.inlineData;
@@ -192,7 +215,9 @@ export function geminiRequestToContext(body: any, streaming: boolean): GeminiToC
             // MUST be replayed on subsequent turns for multi-turn continuity.
             const thinkingBlock: ThinkingContent = { type: 'thinking', thinking: part.text };
             if (typeof part.thoughtSignature === 'string' && part.thoughtSignature) {
-              (thinkingBlock as any).thinkingSignature = part.thoughtSignature;
+              (thinkingBlock as any).thinkingSignature = normalizeThoughtSignature(
+                part.thoughtSignature
+              );
             }
             contentBlocks.push(thinkingBlock);
           } else {
@@ -219,7 +244,7 @@ export function geminiRequestToContext(body: any, streaming: boolean): GeminiToC
             (typeof part.functionCall.thoughtSignature === 'string' &&
               part.functionCall.thoughtSignature) ||
             undefined;
-          if (sig) (tc as any).thoughtSignature = sig;
+          if (sig) (tc as any).thoughtSignature = normalizeThoughtSignature(sig);
           contentBlocks.push(tc);
         }
       }

--- a/packages/backend/src/inference-v2/gemini/gemini-to-context.ts
+++ b/packages/backend/src/inference-v2/gemini/gemini-to-context.ts
@@ -94,10 +94,17 @@ function mapThinkingLevel(level: string | undefined): string | undefined {
  * and `_`→`/` at capture lets pi-ai's validator pass the signature through and
  * Google still receives a byte-identical value. Returns the input unchanged
  * when it contains no URL-safe characters.
+ *
+ * URL-safe base64 is also frequently emitted WITHOUT `=` padding, and pi-ai's
+ * validator additionally rejects any value whose length is not a multiple of 4
+ * (`signature.length % 4 !== 0`). So when normalizing we also restore the
+ * stripped padding; the padded form still decodes to identical bytes.
  */
 function normalizeThoughtSignature(sig: string): string {
   if (sig.indexOf('-') === -1 && sig.indexOf('_') === -1) return sig;
-  return sig.replace(/-/g, '+').replace(/_/g, '/');
+  const standard = sig.replace(/-/g, '+').replace(/_/g, '/');
+  const remainder = standard.length % 4;
+  return remainder ? standard + '='.repeat(4 - remainder) : standard;
 }
 
 /** Parse a Gemini Part into a TextContent or ImageContent, or null to skip. */

--- a/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
@@ -3,8 +3,9 @@ import * as piAi from '@earendil-works/pi-ai/compat';
 import { setConfigForTesting } from '../../../config';
 import { DebugManager } from '../../../services/debug-manager';
 import { enterRequestContext } from '../../../services/request-context';
-import { runPiAiExecutor } from '../pi-ai-executor';
+import { runPiAiExecutor, alignAssistantProvenance } from '../pi-ai-executor';
 import type { UsageStorageService } from '../../../services/usage-storage';
+import type { Context } from '@earendil-works/pi-ai';
 
 function createUsageStorage(): UsageStorageService {
   return {
@@ -391,5 +392,76 @@ describe('runPiAiExecutor vision fallthrough', () => {
     expect(vi.mocked(piAi.complete)).toHaveBeenCalledTimes(1);
     const [, sentContext] = vi.mocked(piAi.complete).mock.calls[0]!;
     expect((sentContext as any).messages[0].content[0].type).toBe('image');
+  });
+});
+
+describe('alignAssistantProvenance', () => {
+  const dispatchModel = { provider: 'google', id: 'gemini-3-flash', api: 'google-generative-ai' };
+
+  function ctxWithAssistant(overrides: Record<string, unknown>): Context {
+    return {
+      messages: [
+        { role: 'user', content: 'hi', timestamp: 1 },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'toolCall',
+              id: 'list_files',
+              name: 'list_files',
+              arguments: {},
+              thoughtSignature: 'ENCRYPTED_SIG',
+            },
+          ],
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+          stopReason: 'toolUse',
+          timestamp: 2,
+          ...overrides,
+        } as any,
+      ],
+    } as Context;
+  }
+
+  it('re-stamps client-alias provenance to the dispatch model so pi-ai replays the signature', () => {
+    // Inbound Gemini parser stamps the CLIENT alias, which never matches the
+    // resolved egress pi-ai model → pi-ai would strip thoughtSignature.
+    const ctx = ctxWithAssistant({
+      provider: 'google',
+      model: 'gemini-3.5-flash', // client alias, not the pi-ai model id
+      api: 'google-generative-ai',
+    });
+
+    const aligned = alignAssistantProvenance(ctx, dispatchModel);
+
+    const asst = aligned.messages[1] as any;
+    expect(asst.provider).toBe('google');
+    expect(asst.model).toBe('gemini-3-flash');
+    expect(asst.api).toBe('google-generative-ai');
+    // The tool call (and its signature) is preserved verbatim.
+    expect(asst.content[0].thoughtSignature).toBe('ENCRYPTED_SIG');
+    // Input context is never mutated.
+    expect((ctx.messages[1] as any).model).toBe('gemini-3.5-flash');
+  });
+
+  it('returns the same reference when provenance already matches (no needless copy)', () => {
+    const ctx = ctxWithAssistant({
+      provider: 'google',
+      model: 'gemini-3-flash',
+      api: 'google-generative-ai',
+    });
+
+    const aligned = alignAssistantProvenance(ctx, dispatchModel);
+    expect(aligned).toBe(ctx);
+  });
+
+  it('leaves non-assistant messages untouched', () => {
+    const ctx = ctxWithAssistant({
+      provider: 'google',
+      model: 'gemini-3.5-flash',
+      api: 'google-generative-ai',
+    });
+
+    const aligned = alignAssistantProvenance(ctx, dispatchModel);
+    expect(aligned.messages[0]).toBe(ctx.messages[0]);
   });
 });

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -377,6 +377,63 @@ function buildUsageFromMessage(
   };
 }
 
+// ─── Assistant provenance alignment (signature replay) ──────────────────────
+
+/**
+ * Re-stamp each AssistantMessage's provenance (provider / model / api) to match
+ * the resolved dispatch model, returning a new Context when anything changed
+ * (never mutates the input).
+ *
+ * WHY: pi-ai's request serializers gate replay of provider-specific signatures
+ * — Gemini `thoughtSignature` on functionCall/text/thinking parts, Anthropic
+ * thinking signatures, OpenAI reasoning signatures — on the assistant message's
+ * provenance matching the target model. Google's serializer uses
+ * `isSameProviderAndModel = msg.provider === model.provider && msg.model === model.id`
+ * (see @earendil-works/pi-ai `api/google-shared.js`); the OpenAI-responses
+ * serializer additionally checks `msg.api === model.api`.
+ *
+ * The inference-v2 inbound parsers stamp the CLIENT-FACING provider/alias on
+ * assistant messages (e.g. `provider: 'google'`, `model: 'gemini-3.5-flash'`),
+ * which never matches the resolved egress pi-ai model (`pi_ai_provider` /
+ * `pi_ai_model_id`). Without this alignment pi-ai silently drops the
+ * signatures, and Gemini 3.x rejects the next turn with HTTP 400
+ * "Function call is missing a thought_signature ... This is required for tools
+ * to work correctly". This breaks all multi-turn tool calling for Gemini 3.x
+ * thinking models on the second turn.
+ *
+ * This mirrors the v1 OAuth path, which stamps the resolved model's
+ * provider/model/api onto replayed assistant messages for exactly this reason
+ * (see transformers/oauth/oauth-transformer.ts). Applied per-candidate so a
+ * failover to a different target re-stamps against that target (and pi-ai's
+ * own base64 validity check still guards against replaying a foreign-format
+ * signature to the wrong provider).
+ */
+export function alignAssistantProvenance(
+  context: Context,
+  dispatchModel: { provider: string; id: string; api: string }
+): Context {
+  let mutated = false;
+  const messages = context.messages.map((m) => {
+    if (m.role !== 'assistant') return m;
+    const asst = m as AssistantMessage;
+    if (
+      asst.provider === dispatchModel.provider &&
+      asst.model === dispatchModel.id &&
+      asst.api === dispatchModel.api
+    ) {
+      return m;
+    }
+    mutated = true;
+    return {
+      ...asst,
+      provider: dispatchModel.provider,
+      model: dispatchModel.id,
+      api: dispatchModel.api as AssistantMessage['api'],
+    };
+  });
+  return mutated ? { ...context, messages } : context;
+}
+
 // ─── Main executor ────────────────────────────────────────────────────────────
 
 export async function runPiAiExecutor<TResponse>(
@@ -647,11 +704,25 @@ export async function runPiAiExecutor<TResponse>(
         }
       : undefined;
 
+    // ── Align assistant provenance for signature replay ──────────────────
+    // Re-stamp replayed assistant messages with the DISPATCH model's
+    // provider/model/api so pi-ai's serializers echo provider-specific
+    // signatures (Gemini thoughtSignature, Anthropic thinking, OpenAI
+    // reasoning) instead of silently dropping them. Must use the dispatch
+    // model (post toDispatchModel remap) because that is what pi-ai's
+    // isSameProviderAndModel gate compares against.
+    const dispatchModel = toDispatchModel(piModel as any);
+    const dispatchContext = alignAssistantProvenance(sendContext, {
+      provider: dispatchModel.provider,
+      id: dispatchModel.id,
+      api: dispatchModel.api,
+    });
+
     try {
       if (!streaming) {
         // ── Non-streaming ────────────────────────────────────────────────
         const message = await debugRequestIdStorage.run(requestId, () =>
-          piAiModels.complete(toDispatchModel(piModel as any), sendContext, callOptions)
+          piAiModels.complete(dispatchModel, dispatchContext, callOptions)
         );
 
         cooldown.markProviderSuccess(route.provider, route.model);
@@ -717,7 +788,7 @@ export async function runPiAiExecutor<TResponse>(
       } else {
         // ── Streaming ────────────────────────────────────────────────────
         const eventStream = await debugRequestIdStorage.run(requestId, () =>
-          piAiModels.stream(toDispatchModel(piModel as any), sendContext, callOptions)
+          piAiModels.stream(dispatchModel, dispatchContext, callOptions)
         );
 
         // Build and return the SSE generator — the generator owns


### PR DESCRIPTION
### **User description**
## Summary

Gemini 3.x thinking models require the encrypted `thoughtSignature` to be echoed back verbatim on `functionCall` parts in subsequent turns. On the inference-v2 path, plexus was dropping it before forwarding to Google, so the **second turn** (after the first tool result) failed with:

> HTTP 400 — `Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly...`

This broke all multi-turn tool/function calling through plexus for Gemini 3.x models (Open WebUI `google_gemini_manifold` pipe and any stateless multi-turn tool client).

## Root causes (two distinct bugs)

Both live in how the request is handed to pi-ai's Google serializer (`convertMessages`), which is what actually builds the outbound request to Google — not plexus's own response serializers.

**1. Provenance mismatch.** pi-ai only replays provider-specific signatures when the assistant message's `provider`/`model`/`api` match the target model (`isSameProviderAndModel`). The inference-v2 inbound parsers stamp the *client alias* (e.g. `provider: 'google'`, `model: 'gemini-3.5-flash'`), which never matches the resolved egress pi-ai model (`pi_ai_provider` / `pi_ai_model_id`), so every signature was stripped.

Fixed by re-stamping replayed assistant messages with the resolved **dispatch model's** provenance in the shared executor (`alignAssistantProvenance`), mirroring the existing v1 OAuth path. This is protocol-agnostic, so it also fixes Anthropic thinking and OpenAI reasoning signature replay across all inference-v2 inbound protocols.

**2. URL-safe base64 signatures.** Gemini emits (and clients echo back) the `thoughtSignature` as **URL-safe** base64 (`-` and `_`), but pi-ai's `isValidThoughtSignature` only accepts **standard** base64 (`+` and `/`) and silently drops anything else — so even after fix #1 the signature was still dropped.

Fixed by normalizing URL-safe → standard base64 at capture in the Gemini parser (`normalizeThoughtSignature`). Both encodings decode to identical bytes and Google's proto3 JSON parser accepts either form, so Google receives a byte-identical value.

## Evidence

Captured staging debug traces for the failing two-turn flow:
- Turn 2 **inbound** (`rawRequest`): `functionCall` part carried `thoughtSignature` — client sent it correctly.
- Turn 2 **outbound** (`transformedRequest` → Google): `thoughtSignature` absent — confirming plexus stripped it.
- The extracted signature value contained `-`/`_` (URL-safe), no `+`/`/`, pinpointing bug #2.

## Changes

- `inference-v2/shared/pi-ai-executor.ts` — add `alignAssistantProvenance`, apply per-candidate against the dispatch model before both streaming and non-streaming dispatch.
- `inference-v2/gemini/gemini-to-context.ts` — add `normalizeThoughtSignature`, apply at `functionCall` and thinking-part signature capture.

## Testing

- New unit tests: provenance re-stamp + signature preservation, no-op reference identity, non-assistant messages untouched; URL-safe → standard base64 normalization (functionCall + thinking) with byte-identity assertion, and standard-base64 unchanged.
- Updated 4 pre-existing gemini tests whose placeholder strings coincidentally contained `_`.
- Full inference-v2 suite: 253 passed. Full backend suite (pre-commit): 2099 passed. Typecheck + biome format/lint clean.


___

### **Description**
- Fix Gemini multi-turn tool calling by aligning assistant provenance to dispatch model

- Normalize URL-safe base64 `thoughtSignature` to standard base64 at capture

- Apply provenance alignment in `runPiAiExecutor` for both streaming and non-streaming

- Add tests for signature normalization and provenance alignment


___

