### PR TITLE
fix(inference-v2): strip placeholder thinking signatures before serialization

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -1,6 +1,101 @@
 # Known Bugs / Missing Instrumentation
 
-All previously tracked bugs in this file have been resolved. See commit history for details.
+---
+
+## inference-v2: `thinkingSignature` placeholder leaking as a signature — MITIGATED, partially verified
+
+**Symptom:** Anthropic (native `cc`) rejects a request with:
+
+```
+400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: Invalid `signature` in `thinking` block"}}
+```
+
+This shows up intermittently, correlated with `WORK`-group failover away from and back to a
+native Anthropic target (e.g. `cc` → `openrouter-s` → `cc`) on aliases with extended thinking
+enabled.
+
+**Root cause:** third-party bug in `@earendil-works/pi-ai`'s OpenAI-completions stream parser
+(`openai-completions.js`), used for OpenRouter/Bedrock-style upstreams. `ensureThinkingBlock()`
+stamps a new thinking block's `thinkingSignature` with the *JSON field name* it matched on the
+delta (`reasoning` | `reasoning_content` | `reasoning_text`) before any real signature has
+arrived. Later, `isEncryptedReasoningDetail()` only recognizes Gemini-style
+`reasoning_details` entries (`{type: "reasoning.encrypted", id, data}`) to correlate a real
+signature back onto the block. Bedrock-via-OpenRouter instead sends
+`{type: "reasoning.text", signature: "..."}` — a shape `isEncryptedReasoningDetail()` doesn't
+recognize — so the real signature is silently dropped and the leftover field-name placeholder
+(literally the string `"reasoning"` in observed traces) is all that remains on
+`thinkingSignature`. Confirmed live on staging: the raw upstream response's terminal
+`reasoning_details` chunk did contain a real base64 Anthropic-format signature, but Plexus/pi-ai
+never picked it up.
+
+Forwarding that placeholder string to a client as if it were a genuine signature is worse than
+omitting it: if a later turn is dispatched to native Anthropic (which validates signatures
+cryptographically), the literal placeholder is rejected outright — this is the `400` above. It
+could also coincidentally look like a signature from a completely different provider.
+
+**Fix (chosen over patching pi-ai):** added `isPlaceholderThinkingSignature()` in
+`packages/backend/src/inference-v2/shared/pi-ai-utils.ts`, recognizing the three known
+placeholder strings. Applied as a guard at every point Plexus's own serializers read
+`thinkingSignature` for output, so the placeholder is omitted/suppressed instead of forwarded:
+
+- `context-to-anthropic.ts`: non-streaming (`messageToAnthropicResponse`) and streaming
+  (`closeCurrentBlock()` inside `eventToAnthropicSSE`) — no `signature`/`signature_delta` is
+  emitted when the value is a placeholder.
+- `context-to-gemini.ts`: non-streaming `buildParts()`'s thinking branch — no `thoughtSignature`
+  is set when the value is a placeholder. (Gemini's streaming thinking-delta path never emitted
+  a signature in the first place, so no change was needed there.)
+
+Shipped in PR [#660](https://github.com/mcowger/plexus/pull/660) (commit `a16ec078`).
+
+**Verification performed on staging (2026-07-04), and what it actually proved:**
+
+Reproduced by forcing `claude-opus-4-8`'s `WORK` group through `cc` → `openrouter-s` → `cc` via
+target `enabled` toggles, with `sticky_session` disabled and debug tracing scoped to
+`["cc","openrouter-s"]`.
+
+- Confirmed the guard works at the point of leakage: a turn served by `openrouter-s` whose raw
+  upstream response carried a real signature in the unrecognized `reasoning.text` shape produced
+  **zero** `signature_delta` events in Plexus's transformed SSE output (previously this would
+  have emitted `signature_delta` with the literal placeholder string). This is a direct,
+  confirmed fix of the leak.
+- Could **not** fully reproduce the original end-to-end 400, because doing so requires a thinking
+  block with a placeholder/empty signature to be replayed to native Anthropic while still
+  attached to an *active tool-use loop* (Anthropic requires the thinking block immediately
+  preceding `tool_use` in the last assistant turn when continuing that loop). In every attempt,
+  by the time a target-switch to `cc` happened, the client had either already resolved the tool
+  loop (`stop_reason: end_turn`) — at which point clients drop thinking blocks from history
+  entirely — or the `openrouter-s` response happened not to include a thinking block at all.
+  Because of this, we only verified "no placeholder leaks out"; we did not directly observe
+  Anthropic's behavior when handed back a thinking block with `signature: ""` (Plexus's
+  `content_block_start` hardcodes `signature: ""` initially, and since the guard suppresses the
+  `signature_delta` update, `""` is what a client ends up storing) while still inside an active
+  tool loop.
+
+**What to look for if this resurfaces:**
+
+- Pull the debug trace (`GET /v0/management/debug/logs/{requestId}`) for the failing request and
+  its immediately preceding turn (same conversation/`previousResponseId` or sticky-session key).
+- In the *prior* turn's `transformedResponse`, check for a `thinking` content block. If its
+  `signature` is empty (`""`) or one of the literal strings `reasoning` / `reasoning_content` /
+  `reasoning_text`, and that turn was served by a non-native (OpenAI-completions-style) provider
+  (e.g. `openrouter-s`, Bedrock-via-OpenRouter, etc.), this is the same bug family.
+  - `""` should now be impossible to leak as a `signature_delta` post-fix, but the *initial*
+    `content_block_start` still hardcodes `signature: ""` in `context-to-anthropic.ts`
+    (`openBlock()`) — deliberately left alone as out of scope for this fix. If Anthropic turns
+    out to reject a replayed empty-string signature under an active tool loop, the next fix is
+    likely either (a) omitting the `signature` key entirely from `content_block_start` until a
+    real value is known, or (b) upstream-patching pi-ai's `isEncryptedReasoningDetail()` to also
+    recognize the `{type: "reasoning.text", signature}` shape so the real signature is captured
+    instead of never being available at all.
+- Check the *failing* turn's `rawRequest` (outgoing) for the replayed `thinking` block's
+  `signature` value to see exactly what was sent to Anthropic.
+- To reproduce deliberately: force a tool-call turn onto a non-native provider (`openrouter-s`),
+  and — while the tool-use loop is still open (i.e. immediately after the model's `tool_use`
+  response, before the tool result round-trip completes) — flip that target's `enabled` off and
+  the native `cc` target's `enabled` on, then let the client send the tool result. This routes
+  the tool-result continuation (which must carry the immediately-preceding thinking block) to
+  `cc`. This is finicky to time by hand; whether a given response includes a thinking block at
+  all (`thinking_tokens > 0`) is not fully controllable from the client side.
 
 ---
 

