### PR TITLE
fix(inference-v2): enforce key access policy on beta routes

### DIFF
--- a/packages/backend/src/inference-v2/index.ts
+++ b/packages/backend/src/inference-v2/index.ts
@@ -32,6 +32,7 @@ import type { QuotaEnforcer } from '../services/quota/quota-enforcer';
 import { checkQuotaMiddleware } from '../services/quota/quota-middleware';
 import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../utils/timeout';
 import { getClientIp } from '../utils/ip';
+import { attachKeyAccessPolicy } from '../utils/auth';
 import { sanitizeHeaders } from '../utils/sanitize-headers';
 import { logger } from '../utils/logger';
 import { openaiRequestToContext } from './openai/openai-to-context';
@@ -179,6 +180,7 @@ export async function handleBetaChatCompletions(
 
   const debug = DebugManager.getInstance();
   const body = request.body as any;
+  body.metadata = attachKeyAccessPolicy(request, { metadata: body.metadata }).metadata;
 
   debug.startLog(requestId, body, sanitizeHeaders(request.headers as any));
 
@@ -335,6 +337,7 @@ export async function handleBetaMessages(
 
   const debug = DebugManager.getInstance();
   const body = request.body as any;
+  body.metadata = attachKeyAccessPolicy(request, { metadata: body.metadata }).metadata;
 
   debug.startLog(requestId, body, sanitizeHeaders(request.headers as any));
 
@@ -492,6 +495,7 @@ export async function handleBetaResponses(
 
   const debug = DebugManager.getInstance();
   const body = request.body as any;
+  body.metadata = attachKeyAccessPolicy(request, { metadata: body.metadata }).metadata;
   const modelAlias: string = body.model ?? '';
 
   debug.startLog(requestId, body, sanitizeHeaders(request.headers as any));
@@ -694,6 +698,7 @@ export async function handleBetaGeminiRequest(
 
   const debug = DebugManager.getInstance();
   const body = request.body as any;
+  body.metadata = attachKeyAccessPolicy(request, { metadata: body.metadata }).metadata;
   // Model alias comes from the URL param — inject into body for the parser
   const params = request.params as any;
   const modelAlias: string =

--- a/packages/backend/src/routes/inference/__tests__/beta-key-routing.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/beta-key-routing.test.ts
@@ -62,6 +62,11 @@ async function createApp(): Promise<{
     keys: {
       stable: { secret: 'sk-stable' },
       beta: { secret: 'sk-beta', beta: true },
+      'beta-restricted': {
+        secret: 'sk-beta-restricted',
+        beta: true,
+        allowedProviders: ['kilocode'],
+      },
     },
     failover: {
       enabled: false,
@@ -175,6 +180,46 @@ describe('beta key stable route routing', () => {
     expect(vi.mocked(runPiAiExecutor).mock.calls[0]![0]).toMatchObject({
       incomingApiType: 'gemini',
       modelAlias: 'test-model',
+    });
+    await fastify.close();
+  });
+
+  it.each([
+    {
+      name: 'chat completions',
+      url: '/v1/chat/completions',
+      payload: { model: 'test-model', messages: [{ role: 'user', content: 'hi' }] },
+    },
+    {
+      name: 'messages',
+      url: '/v1/messages',
+      payload: { model: 'test-model', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] },
+    },
+    {
+      name: 'responses',
+      url: '/v1/responses',
+      payload: { model: 'test-model', input: 'hi' },
+    },
+    {
+      name: 'gemini generateContent',
+      url: '/v1beta/models/test-model:generateContent',
+      payload: { contents: [{ role: 'user', parts: [{ text: 'hi' }] }] },
+    },
+  ])('attaches the key access policy for restricted beta keys on $name', async (testCase) => {
+    const { fastify } = await createApp();
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: testCase.url,
+      headers: { authorization: 'Bearer sk-beta-restricted', 'content-type': 'application/json' },
+      payload: testCase.payload,
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(runPiAiExecutor).toHaveBeenCalledTimes(1);
+    const executorInput = vi.mocked(runPiAiExecutor).mock.calls[0]![0] as any;
+    expect(executorInput.request.body.metadata?.plexus_metadata?.plexus_key_policy).toEqual({
+      allowedProviders: ['kilocode'],
     });
     await fastify.close();
   });


### PR DESCRIPTION
### **User description**
## Summary

Key-based provider/model restrictions (`allowedProviders`, `excludedProviders`, `allowedModels`, `excludedModels`) were silently bypassed for any inference key with `beta: true`, across all four inference-v2 (beta) endpoints: chat completions, messages, responses, and Gemini.

## Root cause

Each `handleBeta*` route handler dispatches straight into the beta/pi-ai path without ever calling `attachKeyAccessPolicy`, which is the only place that reads `request.keyConfig` and writes the policy into `request/body.metadata.plexus_metadata.plexus_key_policy`. `runPiAiExecutor` reads that same metadata field to build its `PolicyRequest`, so on the beta path the policy was always `undefined` and `applyKeyAccessPolicy` short-circuited, allowing routing to any provider/model regardless of key restrictions.

Confirmed in production via traceid `93331fc9-6ae1-4038-b242-91d1e11543c8`: key `OWUI-OR` (`allowedProviders: ["openrouter-s", "kilocode"]`, `beta: true`) was routed to and serviced by provider `cc`, which is not in its allowlist.

Note: `allowedIps` (enforced in the auth hook) and `quota` (enforced via `checkQuotaMiddleware` inside each beta handler) were already unaffected.

## Fix

Attach the key access policy to `body.metadata` in each of the four beta handlers (`handleBetaChatCompletions`, `handleBetaMessages`, `handleBetaResponses`, `handleBetaGeminiRequest`) before calling `runPiAiExecutor`.

## Testing

- Added regression tests in `beta-key-routing.test.ts` covering chat/messages/responses/gemini that assert the key policy is attached to the executor's request metadata for a restricted beta key.
- Verified the new tests fail against the pre-fix code and pass with the fix.
- `bun run test` and `bun run typecheck` pass (also ran automatically via pre-commit hooks).


___

### **Description**
- Enforce key access policy on all four beta inference-v2 routes

- Attach `attachKeyAccessPolicy` to `body.metadata` before executor dispatch

- Add regression tests for restricted beta keys across all beta endpoints


___

