### PR TITLE
fix(inference-v2): simplify no-candidate error and return 503

### DIFF
--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -193,10 +193,8 @@ function buildAllTargetsFailedError(
 }
 
 function buildNoBetaCandidatesError(): Error {
-  const err = new Error(
-    'No beta-compatible candidate found: no configured provider has both pi_ai_provider and pi_ai_model_id set to registry-valid values.'
-  ) as any;
-  err.routingContext = { statusCode: 400, code: 'no_beta_compatible_candidate' };
+  const err = new Error('No candidate targets available') as any;
+  err.routingContext = { statusCode: 503, code: 'no_candidate_targets' };
   return err;
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- Simplify the target-exhaustion error message in the inference-v2 pi-ai executor to "No candidate targets available" (previously referenced pi_ai_provider/pi_ai_model_id internals and beta terminology).
- Return HTTP 503 instead of 400, matching the v1 path's behavior for this case.


___

### **Description**
- Simplify no-candidate error message to "No candidate targets available"

- Change HTTP status code from 400 to 503 for target exhaustion

- Update error code from `no_beta_compatible_candidate` to `no_candidate_targets`


___