--- a/packages/backend/src/inference-v2/anthropic/__tests__/context-to-anthropic.test.ts
+++ b/packages/backend/src/inference-v2/anthropic/__tests__/context-to-anthropic.test.ts
@@ -86,6 +86,26 @@ describe('messageToAnthropicResponse', () => {
     expect(thinkBlock?.thinking).toBe('Deep thought');
   });
 
+  it('omits signature when thinkingSignature is a pi-ai field-name placeholder, not a real signature', () => {
+    // Reproduces the bug behind "Invalid `signature` in `thinking` block" 400s:
+    // pi-ai's openai-completions parser stamps thinkingSignature with the
+    // matched JSON field name (e.g. "reasoning") before a real signature
+    // arrives. If the provider's reasoning_details never carry one (e.g.
+    // Bedrock via OpenRouter using the reasoning.text shape), that leftover
+    // field name is all that's left — it must never be forwarded as if it
+    // were a genuine signature.
+    const msg = makeMessage({
+      content: [
+        { type: 'thinking', thinking: 'Deep thought', thinkingSignature: 'reasoning' } as any,
+      ],
+    });
+    const result = messageToAnthropicResponse(msg, 'claude-opus-4-6');
+    const thinkBlock = result.content.find((b) => b.type === 'thinking') as
+      | { type: 'thinking'; thinking: string; signature?: string }
+      | undefined;
+    expect(thinkBlock?.signature).toBeUndefined();
+  });
+
   it('includes tool_use content block', () => {
     const msg = makeMessage({
       stopReason: 'toolUse',
@@ -234,6 +254,54 @@ describe('eventToAnthropicSSE', () => {
     expect(stopIndex).toBeGreaterThan(-1);
     expect(sigIndex).toBeLessThan(stopIndex);
     expect(allFrames).toContain('sig-abc');
+  });
+
+  it('does not emit signature_delta when thinkingSignature is a placeholder field name', () => {
+    const state = makeAnthropicChunkSerialiserState('claude-opus-4-6');
+    eventToAnthropicSSE(
+      { type: 'start', partial: { content: [], usage: zeroUsage() } } as any,
+      state
+    );
+    eventToAnthropicSSE(
+      {
+        type: 'thinking_start',
+        contentIndex: 0,
+        partial: {
+          content: [{ type: 'thinking', thinking: '', thinkingSignature: '' }],
+          usage: zeroUsage(),
+        },
+      } as any,
+      state
+    );
+    eventToAnthropicSSE(
+      {
+        type: 'thinking_delta',
+        contentIndex: 0,
+        delta: 'Hmm',
+        partial: { content: [], usage: zeroUsage() },
+      } as any,
+      state
+    );
+    // Closing the block: the underlying content carries pi-ai's leftover
+    // field-name placeholder ("reasoning") instead of a real signature —
+    // no signature_delta should be emitted for it.
+    const frames = eventToAnthropicSSE(
+      {
+        type: 'text_start',
+        contentIndex: 1,
+        partial: {
+          content: [
+            { type: 'thinking', thinking: 'Hmm', thinkingSignature: 'reasoning' },
+            { type: 'text', text: '' },
+          ],
+          usage: zeroUsage(),
+        },
+      } as any,
+      state
+    );
+    const allFrames = frames.join('\n---\n');
+    expect(allFrames).not.toContain('signature_delta');
+    expect(allFrames).toContain('content_block_stop');
   });
 
   it('message_delta on done includes full usage breakdown, not just output_tokens', () => {

--- a/packages/backend/src/inference-v2/anthropic/context-to-anthropic.ts
+++ b/packages/backend/src/inference-v2/anthropic/context-to-anthropic.ts
@@ -27,6 +27,7 @@ import type {
   ThinkingContent,
   ToolCall,
 } from '@earendil-works/pi-ai';
+import { isPlaceholderThinkingSignature } from '../shared/pi-ai-utils';
 
 // ─── Anthropic wire types ─────────────────────────────────────────────────────
 
@@ -149,7 +150,9 @@ export function messageToAnthropicResponse(
       thinkingBlocks.push({
         type: 'thinking',
         thinking: tb.thinking,
-        ...(tb.thinkingSignature ? { signature: tb.thinkingSignature } : {}),
+        ...(tb.thinkingSignature && !isPlaceholderThinkingSignature(tb.thinkingSignature)
+          ? { signature: tb.thinkingSignature }
+          : {}),
       });
     } else if (block.type === 'text') {
       textBlocks.push({ type: 'text', text: (block as TextContent).text });
@@ -286,7 +289,7 @@ export function eventToAnthropicSSE(
         const block = content?.[state.activeContentIndex];
         const signature =
           block?.type === 'thinking' ? (block as ThinkingContent).thinkingSignature : undefined;
-        if (signature) {
+        if (signature && !isPlaceholderThinkingSignature(signature)) {
           frames.push(
             sseEvent('content_block_delta', {
               type: 'content_block_delta',

--- a/packages/backend/src/inference-v2/gemini/__tests__/context-to-gemini.test.ts
+++ b/packages/backend/src/inference-v2/gemini/__tests__/context-to-gemini.test.ts
@@ -98,6 +98,22 @@ describe('messageToGeminiResponse', () => {
     expect(thinkPart?.thoughtSignature).toBe('THINK_SIG');
   });
 
+  it('omits thoughtSignature when thinkingSignature is a pi-ai field-name placeholder', () => {
+    // Same underlying pi-ai bug as the Anthropic path: thinkingSignature can be
+    // left holding the matched JSON field name ("reasoning", "reasoning_content",
+    // "reasoning_text") instead of a real signature when the provider's
+    // reasoning_details shape isn't recognized. Must not be forwarded as a
+    // thoughtSignature.
+    const msg = makeMessage({
+      content: [{ type: 'thinking', thinking: 'reasoning', thinkingSignature: 'reasoning' } as any],
+    });
+    const result = messageToGeminiResponse(msg, 'gemini-3.5-flash');
+    const thinkPart = (result.candidates[0]!.content.parts as any[]).find(
+      (p) => p.thought === true
+    );
+    expect(thinkPart?.thoughtSignature).toBeUndefined();
+  });
+
   it('emits thoughtSignature on text parts from textSignature', () => {
     const msg = makeMessage({
       content: [{ type: 'text', text: 'answer', textSignature: 'TEXT_SIG' } as any],

--- a/packages/backend/src/inference-v2/gemini/context-to-gemini.ts
+++ b/packages/backend/src/inference-v2/gemini/context-to-gemini.ts
@@ -36,6 +36,7 @@ import type {
   ThinkingContent,
   ToolCall,
 } from '@earendil-works/pi-ai';
+import { isPlaceholderThinkingSignature } from '../shared/pi-ai-utils';
 
 // ─── Gemini wire types ────────────────────────────────────────────────────────
 
@@ -99,7 +100,11 @@ function buildParts(message: AssistantMessage): GeminiPart[] {
     if (block.type === 'thinking') {
       const tc = block as ThinkingContent;
       const part: GeminiPart = { text: tc.thinking, thought: true };
-      if (typeof tc.thinkingSignature === 'string' && tc.thinkingSignature) {
+      if (
+        typeof tc.thinkingSignature === 'string' &&
+        tc.thinkingSignature &&
+        !isPlaceholderThinkingSignature(tc.thinkingSignature)
+      ) {
         (part as any).thoughtSignature = tc.thinkingSignature;
       }
       parts.push(part);

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -815,3 +815,31 @@ export function isClaudeMaskingApiKeyRoute(route: RouteResult, targetApiType: st
 
   return route.config.useClaudeMasking === true;
 }
+
+// ─── Thinking signature validation ───────────────────────────────────────────
+//
+// pi-ai's openai-completions parser (ensureThinkingBlock) stamps a thinking
+// block's `thinkingSignature` with the *JSON field name* it matched
+// (`reasoning` | `reasoning_content` | `reasoning_text`) as soon as any
+// reasoning delta arrives — before it knows whether the provider will ever
+// send a real cryptographic signature via `reasoning_details[].signature`.
+// When a provider's `reasoning_details` entries don't match pi-ai's
+// `isEncryptedReasoningDetail` shape (Gemini-style {type, id, data}) — e.g.
+// Bedrock/OpenRouter's `{type: "reasoning.text", signature: "..."}` — the real
+// signature is never picked up, and this placeholder field-name string is all
+// that's left on the block. Forwarding it to a client as if it were a genuine
+// signature is worse than omitting it: a later replay to a provider that
+// actually validates signatures (e.g. Anthropic) is rejected outright with
+// "Invalid signature in thinking block", and it could just as easily be
+// mistaken for a signature from an entirely different provider.
+
+const THINKING_SIGNATURE_FIELD_NAME_PLACEHOLDERS = new Set([
+  'reasoning',
+  'reasoning_content',
+  'reasoning_text',
+]);
+
+/** True when `signature` is pi-ai's leftover field-name placeholder, not a real signature. */
+export function isPlaceholderThinkingSignature(signature: string | undefined): boolean {
+  return signature != null && THINKING_SIGNATURE_FIELD_NAME_PLACEHOLDERS.has(signature);
+}


### PR DESCRIPTION
### **User description**
## Summary
- pi-ai's OpenAI-completions parser stamps a thinking block's `thinkingSignature` with the matched JSON field name (`reasoning`/`reasoning_content`/`reasoning_text`) as a placeholder before a real signature arrives. When a provider's `reasoning_details` don't match pi-ai's recognized shape (e.g. Bedrock via OpenRouter using `{type: "reasoning.text", signature}`), the real signature is dropped and this leftover placeholder persists as the final value.
- Forwarding that placeholder to clients as if it were a genuine signature causes a `400 "Invalid signature in thinking block"` error when it's later replayed to a provider that validates signatures (e.g. native Anthropic) — this is the root cause of intermittent thinking-signature 400s seen in production, confirmed via a live repro on staging (forcing failover between `cc` and `openrouter-s` targets).
- Adds `isPlaceholderThinkingSignature()` in `pi-ai-utils.ts` and uses it to omit/suppress the placeholder in both the Anthropic (non-streaming + streaming) and Gemini (non-streaming) response serializers instead of forwarding it.

## Test plan
- [x] `bun run test` — 436/436 tests passing (48/48 files), including 3 new tests covering the placeholder-suppression behavior (2 Anthropic, 1 Gemini)
- [x] `bun run typecheck` — clean across all workspaces
- [x] `bun run format:check` — clean
- [x] Pre-commit hooks (backend-tests, biome-format, biome-lint, typecheck) passed on commit


___

### **Description**
- Add `isPlaceholderThinkingSignature()` in `pi-ai-utils.ts` to detect pi-ai's leftover field-name placeholders (`reasoning`, `reasoning_content`, `reasoning_text`)

- Suppress placeholder signatures in Anthropic response serializers (non-streaming and streaming) to prevent invalid-signature 400s on replay

- Suppress placeholder signatures in Gemini non-streaming response serializer (`context-to-gemini.ts`)

- Add 3 tests covering placeholder-suppression behavior (2 Anthropic, 1 Gemini)


___

