### PR TITLE
fix(inference-v2): honor Anthropic adaptive thinking (was silently disabled)

### DIFF
--- a/packages/backend/src/inference-v2/anthropic/__tests__/anthropic-to-context.test.ts
+++ b/packages/backend/src/inference-v2/anthropic/__tests__/anthropic-to-context.test.ts
@@ -207,18 +207,21 @@ describe('anthropicRequestToContext', () => {
       });
     });
 
-    it('maps thinking.type=adaptive to effort=high (adaptive default)', () => {
+    it('maps thinking.type=adaptive to an adaptive intent (no pinned effort)', () => {
       const result = anthropicRequestToContext({
         model: 'claude-sonnet-5',
         messages: [{ role: 'user', content: 'Think' }],
         thinking: { type: 'adaptive', display: 'summarized' },
       });
       expect(result.generationIntent.reasoning).toEqual({
-        effort: 'high',
+        adaptive: true,
         enabled: true,
         visibility: 'summary',
         source: 'client',
       });
+      // Adaptive must NOT pin a concrete effort at the parser layer — the
+      // egress decides whether to pass through or flatten.
+      expect(result.generationIntent.reasoning.effort).toBeUndefined();
     });
 
     it('maps adaptive display=raw to full visibility', () => {
@@ -228,34 +231,34 @@ describe('anthropicRequestToContext', () => {
         thinking: { type: 'adaptive', display: 'raw' },
       });
       expect(result.generationIntent.reasoning).toEqual({
-        effort: 'high',
+        adaptive: true,
         enabled: true,
         visibility: 'full',
         source: 'client',
       });
     });
 
-    it('maps adaptive with no display to effort=high', () => {
+    it('maps adaptive with no display to a bare adaptive intent', () => {
       const result = anthropicRequestToContext({
         model: 'claude-sonnet-5',
         messages: [{ role: 'user', content: 'Think' }],
         thinking: { type: 'adaptive' },
       });
       expect(result.generationIntent.reasoning).toEqual({
-        effort: 'high',
+        adaptive: true,
         enabled: true,
         source: 'client',
       });
     });
 
-    it('maps enabled type with no budget_tokens to effort=high', () => {
+    it('maps enabled type with no budget_tokens to an adaptive intent', () => {
       const result = anthropicRequestToContext({
         model: 'claude-sonnet-5',
         messages: [{ role: 'user', content: 'Think' }],
         thinking: { type: 'enabled' },
       });
       expect(result.generationIntent.reasoning).toEqual({
-        effort: 'high',
+        adaptive: true,
         enabled: true,
         source: 'client',
       });

--- a/packages/backend/src/inference-v2/anthropic/__tests__/anthropic-to-context.test.ts
+++ b/packages/backend/src/inference-v2/anthropic/__tests__/anthropic-to-context.test.ts
@@ -207,6 +207,60 @@ describe('anthropicRequestToContext', () => {
       });
     });
 
+    it('maps thinking.type=adaptive to effort=high (adaptive default)', () => {
+      const result = anthropicRequestToContext({
+        model: 'claude-sonnet-5',
+        messages: [{ role: 'user', content: 'Think' }],
+        thinking: { type: 'adaptive', display: 'summarized' },
+      });
+      expect(result.generationIntent.reasoning).toEqual({
+        effort: 'high',
+        enabled: true,
+        visibility: 'summary',
+        source: 'client',
+      });
+    });
+
+    it('maps adaptive display=raw to full visibility', () => {
+      const result = anthropicRequestToContext({
+        model: 'claude-sonnet-5',
+        messages: [{ role: 'user', content: 'Think' }],
+        thinking: { type: 'adaptive', display: 'raw' },
+      });
+      expect(result.generationIntent.reasoning).toEqual({
+        effort: 'high',
+        enabled: true,
+        visibility: 'full',
+        source: 'client',
+      });
+    });
+
+    it('maps adaptive with no display to effort=high', () => {
+      const result = anthropicRequestToContext({
+        model: 'claude-sonnet-5',
+        messages: [{ role: 'user', content: 'Think' }],
+        thinking: { type: 'adaptive' },
+      });
+      expect(result.generationIntent.reasoning).toEqual({
+        effort: 'high',
+        enabled: true,
+        source: 'client',
+      });
+    });
+
+    it('maps enabled type with no budget_tokens to effort=high', () => {
+      const result = anthropicRequestToContext({
+        model: 'claude-sonnet-5',
+        messages: [{ role: 'user', content: 'Think' }],
+        thinking: { type: 'enabled' },
+      });
+      expect(result.generationIntent.reasoning).toEqual({
+        effort: 'high',
+        enabled: true,
+        source: 'client',
+      });
+    });
+
     it('builds an explicit-disable intent when thinking.type is disabled', () => {
       const result = anthropicRequestToContext({
         model: 'claude-opus-4-6',

--- a/packages/backend/src/inference-v2/anthropic/anthropic-to-context.ts
+++ b/packages/backend/src/inference-v2/anthropic/anthropic-to-context.ts
@@ -278,14 +278,15 @@ export function anthropicRequestToContext(body: any): AnthropicToContextResult {
     }
   } else if (thinkingType === 'adaptive' || thinkingType === 'enabled') {
     // Adaptive (or 'enabled' with no explicit budget): thinking is on and the
-    // client did not commit to a token budget. Map to effort 'high' to match
-    // the documented adaptive default (e.g. OpenRouter Claude 5: "adaptive
-    // thinking on at effort high"). Emitting a concrete effort avoids the
-    // shared pipeline collapsing an effort-less intent to a lower magnitude —
-    // and, critically, avoids it being flattened to a reasoning-disabling
-    // "none" on the OpenAI-completions egress.
+    // client did not commit to a magnitude — the model decides. Flag this as
+    // `adaptive` rather than pinning an effort, so a native Anthropic adaptive
+    // egress can pass `thinkingEnabled: true` through with no effort (true
+    // model-decides behavior). Egress families that cannot express adaptive
+    // (OpenAI-completions / OpenRouter, Gemini, legacy budget-based Anthropic)
+    // flatten it to the documented default effort via intentToEffort — which,
+    // critically, is never the reasoning-disabling "none".
     reasoningIntent = {
-      effort: 'high',
+      adaptive: true,
       enabled: true,
       source: 'client',
       ...(visibility ? { visibility } : {}),

--- a/packages/backend/src/inference-v2/anthropic/anthropic-to-context.ts
+++ b/packages/backend/src/inference-v2/anthropic/anthropic-to-context.ts
@@ -36,7 +36,7 @@ import type {
 } from '@earendil-works/pi-ai';
 import { jsonSchemaToTypeBox } from '../../transformers/oauth/type-mappers';
 import type { ReasoningIntent } from '../shared/reasoning';
-import { budgetToEffort } from '../shared/reasoning';
+import { budgetToEffort, normalizeVisibility } from '../shared/reasoning';
 import type { GenerationIntent } from '../shared/generation';
 
 // ─── Public result type ───────────────────────────────────────────────────────
@@ -252,18 +252,45 @@ export function anthropicRequestToContext(body: any): AnthropicToContextResult {
   };
 
   // ── Reasoning intent (from thinking config) ──────────────────────────────
-  // Anthropic speaks in token budgets. Preserve the raw budget so an
-  // Anthropic→Anthropic route can round-trip it without re-quantizing.
+  // Anthropic expresses thinking in three ways:
+  //   - { type: 'enabled', budget_tokens } → explicit token budget (legacy)
+  //   - { type: 'adaptive', display }       → thinking on, model picks magnitude
+  //   - { type: 'disabled' }                → explicit off
+  // `display` ('summarized' | 'raw') maps to reasoning-output visibility.
+  // For 'enabled' we preserve the raw budget so an Anthropic→Anthropic route
+  // can round-trip it without re-quantizing.
   let reasoningIntent: ReasoningIntent = { source: 'client' };
-  if (body.thinking?.type === 'enabled' && body.thinking?.budget_tokens != null) {
+  const thinkingType: unknown = body.thinking?.type;
+  const visibility = normalizeVisibility(body.thinking?.display);
+  if (thinkingType === 'enabled' && body.thinking?.budget_tokens != null) {
     const budget: number = body.thinking.budget_tokens;
     const level = budgetToEffort(budget);
     if (level !== 'off') {
-      reasoningIntent = { effort: level, budgetTokens: budget, enabled: true, source: 'client' };
+      reasoningIntent = {
+        effort: level,
+        budgetTokens: budget,
+        enabled: true,
+        source: 'client',
+        ...(visibility ? { visibility } : {}),
+      };
     } else {
       reasoningIntent = { enabled: false, source: 'client' };
     }
-  } else if (body.thinking?.type === 'disabled') {
+  } else if (thinkingType === 'adaptive' || thinkingType === 'enabled') {
+    // Adaptive (or 'enabled' with no explicit budget): thinking is on and the
+    // client did not commit to a token budget. Map to effort 'high' to match
+    // the documented adaptive default (e.g. OpenRouter Claude 5: "adaptive
+    // thinking on at effort high"). Emitting a concrete effort avoids the
+    // shared pipeline collapsing an effort-less intent to a lower magnitude —
+    // and, critically, avoids it being flattened to a reasoning-disabling
+    // "none" on the OpenAI-completions egress.
+    reasoningIntent = {
+      effort: 'high',
+      enabled: true,
+      source: 'client',
+      ...(visibility ? { visibility } : {}),
+    };
+  } else if (thinkingType === 'disabled') {
     reasoningIntent = { enabled: false, source: 'client' };
   }
 

--- a/packages/backend/src/inference-v2/shared/__tests__/build-reasoning-for-model.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/build-reasoning-for-model.test.ts
@@ -98,6 +98,57 @@ describe('buildReasoningOptionsForModel', () => {
       expect(opts.thinkingBudgetTokens).toBeUndefined();
     });
 
+    it('adaptive model + adaptive intent passes through with NO effort (model decides)', () => {
+      const model = {
+        api: 'anthropic-messages',
+        reasoning: true,
+        compat: { forceAdaptiveThinking: true },
+        thinkingLevelMap: { high: 'high', xhigh: 'max' },
+      } as any;
+      const opts = buildReasoningOptionsForModel(
+        model,
+        intent({ adaptive: true, enabled: true, visibility: 'summary' })
+      );
+      // True adaptive: thinking on, no effort pinned, model chooses magnitude.
+      expect(opts.thinkingEnabled).toBe(true);
+      expect(opts.effort).toBeUndefined();
+      expect(opts.thinkingBudgetTokens).toBeUndefined();
+      expect(opts.thinkingDisplay).toBe('summarized');
+      // No leftover streamSimple-compat reasoning level.
+      expect(opts.reasoning).toBeUndefined();
+    });
+
+    it('adaptive model + explicit effort still pins that effort (client committed)', () => {
+      const model = {
+        api: 'anthropic-messages',
+        reasoning: true,
+        compat: { forceAdaptiveThinking: true },
+        thinkingLevelMap: { high: 'high', xhigh: 'max' },
+      } as any;
+      const opts = buildReasoningOptionsForModel(
+        model,
+        intent({ adaptive: true, effort: 'xhigh', enabled: true })
+      );
+      expect(opts.thinkingEnabled).toBe(true);
+      expect(opts.effort).toBe('xhigh');
+    });
+
+    it('legacy (budget) model flattens an adaptive intent to the default-effort budget', () => {
+      const model = { api: 'anthropic-messages', reasoning: true } as any;
+      const opts = buildReasoningOptionsForModel(model, intent({ adaptive: true, enabled: true }));
+      // Non-adaptive model can't express "model decides" — flatten to the
+      // documented default effort (high → 16384 budget).
+      expect(opts.thinkingEnabled).toBe(true);
+      expect(opts.thinkingBudgetTokens).toBe(16384);
+    });
+
+    it('completions egress flattens an adaptive intent to the default effort (not none)', () => {
+      const model = { api: 'openai-completions', reasoning: true } as any;
+      const opts = buildReasoningOptionsForModel(model, intent({ adaptive: true, enabled: true }));
+      expect(opts.reasoningEffort).toBe('high');
+      expect(opts.reasoning).toBe('high');
+    });
+
     it('legacy model uses budget tokens, round-tripping client budget', () => {
       const model = { api: 'anthropic-messages', reasoning: true } as any;
       const opts = buildReasoningOptionsForModel(

--- a/packages/backend/src/inference-v2/shared/__tests__/reasoning.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/reasoning.test.ts
@@ -89,6 +89,16 @@ describe('intentToEffort', () => {
     expect(intentToEffort({ enabled: true, source: 'client' })).toBe('medium');
   });
 
+  it('resolves an adaptive intent to the documented default effort (high)', () => {
+    expect(intentToEffort({ adaptive: true, enabled: true, source: 'client' })).toBe('high');
+  });
+
+  it('prefers an explicit effort over the adaptive default', () => {
+    expect(intentToEffort({ adaptive: true, effort: 'low', enabled: true, source: 'client' })).toBe(
+      'low'
+    );
+  });
+
   it('returns undefined when the client said nothing', () => {
     expect(intentToEffort({ source: 'client' })).toBeUndefined();
   });

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -406,9 +406,19 @@ function buildEnabledOptions(
       base.thinkingDisplay = 'summarized';
     }
     if ((model.compat as { forceAdaptiveThinking?: boolean })?.forceAdaptiveThinking === true) {
-      // Adaptive thinking: pass the effort and let pi-ai map it via
-      // thinkingLevelMap (e.g. xhigh → "max" on Opus 4.6).
-      base.effort = effort;
+      if (intent?.adaptive === true && intent?.effort == null) {
+        // True adaptive: the client enabled thinking without committing to a
+        // magnitude. Pass `thinkingEnabled: true` alone and let the model
+        // decide how much to think — the native semantics of Anthropic
+        // `thinking.type: 'adaptive'`. Do NOT pin `effort`, and drop the
+        // streamSimple-compat `reasoning` level so nothing re-quantizes it.
+        delete base.reasoning;
+      } else {
+        // Client committed to a magnitude (explicit effort / reasoning suffix):
+        // pass it and let pi-ai map it via thinkingLevelMap (e.g. xhigh → "max"
+        // on Opus 4.6).
+        base.effort = effort;
+      }
     } else {
       // Budget-based thinking for older Claude models. Round-trip the client's
       // exact budget when they gave one; otherwise derive from the effort.

--- a/packages/backend/src/inference-v2/shared/reasoning.ts
+++ b/packages/backend/src/inference-v2/shared/reasoning.ts
@@ -52,6 +52,18 @@ export interface ReasoningIntent {
    *   undefined → client said nothing; defer to the model's native default
    */
   enabled?: boolean;
+  /**
+   * Adaptive thinking: the client enabled reasoning but did NOT commit to a
+   * magnitude — the model decides how much to think (Anthropic
+   * `thinking.type: 'adaptive'`, the only mode on Claude 5+).
+   *
+   * On a native adaptive-thinking Anthropic egress this is passed through as
+   * `thinkingEnabled: true` with no `effort`, so the model chooses. On egress
+   * families that cannot express "let the model decide" (OpenAI-completions /
+   * OpenRouter, Gemini, legacy budget-based Anthropic) it resolves to the
+   * documented adaptive default effort via {@link intentToEffort}.
+   */
+  adaptive?: boolean;
   /** Unified reasoning-output visibility (summary / full / hidden). */
   visibility?: ReasoningVisibility;
   /**
@@ -184,6 +196,14 @@ export function clampEffortToWindow(
 }
 
 /**
+ * Default effort for adaptive thinking when it must be flattened to a concrete
+ * bucket (egress families that cannot express "let the model decide"). Matches
+ * the documented adaptive default, e.g. OpenRouter Claude 5: "adaptive thinking
+ * on at effort high".
+ */
+export const ADAPTIVE_DEFAULT_EFFORT: ReasoningEffort = 'high';
+
+/**
  * Resolve a ReasoningIntent to a concrete effort bucket (or 'off'), using
  * `budgetTokens` when no explicit `effort` was given.
  */
@@ -191,6 +211,9 @@ export function intentToEffort(intent: ReasoningIntent): ReasoningEffort | 'off'
   if (intent.enabled === false) return 'off';
   if (intent.effort) return intent.effort;
   if (intent.budgetTokens != null) return budgetToEffort(intent.budgetTokens);
+  // Adaptive: model-decides-magnitude, flattened to the documented default for
+  // egress paths that require a concrete effort.
+  if (intent.adaptive) return ADAPTIVE_DEFAULT_EFFORT;
   if (intent.enabled === true) return 'medium'; // enabled but unspecified magnitude
   return undefined;
 }


### PR DESCRIPTION
### **User description**
## Problem

On the inference-v2 path, an incoming Anthropic request with:

```json
"thinking": { "type": "adaptive", "display": "summarized" }
```

was being transformed into:

```json
"reasoning": { "effort": "none" }
```

— i.e. **reasoning was silently disabled**. Discovered via debug trace `71d767c9-…` (client: `claude-sonnet-5`, egress: `openai-completions` via OpenRouter).

### Root cause

`anthropic-to-context.ts` only mapped `thinking.type` values `'enabled'` and `'disabled'`. Anthropic's `'adaptive'` mode — the *only* thinking mode on Claude 5 Sonnet — fell through to an empty reasoning intent, which `intentToEffort()` resolved to `undefined` → rendered as the reasoning-disabling `effort: 'none'` on the OpenAI-completions egress.

This is not an OpenRouter capability gap: OpenRouter supports adaptive thinking. Per its own docs, the correct translation is reasoning **on** (`reasoning.enabled=true`; adaptive default effort `high`), and `effort: 'none'` is the one value that turns it off.

## Fix

**Commit 1** — map `adaptive` (and `enabled` without a budget) to enabled reasoning; also carry `thinking.display` through as reasoning visibility (`summarized`→`summary`, `raw`→`full`).

**Commit 2** — preserve *true* adaptive semantics per egress family instead of pinning an effort at the parser:

- New `ReasoningIntent.adaptive` flag (thinking on, magnitude unspecified — model decides) + `ADAPTIVE_DEFAULT_EFFORT = 'high'`.
- **Native adaptive Anthropic models** (`compat.forceAdaptiveThinking`, e.g. Claude 5 / Opus 4.6+): pass `thinkingEnabled: true` through with **no `effort`** → the model decides how much to think (native `thinking.type: 'adaptive'` semantics).
- **Egress families that cannot express "model decides"** (OpenAI-completions / OpenRouter, Gemini, legacy budget-based Anthropic): flatten to the documented adaptive default effort `high` via `intentToEffort` — never `none`.
- An explicit `effort` or `:effort` alias suffix still overrides adaptive on every path.

### Behavior matrix (adaptive request, no explicit magnitude)

| Egress | Result | Semantics |
|---|---|---|
| Native Anthropic adaptive (Claude 5, Opus 4.6+) | `{ thinkingEnabled: true, thinkingDisplay }`, no effort | True adaptive, model decides |
| Legacy budget Anthropic (Sonnet 4.6) | `{ thinkingEnabled: true, thinkingBudgetTokens: 16384 }` | Flattened to default |
| OpenAI-completions / OpenRouter | `{ reasoningEffort: 'high', reasoning: 'high' }` | Reasoning ON at adaptive default |
| Gemini | level/budget from `high` | Reasoning ON |

## Tests

- Parser: adaptive intent shape + visibility mapping.
- Egress: native pass-through (no effort) vs flatten per family; explicit-effort override.
- `intentToEffort`: adaptive → `high`, explicit-effort precedence.

Full backend suite (2110 tests) + typecheck pass locally via pre-commit hooks.

___

### **Description**
- Fix Anthropic `adaptive` thinking silently disabling reasoning on inference-v2 path

- Add `ReasoningIntent.adaptive` flag and `ADAPTIVE_DEFAULT_EFFORT` to preserve model-decides semantics

- Native adaptive Anthropic egress passes `thinkingEnabled` with no effort; others flatten to `high`

- Map `thinking.display` to reasoning visibility (`summarized`→`summary`, `raw`→`full`)

- Add tests for adaptive intent parsing, egress flattening, and `intentToEffort` resolution


___

