### PR TITLE
Quota follow-ups: shared status card, consolidated ranking, default_quotas validation

### DIFF
--- a/packages/backend/src/routes/management/__tests__/system-settings-default-quotas.test.ts
+++ b/packages/backend/src/routes/management/__tests__/system-settings-default-quotas.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+
+const serviceState = vi.hoisted(() => {
+  const state = {
+    quotas: {} as Record<string, unknown>,
+    setSettingsBulk: vi.fn(async () => {}),
+    getAllUserQuotas: vi.fn(async () => state.quotas),
+  };
+  return state;
+});
+
+vi.mock('../../../services/config-service', () => ({
+  ConfigService: {
+    getInstance: vi.fn(() => ({
+      setSettingsBulk: serviceState.setSettingsBulk,
+      getRepository: vi.fn(() => ({
+        getAllUserQuotas: serviceState.getAllUserQuotas,
+      })),
+    })),
+  },
+}));
+
+import { registerConfigRoutes } from '../config';
+
+describe('PATCH /v0/management/system-settings — default_quotas validation', () => {
+  let fastify: FastifyInstance;
+
+  beforeEach(async () => {
+    serviceState.quotas = { 'my-quota': { type: 'daily', limitType: 'requests', limit: 100 } };
+    serviceState.setSettingsBulk.mockClear();
+    serviceState.getAllUserQuotas.mockClear();
+
+    fastify = Fastify();
+    await registerConfigRoutes(fastify);
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  const patch = (payload: unknown) =>
+    fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/system-settings',
+      payload: payload as object,
+    });
+
+  it('400s when default_quotas references an undefined quota name', async () => {
+    const res = await patch({ default_quotas: ['my-quota', 'ghost-quota'] });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.type).toBe('invalid_request_error');
+    expect(res.json().error.message).toContain('ghost-quota');
+    expect(serviceState.setSettingsBulk).not.toHaveBeenCalled();
+  });
+
+  it('400s when default_quotas is not an array', async () => {
+    const res = await patch({ default_quotas: 'my-quota' });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.type).toBe('invalid_request_error');
+    expect(serviceState.setSettingsBulk).not.toHaveBeenCalled();
+  });
+
+  it('400s when default_quotas contains non-string entries', async () => {
+    const res = await patch({ default_quotas: [1] });
+
+    expect(res.statusCode).toBe(400);
+    expect(serviceState.setSettingsBulk).not.toHaveBeenCalled();
+  });
+
+  it('200s when every name exists in user_quotas', async () => {
+    const res = await patch({ default_quotas: ['my-quota'] });
+
+    expect(res.statusCode).toBe(200);
+    expect(serviceState.setSettingsBulk).toHaveBeenCalledWith({ default_quotas: ['my-quota'] });
+  });
+
+  it('200s for an empty array', async () => {
+    const res = await patch({ default_quotas: [] });
+
+    expect(res.statusCode).toBe(200);
+    expect(serviceState.setSettingsBulk).toHaveBeenCalledWith({ default_quotas: [] });
+  });
+
+  it('200s for null (clearing the setting)', async () => {
+    const res = await patch({ default_quotas: null });
+
+    expect(res.statusCode).toBe(200);
+    expect(serviceState.setSettingsBulk).toHaveBeenCalledWith({ default_quotas: null });
+  });
+
+  it('leaves other settings free-form and skips the quota lookup', async () => {
+    const res = await patch({ some_other_setting: 'whatever' });
+
+    expect(res.statusCode).toBe(200);
+    expect(serviceState.getAllUserQuotas).not.toHaveBeenCalled();
+    expect(serviceState.setSettingsBulk).toHaveBeenCalledWith({ some_other_setting: 'whatever' });
+  });
+});

--- a/packages/backend/src/routes/management/__tests__/usage-summary.test.ts
+++ b/packages/backend/src/routes/management/__tests__/usage-summary.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import Fastify from 'fastify';
 import { registerUsageRoutes } from '../usage';
 import { UsageStorageService } from '../../../services/usage-storage';
