### PR TITLE
feat(inference-v2): add automatic custom-provider fallbacks and pricing enrichment

### DIFF
--- a/packages/backend/src/db/seed-fallback-providers.ts
+++ b/packages/backend/src/db/seed-fallback-providers.ts
@@ -1,0 +1,46 @@
+import { eq } from 'drizzle-orm';
+import { getDatabase, getSchema } from './client';
+import { logger } from '../utils/logger';
+
+export const FALLBACK_PROVIDERS = [
+  { name: 'fallback-chat', definition: JSON.stringify({ api: 'openai-completions' }) },
+  { name: 'fallback-responses', definition: JSON.stringify({ api: 'openai-responses' }) },
+  { name: 'fallback-anthropic', definition: JSON.stringify({ api: 'anthropic-messages' }) },
+  { name: 'fallback-gemini', definition: JSON.stringify({ api: 'google-generative-ai' }) },
+];
+
+export async function seedFallbackProviders() {
+  try {
+    const db = getDatabase();
+    const schema = getSchema();
+
+    // Check if piAiCustomProviders exists in the schema (it should)
+    if (!schema || !schema.piAiCustomProviders) {
+      logger.warn('piAiCustomProviders table not found in schema, skipping seed');
+      return;
+    }
+
+    const customProvidersTable = schema.piAiCustomProviders;
+    const now = Math.floor(Date.now() / 1000);
+
+    for (const provider of FALLBACK_PROVIDERS) {
+      const existing = await db
+        .select()
+        .from(customProvidersTable)
+        .where(eq(customProvidersTable.name, provider.name))
+        .limit(1);
+
+      if (!existing || existing.length === 0) {
+        await db.insert(customProvidersTable).values({
+          name: provider.name,
+          definition: provider.definition,
+          createdAt: now,
+          updatedAt: now,
+        });
+        logger.debug(`Seeded fallback provider: ${provider.name}`);
+      }
+    }
+  } catch (error) {
+    logger.error('Failed to seed fallback providers', error);
+  }
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -71,6 +71,7 @@ import { runMigrations } from './db/migrate';
 import { runEncryptionMigration } from './db/encrypt-migration';
 import { isEncryptionEnabled } from './utils/encryption';
 import { mcpProcessManager } from './services/mcp-local/mcp-process-manager';
+import { seedFallbackProviders } from './db/seed-fallback-providers';
 
 /**
  * Plexus Backend Server
@@ -152,6 +153,7 @@ try {
   initializeDatabase();
   await runMigrations();
   await runEncryptionMigration();
+  await seedFallbackProviders();
 } catch (e) {
   logger.error('Failed to initialize database or run migrations', e);
   process.exit(1);

--- a/packages/backend/src/inference-v2/shared/__tests__/pi-ai-utils.test.ts
+++ b/packages/backend/src/inference-v2/shared/__tests__/pi-ai-utils.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   resolveBaseUrl,
   buildReasoningOptions,
   buildPiAiModel,
+  resolveModelCost,
   buildThinkingOptions,
 } from '../pi-ai-utils';
+import { PricingManager } from '../../../services/pricing-manager';
 
 // pi-ai is globally mocked in test/vitest.setup.ts
 
@@ -167,7 +169,7 @@ describe('buildReasoningOptions', () => {
 describe('buildPiAiModel', () => {
   it('returns pi-ai model with baseUrl overridden from provider config', () => {
     const model = buildPiAiModel(
-      { api_base_url: 'https://api.anthropic.com/v1' },
+      { api_base_url: 'https://api.anthropic.com/v1' } as any,
       'anthropic',
       'claude-opus-4-6',
       'chat'
@@ -182,12 +184,114 @@ describe('buildPiAiModel', () => {
 
   it('returns pi-ai model with baseUrl from record config', () => {
     const model = buildPiAiModel(
-      { api_base_url: { 'anthropic-messages': 'https://api.anthropic.com/v1' } },
+      { api_base_url: { 'anthropic-messages': 'https://api.anthropic.com/v1' } } as any,
       'anthropic',
       'claude-sonnet-4',
       'messages'
     );
     expect(model!.baseUrl).toBe('https://api.anthropic.com');
+  });
+
+  describe('pricing overrides', () => {
+    beforeEach(() => {
+      vi.spyOn(PricingManager.getInstance(), 'getPricing').mockImplementation((slug) => {
+        if (slug === 'test/model') {
+          return {
+            prompt: '0.000001',
+            completion: '0.000002',
+            input_cache_read: '0.0000005',
+            input_cache_write: '0.0000015',
+          };
+        }
+        return undefined;
+      });
+    });
+
+    it('applies simple pricing override without discount', () => {
+      const model = buildPiAiModel(
+        { api_base_url: 'https://api.anthropic.com' } as any,
+        'anthropic',
+        'claude-opus-4-6',
+        'chat',
+        {
+          pricing: {
+            source: 'simple',
+            input: 10,
+            output: 20,
+            cached: 5,
+            cache_write: 15,
+          },
+        } as any
+      );
+      expect(model!.cost).toEqual({
+        input: 10,
+        output: 20,
+        cacheRead: 5,
+        cacheWrite: 15,
+      });
+    });
+
+    it('applies simple pricing override with discount', () => {
+      const model = buildPiAiModel(
+        { api_base_url: 'https://api.anthropic.com', discount: 0.1 } as any,
+        'anthropic',
+        'claude-opus-4-6',
+        'chat',
+        {
+          pricing: {
+            source: 'simple',
+            input: 10,
+            output: 20,
+            cached: 5,
+            cache_write: 15,
+          },
+        } as any
+      );
+      expect(model!.cost).toEqual({
+        input: 9,
+        output: 18,
+        cacheRead: 4.5,
+        cacheWrite: 13.5,
+      });
+    });
+
+    it('applies openrouter pricing override with discount', () => {
+      const model = buildPiAiModel(
+        { api_base_url: 'https://api.anthropic.com', discount: 0.2 } as any,
+        'anthropic',
+        'claude-opus-4-6',
+        'chat',
+        {
+          pricing: {
+            source: 'openrouter',
+            slug: 'test/model',
+          },
+        } as any
+      );
+      expect(model!.cost.input).toBeCloseTo(0.8, 5);
+      expect(model!.cost.output).toBeCloseTo(1.6, 5);
+      expect(model!.cost.cacheRead).toBeCloseTo(0.4, 5);
+      expect(model!.cost.cacheWrite).toBeCloseTo(1.2, 5);
+    });
+
+    it('applies provider discount to base cost when no explicit pricing is defined', () => {
+      // The mocked base model has empty costs by default, let's inject some for this test
+      const testModel = buildPiAiModel(
+        { api_base_url: 'https://api.anthropic.com', discount: 0.5 } as any,
+        'anthropic',
+        'claude-opus-4-6', // mock doesn't have costs for this
+        'chat'
+      );
+
+      // Manually set base costs and call resolveModelCost to test the logic
+      const baseCost = { input: 10, output: 20, cacheRead: 5, cacheWrite: 15 };
+      const resolved = resolveModelCost(baseCost, { discount: 0.5 } as any);
+
+      expect(resolved.input).toBe(5);
+      expect(resolved.output).toBe(10);
+      expect(resolved.cacheRead).toBe(2.5);
+      expect(resolved.cacheWrite).toBe(7.5);
+    });
   });
 });
 

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -780,7 +780,8 @@ export async function runPiAiExecutor<TResponse>(
             vfConfig.descriptor_model,
             vfConfig.default_prompt || DEFAULT_VISION_DESCRIPTION_PROMPT,
             usageStorage,
-            { sourceIp, keyName, attribution }
+            { sourceIp, keyName, attribution },
+            incomingApiType
           );
           usedVisionFallthrough = true;
           visionFallthroughModel = vfConfig.descriptor_model;

--- a/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-executor.ts
@@ -46,8 +46,9 @@ import {
   buildQuotaHeaders,
   buildQuotaExceededError,
 } from '../../services/quota/quota-middleware';
+import { calculateCosts } from '../../utils/calculate-costs';
 import { logger } from '../../utils/logger';
-import { getConfig } from '../../config';
+import { getConfig, getProviderTypes } from '../../config';
 import { applyKeyAccessPolicy, type PolicyRequest } from '../../services/key-access-policy';
 import {
   buildPiAiModel,
@@ -653,8 +654,43 @@ export async function runPiAiExecutor<TResponse>(
       return resolvePiAiModel(piAiProvider, piAiModelId) != null;
     }
 
-    const piAiProvider = (c.config as any).pi_ai_provider as string | undefined;
-    const piAiModelId = (c.modelConfig as any)?.pi_ai_model_id as string | undefined;
+    let piAiProvider = (c.config as any).pi_ai_provider as string | undefined;
+    let piAiModelId = (c.modelConfig as any)?.pi_ai_model_id as string | undefined;
+
+    if (!piAiProvider) {
+      const availableTypes =
+        c.modelConfig?.access_via && c.modelConfig.access_via.length > 0
+          ? c.modelConfig.access_via
+          : getProviderTypes(c.config);
+
+      let targetType = availableTypes[0] || 'chat';
+      if (incomingApiType) {
+        const incoming = incomingApiType.toLowerCase();
+        const match = availableTypes.find((t: string) => t.toLowerCase() === incoming);
+        if (match) targetType = match;
+      }
+
+      switch (targetType.toLowerCase()) {
+        case 'messages':
+          piAiProvider = 'fallback-anthropic';
+          break;
+        case 'gemini':
+          piAiProvider = 'fallback-gemini';
+          break;
+        case 'responses':
+          piAiProvider = 'fallback-responses';
+          break;
+        case 'chat':
+        default:
+          piAiProvider = 'fallback-chat';
+          break;
+      }
+
+      if (!piAiModelId) {
+        piAiModelId = c.model;
+      }
+    }
+
     if (!piAiProvider || !piAiModelId) return false;
     return resolvePiAiModel(piAiProvider, piAiModelId) != null;
   });
@@ -813,6 +849,40 @@ export async function runPiAiExecutor<TResponse>(
     } else {
       piAiProvider = (route.config as any).pi_ai_provider as string | undefined;
       piAiModelId = (route.modelConfig as any)?.pi_ai_model_id as string | undefined;
+
+      if (!piAiProvider) {
+        const availableTypes =
+          route.modelConfig?.access_via && route.modelConfig.access_via.length > 0
+            ? route.modelConfig.access_via
+            : getProviderTypes(route.config);
+
+        let targetType = availableTypes[0] || 'chat';
+        if (incomingApiType) {
+          const incoming = incomingApiType.toLowerCase();
+          const match = availableTypes.find((t: string) => t.toLowerCase() === incoming);
+          if (match) targetType = match;
+        }
+
+        switch (targetType.toLowerCase()) {
+          case 'messages':
+            piAiProvider = 'fallback-anthropic';
+            break;
+          case 'gemini':
+            piAiProvider = 'fallback-gemini';
+            break;
+          case 'responses':
+            piAiProvider = 'fallback-responses';
+            break;
+          case 'chat':
+          default:
+            piAiProvider = 'fallback-chat';
+            break;
+        }
+
+        if (!piAiModelId) {
+          piAiModelId = route.model;
+        }
+      }
     }
 
     logger.debug('[pi-ai-executor] RESOLVED_CANDIDATE_ROUTE:', {
@@ -840,7 +910,13 @@ export async function runPiAiExecutor<TResponse>(
         ? { ...route.config, api_base_url: '' }
         : route.config;
 
-    const piModel = buildPiAiModel(configForBuild, piAiProvider, piAiModelId, incomingApiType);
+    const piModel = buildPiAiModel(
+      configForBuild,
+      piAiProvider,
+      piAiModelId,
+      incomingApiType,
+      route.modelConfig
+    );
     if (!piModel) {
       // Should not happen (beta filter resolves the same way) but fail closed.
       concurrency.release(route.provider, route.model);
@@ -1083,7 +1159,7 @@ export async function runPiAiExecutor<TResponse>(
         // ── Build usage record ─────────────────────────────────────────
         const ttftMs = consumeTtfb(requestId);
         const usageData = buildUsageFromMessage(message, piModel as any, startTime, ttftMs, route);
-        const usageRecord = {
+        const usageRecord: any = {
           requestId,
           date: new Date().toISOString(),
           sourceIp,
@@ -1113,6 +1189,18 @@ export async function runPiAiExecutor<TResponse>(
           visionFallthroughModel,
           ...usageData,
         };
+
+        if (route.modelConfig?.pricing) {
+          calculateCosts(usageRecord, route.modelConfig.pricing, route.config.discount);
+        } else if (route.config.discount) {
+          const discountMultiplier = 1 - route.config.discount;
+          usageRecord.costInput = (usageRecord.costInput ?? 0) * discountMultiplier;
+          usageRecord.costOutput = (usageRecord.costOutput ?? 0) * discountMultiplier;
+          usageRecord.costCached = (usageRecord.costCached ?? 0) * discountMultiplier;
+          usageRecord.costCacheWrite = (usageRecord.costCacheWrite ?? 0) * discountMultiplier;
+          usageRecord.costTotal = (usageRecord.costTotal ?? 0) * discountMultiplier;
+          usageRecord.costMetadata = JSON.stringify({ discount: route.config.discount });
+        }
 
         const serialized = serializeMessage(message);
         let finalResponse = serialized;
@@ -1428,7 +1516,7 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
         doRelease();
 
         const usageData = buildUsageFromMessage(msg, piModel, startTime, ttftMs, route);
-        const usageRecord = {
+        const usageRecord: any = {
           requestId,
           date: new Date().toISOString(),
           sourceIp,
@@ -1459,6 +1547,18 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
           ...usageData,
         };
 
+        if (route.modelConfig?.pricing) {
+          calculateCosts(usageRecord, route.modelConfig.pricing, route.config.discount);
+        } else if (route.config.discount) {
+          const discountMultiplier = 1 - route.config.discount;
+          usageRecord.costInput = (usageRecord.costInput ?? 0) * discountMultiplier;
+          usageRecord.costOutput = (usageRecord.costOutput ?? 0) * discountMultiplier;
+          usageRecord.costCached = (usageRecord.costCached ?? 0) * discountMultiplier;
+          usageRecord.costCacheWrite = (usageRecord.costCacheWrite ?? 0) * discountMultiplier;
+          usageRecord.costTotal = (usageRecord.costTotal ?? 0) * discountMultiplier;
+          usageRecord.costMetadata = JSON.stringify({ discount: route.config.discount });
+        }
+
         if (transformedStreamSnapshot) {
           debug.addTransformedResponse(requestId, transformedStreamSnapshot);
           debug.addTransformedResponseSnapshot(requestId, transformedStreamSnapshot);
@@ -1485,7 +1585,7 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
 
       if (event.type === 'error') {
         const errorMessage = extractPiAiErrorMessage(event.error) ?? 'Upstream error';
-        const usageRecord = {
+        const usageRecord: any = {
           requestId,
           date: new Date().toISOString(),
           sourceIp,
@@ -1528,6 +1628,18 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
           visionFallthroughModel,
         };
 
+        if (route.modelConfig?.pricing) {
+          calculateCosts(usageRecord, route.modelConfig.pricing, route.config.discount);
+        } else if (route.config.discount) {
+          const discountMultiplier = 1 - route.config.discount;
+          usageRecord.costInput = (usageRecord.costInput ?? 0) * discountMultiplier;
+          usageRecord.costOutput = (usageRecord.costOutput ?? 0) * discountMultiplier;
+          usageRecord.costCached = (usageRecord.costCached ?? 0) * discountMultiplier;
+          usageRecord.costCacheWrite = (usageRecord.costCacheWrite ?? 0) * discountMultiplier;
+          usageRecord.costTotal = (usageRecord.costTotal ?? 0) * discountMultiplier;
+          usageRecord.costMetadata = JSON.stringify({ discount: route.config.discount });
+        }
+
         if (transformedStreamSnapshot) {
           debug.addTransformedResponse(requestId, transformedStreamSnapshot);
           debug.addTransformedResponseSnapshot(requestId, transformedStreamSnapshot);
@@ -1552,7 +1664,7 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
     doRelease();
 
     // Save error usage record
-    const usageRecord = {
+    const usageRecord: any = {
       requestId,
       date: new Date().toISOString(),
       sourceIp,
@@ -1598,6 +1710,18 @@ async function* buildSSEGenerator(p: SSEGeneratorParams): AsyncGenerator<string>
       isVisionFallthrough,
       visionFallthroughModel,
     };
+
+    if (route.modelConfig?.pricing) {
+      calculateCosts(usageRecord, route.modelConfig.pricing, route.config.discount);
+    } else if (route.config.discount) {
+      const discountMultiplier = 1 - route.config.discount;
+      usageRecord.costInput = (usageRecord.costInput ?? 0) * discountMultiplier;
+      usageRecord.costOutput = (usageRecord.costOutput ?? 0) * discountMultiplier;
+      usageRecord.costCached = (usageRecord.costCached ?? 0) * discountMultiplier;
+      usageRecord.costCacheWrite = (usageRecord.costCacheWrite ?? 0) * discountMultiplier;
+      usageRecord.costTotal = (usageRecord.costTotal ?? 0) * discountMultiplier;
+      usageRecord.costMetadata = JSON.stringify({ discount: route.config.discount });
+    }
 
     usageStorage.saveRequest(usageRecord as any).catch(() => {});
     usageStorage.saveError(requestId, err, { apiType: incomingApiType }).catch(() => {});

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -795,14 +795,29 @@ export function resolveModelCost(
           cost.cacheRead *= multiplier;
           cost.cacheWrite *= multiplier;
         }
+      } else if (effectiveDiscount) {
+        // Fall back to discounting the base cost if openrouter pricing hasn't loaded yet
+        const multiplier = 1 - effectiveDiscount;
+        cost.input = (cost.input ?? 0) * multiplier;
+        cost.output = (cost.output ?? 0) * multiplier;
+        cost.cacheRead = (cost.cacheRead ?? 0) * multiplier;
+        cost.cacheWrite = (cost.cacheWrite ?? 0) * multiplier;
       }
+    } else if (effectiveDiscount) {
+      // For any other pricing source that didn't get explicit cost mapping here,
+      // still apply the discount to the base cost as a fallback
+      const multiplier = 1 - effectiveDiscount;
+      cost.input = (cost.input ?? 0) * multiplier;
+      cost.output = (cost.output ?? 0) * multiplier;
+      cost.cacheRead = (cost.cacheRead ?? 0) * multiplier;
+      cost.cacheWrite = (cost.cacheWrite ?? 0) * multiplier;
     }
   } else if (routeConfig.discount) {
     const multiplier = 1 - routeConfig.discount;
-    cost.input *= multiplier;
-    cost.output *= multiplier;
-    cost.cacheRead *= multiplier;
-    cost.cacheWrite *= multiplier;
+    cost.input = (cost.input ?? 0) * multiplier;
+    cost.output = (cost.output ?? 0) * multiplier;
+    cost.cacheRead = (cost.cacheRead ?? 0) * multiplier;
+    cost.cacheWrite = (cost.cacheWrite ?? 0) * multiplier;
   }
 
   return cost;

--- a/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
+++ b/packages/backend/src/inference-v2/shared/pi-ai-utils.ts
@@ -15,6 +15,7 @@ import {
 } from '@earendil-works/pi-ai';
 import { getBuiltinModel, builtinModels } from '@earendil-works/pi-ai/providers/all';
 import type { Model as PiAiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
+import { PricingManager } from '../../services/pricing-manager';
 
 export const piAiModels = builtinModels();
 
@@ -668,16 +669,19 @@ export function resolvePiAiModel(piAiProvider: string, piAiModelId: string): PiA
   //    when its `provider` field equals the referencing pi-ai provider.
   //    First, look up via the compound key `${piAiProvider}:${piAiModelId}`,
   //    then fall back to the plain key `piAiModelId` for backwards compatibility.
-  const compoundKey = piAiModelId.includes(':') ? piAiModelId : `${piAiProvider}:${piAiModelId}`;
-  const modelSpec = customModels?.[compoundKey] ?? customModels?.[piAiModelId];
+  //    We bypass custom models for system fallback providers so they always fall through to the skeleton.
+  if (!piAiProvider.startsWith('fallback-')) {
+    const compoundKey = piAiModelId.includes(':') ? piAiModelId : `${piAiProvider}:${piAiModelId}`;
+    const modelSpec = customModels?.[compoundKey] ?? customModels?.[piAiModelId];
 
-  if (modelSpec && modelSpec.provider === piAiProvider) {
-    const resolved = resolveCustomModel(modelSpec, piAiProvider, piAiModelId);
-    if (resolved) {
-      // A custom provider may still override the wire api/compat.
-      return applyCustomProvider(resolved, customProviders?.[piAiProvider]);
+    if (modelSpec && modelSpec.provider === piAiProvider) {
+      const resolved = resolveCustomModel(modelSpec, piAiProvider, piAiModelId);
+      if (resolved) {
+        // A custom provider may still override the wire api/compat.
+        return applyCustomProvider(resolved, customProviders?.[piAiProvider]);
+      }
+      return null;
     }
-    return null;
   }
 
   // 2. Custom provider with a registry/base model.
@@ -746,16 +750,78 @@ function applyCustomProvider(
 // resolved (caller fails the candidate). Base URL resolution keys off the
 // *upstream* pi-ai API (piModel.api), not the client-facing route type.
 
+export function resolveModelCost(
+  baseCost: PiAiModel<any>['cost'],
+  routeConfig: RouteResult['config'],
+  modelConfig?: RouteResult['modelConfig']
+): PiAiModel<any>['cost'] {
+  let cost = { ...baseCost };
+
+  if (modelConfig?.pricing) {
+    const pricing = modelConfig.pricing;
+    const pricingDiscount = 'discount' in pricing ? (pricing as any).discount : undefined;
+    const effectiveDiscount = pricingDiscount ?? routeConfig.discount;
+
+    if (pricing.source === 'simple') {
+      cost = {
+        input: pricing.input || 0,
+        output: pricing.output || 0,
+        cacheRead: pricing.cached || 0,
+        cacheWrite: pricing.cache_write || 0,
+      };
+
+      if (effectiveDiscount) {
+        const multiplier = 1 - effectiveDiscount;
+        cost.input *= multiplier;
+        cost.output *= multiplier;
+        cost.cacheRead *= multiplier;
+        cost.cacheWrite *= multiplier;
+      }
+    } else if (pricing.source === 'openrouter' && pricing.slug) {
+      const openRouterPricing = PricingManager.getInstance().getPricing(pricing.slug);
+      if (openRouterPricing) {
+        cost = {
+          // OpenRouter pricing is per-token floats, pi-ai expects per-million
+          input: (parseFloat(openRouterPricing.prompt) || 0) * 1_000_000,
+          output: (parseFloat(openRouterPricing.completion) || 0) * 1_000_000,
+          cacheRead: (parseFloat(openRouterPricing.input_cache_read || '0') || 0) * 1_000_000,
+          cacheWrite: (parseFloat(openRouterPricing.input_cache_write || '0') || 0) * 1_000_000,
+        };
+
+        if (effectiveDiscount) {
+          const multiplier = 1 - effectiveDiscount;
+          cost.input *= multiplier;
+          cost.output *= multiplier;
+          cost.cacheRead *= multiplier;
+          cost.cacheWrite *= multiplier;
+        }
+      }
+    }
+  } else if (routeConfig.discount) {
+    const multiplier = 1 - routeConfig.discount;
+    cost.input *= multiplier;
+    cost.output *= multiplier;
+    cost.cacheRead *= multiplier;
+    cost.cacheWrite *= multiplier;
+  }
+
+  return cost;
+}
+
 export function buildPiAiModel(
-  providerConfig: Pick<ProviderConfig, 'api_base_url'>,
+  routeConfig: RouteResult['config'],
   piAiProvider: string,
   piAiModelId: string,
-  incomingApiType?: string
+  incomingApiType?: string,
+  modelConfig?: RouteResult['modelConfig']
 ): PiAiModel<any> | null {
   const piModel = resolvePiAiModel(piAiProvider, piAiModelId);
   if (!piModel) return null;
-  const baseUrl = resolveBaseUrl(providerConfig.api_base_url, piModel.api, incomingApiType);
-  return { ...piModel, baseUrl };
+
+  const baseUrl = resolveBaseUrl(routeConfig.api_base_url, piModel.api, incomingApiType);
+  const cost = resolveModelCost(piModel.cost, routeConfig, modelConfig);
+
+  return { ...piModel, baseUrl, cost };
 }
 
 // ─── Energy helpers ───────────────────────────────────────────────────────────

--- a/packages/backend/src/inference-v2/shared/vision-fallthrough.ts
+++ b/packages/backend/src/inference-v2/shared/vision-fallthrough.ts
@@ -227,7 +227,8 @@ async function describeImage(
   descriptorModel: string,
   prompt: string,
   usageStorage?: UsageStorageService,
-  parentMeta?: VisionFallthroughParentMeta
+  parentMeta?: VisionFallthroughParentMeta,
+  incomingApiType?: string
 ): Promise<string> {
   const key = cacheKeyFor(image, descriptorModel);
   const cached = cacheGet(key);
@@ -270,6 +271,11 @@ async function describeImage(
           : getProviderTypes(c.config);
 
       let targetType = availableTypes[0] || 'chat';
+      if (incomingApiType) {
+        const incoming = incomingApiType.toLowerCase();
+        const match = availableTypes.find((t: string) => t.toLowerCase() === incoming);
+        if (match) targetType = match;
+      }
 
       switch (targetType.toLowerCase()) {
         case 'messages':
@@ -354,6 +360,11 @@ async function describeImage(
             : getProviderTypes(route.config);
 
         let targetType = availableTypes[0] || 'chat';
+        if (incomingApiType) {
+          const incoming = incomingApiType.toLowerCase();
+          const match = availableTypes.find((t: string) => t.toLowerCase() === incoming);
+          if (match) targetType = match;
+        }
 
         switch (targetType.toLowerCase()) {
           case 'messages':
@@ -467,7 +478,8 @@ export async function applyVisionFallthrough(
   descriptorModel: string,
   prompt: string,
   usageStorage?: UsageStorageService,
-  parentMeta?: VisionFallthroughParentMeta
+  parentMeta?: VisionFallthroughParentMeta,
+  incomingApiType?: string
 ): Promise<Context> {
   const images = collectImages(context.messages);
   if (images.length === 0) return context;
@@ -477,7 +489,9 @@ export async function applyVisionFallthrough(
   );
 
   const descriptions = await Promise.all(
-    images.map((image) => describeImage(image, descriptorModel, prompt, usageStorage, parentMeta))
+    images.map((image) =>
+      describeImage(image, descriptorModel, prompt, usageStorage, parentMeta, incomingApiType)
+    )
   );
 
   const messages = injectDescriptions(context.messages, descriptions);

--- a/packages/backend/src/inference-v2/shared/vision-fallthrough.ts
+++ b/packages/backend/src/inference-v2/shared/vision-fallthrough.ts
@@ -18,6 +18,7 @@ import crypto from 'node:crypto';
 import { calculateCost } from '@earendil-works/pi-ai';
 import type { Context, ImageContent, Message, TextContent } from '@earendil-works/pi-ai';
 import { Router } from '../../services/router';
+import { getProviderTypes } from '../../config';
 import { CooldownManager } from '../../services/cooldown-manager';
 import { ConcurrencyTracker } from '../../services/concurrency-tracker';
 import type { UsageStorageService } from '../../services/usage-storage';
@@ -259,8 +260,38 @@ async function describeImage(
   }
 
   const betaCandidates = candidates.filter((c) => {
-    const piAiProvider = (c.config as any).pi_ai_provider as string | undefined;
-    const piAiModelId = (c.modelConfig as any)?.pi_ai_model_id as string | undefined;
+    let piAiProvider = (c.config as any).pi_ai_provider as string | undefined;
+    let piAiModelId = (c.modelConfig as any)?.pi_ai_model_id as string | undefined;
+
+    if (!piAiProvider) {
+      const availableTypes =
+        c.modelConfig?.access_via && c.modelConfig.access_via.length > 0
+          ? c.modelConfig.access_via
+          : getProviderTypes(c.config);
+
+      let targetType = availableTypes[0] || 'chat';
+
+      switch (targetType.toLowerCase()) {
+        case 'messages':
+          piAiProvider = 'fallback-anthropic';
+          break;
+        case 'gemini':
+          piAiProvider = 'fallback-gemini';
+          break;
+        case 'responses':
+          piAiProvider = 'fallback-responses';
+          break;
+        case 'chat':
+        default:
+          piAiProvider = 'fallback-chat';
+          break;
+      }
+
+      if (!piAiModelId) {
+        piAiModelId = c.model;
+      }
+    }
+
     if (!piAiProvider || !piAiModelId) return false;
     return resolvePiAiModel(piAiProvider, piAiModelId) != null;
   });
@@ -313,9 +344,45 @@ async function describeImage(
 
     const startTime = Date.now();
     try {
-      const piAiProvider = (route.config as any).pi_ai_provider as string;
-      const piAiModelId = (route.modelConfig as any)?.pi_ai_model_id as string;
-      const piModel = buildPiAiModel(route.config, piAiProvider, piAiModelId, 'chat');
+      let piAiProvider = (route.config as any).pi_ai_provider as string;
+      let piAiModelId = (route.modelConfig as any)?.pi_ai_model_id as string;
+
+      if (!piAiProvider) {
+        const availableTypes =
+          route.modelConfig?.access_via && route.modelConfig.access_via.length > 0
+            ? route.modelConfig.access_via
+            : getProviderTypes(route.config);
+
+        let targetType = availableTypes[0] || 'chat';
+
+        switch (targetType.toLowerCase()) {
+          case 'messages':
+            piAiProvider = 'fallback-anthropic';
+            break;
+          case 'gemini':
+            piAiProvider = 'fallback-gemini';
+            break;
+          case 'responses':
+            piAiProvider = 'fallback-responses';
+            break;
+          case 'chat':
+          default:
+            piAiProvider = 'fallback-chat';
+            break;
+        }
+
+        if (!piAiModelId) {
+          piAiModelId = route.model;
+        }
+      }
+
+      const piModel = buildPiAiModel(
+        route.config,
+        piAiProvider,
+        piAiModelId,
+        'chat',
+        route.modelConfig
+      );
       if (!piModel) {
         doRelease();
         continue;

--- a/packages/backend/src/routes/management/pi-ai-custom.ts
+++ b/packages/backend/src/routes/management/pi-ai-custom.ts
@@ -62,6 +62,14 @@ export async function registerPiAiCustomRoutes(fastify: FastifyInstance) {
     '/v0/management/pi/custom-providers/:name',
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { name } = request.params as { name: string };
+      if (name.startsWith('fallback-')) {
+        return reply.code(403).send({
+          error: {
+            message: 'System fallback providers cannot be deleted',
+            type: 'forbidden_error',
+          },
+        });
+      }
       try {
         const all = await configService.getRepository().getAllPiAiCustomProviders();
         if (!all[name]) {

--- a/packages/frontend/src/pages/PiRegistry.tsx
+++ b/packages/frontend/src/pages/PiRegistry.tsx
@@ -639,6 +639,7 @@ function ProviderRow({
 
   // Child models: those scoped to this provider (def.provider === name).
   const childModels = Object.entries(models).filter(([, m]) => m.provider === name);
+  const isSystemDefault = name.startsWith('fallback-');
 
   return (
     <div className="border border-border-glass rounded-md">
@@ -649,6 +650,11 @@ function ProviderRow({
         <div className="flex items-center gap-2">
           {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
           <span className="font-mono text-[13px] text-text">{name}</span>
+          {isSystemDefault && (
+            <Badge status="info" style={{ fontSize: '10px', padding: '2px 8px' }}>
+              System Default
+            </Badge>
+          )}
           <Badge status="neutral" style={{ fontSize: '10px', padding: '2px 8px' }}>
             {apiVal}
           </Badge>
@@ -656,22 +662,24 @@ function ProviderRow({
             {childModels.length} model{childModels.length === 1 ? '' : 's'}
           </Badge>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={async (e) => {
-            e.stopPropagation();
-            try {
-              await api.deletePiCustomProvider(name);
-              toast.success(`Deleted '${name}'`);
-              onChanged();
-            } catch (e: any) {
-              toast.error(e?.message ?? 'Failed to delete');
-            }
-          }}
-        >
-          <Trash2 size={14} style={{ color: 'var(--color-danger)' }} />
-        </Button>
+        {!isSystemDefault && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={async (e) => {
+              e.stopPropagation();
+              try {
+                await api.deletePiCustomProvider(name);
+                toast.success(`Deleted '${name}'`);
+                onChanged();
+              } catch (e: any) {
+                toast.error(e?.message ?? 'Failed to delete');
+              }
+            }}
+          >
+            <Trash2 size={14} style={{ color: 'var(--color-danger)' }} />
+          </Button>
+        )}
       </div>
       {open && (
         <div className="p-3 pt-0">


### PR DESCRIPTION
### **User description**
This PR introduces a zero-config beta routing support strategy for inference-v2 to significantly reduce friction. When a target model lacks a pi_ai_provider hint, inference-v2 automatically maps it to a seeded 'fallback-*' custom provider (like fallback-chat or fallback-anthropic) based on its legacy wire protocol.\n\nIt also accurately enforces cost metadata. buildPiAiModel now natively honors 'simple' and 'openrouter' pricing configured via Plexus route configurations, applying discounts correctly and mapping them to pi-ai's per-million cost schema to prevent double-discounting anomalies.


___

### **Description**
- Add automatic fallback provider routing for models lacking `pi_ai_provider`

- Seed system `fallback-*` providers on startup and protect from deletion

- Enrich `buildPiAiModel` with `simple` and `openrouter` pricing support

- Apply provider discounts to usage cost records across all executor paths

- Add pricing and fallback resolution tests; mark system providers in UI


___

