### PR TITLE
fix(inference-v2): fold pre-flight stream failures into candidate failover

### DIFF
--- a/packages/backend/src/inference-v2/anthropic/__tests__/context-to-anthropic.test.ts
+++ b/packages/backend/src/inference-v2/anthropic/__tests__/context-to-anthropic.test.ts
@@ -337,6 +337,28 @@ describe('eventToAnthropicSSE', () => {
     expect(allFrames).toContain('message_stop');
   });
 
+  it('REGRESSION: an error event with no preceding start still emits message_start before message_delta', () => {
+    // pi-ai's stream() resolves synchronously and reports pre-flight
+    // connection failures (auth/network issues before any content) as a
+    // lone 'error' event — no 'start' ever fires. The executor's
+    // peekFirstStreamEvent normally folds this into candidate failover
+    // before the client ever sees it, but this serialiser must still be
+    // correct standalone for any provider/ordering that reaches it, since
+    // clients (e.g. the Anthropic SDK) reject a message_delta that arrives
+    // without a prior message_start.
+    const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
+    const error = { ...makeMessage({ stopReason: 'error' }), errorMessage: 'Upstream error' };
+    const frames = eventToAnthropicSSE({ type: 'error', reason: 'error', error } as any, state);
+
+    const startIndex = frames.findIndex((f) => f.includes('"type":"message_start"'));
+    const deltaIndex = frames.findIndex((f) => f.includes('"type":"message_delta"'));
+    const stopIndex = frames.findIndex((f) => f.includes('"type":"message_stop"'));
+
+    expect(startIndex).toBeGreaterThanOrEqual(0);
+    expect(deltaIndex).toBeGreaterThan(startIndex);
+    expect(stopIndex).toBeGreaterThan(deltaIndex);
+  });
+
   it('SSE frames start with "event: " or "data: "', () => {
     const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
     eventToAnthropicSSE(

--- a/packages/backend/src/inference-v2/anthropic/context-to-anthropic.ts
+++ b/packages/backend/src/inference-v2/anthropic/context-to-anthropic.ts
@@ -190,7 +190,15 @@ export interface AnthropicChunkSerialiserState {
   /** tool_call id of the active tool_use block */
   activeToolId: string | null;
   sentStart: boolean;
-  /** True after the 'start' event, until message_start has actually been flushed */
+  /**
+   * True until message_start has actually been flushed. Starts `true`
+   * (rather than being armed only by a 'start' event) so that any event
+   * arriving without a preceding 'start' — e.g. an upstream pre-flight
+   * failure pi-ai reports as a lone 'error' — still gets a message_start
+   * flushed ahead of it instead of silently dropping it. See
+   * pi-ai-executor.ts's peekFirstStreamEvent for the primary defense; this
+   * is the fallback for any provider/event ordering that slips past it.
+   */
   pendingStart: boolean;
 }
 
@@ -204,7 +212,7 @@ export function makeAnthropicChunkSerialiserState(model: string): AnthropicChunk
     activeContentIndex: null,
     activeToolId: null,
     sentStart: false,
-    pendingStart: false,
+    pendingStart: true,
   };
 }
 

--- a/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as piAi from '@earendil-works/pi-ai/compat';
 import { setConfigForTesting } from '../../../config';
 import { DebugManager } from '../../../services/debug-manager';
+import { CooldownManager } from '../../../services/cooldown-manager';
 import { enterRequestContext } from '../../../services/request-context';
 import { runPiAiExecutor, alignAssistantProvenance } from '../pi-ai-executor';
 import type { UsageStorageService } from '../../../services/usage-storage';
@@ -33,6 +34,13 @@ function createUsageStorage(): UsageStorageService {
   } as unknown as UsageStorageService;
 }
 