@@ -26,11 +26,15 @@ describe('Usage summary route', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await fastify.close();
     await closeDatabase();
   });
 
   it('aggregates kwhUsed in summary series buckets', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00.000Z'));
+
     const now = new Date();
     now.setSeconds(0, 0);
 

--- a/packages/backend/src/routes/management/_quota-response.ts
+++ b/packages/backend/src/routes/management/_quota-response.ts
@@ -60,17 +60,6 @@ export function serializeQuotaSnapshot(check: QuotaCheckSnapshot): QuotaSnapshot
 }
 
 /**
- * Legacy single-quota shim: the most-constrained check in a key's context
- * (smallest remaining/limit ratio). Both routes keep exposing their
- * pre-Phase-5 top-level fields (derived from this) for wire compat,
- * alongside the new `quotas` array.
- */
-export function mostConstrained(checks: QuotaCheckSnapshot[]): QuotaCheckSnapshot | null {
-  if (checks.length === 0) return null;
-  return checks.reduce((min, c) => (c.remaining / c.limit < min.remaining / min.limit ? c : min));
-}
-
-/**
  * Effective quota-name set for a key, flattened to a plain name list for
  * membership validation on `/quota/clear` and `/quota/recompute` (which the
  * enforcer itself does not guard). Delegates to the enforcer's own

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -445,6 +445,32 @@ export async function registerConfigRoutes(
       return reply.code(400).send({ error: 'Object body is required' });
     }
 
+    // `default_quotas` is the one system setting with referential integrity:
+    // every name must exist in `user_quotas`, mirroring the membership checks
+    // on /quota/clear and /quota/recompute (the runtime only skip-and-warns on
+    // dangling names, silently enforcing nothing). `null` clears the setting.
+    if ('default_quotas' in body && body.default_quotas != null) {
+      const dq = body.default_quotas;
+      if (!Array.isArray(dq) || dq.some((v) => typeof v !== 'string')) {
+        return reply.code(400).send({
+          error: {
+            message: `'default_quotas' must be an array of quota names`,
+            type: 'invalid_request_error',
+          },
+        });
+      }
+      const defined = await configService.getRepository().getAllUserQuotas();
+      const unknown = dq.filter((name) => !(name in defined));
+      if (unknown.length > 0) {
+        return reply.code(400).send({
+          error: {
+            message: `Unknown quota name(s) in 'default_quotas': ${unknown.join(', ')}. Quotas must be defined in user_quotas first.`,
+            type: 'invalid_request_error',
+          },
+        });
+      }
+    }
+
     try {
       await configService.setSettingsBulk(body);
       logger.debug('System settings updated via API');

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -460,7 +460,7 @@ export async function registerConfigRoutes(
         });
       }
       const defined = await configService.getRepository().getAllUserQuotas();
-      const unknown = dq.filter((name) => !(name in defined));
+      const unknown = dq.filter((name) => !Object.hasOwn(defined, name));
       if (unknown.length > 0) {
         return reply.code(400).send({
           error: {

--- a/packages/backend/src/routes/management/quota-enforcement.ts
+++ b/packages/backend/src/routes/management/quota-enforcement.ts
@@ -2,11 +2,8 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
 import { ConfigService } from '../../services/config-service';
 import { logger } from '../../utils/logger';
-import {
-  mostConstrained,
-  resolveAttachedQuotaNames,
-  serializeQuotaSnapshot,
-} from './_quota-response';
+import { mostConstrained } from '@plexus/shared';
+import { resolveAttachedQuotaNames, serializeQuotaSnapshot } from './_quota-response';
 
 /**
  * Register admin API endpoints for quota enforcement management.

--- a/packages/backend/src/routes/management/self.ts
+++ b/packages/backend/src/routes/management/self.ts
@@ -6,7 +6,8 @@ import { DebugManager } from '../../services/debug-manager';
 import { ConfigService } from '../../services/config-service';
 import { ConfigRepository } from '../../db/config-repository';
 import { QuotaEnforcer } from '../../services/quota/quota-enforcer';
-import { mostConstrained, serializeQuotaSnapshot } from './_quota-response';
+import { mostConstrained } from '@plexus/shared';
+import { serializeQuotaSnapshot } from './_quota-response';
 import type { Principal } from './_principal';
 
 const toggleSchema = z.object({

--- a/packages/backend/src/services/quota/__tests__/quota-enforcer.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-enforcer.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
-import { QuotaEnforcer, SHARED_OWNER } from '../quota-enforcer';
+import { QuotaEnforcer, SHARED_OWNER, QuotaCheckSnapshot, QuotaContext } from '../quota-enforcer';
 import { setConfigForTesting, PlexusConfig } from '../../../config';
 import { getDatabase, getSchema, getCurrentDialect } from '../../../db/client';
 import { runMigrations } from '../../../db/migrate';
@@ -378,6 +378,36 @@ describe('QuotaEnforcer', () => {
 
     test('returns null for a null context', () => {
       expect(QuotaEnforcer.selectHeaderQuota(null, 'openai', 'gpt-4')).toBeNull();
+    });
+
+    test('a zero-limit quota is selected as fully constrained (regression: NaN ratio)', () => {
+      const snapshot = (overrides: Partial<QuotaCheckSnapshot>): QuotaCheckSnapshot => ({
+        quotaName: 'q',
+        limitType: 'requests',
+        limit: 100,
+        currentUsage: 0,
+        remaining: 100,
+        allowed: true,
+        resetsAtMs: Date.now(),
+        scope: {},
+        global: true,
+        shared: false,
+        source: 'assigned',
+        ...overrides,
+      });
+      // Before consolidation, the unguarded `remaining / limit` made the
+      // zero-limit check's ratio NaN, so it silently lost the reduce.
+      const ctx: QuotaContext = {
+        keyName: 'k',
+        checks: [
+          snapshot({ quotaName: 'nearly-used', limit: 100, currentUsage: 90, remaining: 10 }),
+          snapshot({ quotaName: 'zero-limit', limit: 0, remaining: 0, allowed: false }),
+        ],
+        blockedGlobal: null,
+      };
+
+      const header = QuotaEnforcer.selectHeaderQuota(ctx, 'openai', 'gpt-4');
+      expect(header!.quotaName).toBe('zero-limit');
     });
   });
 

--- a/packages/backend/src/services/quota/__tests__/quota-middleware.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-middleware.test.ts
@@ -120,6 +120,25 @@ describe('buildQuotaExceededBody', () => {
     const body: any = buildQuotaExceededBody([partiallyUsed, nearlyExhausted]);
     expect(body.error.quota_name).toBe('nearly-exhausted');
   });
+
+  test('a zero-limit snapshot becomes the primary (fully constrained, not NaN)', () => {
+    const nearlyExhausted = makeSnapshot({
+      quotaName: 'nearly-exhausted',
+      limit: 1000,
+      currentUsage: 990,
+      remaining: 10, // ratio 0.01
+    });
+    const zeroLimit = makeSnapshot({
+      quotaName: 'zero-limit',
+      limit: 0,
+      currentUsage: 0,
+      remaining: 0, // fully constrained (ratio 0), not NaN
+    });
+
+    const body: any = buildQuotaExceededBody([nearlyExhausted, zeroLimit]);
+    expect(body.error.quota_name).toBe('zero-limit');
+    expect(body.error.blocking_quotas).toHaveLength(2);
+  });
 });
 
 describe('buildQuotaExceededError', () => {

--- a/packages/backend/src/services/quota/__tests__/quota-ranking.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-ranking.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest';
+import {
+  constrainedRatio,
+  mostConstrained,
+  sortMostConstrainedFirst,
+  QuotaRatioFields,
+} from '@plexus/shared';
+
+const entry = (name: string, limit: number, remaining: number) => ({ name, limit, remaining });
+
+describe('constrainedRatio', () => {
+  test('returns remaining/limit for a positive limit', () => {
+    expect(constrainedRatio({ limit: 100, remaining: 25 })).toBe(0.25);
+  });
+
+  test('treats a zero limit as fully constrained instead of NaN', () => {
+    expect(constrainedRatio({ limit: 0, remaining: 0 })).toBe(0);
+  });
+});
+
+describe('mostConstrained', () => {
+  test('returns null for an empty list', () => {
+    expect(mostConstrained([])).toBeNull();
+  });
+
+  test('returns the sole entry of a single-element list', () => {
+    const only = entry('only', 100, 50);
+    expect(mostConstrained([only])).toBe(only);
+  });
+
+  test('picks the entry with the smallest remaining/limit ratio', () => {
+    const loose = entry('loose', 1000, 900); // ratio 0.9
+    const tight = entry('tight', 10, 1); // ratio 0.1
+    expect(mostConstrained([loose, tight])).toBe(tight);
+  });
+
+  test('a zero-limit entry beats a nearly-exhausted positive-limit entry', () => {
+    // Regression: the old unguarded `remaining / limit` produced NaN for
+    // limit=0, whose comparisons are always false, so the zero-limit entry
+    // could never win the reduce.
+    const nearlyExhausted = entry('nearly-exhausted', 100, 10); // ratio 0.1
+    const zeroLimit = entry('zero-limit', 0, 0); // fully constrained
+    expect(mostConstrained([nearlyExhausted, zeroLimit])).toBe(zeroLimit);
+  });
+
+  test('an all-zero-limit list returns the first entry, never NaN artifacts', () => {
+    const first = entry('first', 0, 0);
+    const second = entry('second', 0, 0);
+    expect(mostConstrained([first, second])).toBe(first);
+  });
+
+  test('first entry wins ties', () => {
+    const a = entry('a', 100, 0);
+    const b = entry('b', 10, 0);
+    expect(mostConstrained([a, b])).toBe(a);
+  });
+});
+
+describe('sortMostConstrainedFirst', () => {
+  test('orders by ascending remaining/limit ratio with zero-limit entries first', () => {
+    const loose = entry('loose', 1000, 900); // ratio 0.9
+    const tight = entry('tight', 10, 1); // ratio 0.1
+    const zeroLimit = entry('zero-limit', 0, 0); // ratio 0
+    const sorted = sortMostConstrainedFirst([loose, tight, zeroLimit]);
+    expect(sorted.map((e) => e.name)).toEqual(['zero-limit', 'tight', 'loose']);
+  });
+
+  test('does not mutate the input array', () => {
+    const input: (QuotaRatioFields & { name: string })[] = [
+      entry('loose', 1000, 900),
+      entry('tight', 10, 1),
+    ];
+    sortMostConstrainedFirst(input);
+    expect(input.map((e) => e.name)).toEqual(['loose', 'tight']);
+  });
+});

--- a/packages/backend/src/services/quota/quota-enforcer.ts
+++ b/packages/backend/src/services/quota/quota-enforcer.ts
@@ -1,5 +1,6 @@
 import { and, eq, gte, inArray, isNotNull, notInArray, or, sql } from 'drizzle-orm';
 import parseDuration from 'parse-duration';
+import { mostConstrained } from '@plexus/shared';
 import { logger } from '../../utils/logger';
 import { getConfig, PlexusConfig, QuotaDefinition, KeyConfig } from '../../config';
 import { getDatabase, getSchema, getCurrentDialect } from '../../db/client';
@@ -356,11 +357,7 @@ export class QuotaEnforcer {
     if (!ctx) return null;
 
     const applicable = ctx.checks.filter((c) => scopeMatches(c.scope, provider, model));
-    if (applicable.length === 0) return null;
-
-    return applicable.reduce((min, c) =>
-      c.remaining / c.limit < min.remaining / min.limit ? c : min
-    );
+    return mostConstrained(applicable);
   }
 
   private computeUsageValue(limitType: 'requests' | 'tokens' | 'cost', usage: UsageRecord): number {

--- a/packages/backend/src/services/quota/quota-middleware.ts
+++ b/packages/backend/src/services/quota/quota-middleware.ts
@@ -1,4 +1,5 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
+import { mostConstrained } from '@plexus/shared';
 import { QuotaEnforcer, UsageRecord, QuotaContext, QuotaCheckSnapshot } from './quota-enforcer';
 import { logger } from '../../utils/logger';
 
@@ -17,26 +18,15 @@ export interface QuotaCheckResult {
 }
 
 /**
- * Pick the most-constrained snapshot (smallest remaining/limit ratio) out of
- * a blocking set — used to populate the legacy single-quota top-level
- * fields on the 429 body. Pure; assumes `blocking` is non-empty. A
- * `limit === 0` definition is treated as fully constrained (ratio 0) rather
- * than dividing by zero.
- */
-function selectMostConstrained(blocking: QuotaCheckSnapshot[]): QuotaCheckSnapshot {
-  const ratio = (q: QuotaCheckSnapshot) => (q.limit > 0 ? q.remaining / q.limit : 0);
-  return blocking.reduce((min, q) => (ratio(q) < ratio(min) ? q : min));
-}
-
-/**
  * Build the 429 response body for one or more exhausted quotas. Keeps the
  * legacy top-level shape (message/quota_name/current_usage/limit/resets_at,
  * derived from the most-constrained blocking snapshot) for backward
  * compatibility, and adds `blocking_quotas` — one entry per blocking
  * snapshot — so callers can see every quota that contributed to the block.
+ * Assumes `blocking` is non-empty.
  */
 export function buildQuotaExceededBody(blocking: QuotaCheckSnapshot[]): Record<string, unknown> {
-  const primary = selectMostConstrained(blocking);
+  const primary = mostConstrained(blocking)!;
   return {
     error: {
       message: `Quota exceeded: ${primary.quotaName} limit of ${primary.limit} reached`,
@@ -75,7 +65,7 @@ export function buildQuotaExceededError(
   blocking: QuotaCheckSnapshot[],
   retryHistory?: unknown[]
 ): Error {
-  const primary = selectMostConstrained(blocking);
+  const primary = mostConstrained(blocking)!;
   const error = new Error(
     `Quota exceeded: ${primary.quotaName} limit of ${primary.limit} reached`
   ) as Error & { routingContext?: Record<string, unknown> };

--- a/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
@@ -21,13 +21,13 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Key, Layers, Boxes, Gauge, Activity, AlertTriangle, Users } from 'lucide-react';
+import { Key, Layers, Boxes, Gauge, Activity, AlertTriangle } from 'lucide-react';
 import { api, type PieChartDataPoint, type QuotaStatusEntry } from '../../../lib/api';
 import { formatNumber, formatTokens, formatCost } from '../../../lib/format';
 import { Card } from '../../ui/Card';
-import { QuotaProgressBar } from '../../quota/QuotaProgressBar';
+import { QuotaStatusCard } from '../../quota';
 import { TimeRangeSelector } from '../TimeRangeSelector';
-import { statusForPercent, formatQuotaValue, sortMostConstrainedFirst } from '../../../lib/quota';
+import { sortMostConstrainedFirst } from '../../../lib/quota';
 
 type TimeRange = 'hour' | 'day' | 'week' | 'month';
 
@@ -50,25 +50,6 @@ interface SummaryStats {
   cachedTokens: number;
   cacheWriteTokens: number;
   todayCost: number;
-}
-
-/**
- * Format an ISO resets-at timestamp as a short relative string, e.g.
- * "in 3h 20m". Falls back to an absolute date for far-future resets.
- */
-function formatResetsIn(iso: string | null): string {
-  if (!iso) return '—';
-  const resetsAt = new Date(iso).getTime();
-  const diffMs = resetsAt - Date.now();
-  if (diffMs <= 0) return 'resetting now';
-  const diffSeconds = Math.floor(diffMs / 1000);
-  const days = Math.floor(diffSeconds / 86400);
-  const hours = Math.floor((diffSeconds % 86400) / 3600);
-  const minutes = Math.floor((diffSeconds % 3600) / 60);
-  if (days > 7) return `on ${new Date(iso).toLocaleDateString()}`;
-  if (days > 0) return `in ${days}d ${hours}h`;
-  if (hours > 0) return `in ${hours}h ${minutes}m`;
-  return `in ${minutes}m`;
 }
 
 /**
@@ -297,51 +278,9 @@ export const OverallTab: React.FC = () => {
             </p>
           ) : (
             <div className="space-y-4">
-              {sortMostConstrainedFirst(quotas).map((q) => {
-                const pct = q.limit > 0 ? Math.min(100, (q.currentUsage / q.limit) * 100) : 0;
-                return (
-                  <div key={q.name} className="space-y-2">
-                    <div className="flex flex-wrap items-center gap-1.5 text-xs">
-                      <span className="font-medium text-text">{q.name}</span>
-                      {q.source === 'default' && (
-                        <span className="px-1.5 py-0.5 rounded-md bg-bg-subtle border border-border-glass text-text-muted uppercase tracking-wider text-[10px]">
-                          default
-                        </span>
-                      )}
-                      {q.shared && (
-                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-primary/10 border border-primary/20 text-primary uppercase tracking-wider text-[10px]">
-                          <Users size={10} /> shared
-                        </span>
-                      )}
-                    </div>
-                    <QuotaProgressBar
-                      label={q.limitType}
-                      value={q.currentUsage}
-                      max={q.limit}
-                      displayValue={`${formatQuotaValue(q.currentUsage, q.limitType)} / ${formatQuotaValue(q.limit, q.limitType)}`}
-                      status={statusForPercent(pct)}
-                      size="md"
-                    />
-                    <div className="flex items-center justify-between text-xs text-text-muted">
-                      <span>
-                        Remaining:{' '}
-                        <span className="text-text font-medium">
-                          {formatQuotaValue(q.remaining, q.limitType)}
-                        </span>
-                      </span>
-                      <span>Resets {formatResetsIn(q.resetsAt)}</span>
-                    </div>
-                    {!q.allowed && (
-                      <div className="flex items-center gap-2 text-xs text-danger">
-                        <AlertTriangle size={14} />
-                        <span>
-                          Quota exhausted — new requests will be rejected until it resets.
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+              {sortMostConstrainedFirst(quotas).map((q) => (
+                <QuotaStatusCard key={q.name} entry={q} resetsAtFormat="relative" />
+              ))}
             </div>
           )}
         </Card>

--- a/packages/frontend/src/components/quota/QuotaChip.tsx
+++ b/packages/frontend/src/components/quota/QuotaChip.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { QuotaStatusEntry } from '../../lib/api';
+
+/** Small pill used to label quota scope/source facts (shared, default,
+ * scoped) across the Keys list rows, the quota status modal, and the shared
+ * QuotaStatusCard. */
+export const QuotaChip: React.FC<{ children: React.ReactNode; tone?: 'default' | 'muted' }> = ({
+  children,
+  tone = 'default',
+}) => (
+  <span
+    className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider rounded-md ${
+      tone === 'muted'
+        ? 'bg-bg-subtle text-text-muted border border-border-glass'
+        : 'bg-primary/10 text-primary border border-primary/20'
+    }`}
+  >
+    {children}
+  </span>
+);
+
+/** Whether a quota entry's scope narrows it to specific providers/models. */
+export function hasScope(scope: QuotaStatusEntry['scope'] | undefined): boolean {
+  if (!scope) return false;
+  return Boolean(
+    scope.allowedProviders?.length ||
+      scope.excludedProviders?.length ||
+      scope.allowedModels?.length ||
+      scope.excludedModels?.length
+  );
+}

--- a/packages/frontend/src/components/quota/QuotaChip.tsx
+++ b/packages/frontend/src/components/quota/QuotaChip.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { QuotaStatusEntry } from '../../lib/api';
 
 /** Small pill used to label quota scope/source facts (shared, default,
  * scoped) across the Keys list rows, the quota status modal, and the shared
@@ -19,8 +18,17 @@ export const QuotaChip: React.FC<{ children: React.ReactNode; tone?: 'default' |
   </span>
 );
 
-/** Whether a quota entry's scope narrows it to specific providers/models. */
-export function hasScope(scope: QuotaStatusEntry['scope'] | undefined): boolean {
+/** The four optional scope-narrowing lists shared by quota status entries
+ * (`QuotaStatusEntry['scope']`) and quota definitions (`UserQuota`). */
+export interface QuotaScopeFields {
+  allowedProviders?: string[];
+  excludedProviders?: string[];
+  allowedModels?: string[];
+  excludedModels?: string[];
+}
+
+/** Whether a quota's scope narrows it to specific providers/models. */
+export function hasScope(scope: QuotaScopeFields | undefined): boolean {
   if (!scope) return false;
   return Boolean(
     scope.allowedProviders?.length ||

--- a/packages/frontend/src/components/quota/QuotaStatusCard.tsx
+++ b/packages/frontend/src/components/quota/QuotaStatusCard.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { AlertCircle, AlertTriangle, Check, Info, RefreshCw, Users, Wrench } from 'lucide-react';
+import type { QuotaStatusEntry } from '../../lib/api';
+import { Button } from '../ui/Button';
+import { QuotaProgressBar } from './QuotaProgressBar';
+import { QuotaChip, hasScope } from './QuotaChip';
+import { statusForPercent, formatQuotaValue } from '../../lib/quota';
+import { formatResetsIn } from '../../lib/format';
+
+export interface QuotaStatusCardProps {
+  entry: QuotaStatusEntry;
+  /** 'inline' (default): plain block for end-user views (MyKey, OverallTab) —
+   * no status icon, no scoped chip/suffix, no warnAt line.
+   * 'detailed': bordered card for the admin quota-status modal — leading
+   * allowed/blocked icon, scoped chip and " (scoped)" label suffix, warnAt
+   * line, admin-phrased exhausted banner. */
+  variant?: 'inline' | 'detailed';
+  /** How the "Resets …" timestamp renders: absolute locale string (MyKey,
+   * Keys modal) or relative "in 3h 20m" (OverallTab). */
+  resetsAtFormat?: 'absolute' | 'relative';
+  /** When provided, renders the reset-usage icon button. */
+  onReset?: (quotaName: string) => void;
+  /** When provided, renders the recompute-usage icon button. */
+  onRecompute?: (quotaName: string) => void;
+  /** Rolling requests/tokens defs can't be recomputed from historical data —
+   * disables the recompute button and swaps its icon for an explanation. */
+  recomputeLeaky?: boolean;
+  /** Recompute in flight for this quota — disables the recompute button. */
+  recomputing?: boolean;
+}
+
+/**
+ * Per-quota status block shared by every view that renders a
+ * `QuotaStatusEntry`: name + source/shared chips, progress bar,
+ * remaining/resets row, and exhausted banner. Introduced so the three
+ * previously-duplicated variants (MyKey, OverallTab, Keys admin modal) can't
+ * drift apart.
+ */
+export const QuotaStatusCard: React.FC<QuotaStatusCardProps> = ({
+  entry,
+  variant = 'inline',
+  resetsAtFormat = 'absolute',
+  onReset,
+  onRecompute,
+  recomputeLeaky = false,
+  recomputing = false,
+}) => {
+  const detailed = variant === 'detailed';
+  const pct = entry.limit > 0 ? Math.min(100, (entry.currentUsage / entry.limit) * 100) : 0;
+  const resetsLabel =
+    resetsAtFormat === 'relative'
+      ? formatResetsIn(entry.resetsAt)
+      : new Date(entry.resetsAt).toLocaleString();
+
+  const chips = (
+    <div className="flex flex-wrap items-center gap-1.5 min-w-0 text-xs">
+      {detailed &&
+        (entry.allowed ? (
+          <Check className="text-success shrink-0" size={16} />
+        ) : (
+          <AlertCircle className="text-danger shrink-0" size={16} />
+        ))}
+      <span className="font-medium text-text truncate">{entry.name}</span>
+      {entry.source === 'default' && <QuotaChip tone="muted">default</QuotaChip>}
+      {entry.shared && (
+        <QuotaChip>
+          <Users size={10} /> shared
+        </QuotaChip>
+      )}
+      {detailed && hasScope(entry.scope) && <QuotaChip tone="muted">scoped</QuotaChip>}
+    </div>
+  );
+
+  const actions = (onReset || onRecompute) && (
+    <div className="flex shrink-0 items-center gap-1">
+      {onReset && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => onReset(entry.name)}
+          aria-label={`Reset ${entry.name}`}
+          title="Reset usage"
+        >
+          <RefreshCw size={14} />
+        </Button>
+      )}
+      {onRecompute && (
+        <span
+          title={
+            recomputeLeaky
+              ? 'Recompute is unavailable for rolling requests/tokens quotas — their usage cannot be reconstructed from historical data.'
+              : 'Recompute usage from historical request logs'
+          }
+        >
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onRecompute(entry.name)}
+            disabled={recomputeLeaky || recomputing}
+            aria-label={`Recompute ${entry.name}`}
+          >
+            {recomputeLeaky ? <Info size={14} /> : <Wrench size={14} />}
+          </Button>
+        </span>
+      )}
+    </div>
+  );
+
+  return (
+    <div
+      className={
+        detailed
+          ? 'flex flex-col gap-2 p-3 bg-bg-subtle rounded-md border border-border-glass'
+          : 'flex flex-col gap-2'
+      }
+    >
+      {actions ? (
+        <div className="flex items-start justify-between gap-2">
+          {chips}
+          {actions}
+        </div>
+      ) : (
+        chips
+      )}
+
+      <QuotaProgressBar
+        label={detailed && !entry.global ? `${entry.limitType} (scoped)` : entry.limitType}
+        value={entry.currentUsage}
+        max={entry.limit}
+        displayValue={`${formatQuotaValue(entry.currentUsage, entry.limitType)} / ${formatQuotaValue(entry.limit, entry.limitType)}`}
+        status={statusForPercent(pct)}
+        size="md"
+      />
+
+      <div className="flex items-center justify-between text-xs text-text-muted">
+        <span>
+          Remaining:{' '}
+          <span className="text-text font-medium">
+            {formatQuotaValue(entry.remaining, entry.limitType)}
+          </span>
+        </span>
+        <span>Resets {resetsLabel}</span>
+      </div>
+
+      {detailed && entry.warnAt !== undefined && (
+        <p className="text-[11px] text-text-muted">
+          Warns at {Math.round(entry.warnAt * 100)}% usage
+        </p>
+      )}
+
+      {!entry.allowed && (
+        <div className="flex items-center gap-2 text-xs text-danger">
+          {detailed ? (
+            <>
+              <AlertCircle size={12} />
+              <span>Exhausted — requests using this quota are being rejected.</span>
+            </>
+          ) : (
+            <>
+              <AlertTriangle size={14} />
+              <span>Quota exhausted — new requests will be rejected until it resets.</span>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/frontend/src/components/quota/QuotaStatusCard.tsx
+++ b/packages/frontend/src/components/quota/QuotaStatusCard.tsx
@@ -4,7 +4,7 @@ import type { QuotaStatusEntry } from '../../lib/api';
 import { Button } from '../ui/Button';
 import { QuotaProgressBar } from './QuotaProgressBar';
 import { QuotaChip, hasScope } from './QuotaChip';
-import { statusForPercent, formatQuotaValue } from '../../lib/quota';
+import { statusForPercent, formatQuotaValue, quotaUsagePercent } from '../../lib/quota';
 import { formatResetsIn } from '../../lib/format';
 
 export interface QuotaStatusCardProps {
@@ -46,7 +46,7 @@ export const QuotaStatusCard: React.FC<QuotaStatusCardProps> = ({
   recomputing = false,
 }) => {
   const detailed = variant === 'detailed';
-  const pct = entry.limit > 0 ? Math.min(100, (entry.currentUsage / entry.limit) * 100) : 0;
+  const pct = quotaUsagePercent(entry);
   const resetsLabel =
     resetsAtFormat === 'relative'
       ? formatResetsIn(entry.resetsAt)

--- a/packages/frontend/src/components/quota/index.ts
+++ b/packages/frontend/src/components/quota/index.ts
@@ -1,4 +1,6 @@
 export { QuotaProgressBar } from './QuotaProgressBar';
+export { QuotaStatusCard } from './QuotaStatusCard';
+export { QuotaChip, hasScope } from './QuotaChip';
 export { WaferQuotaDisplay } from './WaferQuotaDisplay';
 export { WaferQuotaConfig } from './WaferQuotaConfig';
 export { OpenCodeGoQuotaConfig } from './OpenCodeGoQuotaConfig';

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -44,6 +44,25 @@ export function formatTimeAgo(seconds: number): string {
 }
 
 /**
+ * Format an ISO resets-at timestamp as a short relative string, e.g.
+ * "in 3h 20m". Falls back to an absolute date for far-future resets.
+ */
+export function formatResetsIn(iso: string | null): string {
+  if (!iso) return '—';
+  const resetsAt = new Date(iso).getTime();
+  const diffMs = resetsAt - Date.now();
+  if (diffMs <= 0) return 'resetting now';
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const days = Math.floor(diffSeconds / 86400);
+  const hours = Math.floor((diffSeconds % 86400) / 3600);
+  const minutes = Math.floor((diffSeconds % 3600) / 60);
+  if (days > 7) return `on ${new Date(iso).toLocaleDateString()}`;
+  if (days > 0) return `in ${days}d ${hours}h`;
+  if (hours > 0) return `in ${hours}h ${minutes}m`;
+  return `in ${minutes}m`;
+}
+
+/**
  * Format large numbers with K, M, B suffixes (e.g., "1.3k", "2.5M")
  */
 export function formatNumber(num: number, decimals: number = 1): string {

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -59,7 +59,7 @@ export function formatResetsIn(iso: string | null): string {
   if (days > 7) return `on ${new Date(iso).toLocaleDateString()}`;
   if (days > 0) return `in ${days}d ${hours}h`;
   if (hours > 0) return `in ${hours}h ${minutes}m`;
-  return `in ${minutes}m`;
+  return minutes > 0 ? `in ${minutes}m` : 'in <1m';
 }
 
 /**

--- a/packages/frontend/src/lib/quota.ts
+++ b/packages/frontend/src/lib/quota.ts
@@ -26,3 +26,16 @@ export function formatQuotaValue(value: number, limitType: QuotaStatusEntry['lim
 /** Most-constrained ranking now lives in @plexus/shared so the backend's
  * selectors and every frontend view use the exact same ratio logic. */
 export { mostConstrained, sortMostConstrainedFirst } from '@plexus/shared';
+
+/**
+ * Usage percentage for a quota entry, shared by QuotaStatusCard and the Keys
+ * list rows so the zero-limit behavior can't drift. A `limit <= 0` entry has
+ * no headroom at all, so when blocked it renders as fully used (100%) rather
+ * than an ok-looking empty bar.
+ */
+export function quotaUsagePercent(
+  entry: Pick<QuotaStatusEntry, 'limit' | 'currentUsage' | 'allowed'>
+): number {
+  if (entry.limit > 0) return Math.min(100, (entry.currentUsage / entry.limit) * 100);
+  return entry.allowed ? 0 : 100;
+}

--- a/packages/frontend/src/lib/quota.ts
+++ b/packages/frontend/src/lib/quota.ts
@@ -23,10 +23,6 @@ export function formatQuotaValue(value: number, limitType: QuotaStatusEntry['lim
   return limitType === 'cost' ? formatCost(value, 5) : formatNumber(value);
 }
 
-/** Sort most-constrained (least remaining headroom) first, mirroring the
- * backend's own `mostConstrained` shim. A `limit === 0` entry is treated as
- * fully constrained (ratio 0) rather than dividing by zero. */
-export function sortMostConstrainedFirst(entries: QuotaStatusEntry[]): QuotaStatusEntry[] {
-  const ratio = (e: QuotaStatusEntry) => (e.limit > 0 ? e.remaining / e.limit : 0);
-  return [...entries].sort((a, b) => ratio(a) - ratio(b));
-}
+/** Most-constrained ranking now lives in @plexus/shared so the backend's
+ * selectors and every frontend view use the exact same ratio logic. */
+export { mostConstrained, sortMostConstrainedFirst } from '@plexus/shared';

--- a/packages/frontend/src/pages/Keys.tsx
+++ b/packages/frontend/src/pages/Keys.tsx
@@ -7,7 +7,7 @@ import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
 import { Tabs } from '../components/ui/Tabs';
 import { Switch } from '../components/ui/Switch';
-import { QuotaProgressBar } from '../components/quota/QuotaProgressBar';
+import { QuotaStatusCard, QuotaChip } from '../components/quota';
 import { PageHeader } from '../components/layout/PageHeader';
 import { PageContainer } from '../components/layout/PageContainer';
 import { useToast } from '../contexts/ToastContext';
@@ -22,18 +22,11 @@ import {
   Shield,
   AlertCircle,
   BarChart3,
-  Wrench,
   Users,
-  Info,
 } from 'lucide-react';
 import { formatNumber, formatCost } from '../lib/format';
 import { isClipboardAvailable, copyToClipboard, generateUUID } from '../lib/clipboard';
-import {
-  statusForPercent,
-  formatQuotaValue,
-  sortMostConstrainedFirst,
-  mostConstrained,
-} from '../lib/quota';
+import { formatQuotaValue, sortMostConstrainedFirst, mostConstrained } from '../lib/quota';
 
 const EMPTY_KEY: KeyConfig = {
   key: '',
@@ -71,33 +64,6 @@ function isLeakyRollingDef(def: UserQuota | undefined): boolean {
 function entryUsagePercent(entry: QuotaStatusEntry): number {
   if (!entry.limit || entry.limit === 0) return 0;
   return Math.min(100, (entry.currentUsage / entry.limit) * 100);
-}
-
-/** Small pill used to label quota scope/source facts (shared, default,
- * scoped) across the list rows and the status modal. */
-const QuotaChip: React.FC<{ children: React.ReactNode; tone?: 'default' | 'muted' }> = ({
-  children,
-  tone = 'default',
-}) => (
-  <span
-    className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider rounded-md ${
-      tone === 'muted'
-        ? 'bg-bg-subtle text-text-muted border border-border-glass'
-        : 'bg-primary/10 text-primary border border-primary/20'
-    }`}
-  >
-    {children}
-  </span>
-);
-
-function hasScope(scope: QuotaStatusEntry['scope'] | undefined): boolean {
-  if (!scope) return false;
-  return Boolean(
-    scope.allowedProviders?.length ||
-      scope.excludedProviders?.length ||
-      scope.allowedModels?.length ||
-      scope.excludedModels?.length
-  );
 }
 
 function defHasScope(def: UserQuota | undefined): boolean {
@@ -1475,99 +1441,17 @@ export const Keys = () => {
                   </p>
                 </div>
               ) : (
-                sortMostConstrainedFirst(selectedQuotaStatus.quotas).map((entry) => {
-                  const def = quotas[entry.name];
-                  const leaky = isLeakyRollingDef(def);
-                  const pct = entryUsagePercent(entry);
-                  return (
-                    <div
-                      key={entry.name}
-                      className="flex flex-col gap-2 p-3 bg-bg-subtle rounded-md border border-border-glass"
-                    >
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="flex flex-wrap items-center gap-1.5 min-w-0">
-                          {entry.allowed ? (
-                            <Check className="text-success shrink-0" size={16} />
-                          ) : (
-                            <AlertCircle className="text-danger shrink-0" size={16} />
-                          )}
-                          <span className="font-medium text-text truncate">{entry.name}</span>
-                          {entry.source === 'default' && (
-                            <QuotaChip tone="muted">default</QuotaChip>
-                          )}
-                          {entry.shared && (
-                            <QuotaChip>
-                              <Users size={10} /> shared
-                            </QuotaChip>
-                          )}
-                          {hasScope(entry.scope) && <QuotaChip tone="muted">scoped</QuotaChip>}
-                        </div>
-                        <div className="flex shrink-0 items-center gap-1">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => handleClearQuota(selectedQuotaStatus.key, entry.name)}
-                            aria-label={`Reset ${entry.name}`}
-                            title="Reset usage"
-                          >
-                            <RefreshCw size={14} />
-                          </Button>
-                          <span
-                            title={
-                              leaky
-                                ? 'Recompute is unavailable for rolling requests/tokens quotas — their usage cannot be reconstructed from historical data.'
-                                : 'Recompute usage from historical request logs'
-                            }
-                          >
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              onClick={() =>
-                                handleRecomputeQuota(selectedQuotaStatus.key, entry.name)
-                              }
-                              disabled={leaky || recomputingQuota === entry.name}
-                              aria-label={`Recompute ${entry.name}`}
-                            >
-                              {leaky ? <Info size={14} /> : <Wrench size={14} />}
-                            </Button>
-                          </span>
-                        </div>
-                      </div>
-
-                      <QuotaProgressBar
-                        label={`${entry.limitType}${entry.global ? '' : ' (scoped)'}`}
-                        value={entry.currentUsage}
-                        max={entry.limit}
-                        displayValue={`${formatQuotaValue(entry.currentUsage, entry.limitType)} / ${formatQuotaValue(entry.limit, entry.limitType)}`}
-                        status={statusForPercent(pct)}
-                        size="md"
-                      />
-
-                      <div className="flex items-center justify-between text-xs text-text-muted">
-                        <span>
-                          Remaining:{' '}
-                          <span className="text-text font-medium">
-                            {formatQuotaValue(entry.remaining, entry.limitType)}
-                          </span>
-                        </span>
-                        <span>Resets {new Date(entry.resetsAt).toLocaleString()}</span>
-                      </div>
-
-                      {entry.warnAt !== undefined && (
-                        <p className="text-[11px] text-text-muted">
-                          Warns at {Math.round(entry.warnAt * 100)}% usage
-                        </p>
-                      )}
-
-                      {!entry.allowed && (
-                        <div className="flex items-center gap-2 text-xs text-danger">
-                          <AlertCircle size={12} />
-                          <span>Exhausted — requests using this quota are being rejected.</span>
-                        </div>
-                      )}
-                    </div>
-                  );
-                })
+                sortMostConstrainedFirst(selectedQuotaStatus.quotas).map((entry) => (
+                  <QuotaStatusCard
+                    key={entry.name}
+                    entry={entry}
+                    variant="detailed"
+                    onReset={(name) => handleClearQuota(selectedQuotaStatus.key, name)}
+                    onRecompute={(name) => handleRecomputeQuota(selectedQuotaStatus.key, name)}
+                    recomputeLeaky={isLeakyRollingDef(quotas[entry.name])}
+                    recomputing={recomputingQuota === entry.name}
+                  />
+                ))
               )}
             </div>
           )}

