### PR TITLE
fix(inference-v2): correct messages<>messages response transformation and streaming tool-rename reversal

### DIFF
--- a/packages/backend/src/inference-v2/anthropic/__tests__/anthropic-to-context.test.ts
+++ b/packages/backend/src/inference-v2/anthropic/__tests__/anthropic-to-context.test.ts
@@ -154,6 +154,27 @@ describe('anthropicRequestToContext', () => {
       expect(blocks.find((b: any) => b.type === 'thinking')?.thinking).toBe('My thought');
     });
 
+    it('REGRESSION: preserves the thinking block signature in assistant history', () => {
+      // Without this, a thinking block echoed back in a follow-up request (e.g.
+      // multi-turn tool use with extended thinking) loses its signature and
+      // Anthropic rejects it as tampered/missing on the next turn.
+      const result = anthropicRequestToContext({
+        model: 'claude-opus-4-6',
+        messages: [
+          { role: 'user', content: 'Think!' },
+          {
+            role: 'assistant',
+            content: [
+              { type: 'thinking', thinking: 'My thought', signature: 'sig-xyz' },
+              { type: 'text', text: 'Answer' },
+            ],
+          },
+        ],
+      });
+      const blocks = result.context.messages[1]!.content as any[];
+      expect(blocks.find((b: any) => b.type === 'thinking')?.thinkingSignature).toBe('sig-xyz');
+    });
+
     it('maps tool_use blocks to ToolCall', () => {
       const result = anthropicRequestToContext({
         model: 'claude-opus-4-6',

--- a/packages/backend/src/inference-v2/anthropic/__tests__/context-to-anthropic.test.ts
+++ b/packages/backend/src/inference-v2/anthropic/__tests__/context-to-anthropic.test.ts
@@ -8,6 +8,17 @@ import {
 
 // @earendil-works/pi-ai and utils/logger are globally mocked in test/vitest.setup.ts
 
+function zeroUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
 function makeMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
   return {
     role: 'assistant',
@@ -117,17 +128,157 @@ describe('messageToAnthropicResponse', () => {
 });
 
 describe('eventToAnthropicSSE', () => {
-  it('start event emits message_start SSE', () => {
+  it('start event alone defers message_start (no usage known yet)', () => {
     const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
-    const frames = eventToAnthropicSSE({ type: 'start', partial: { content: [] } } as any, state);
-    expect(frames.some((f) => f.includes('message_start'))).toBe(true);
+    const frames = eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
+    expect(frames.some((f) => f.includes('message_start'))).toBe(false);
+    expect(state.pendingStart).toBe(true);
+  });
+
+  it('REGRESSION: message_start usage reflects the real usage from the first content event, not the zeroed usage on "start"', () => {
+    // Reproduces the bug from debug trace 216ce9bf-bdd9-4bc9-9806-14eb345faecd:
+    // pi-ai emits 'start' before reading any upstream bytes, so partial.usage is
+    // always {input:0, output:0, cacheRead:0, cacheWrite:0} at that point. The
+    // real usage (e.g. cache_read_input_tokens from a cached system prompt) only
+    // lands in partial.usage once the upstream message_start SSE has been
+    // processed — which happens before the *next* pi-ai event. The old code sent
+    // message_start immediately on 'start' and permanently lost that usage.
+    const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
+
+    // 'start' fires with zero usage, exactly like the real upstream stream.
+    const startFrames = eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
+    expect(startFrames.some((f) => f.includes('message_start'))).toBe(false);
+
+    // The next event (thinking_start) carries the real usage merged in by pi-ai
+    // after processing the upstream message_start event.
+    const realUsage = {
+      input: 2,
+      output: 7,
+      cacheRead: 8441,
+      cacheWrite: 0,
+      totalTokens: 8450,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    };
+    const thinkingStartFrames = eventToAnthropicSSE(
+      {
+        type: 'thinking_start',
+        contentIndex: 0,
+        partial: {
+          content: [{ type: 'thinking', thinking: '', thinkingSignature: '' }],
+          usage: realUsage,
+        },
+      } as any,
+      state
+    );
+
+    const messageStartFrame = thinkingStartFrames.find((f) => f.includes('message_start'));
+    expect(messageStartFrame).toBeDefined();
+    const data = JSON.parse(messageStartFrame!.split('\ndata: ')[1]!);
+    expect(data.message.usage.input_tokens).toBe(2);
+    expect(data.message.usage.output_tokens).toBe(7);
+    expect(data.message.usage.cache_read_input_tokens).toBe(8441);
+  });
+
+  it('emits signature_delta for a thinking block before content_block_stop', () => {
+    const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
+    eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
+    eventToAnthropicSSE(
+      {
+        type: 'thinking_start',
+        contentIndex: 0,
+        partial: {
+          content: [{ type: 'thinking', thinking: '', thinkingSignature: '' }],
+          usage: zeroUsage(),
+        },
+      } as any,
+      state
+    );
+    eventToAnthropicSSE(
+      {
+        type: 'thinking_delta',
+        contentIndex: 0,
+        delta: 'Hmm',
+        partial: { content: [], usage: zeroUsage() },
+      } as any,
+      state
+    );
+    // Closing the thinking block (by starting a text block) should emit the
+    // accumulated signature before content_block_stop.
+    const frames = eventToAnthropicSSE(
+      {
+        type: 'text_start',
+        contentIndex: 1,
+        partial: {
+          content: [
+            { type: 'thinking', thinking: 'Hmm', thinkingSignature: 'sig-abc' },
+            { type: 'text', text: '' },
+          ],
+          usage: zeroUsage(),
+        },
+      } as any,
+      state
+    );
+    const allFrames = frames.join('\n---\n');
+    const sigIndex = allFrames.indexOf('signature_delta');
+    const stopIndex = allFrames.indexOf('content_block_stop');
+    expect(sigIndex).toBeGreaterThan(-1);
+    expect(stopIndex).toBeGreaterThan(-1);
+    expect(sigIndex).toBeLessThan(stopIndex);
+    expect(allFrames).toContain('sig-abc');
+  });
+
+  it('message_delta on done includes full usage breakdown, not just output_tokens', () => {
+    const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
+    eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
+    const message = makeMessage({
+      stopReason: 'toolUse',
+      usage: {
+        input: 2,
+        output: 81,
+        cacheRead: 8441,
+        cacheWrite: 0,
+        totalTokens: 8524,
+        reasoning: 23,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      } as any,
+    });
+    const frames = eventToAnthropicSSE({ type: 'done', reason: 'toolUse', message } as any, state);
+    const deltaFrame = frames.find((f) => f.includes('message_delta'))!;
+    const data = JSON.parse(deltaFrame.split('\ndata: ')[1]!);
+    expect(data.usage.input_tokens).toBe(2);
+    expect(data.usage.output_tokens).toBe(81);
+    expect(data.usage.cache_read_input_tokens).toBe(8441);
+    expect(data.usage.output_tokens_details.thinking_tokens).toBe(23);
   });
 
   it('text_delta emits content_block_start + content_block_delta', () => {
     const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
     // Trigger start first
-    eventToAnthropicSSE({ type: 'start', partial: { content: [] } } as any, state);
-    const frames = eventToAnthropicSSE({ type: 'text_delta', delta: 'Hello' } as any, state);
+    eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
+    const frames = eventToAnthropicSSE(
+      {
+        type: 'text_delta',
+        contentIndex: 0,
+        delta: 'Hello',
+        partial: { content: [], usage: zeroUsage() },
+      } as any,
+      state
+    );
     const allFrames = frames.join('\n');
     expect(allFrames).toContain('text_delta');
     expect(allFrames).toContain('Hello');
@@ -135,9 +286,20 @@ describe('eventToAnthropicSSE', () => {
 
   it('thinking_delta emits thinking block delta', () => {
     const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
-    eventToAnthropicSSE({ type: 'start', partial: { content: [] } } as any, state);
+    eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
     const frames = eventToAnthropicSSE(
-      { type: 'thinking_delta', delta: 'Thinking...' } as any,
+      {
+        type: 'thinking_delta',
+        contentIndex: 0,
+        delta: 'Thinking...',
+        partial: {
+          content: [{ type: 'thinking', thinking: 'Thinking...', thinkingSignature: '' }],
+          usage: zeroUsage(),
+        },
+      } as any,
       state
     );
     const allFrames = frames.join('\n');
@@ -147,8 +309,14 @@ describe('eventToAnthropicSSE', () => {
 
   it('toolcall_start emits tool_use block start', () => {
     const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
-    eventToAnthropicSSE({ type: 'start', partial: { content: [] } } as any, state);
-    const partial = { content: [{ type: 'toolCall', id: 'c1', name: 'fn', arguments: {} }] };
+    eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
+    const partial = {
+      content: [{ type: 'toolCall', id: 'c1', name: 'fn', arguments: {} }],
+      usage: zeroUsage(),
+    };
     const frames = eventToAnthropicSSE(
       { type: 'toolcall_start', contentIndex: 0, partial } as any,
       state
@@ -158,7 +326,10 @@ describe('eventToAnthropicSSE', () => {
 
   it('done event emits message_delta and message_stop', () => {
     const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
-    eventToAnthropicSSE({ type: 'start', partial: { content: [] } } as any, state);
+    eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
     const message = makeMessage({ stopReason: 'stop' });
     const frames = eventToAnthropicSSE({ type: 'done', reason: 'stop', message } as any, state);
     const allFrames = frames.join('\n');
@@ -168,7 +339,19 @@ describe('eventToAnthropicSSE', () => {
 
   it('SSE frames start with "event: " or "data: "', () => {
     const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
-    const frames = eventToAnthropicSSE({ type: 'start', partial: { content: [] } } as any, state);
+    eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
+    const frames = eventToAnthropicSSE(
+      {
+        type: 'text_delta',
+        contentIndex: 0,
+        delta: 'Hi',
+        partial: { content: [], usage: zeroUsage() },
+      } as any,
+      state
+    );
     for (const frame of frames) {
       // Each frame is event:/data: lines separated by \n
       const lines = frame.split('\n').filter((l) => l.trim());

--- a/packages/backend/src/inference-v2/anthropic/anthropic-to-context.ts
+++ b/packages/backend/src/inference-v2/anthropic/anthropic-to-context.ts
@@ -204,10 +204,13 @@ export function anthropicRequestToContext(body: any): AnthropicToContextResult {
         if (block.type === 'text') {
           contentBlocks.push({ type: 'text', text: block.text ?? '' } as TextContent);
         } else if (block.type === 'thinking') {
-          // Preserve thinking blocks — required for multi-turn extended thinking
+          // Preserve thinking blocks — required for multi-turn extended thinking.
+          // The signature must also round-trip or Anthropic rejects the block
+          // as tampered/missing on the next turn.
           contentBlocks.push({
             type: 'thinking',
             thinking: block.thinking ?? '',
+            ...(block.signature ? { thinkingSignature: block.signature } : {}),
           } as ThinkingContent);
         } else if (block.type === 'tool_use') {
           contentBlocks.push({

--- a/packages/backend/src/inference-v2/anthropic/context-to-anthropic.ts
+++ b/packages/backend/src/inference-v2/anthropic/context-to-anthropic.ts
@@ -39,7 +39,7 @@ export interface AnthropicUsage {
 
 export type AnthropicContentBlock =
   | { type: 'text'; text: string }
-  | { type: 'thinking'; thinking: string }
+  | { type: 'thinking'; thinking: string; signature?: string }
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> };
 
 export interface AnthropicMessage {
@@ -84,6 +84,37 @@ function makeMessageId(): string {
   return `msg_${Date.now().toString(36)}`;
 }
 
+/** Full `message_start.message.usage` shape, including the nested cache_creation split. */
+function buildStartUsage(u: Usage | undefined) {
+  const cacheWrite = u?.cacheWrite ?? 0;
+  const cacheWrite1h = u?.cacheWrite1h ?? 0;
+  const cacheWrite5m = Math.max(0, cacheWrite - cacheWrite1h);
+  return {
+    input_tokens: u?.input ?? 0,
+    output_tokens: u?.output ?? 0,
+    cache_read_input_tokens: u?.cacheRead ?? 0,
+    cache_creation_input_tokens: cacheWrite,
+    cache_creation: {
+      ephemeral_5m_input_tokens: cacheWrite5m,
+      ephemeral_1h_input_tokens: cacheWrite1h,
+    },
+  };
+}
+
+/** Full `message_delta.usage` shape, including input/cache tokens and thinking-token breakdown. */
+function buildDeltaUsage(u: Usage) {
+  const usage: Record<string, unknown> = {
+    input_tokens: u.input,
+    output_tokens: u.output,
+    cache_read_input_tokens: u.cacheRead,
+    cache_creation_input_tokens: u.cacheWrite,
+  };
+  if (u.reasoning != null) {
+    usage.output_tokens_details = { thinking_tokens: u.reasoning };
+  }
+  return usage;
+}
+
 // ─── Non-streaming serialiser ─────────────────────────────────────────────────
 
 export function messageToAnthropicResponse(
@@ -114,7 +145,12 @@ export function messageToAnthropicResponse(
 
   for (const block of message.content) {
     if (block.type === 'thinking') {
-      thinkingBlocks.push({ type: 'thinking', thinking: (block as ThinkingContent).thinking });
+      const tb = block as ThinkingContent;
+      thinkingBlocks.push({
+        type: 'thinking',
+        thinking: tb.thinking,
+        ...(tb.thinkingSignature ? { signature: tb.thinkingSignature } : {}),
+      });
     } else if (block.type === 'text') {
       textBlocks.push({ type: 'text', text: (block as TextContent).text });
     } else if (block.type === 'toolCall') {
@@ -149,9 +185,13 @@ export interface AnthropicChunkSerialiserState {
   activeBlockType: 'text' | 'thinking' | 'tool_use' | null;
   /** Index of the currently open content_block */
   activeBlockIndex: number | null;
+  /** Index into the pi-ai partial message's `content` array for the active block */
+  activeContentIndex: number | null;
   /** tool_call id of the active tool_use block */
   activeToolId: string | null;
   sentStart: boolean;
+  /** True after the 'start' event, until message_start has actually been flushed */
+  pendingStart: boolean;
 }
 
 export function makeAnthropicChunkSerialiserState(model: string): AnthropicChunkSerialiserState {
@@ -161,14 +201,40 @@ export function makeAnthropicChunkSerialiserState(model: string): AnthropicChunk
     nextBlockIndex: 0,
     activeBlockType: null,
     activeBlockIndex: null,
+    activeContentIndex: null,
     activeToolId: null,
     sentStart: false,
+    pendingStart: false,
   };
 }
 
 /** Encode one SSE event as `event: <name>\ndata: <json>\n\n` */
 function sseEvent(name: string, data: unknown): string {
   return `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/**
+ * pi-ai emits its 'start' event before reading any bytes from the upstream
+ * response, so `usage` is always zero at that point even though Anthropic's
+ * own message_start carries real input/cache-read token counts. Real usage
+ * only lands in `output.usage` once the upstream message_start SSE has been
+ * processed, which happens synchronously before the *next* pi-ai event is
+ * emitted. So we defer sending our message_start until that next event,
+ * using its usage snapshot.
+ */
+function usageFromEvent(event: AssistantMessageEvent): Usage | undefined {
+  if (event.type === 'done') return event.message.usage;
+  if (event.type === 'error') return event.error.usage;
+  if ('partial' in event) return event.partial.usage;
+  return undefined;
+}
+
+/** The assistant message's content array, regardless of which event shape carries it. */
+function contentFromEvent(event: AssistantMessageEvent): AssistantMessage['content'] | undefined {
+  if (event.type === 'done') return event.message.content;
+  if (event.type === 'error') return event.error.content;
+  if ('partial' in event) return event.partial.content;
+  return undefined;
 }
 
 /**
@@ -182,8 +248,46 @@ export function eventToAnthropicSSE(
   const frames: string[] = [];
 
   // ── Helpers local to this call ───────────────────────────────────────────
+
+  /** Flush the deferred message_start (+ ping) using the best usage snapshot available. */
+  const ensureStarted = () => {
+    if (!state.pendingStart) return;
+    state.pendingStart = false;
+    frames.push(
+      sseEvent('message_start', {
+        type: 'message_start',
+        message: {
+          id: state.messageId,
+          type: 'message',
+          role: 'assistant',
+          model: state.model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: buildStartUsage(usageFromEvent(event)),
+        },
+      })
+    );
+    frames.push(sseEvent('ping', { type: 'ping' }));
+  };
+
   const closeCurrentBlock = () => {
     if (state.activeBlockType !== null && state.activeBlockIndex !== null) {
+      if (state.activeBlockType === 'thinking' && state.activeContentIndex !== null) {
+        const content = contentFromEvent(event);
+        const block = content?.[state.activeContentIndex];
+        const signature =
+          block?.type === 'thinking' ? (block as ThinkingContent).thinkingSignature : undefined;
+        if (signature) {
+          frames.push(
+            sseEvent('content_block_delta', {
+              type: 'content_block_delta',
+              index: state.activeBlockIndex,
+              delta: { type: 'signature_delta', signature },
+            })
+          );
+        }
+      }
       frames.push(
         sseEvent('content_block_stop', {
           type: 'content_block_stop',
@@ -192,24 +296,26 @@ export function eventToAnthropicSSE(
       );
       state.activeBlockType = null;
       state.activeBlockIndex = null;
+      state.activeContentIndex = null;
       state.activeToolId = null;
     }
   };
 
   const openBlock = (
     type: 'text' | 'thinking' | 'tool_use',
-    extra?: { id?: string; name?: string }
+    extra?: { id?: string; name?: string; contentIndex?: number }
   ) => {
     closeCurrentBlock();
     const index = state.nextBlockIndex++;
     state.activeBlockIndex = index;
     state.activeBlockType = type;
+    state.activeContentIndex = extra?.contentIndex ?? null;
 
     let content_block: Record<string, unknown>;
     if (type === 'text') {
       content_block = { type: 'text', text: '' };
     } else if (type === 'thinking') {
-      content_block = { type: 'thinking', thinking: '' };
+      content_block = { type: 'thinking', thinking: '', signature: '' };
     } else {
       // tool_use
       state.activeToolId = extra?.id ?? null;
@@ -229,42 +335,24 @@ export function eventToAnthropicSSE(
 
   switch (event.type) {
     case 'start': {
-      // message_start with empty content and initial usage (all zeros)
+      // Real usage isn't available yet (pi-ai emits 'start' before reading any
+      // upstream bytes) — defer message_start until the next event, which by
+      // then has the upstream message_start's usage merged into `partial.usage`.
       state.sentStart = true;
-      const usage = event.partial.usage;
-      frames.push(
-        sseEvent('message_start', {
-          type: 'message_start',
-          message: {
-            id: state.messageId,
-            type: 'message',
-            role: 'assistant',
-            model: state.model,
-            content: [],
-            stop_reason: null,
-            stop_sequence: null,
-            usage: {
-              input_tokens: usage?.input ?? 0,
-              output_tokens: usage?.output ?? 0,
-              cache_read_input_tokens: usage?.cacheRead ?? 0,
-              cache_creation_input_tokens: usage?.cacheWrite ?? 0,
-            },
-          },
-        })
-      );
-      // Emit an initial ping-style empty delta so clients know the stream started
-      frames.push(sseEvent('ping', { type: 'ping' }));
+      state.pendingStart = true;
       break;
     }
 
     case 'thinking_start': {
-      openBlock('thinking');
+      ensureStarted();
+      openBlock('thinking', { contentIndex: event.contentIndex });
       break;
     }
 
     case 'thinking_delta': {
+      ensureStarted();
       if (state.activeBlockType !== 'thinking') {
-        openBlock('thinking');
+        openBlock('thinking', { contentIndex: event.contentIndex });
       }
       frames.push(
         sseEvent('content_block_delta', {
@@ -277,16 +365,19 @@ export function eventToAnthropicSSE(
     }
 
     case 'thinking_end': {
-      // The block will be closed on the next different block or on done
+      // The block (and its signature_delta) is closed on the next different
+      // block or on done — see closeCurrentBlock.
       break;
     }
 
     case 'text_start': {
+      ensureStarted();
       openBlock('text');
       break;
     }
 
     case 'text_delta': {
+      ensureStarted();
       if (state.activeBlockType !== 'text') {
         openBlock('text');
       }
@@ -306,6 +397,7 @@ export function eventToAnthropicSSE(
     }
 
     case 'toolcall_start': {
+      ensureStarted();
       // Get tool info from the partial message at contentIndex
       const partialBlock = event.partial.content[event.contentIndex];
       const tc = partialBlock?.type === 'toolCall' ? (partialBlock as ToolCall) : null;
@@ -314,6 +406,7 @@ export function eventToAnthropicSSE(
     }
 
     case 'toolcall_delta': {
+      ensureStarted();
       if (state.activeBlockType !== 'tool_use') {
         // Shouldn't happen, but open defensively
         openBlock('tool_use');
@@ -334,8 +427,8 @@ export function eventToAnthropicSSE(
     }
 
     case 'done': {
+      ensureStarted();
       closeCurrentBlock();
-      const finalUsage = event.message.usage;
       frames.push(
         sseEvent('message_delta', {
           type: 'message_delta',
@@ -343,9 +436,7 @@ export function eventToAnthropicSSE(
             stop_reason: mapStopReason(event.reason),
             stop_sequence: null,
           },
-          usage: {
-            output_tokens: finalUsage.output,
-          },
+          usage: buildDeltaUsage(event.message.usage),
         })
       );
       frames.push(sseEvent('message_stop', { type: 'message_stop' }));
@@ -353,12 +444,13 @@ export function eventToAnthropicSSE(
     }
 
     case 'error': {
+      ensureStarted();
       closeCurrentBlock();
       frames.push(
         sseEvent('message_delta', {
           type: 'message_delta',
           delta: { stop_reason: 'error', stop_sequence: null },
-          usage: { output_tokens: 0 },
+          usage: buildDeltaUsage(event.error.usage),
         })
       );
       frames.push(sseEvent('message_stop', { type: 'message_stop' }));

--- a/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
@@ -9,6 +9,18 @@ import type { Context } from '@earendil-works/pi-ai';
 import { registerSpy } from '../../../../test/test-utils';
 import { OAuthAuthManager } from '../../../services/oauth-auth-manager';
 
+// Isolates the executor-wiring regression test below from the real
+// tool-rename-clustering pipeline (already covered by
+// tool-fingerprint/__tests__/apply-masking.test.ts) — we only care that
+// whatever rename pairs onPayload computes actually reach the SSE reverse
+// step.
+vi.mock('../tool-fingerprint/apply-masking', () => ({
+  applyClaudeCodeMasking: vi.fn((payloadStr: string) => ({
+    payload: JSON.parse(payloadStr),
+    toolRenamePairs: [['search_web', 'mcp__search__web']],
+  })),
+}));
+
 function createUsageStorage(): UsageStorageService {
   return {
     saveRequest: vi.fn(async () => undefined),
@@ -530,5 +542,109 @@ describe('runPiAiExecutor with OAuth and Claude Masking', () => {
 
     expect(result.response).toBeDefined();
     expect((result.response as any).content[0].text).toBe('hello oauth');
+  });
+});
+
+describe('runPiAiExecutor Claude-masking streaming tool-rename reversal (regression)', () => {
+  // Regression for trace 0aa9f550-2234-4e8f-8220-a6f7e50835b6: a client's
+  // `search_web` tool got fingerprint-renamed to `mcp__search__web` on the
+  // outgoing request, but the renamed name leaked back into the streamed
+  // tool_use block unreversed, so the client never recognized its own call.
+  //
+  // Root cause: pi-ai's `piAiModels.stream()` returns its event stream
+  // synchronously via `lazyStream()` (see @earendil-works/pi-ai's
+  // dist/api/lazy.js) — the async setup that actually calls `onPayload`
+  // (and, through it, computes `toolRenamePairs`) only runs once the
+  // returned stream is iterated. `buildSSEGenerator()` used to snapshot
+  // `toolRenamePairs` into its params BEFORE that iteration started, so it
+  // was permanently bound to the pre-onPayload `[]`. This test reproduces
+  // that exact ordering with a fake stream whose generator body — like the
+  // real pi-ai driver — calls `onPayload` only once iteration begins.
+  beforeEach(() => {
+    DebugManager.getInstance().resetForTesting();
+    setConfigForTesting({
+      providers: {
+        'anthropic-masked': {
+          api_base_url: 'https://api.anthropic.com',
+          api_key: 'sk-ant-oat01-test-masking-key',
+          useClaudeMasking: true,
+          models: {
+            'claude-3-5-sonnet-20241022': {
+              pricing: { source: 'simple', input: 0, output: 0 },
+            },
+          },
+        },
+      },
+      models: {
+        'claude-3-5-sonnet-20241022': {
+          priority: 'selector',
+          targets: [{ provider: 'anthropic-masked', model: 'claude-3-5-sonnet-20241022' }],
+        },
+      },
+      keys: {},
+      failover: { enabled: false, retryableStatusCodes: [], retryableErrors: [] },
+      quotas: [],
+    } as any);
+  });
+
+  it('reverses a fingerprint-renamed tool name in streamed SSE frames even though onPayload resolves after piAiModels.stream() returns', async () => {
+    vi.mocked(piAi.stream).mockImplementation((async (_model: any, _context: any, options: any) => {
+      // Returning the un-started async generator here — before its body
+      // (and thus onPayload) has run — mirrors pi-ai's real lazyStream
+      // timing exactly.
+      return (async function* () {
+        await options.onPayload?.(JSON.stringify({ tools: [{ name: 'search_web' }] }));
+        const partial = {
+          role: 'assistant',
+          content: [{ type: 'toolCall', id: 'call-1', name: 'mcp__search__web', arguments: {} }],
+          api: 'anthropic-messages',
+          provider: 'anthropic',
+          model: 'claude-3-5-sonnet-20241022',
+          usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+          stopReason: 'toolUse',
+          timestamp: Date.now(),
+        };
+        yield { type: 'toolcall_start', partial } as any;
+        yield { type: 'done', message: partial, reason: 'toolUse' } as any;
+      })();
+    }) as any);
+
+    const usageStorage = createUsageStorage();
+    DebugManager.getInstance().setStorage(usageStorage);
+
+    const result = await runPiAiExecutor({
+      requestId: 'req-claude-masking-tool-rename',
+      incomingApiType: 'messages',
+      modelAlias: 'claude-3-5-sonnet-20241022',
+      context: { messages: [] } as any,
+      generationIntent: { reasoning: { source: 'client' } } as any,
+      streaming: true,
+      request: {
+        body: {},
+        keyName: 'beta-key',
+        attribution: 'open-webui',
+        ip: '127.0.0.1',
+      } as any,
+      usageStorage,
+      serializeMessage: (msg) => msg as any,
+      serializeChunks: (event: any) => {
+        if (event.type === 'toolcall_start') {
+          const name = event.partial.content[0].name;
+          return [
+            `event: content_block_start\ndata: {"type":"content_block_start","content_block":{"type":"tool_use","id":"call-1","name":"${name}"}}\n\n`,
+          ];
+        }
+        return [];
+      },
+    });
+
+    const frames: string[] = [];
+    for await (const frame of result.stream!) {
+      frames.push(frame);
+    }
+    const snapshot = frames.join('');
+
+    expect(snapshot).toContain('"name":"search_web"');
+    expect(snapshot).not.toContain('mcp__search__web');
   });
 });

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -1090,7 +1090,7 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
     eventStream,
     route,
     piModel,
-    toolRenamePairs,
+    toolRenamePairs: initialToolRenamePairs,
     attemptTimeout,
     stallTtfbMs,
     stallCooldownEnabled,
@@ -1174,6 +1174,13 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
       const isOAuth = isOAuthRoute(route, incomingApiType);
       const isClaudeMasking = isClaudeMaskingApiKeyRoute(route, incomingApiType);
       const frames = serializeChunks(event);
+      // `initialToolRenamePairs` is a snapshot taken before pi-ai's lazyStream
+      // ran its async setup (which calls onPayload and computes the real
+      // rename pairs), so it is always [] here — see pi-ai-executor.ts's
+      // onPayload comment. onPayload mutates piModel.__toolRenamePairs
+      // in place before emitting any event, so read that live value instead.
+      const toolRenamePairs: RenamePair[] =
+        (piModel as any).__toolRenamePairs ?? initialToolRenamePairs;
       for (const frame of frames) {
         if (!hasEmittedClientFrame && frame.trim()) {
           hasEmittedClientFrame = true;


### PR DESCRIPTION
### **User description**
## Summary

Two related bugs found via debug-trace investigation on the `inference-v2` Anthropic messages<->messages path:

### 1. Response-transformation defects (trace `216ce9bf-bdd9-4bc9-9806-14eb345faecd`)

`context-to-anthropic.ts` / `anthropic-to-context.ts`:
- `message_start` usage was emitted zeroed/deferred instead of reflecting the real usage from the first content event (pi-ai emits its `'start'` event before reading any upstream bytes, so `partial.usage` is always zero at that point).
- `cache_creation` breakdown (`ephemeral_5m_input_tokens`/`ephemeral_1h_input_tokens`) was dropped.
- `signature_delta` was never emitted for thinking blocks, and inbound thinking-block `signature` was not preserved into history — breaking multi-turn signed-thinking round trips.
- `message_delta` on `done` only included `output_tokens`, not the full usage breakdown.

Fixed all four, with regression tests reproducing each exact symptom, and verified live against staging (including a full multi-turn signature round-trip).

### 2. Streaming tool-rename reversal (trace `0aa9f550-2234-4e8f-8220-a6f7e50835b6`)

A separate bug: an Open WebUI client's `search_web` tool gets fingerprint-renamed to `mcp__search__web` on the outgoing request (expected Claude-Code-masking behavior), but the rename was never reversed in the streamed response, so the client couldn't recognize its own `tool_use` call.

Root cause: `piAiModels.stream()` returns its event stream synchronously via pi-ai's `lazyStream()` — the async setup that calls `onPayload` (which computes `toolRenamePairs`) only runs once the stream is iterated. `buildSSEGenerator` was snapshotting `toolRenamePairs` *before* that iteration began, so it was permanently bound to the pre-`onPayload` empty array. Every `reverseToolRenames()` call in the streaming loop reversed nothing. The non-streaming path was unaffected since it reads `toolRenamePairs` only after the response fully resolves.

Fix: read the live value off `piModel.__toolRenamePairs`, which `onPayload` already mutates in place before any SSE event is emitted, instead of the stale pre-iteration snapshot.

Added a regression test reproducing pi-ai's exact `lazyStream` timing (a fake stream whose generator body calls `onPayload` only once iterated) — confirmed to fail without the fix and pass with it.

## Testing
- `bun run test`: 2146/2146 passing
- `bun run typecheck`: clean
- Live verification against staging for fix #1 (multi-turn signed-thinking round trip)


___

### **Description**
- Defer `message_start` SSE until real upstream usage arrives, preserving full usage breakdown

- Preserve thinking-block `signature` round-trip in both request parsing and response serialization

- Emit `signature_delta` before `content_block_stop` and include full usage in `message_delta`

- Fix streaming tool-rename reversal by reading live `__toolRenamePairs` instead of stale snapshot

- Add regression tests for thinking signatures, usage propagation, and tool-rename timing


___