+/**
+ * A pre-flight failure: pi-ai reports a connection failure that happened
+ * before any content was produced as a lone `error` event with no
+ * preceding `start` (see anthropic-messages.ts / openai-completions.ts
+ * etc. in pi-ai — `start` is only pushed after the upstream connection
+ * succeeds; failures before that go straight to `error`).
+ */
 async function* errorStream() {
   yield {
     type: 'error',
@@ -61,6 +69,7 @@ async function* successStream() {
 describe('runPiAiExecutor streaming errors', () => {
   beforeEach(() => {
     DebugManager.getInstance().resetForTesting();
+    CooldownManager.resetForTesting();
     setConfigForTesting({
       providers: {
         'openai-s': {
@@ -87,16 +96,101 @@ describe('runPiAiExecutor streaming errors', () => {
     } as any);
   });
 
-  it('saves terminal usage and error records for streamed error events', async () => {
+  it('folds a pre-flight error (no start event) into candidate failover, rejecting once no candidates remain', async () => {
+    // pi-ai's stream() resolves synchronously and reports pre-flight
+    // connection failures as a lone 'error' event with no preceding
+    // 'start'. With only one candidate configured, the peek in
+    // runPiAiExecutor should surface this exactly like a synchronously
+    // thrown stream() failure: no client-visible frames, a rejected
+    // promise once candidates are exhausted.
     vi.mocked(piAi.stream).mockResolvedValue(errorStream() as any);
     const usageStorage = createUsageStorage();
     DebugManager.getInstance().setStorage(usageStorage);
     DebugManager.getInstance().enableForKey('beta-key');
     enterRequestContext({ keyName: 'beta-key' });
 
+    await expect(
+      runPiAiExecutor({
+        requestId: 'req-stream-error',
+        incomingApiType: 'responses',
+        modelAlias: 'gpt-5.4',
+        context: { messages: [] } as any,
+        generationIntent: { reasoning: { source: 'client' } } as any,
+        streaming: true,
+        request: {
+          body: {},
+          keyName: 'beta-key',
+          attribution: 'opencode',
+          ip: '127.0.0.1',
+        } as any,
+        usageStorage,
+        serializeMessage: (msg) => msg as any,
+        serializeChunks: () => ['event: response.completed\ndata: {}\n\n'],
+      })
+    ).rejects.toThrow(/One of "input" or "previous_response_id"/);
+
+    // Nothing was ever committed to the client, so there's no stream-side
+    // usage/error record to save — the caller (HTTP handler) surfaces and
+    // logs the final rejection itself.
+    expect(usageStorage.saveRequest).not.toHaveBeenCalled();
+  });
+
+  it('absorbs a pre-flight error as a transparent retry to the next candidate', async () => {
+    // First candidate fails before any content (bare 'error', no 'start');
+    // second candidate succeeds. The client should only ever see frames
+    // from the successful candidate.
+    vi.mocked(piAi.stream)
+      .mockResolvedValueOnce(errorStream() as any)
+      .mockResolvedValueOnce(successStream() as any);
+
+    setConfigForTesting({
+      providers: {
+        'openai-s': {
+          api_base_url: 'https://api.openai.com/v1',
+          api_key: 'sk-test',
+          pi_ai_provider: 'openai-codex',
+          models: {
+            'gpt-5.4': {
+              pricing: { source: 'simple', input: 0, output: 0 },
+              pi_ai_model_id: 'gpt-5.4',
+            },
+          },
+        },
+        'openai-backup': {
+          api_base_url: 'https://api.openai.com/v1',
+          api_key: 'sk-test-2',
+          pi_ai_provider: 'openai-codex',
+          models: {
+            'gpt-5.4': {
+              pricing: { source: 'simple', input: 0, output: 0 },
+              pi_ai_model_id: 'gpt-5.4',
+            },
+          },
+        },
+      },
+      models: {
+        'gpt-5.4': {
+          priority: 'selector',
+          selector: 'in_order',
+          targets: [
+            { provider: 'openai-s', model: 'gpt-5.4' },
+            { provider: 'openai-backup', model: 'gpt-5.4' },
+          ],
+        },
+      },
+      keys: {},
+      failover: { enabled: true, retryableStatusCodes: [], retryableErrors: [] },
+      quotas: [],
+    } as any);
+
+    const usageStorage = createUsageStorage();
+    DebugManager.getInstance().setStorage(usageStorage);
+    DebugManager.getInstance().enableForKey('beta-key');
+    enterRequestContext({ keyName: 'beta-key' });
+
     const result = await runPiAiExecutor({
-      requestId: 'req-stream-error',
-      incomingApiType: 'responses',
+      requestId: 'req-stream-failover',
+      incomingApiType: 'gemini',
       modelAlias: 'gpt-5.4',
       context: { messages: [] } as any,
       generationIntent: { reasoning: { source: 'client' } } as any,
@@ -109,7 +203,17 @@ describe('runPiAiExecutor streaming errors', () => {
       } as any,
       usageStorage,
       serializeMessage: (msg) => msg as any,
-      serializeChunks: () => ['event: response.completed\ndata: {}\n\n'],
+      serializeChunks: (event) => {
+        if (event.type === 'text_delta') {
+          return [
+            `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ text: event.delta }] } }] })}\n\n`,
+          ];
+        }
+        if (event.type === 'done') {
+          return [`data: ${JSON.stringify({ candidates: [{ finishReason: 'STOP' }] })}\n\n`];
+        }
+        return [];
+      },
     });
 
     const frames: string[] = [];
@@ -117,29 +221,19 @@ describe('runPiAiExecutor streaming errors', () => {
       frames.push(frame);
     }
 
-    expect(frames).toHaveLength(1);
+    // Only the second candidate's frames ever reached the "client" — no
+    // trace of the first candidate's pre-flight failure leaked through.
+    const snapshot = frames.join('');
+    expect(snapshot).toContain('"candidates"');
+    expect(vi.mocked(piAi.stream)).toHaveBeenCalledTimes(2);
     expect(usageStorage.saveRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        requestId: 'req-stream-error',
-        apiKey: 'beta-key',
-        incomingApiType: 'responses',
-        incomingModelAlias: 'gpt-5.4',
-        provider: 'openai-s',
-        responseStatus: 'error',
-        finishReason: 'error',
+        requestId: 'req-stream-failover',
+        provider: 'openai-backup',
+        attemptCount: 2,
+        responseStatus: 'success',
+        allAttemptedProviders: 'openai-s/gpt-5.4, openai-backup/gpt-5.4',
       })
-    );
-    expect(usageStorage.saveError).toHaveBeenCalledWith(
-      'req-stream-error',
-      expect.any(Error),
-      expect.objectContaining({
-        apiType: 'responses',
-        provider: 'openai-s',
-        targetModel: 'gpt-5.4',
-      })
-    );
-    expect(usageStorage.saveDebugLog).toHaveBeenCalledWith(
-      expect.objectContaining({ requestId: 'req-stream-error' })
     );
   });
 

--- a/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/pi-ai-executor.test.ts
@@ -235,6 +235,19 @@ describe('runPiAiExecutor streaming errors', () => {
         allAttemptedProviders: 'openai-s/gpt-5.4, openai-backup/gpt-5.4',
       })
     );
+
+    // The absorbed pre-flight failure is still persisted to the errors
+    // table, flagged as a preflight failure, even though the client never
+    // saw it.
+    expect(usageStorage.saveError).toHaveBeenCalledWith(
+      'req-stream-failover',
+      expect.objectContaining({ isPreflightStreamError: true }),
+      expect.objectContaining({
+        provider: 'openai-s',
+        targetModel: 'gpt-5.4',
+        preflight: true,
+      })
+    );
   });
 
   it('saves serialized stream frames as the transformed response snapshot', async () => {

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -277,6 +277,11 @@ function isRetryable(err: any, signal: AbortSignal | undefined): boolean {
   const code = err?.routingContext?.code;
   if (code === 'client_disconnected') return false;
 
+  // Pre-flight stream failure (see peekFirstStreamEvent below): the failure
+  // was discovered before any bytes reached the client, so retrying the next
+  // candidate is always safe — never worse than surfacing it.
+  if (err?.isPreflightStreamError) return true;
+
   // AbortError (from attempt timeout) → upstream_timeout → retryable
   if (err?.name === 'AbortError' || err instanceof DOMException) return true;
 
@@ -327,6 +332,46 @@ function nextWithTtfbTimeout<T>(
       }
     );
   });
+}
+
+// ─── Pre-flight peek ──────────────────────────────────────────────────────────
+
+/**
+ * pi-ai's `stream()` resolves synchronously and never rejects — a connection
+ * failure that happens before any content is produced (auth/network/OAuth
+ * token issues, etc.) is instead reported as a lone `error` event with no
+ * preceding `start`. Left alone, that gets forwarded straight into the
+ * client's SSE stream as a bare `error`/terminal frame with no `start` ever
+ * sent — a protocol violation for wire formats (like Anthropic messages)
+ * that require `message_start` before any other event.
+ *
+ * Since nothing has reached the client yet at this point (no HTTP response
+ * has been committed), this failure is exactly as safe to retry as a
+ * `stream()` call that threw synchronously. This peeks the first event off
+ * the iterator so the per-candidate loop can fold it into the existing
+ * failover path instead of committing a broken stream to the client.
+ */
+async function peekFirstStreamEvent<T>(
+  iterator: AsyncIterator<T>,
+  stallTtfbMs: number | null
+): Promise<IteratorResult<T>> {
+  return stallTtfbMs != null
+    ? nextWithTtfbTimeout(iterator.next() as Promise<IteratorResult<T>>, stallTtfbMs, () => {})
+    : (iterator.next() as Promise<IteratorResult<T>>);
+}
+
+/** Re-attaches an already-consumed first result to the front of an iterator. */
+function primeAsyncIterable<T>(first: T, rest: AsyncIterator<T>): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield first;
+      while (true) {
+        const next = await rest.next();
+        if (next.done) return;
+        yield next.value;
+      }
+    },
+  };
 }
 
 // ─── UsageRecord population from pi-ai ───────────────────────────────────────
@@ -1020,11 +1065,34 @@ export async function runPiAiExecutor<TResponse>(
           piAiModels.stream(dispatchModel, dispatchContext, callOptions)
         );
 
+        // ── Pre-flight peek ────────────────────────────────────────────
+        // Consume the first event before committing to this candidate. If
+        // it's a pre-`start` `error`, throw so the existing catch(err) below
+        // treats it exactly like a synchronously-thrown stream() failure —
+        // cooldown, retryHistory, and failover to the next candidate — since
+        // nothing has been sent to the client yet.
+        const iterator = (eventStream as AsyncIterable<AssistantMessageEvent>)[
+          Symbol.asyncIterator
+        ]();
+        const firstResult = await peekFirstStreamEvent(iterator, stallTtfbMs);
+
+        if (!firstResult.done && firstResult.value.type === 'error') {
+          const preflightErr = new Error(
+            extractPiAiErrorMessage(firstResult.value.error) ?? 'Upstream error'
+          ) as any;
+          preflightErr.isPreflightStreamError = true;
+          throw preflightErr;
+        }
+
+        const primedStream: AsyncIterable<AssistantMessageEvent> = firstResult.done
+          ? { async *[Symbol.asyncIterator]() {} }
+          : primeAsyncIterable(firstResult.value, iterator);
+
         // Build and return the SSE generator — the generator owns
         // release, timeout cleanup, usage, quota, debug flush.
         const gen = buildSSEGenerator({
           requestId,
-          eventStream,
+          eventStream: primedStream,
           route,
           piModel: piModel as any,
           toolRenamePairs,

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -211,6 +211,8 @@ interface RetryAttemptRecord {
   reason: string;
   statusCode?: number;
   retryable?: boolean;
+  /** True when pi-ai reported this failure before any 'start' event — see peekFirstStreamEvent. */
+  preflight?: boolean;
 }
 
 function appendSkippedAttempt(
@@ -264,6 +266,7 @@ function appendFailureAttempt(
     reason,
     statusCode: typeof statusCode === 'number' ? statusCode : undefined,
     retryable,
+    preflight: error?.isPreflightStreamError === true || undefined,
   });
 }
 
@@ -1151,10 +1154,28 @@ export async function runPiAiExecutor<TResponse>(
       const canRetry = failoverEnabled && !isLast && isRetryable(effectiveErr, signal);
       appendFailureAttempt(retryHistory, route, effectiveErr, incomingApiType, canRetry);
 
+      // Pre-flight failures (see peekFirstStreamEvent) are invisible to the
+      // client whenever they're absorbed by failover, so they'd otherwise
+      // leave no trace anywhere but the DB usage/error record. Surface them
+      // in the application log too.
+      if (effectiveErr?.isPreflightStreamError) {
+        logger.warn(
+          `[pi-ai-executor] Pre-flight stream error on ${route.provider}/${route.model} (requestId=${requestId}): ${effectiveErr.message}${
+            canRetry ? ' — retrying next candidate' : ' — no candidates remain'
+          }`
+        );
+      }
+
       if (canRetry) {
         if (usageStorage) {
           usageStorage
-            .saveError(requestId, effectiveErr, { apiType: incomingApiType })
+            .saveError(requestId, effectiveErr, {
+              apiType: incomingApiType,
+              provider: route.provider,
+              targetModel: route.model,
+              preflight: effectiveErr?.isPreflightStreamError === true || undefined,
+              retryHistory: JSON.stringify(retryHistory),
+            })
             .catch(() => {});
         }
         lastError = effectiveErr;

--- a/packages/backend/src/services/cooldown-manager.ts
+++ b/packages/backend/src/services/cooldown-manager.ts
@@ -29,6 +29,11 @@ export class CooldownManager {
     return CooldownManager.instance;
   }
 
+  /** For testing only */
+  public static resetForTesting(): void {
+    CooldownManager.instance = undefined as any;
+  }
+
   private ensureDb() {
     if (!this.db) {
       this.db = getDatabase();


### PR DESCRIPTION
### **User description**
## Summary

pi-ai's `stream()` resolves synchronously and never rejects — a connection failure before any content is produced (auth/network/OAuth token issues, etc.) is instead reported as a lone `error` event with no preceding `start`. This previously reached clients as a `message_delta` with no `message_start` (occasional race condition reported on the messages API with OAuth Anthropic models), and skipped Plexus's existing per-candidate failover entirely.

- `runPiAiExecutor` now peeks the first event of every streaming attempt before committing to that candidate. A pre-`start` `error` is thrown as a synthetic `isPreflightStreamError`, which `isRetryable()` always treats as retryable, folding it into the existing cooldown/retryHistory/failover loop exactly like a synchronously-thrown `stream()` call — invisible to the client whenever another candidate remains, reported via the existing `buildAllTargetsFailedError` path only once candidates are exhausted.
- `context-to-anthropic.ts`'s `pendingStart` now defaults to `true` (rather than being armed only by a `'start'` event) as defense-in-depth, so the serializer itself can never emit `message_delta`/`message_stop` before `message_start`.
- Pre-flight failures are now visible in the `inference_errors` table (flagged via a new `preflight` field on retry-history entries) and via a `logger.warn`, even when transparently absorbed by failover and never seen by the client.
- Adds `CooldownManager.resetForTesting()` singleton-reset hook needed for test isolation.

## Test plan
- `bun run test:force-all` — 2286/2286 passed
- New regression tests: pre-flight error folds into failover and rejects once candidates are exhausted, transparent retry to a healthy candidate, DB error-row assertions, and a serializer-level regression test for out-of-order `message_start`.


___

### **Description**
- Fold pre-flight stream errors (lone `error` with no `start`) into candidate failover via a new `peekFirstStreamEvent` peek in `runPiAiExecutor`

- Default `pendingStart` to `true` in `context-to-anthropic.ts` as defense-in-depth so `message_start` always precedes `message_delta`

- Surface absorbed pre-flight failures in the `inference_errors` table and via `logger.warn`, flagged with a new `preflight` field

- Add `CooldownManager.resetForTesting()` singleton-reset hook and regression tests for failover and serializer ordering


___