--- a/packages/frontend/src/pages/Keys.tsx
+++ b/packages/frontend/src/pages/Keys.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { api, KeyConfig, UserQuota, QuotaStatusEntry, Provider } from '../lib/api';
+import { api, KeyConfig, UserQuota, Provider } from '../lib/api';
 import { Input } from '../components/ui/Input';
 import { TagSelect } from '../components/ui/TagSelect';
 import { Card } from '../components/ui/Card';
@@ -7,7 +7,7 @@ import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
 import { Tabs } from '../components/ui/Tabs';
 import { Switch } from '../components/ui/Switch';
-import { QuotaStatusCard, QuotaChip } from '../components/quota';
+import { QuotaStatusCard, QuotaChip, hasScope } from '../components/quota';
 import { PageHeader } from '../components/layout/PageHeader';
 import { PageContainer } from '../components/layout/PageContainer';
 import { useToast } from '../contexts/ToastContext';
@@ -26,7 +26,12 @@ import {
 } from 'lucide-react';
 import { formatNumber, formatCost } from '../lib/format';
 import { isClipboardAvailable, copyToClipboard, generateUUID } from '../lib/clipboard';
-import { formatQuotaValue, sortMostConstrainedFirst, mostConstrained } from '../lib/quota';
+import {
+  formatQuotaValue,
+  sortMostConstrainedFirst,
+  mostConstrained,
+  quotaUsagePercent,
+} from '../lib/quota';
 
 const EMPTY_KEY: KeyConfig = {
   key: '',
@@ -59,21 +64,6 @@ type QuotaStatusResponse = NonNullable<Awaited<ReturnType<typeof api.getQuotaSta
 function isLeakyRollingDef(def: UserQuota | undefined): boolean {
   if (!def) return false;
   return def.type === 'rolling' && (def.limitType === 'requests' || def.limitType === 'tokens');
-}
-
-function entryUsagePercent(entry: QuotaStatusEntry): number {
-  if (!entry.limit || entry.limit === 0) return 0;
-  return Math.min(100, (entry.currentUsage / entry.limit) * 100);
-}
-
-function defHasScope(def: UserQuota | undefined): boolean {
-  if (!def) return false;
-  return Boolean(
-    def.allowedProviders?.length ||
-      def.excludedProviders?.length ||
-      def.allowedModels?.length ||
-      def.excludedModels?.length
-  );
 }
 
 export const Keys = () => {
@@ -491,7 +481,7 @@ export const Keys = () => {
                 filteredKeys.map((key) => {
                   const status = quotaStatuses[key.key];
                   const primary = status ? mostConstrained(status.quotas) : null;
-                  const usagePercent = primary ? entryUsagePercent(primary) : 0;
+                  const usagePercent = primary ? quotaUsagePercent(primary) : 0;
                   const quotaNames = key.quotas && key.quotas.length > 0 ? key.quotas : null;
                   const usingDefaults = !quotaNames && defaultQuotaNames.length > 0;
 
@@ -669,7 +659,7 @@ export const Keys = () => {
                   {filteredKeys.map((key) => {
                     const status = quotaStatuses[key.key];
                     const primary = status ? mostConstrained(status.quotas) : null;
-                    const usagePercent = primary ? entryUsagePercent(primary) : 0;
+                    const usagePercent = primary ? quotaUsagePercent(primary) : 0;
                     const quotaNames = key.quotas && key.quotas.length > 0 ? key.quotas : null;
                     const usingDefaults = !quotaNames && defaultQuotaNames.length > 0;
 
@@ -859,7 +849,7 @@ export const Keys = () => {
                                   <Users size={10} /> shared
                                 </QuotaChip>
                               )}
-                              {defHasScope(quota) && <QuotaChip tone="muted">scoped</QuotaChip>}
+                              {hasScope(quota) && <QuotaChip tone="muted">scoped</QuotaChip>}
                             </div>
                             <div className="mt-1 text-xs text-text-muted">
                               {quota.type}
@@ -958,7 +948,7 @@ export const Keys = () => {
                                   <Users size={10} /> shared
                                 </QuotaChip>
                               )}
-                              {defHasScope(quota) && <QuotaChip tone="muted">scoped</QuotaChip>}
+                              {hasScope(quota) && <QuotaChip tone="muted">scoped</QuotaChip>}
                             </div>
                           </td>
                           <td className="px-4 py-3 text-left border-b border-border-glass text-text">

--- a/packages/frontend/src/pages/Keys.tsx
+++ b/packages/frontend/src/pages/Keys.tsx
@@ -28,7 +28,12 @@ import {
 } from 'lucide-react';
 import { formatNumber, formatCost } from '../lib/format';
 import { isClipboardAvailable, copyToClipboard, generateUUID } from '../lib/clipboard';
-import { statusForPercent, formatQuotaValue, sortMostConstrainedFirst } from '../lib/quota';
+import {
+  statusForPercent,
+  formatQuotaValue,
+  sortMostConstrainedFirst,
+  mostConstrained,
+} from '../lib/quota';
 
 const EMPTY_KEY: KeyConfig = {
   key: '',
@@ -61,15 +66,6 @@ type QuotaStatusResponse = NonNullable<Awaited<ReturnType<typeof api.getQuotaSta
 function isLeakyRollingDef(def: UserQuota | undefined): boolean {
   if (!def) return false;
   return def.type === 'rolling' && (def.limitType === 'requests' || def.limitType === 'tokens');
-}
-
-/** The entry with the smallest remaining/limit ratio — mirrors the backend's
- * `mostConstrained` helper used for the legacy single-quota shim fields.
- * A `limit === 0` entry is treated as fully constrained (ratio 0). */
-function mostConstrainedEntry(entries: QuotaStatusEntry[]): QuotaStatusEntry | null {
-  if (entries.length === 0) return null;
-  const ratio = (e: QuotaStatusEntry) => (e.limit > 0 ? e.remaining / e.limit : 0);
-  return entries.reduce((min, c) => (ratio(c) < ratio(min) ? c : min));
 }
 
 function entryUsagePercent(entry: QuotaStatusEntry): number {
@@ -528,7 +524,7 @@ export const Keys = () => {
               ) : (
                 filteredKeys.map((key) => {
                   const status = quotaStatuses[key.key];
-                  const primary = status ? mostConstrainedEntry(status.quotas) : null;
+                  const primary = status ? mostConstrained(status.quotas) : null;
                   const usagePercent = primary ? entryUsagePercent(primary) : 0;
                   const quotaNames = key.quotas && key.quotas.length > 0 ? key.quotas : null;
                   const usingDefaults = !quotaNames && defaultQuotaNames.length > 0;
@@ -706,7 +702,7 @@ export const Keys = () => {
                 <tbody>
                   {filteredKeys.map((key) => {
                     const status = quotaStatuses[key.key];
-                    const primary = status ? mostConstrainedEntry(status.quotas) : null;
+                    const primary = status ? mostConstrained(status.quotas) : null;
                     const usagePercent = primary ? entryUsagePercent(primary) : 0;
                     const quotaNames = key.quotas && key.quotas.length > 0 ? key.quotas : null;
                     const usingDefaults = !quotaNames && defaultQuotaNames.length > 0;

--- a/packages/frontend/src/pages/MyKey.tsx
+++ b/packages/frontend/src/pages/MyKey.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
-import { RotateCw, AlertTriangle, Users } from 'lucide-react';
+import { RotateCw, AlertTriangle } from 'lucide-react';
 import { api, type QuotaStatusEntry } from '../lib/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useToast } from '../contexts/ToastContext';
@@ -10,11 +10,11 @@ import { Input } from '../components/ui/Input';
 import { Modal } from '../components/ui/Modal';
 import { Switch } from '../components/ui/Switch';
 import { CopyButton } from '../components/ui/CopyButton';
-import { QuotaProgressBar } from '../components/quota/QuotaProgressBar';
+import { QuotaStatusCard } from '../components/quota';
 import { PageHeader } from '../components/layout/PageHeader';
 import { PageContainer } from '../components/layout/PageContainer';
 import { Skeleton } from '../components/ui/Skeleton';
-import { statusForPercent, formatQuotaValue, sortMostConstrainedFirst } from '../lib/quota';
+import { sortMostConstrainedFirst } from '../lib/quota';
 
 interface SelfInfo {
   role: 'admin' | 'limited';
@@ -193,51 +193,9 @@ export const MyKey: React.FC = () => {
               </p>
             ) : (
               <div className="flex flex-col gap-4">
-                {sortMostConstrainedFirst(quotas).map((q) => {
-                  const pct = q.limit > 0 ? Math.min(100, (q.currentUsage / q.limit) * 100) : 0;
-                  return (
-                    <div key={q.name} className="flex flex-col gap-2">
-                      <div className="flex flex-wrap items-center gap-1.5 text-xs">
-                        <span className="font-medium text-text">{q.name}</span>
-                        {q.source === 'default' && (
-                          <span className="px-1.5 py-0.5 rounded-md bg-bg-subtle border border-border-glass text-text-muted uppercase tracking-wider text-[10px]">
-                            default
-                          </span>
-                        )}
-                        {q.shared && (
-                          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-primary/10 border border-primary/20 text-primary uppercase tracking-wider text-[10px]">
-                            <Users size={10} /> shared
-                          </span>
-                        )}
-                      </div>
-                      <QuotaProgressBar
-                        label={q.limitType}
-                        value={q.currentUsage}
-                        max={q.limit}
-                        displayValue={`${formatQuotaValue(q.currentUsage, q.limitType)} / ${formatQuotaValue(q.limit, q.limitType)}`}
-                        status={statusForPercent(pct)}
-                        size="md"
-                      />
-                      <div className="flex items-center justify-between text-xs text-text-muted">
-                        <span>
-                          Remaining:{' '}
-                          <span className="text-text font-medium">
-                            {formatQuotaValue(q.remaining, q.limitType)}
-                          </span>
-                        </span>
-                        <span>Resets {new Date(q.resetsAt).toLocaleString()}</span>
-                      </div>
-                      {!q.allowed && (
-                        <div className="flex items-center gap-2 text-xs text-danger">
-                          <AlertTriangle size={14} />
-                          <span>
-                            Quota exhausted — new requests will be rejected until it resets.
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
+                {sortMostConstrainedFirst(quotas).map((q) => (
+                  <QuotaStatusCard key={q.name} entry={q} />
+                ))}
               </div>
             )}
           </Card>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,3 +42,7 @@ export type {
 
 // Cooldown time formatting utilities
 export { formatMinutesToMinSec, formatMsToMinSec } from './format-time';
+
+// Quota ranking (most-constrained selection) shared by backend and frontend
+export { constrainedRatio, mostConstrained, sortMostConstrainedFirst } from './quota-ranking';
+export type { QuotaRatioFields } from './quota-ranking';

--- a/packages/shared/src/quota-ranking.ts
+++ b/packages/shared/src/quota-ranking.ts
@@ -1,0 +1,35 @@
+/**
+ * Ranking helpers for "most-constrained quota" selection, shared by the
+ * backend (`QuotaCheckSnapshot`) and frontend (`QuotaStatusEntry`) — both
+ * shapes carry the two fields the ratio needs, so the helpers stay generic
+ * over them instead of importing either wire type.
+ */
+
+/** Minimal shape needed to rank quotas by constraint. */
+export interface QuotaRatioFields {
+  limit: number;
+  remaining: number;
+}
+
+/**
+ * Remaining-headroom ratio (`remaining / limit`). A `limit <= 0` entry is
+ * treated as fully constrained (ratio 0) rather than dividing by zero —
+ * `0 / 0` is `NaN`, whose comparisons are always false, which would make a
+ * zero-limit quota silently unselectable.
+ */
+export function constrainedRatio(entry: QuotaRatioFields): number {
+  return entry.limit > 0 ? entry.remaining / entry.limit : 0;
+}
+
+/** Entry with the smallest remaining/limit ratio (first wins ties); null for
+ * an empty list. */
+export function mostConstrained<T extends QuotaRatioFields>(entries: T[]): T | null {
+  if (entries.length === 0) return null;
+  return entries.reduce((min, e) => (constrainedRatio(e) < constrainedRatio(min) ? e : min));
+}
+
+/** New array sorted most-constrained (least remaining headroom) first.
+ * Does not mutate the input. */
+export function sortMostConstrainedFirst<T extends QuotaRatioFields>(entries: T[]): T[] {
+  return [...entries].sort((a, b) => constrainedRatio(a) - constrainedRatio(b));
+}


### PR DESCRIPTION
### **User description**
Closes #653, #654, #655.

## Summary

- **#654** — Consolidate the three duplicated "most-constrained quota" selectors (Keys list, enforcement middleware, quota-status response) into a single `mostConstrained` helper in `@plexus/shared`, used consistently by backend and frontend.
- **#655** — Extract a shared `QuotaStatusCard` / `QuotaChip` component used by the Keys quota-status modal, the Dashboard Overall tab, and the My Key page, replacing three separate inline renderings.
- **#653** — Validate `default_quotas` against the configured `user_quotas` on `PATCH /v0/management/system-settings`, rejecting unknown/invalid quota names and supporting clearing the field via `null`.
- Review-feedback fixes on top of the above:
  - `default_quotas` membership check uses `Object.hasOwn` so inherited object properties (e.g. `toString`) can't pass validation.
  - New shared `quotaUsagePercent` renders blocked zero-limit quotas as exhausted instead of an ok-looking empty bar (used by both `QuotaStatusCard` and the Keys list rows).
  - `formatResetsIn` returns `"in <1m"` instead of `"in 0m"` for sub-minute resets.
  - `hasScope` takes a structural `QuotaScopeFields` type, replacing `Keys.tsx`'s duplicate `defHasScope`.

## Screenshots

UI screenshots of the shared `QuotaStatusCard`, captured against the branch tip on a live dev server. All three quota surfaces now render through the single shared component.

### Keys page — quota status modal (`variant="detailed"`)
Leading allowed/blocked status icon, `SHARED` chip, per-quota reset (↻) and recompute buttons — recompute correctly disabled with the info icon for the leaky rolling-tokens quota — plus the "Warns at 80% usage" line and absolute reset timestamps.

![Keys quota status modal, detailed variant](https://raw.githubusercontent.com/darkspadez/plexus/pr-69-assets/keys-quota-modal-detailed.png)

### Dashboard Overall tab — limited user (`resetsAtFormat="relative"`)
Same card in its inline variant with relative reset times ("Resets in 59m").

![Overall tab quota card, inline variant with relative resets](https://raw.githubusercontent.com/darkspadez/plexus/pr-69-assets/overall-tab-inline-relative.png)

### My Key page — limited user (inline, absolute resets)

![My Key quota card, inline variant with absolute resets](https://raw.githubusercontent.com/darkspadez/plexus/pr-69-assets/mykey-inline-absolute.png)

*(Images hosted on the orphan `pr-69-assets` branch of the fork to keep them out of the PR diff.)*

## Test plan

- [x] `bun run test` passes, including new coverage for `PATCH /v0/management/system-settings` validation and quota-ranking edge cases.
- [x] `bun run typecheck` passes.
- [x] Manually verified all three quota surfaces (Keys modal, Dashboard Overall tab, My Key page) render consistently via the shared component in a live dev server.


___

### **Description**
- Consolidate duplicated most-constrained quota selectors into shared `@plexus/shared` helper, fixing zero-limit NaN ratio bug

- Extract shared `QuotaStatusCard` and `QuotaChip` components, unifying quota display across MyKey, OverallTab, and Keys pages

- Validate `default_quotas` against `user_quotas` on `PATCH /v0/management/system-settings`, rejecting unknown quota names

- Add regression tests for zero-limit quota ranking and `default_quotas` validation


___

