### PR TITLE
fix(ci): run PR tests outside trusted context

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,7 +2,7 @@ name: PR Tests
 run-name: "PR: ${{ github.event.pull_request.title || format('PR #{0}', github.event.inputs.pr_number) }}"
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
   workflow_dispatch:
     inputs:
@@ -18,12 +18,15 @@ on:
 
 permissions:
   contents: read
-  checks: write
+  pull-requests: read
 
 jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Get PR info for workflow_dispatch
         if: github.event_name == 'workflow_dispatch'
@@ -39,27 +42,12 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('head_repo_full_name', pr.head.repo.full_name);
 
-      - name: Create PR check for workflow_dispatch
-        if: github.event_name == 'workflow_dispatch'
-        id: create-check
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { data: check } = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'PR Tests',
-              head_sha: '${{ steps.get-pr.outputs.head_sha }}',
-              status: 'in_progress',
-              started_at: new Date().toISOString()
-            });
-            core.setOutput('check_id', check.id);
-
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || steps.get-pr.outputs.head_repo_full_name }}
           ref: ${{ github.event.pull_request.head.sha || steps.get-pr.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -77,19 +65,44 @@ jobs:
       - name: Run backend tests
         run: cd packages/backend && bun run test:force-all
 
-      - name: Update PR check to complete
+  record-dispatch-check:
+    name: Record workflow_dispatch check
+    needs: test
+    if: github.event_name == 'workflow_dispatch' && always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+    steps:
+      - name: Create completed PR check
         if: github.event_name == 'workflow_dispatch' && always()
         uses: actions/github-script@v9
         with:
           script: |
-            const conclusion = '${{ job.status }}' === 'success' ? 'success' : 'failure';
-            await github.rest.checks.update({
+            const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              check_run_id: '${{ steps.create-check.outputs.check_id }}',
-              status: 'completed',
-              conclusion: conclusion,
-              completed_at: new Date().toISOString()
+              pull_number: parseInt('${{ github.event.inputs.pr_number }}')
             });
 
+            const result = '${{ needs.test.result }}';
+            const conclusion = result === 'success'
+              ? 'success'
+              : result === 'cancelled'
+                ? 'cancelled'
+                : result === 'skipped'
+                  ? 'skipped'
+                  : 'failure';
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'PR Tests',
+              head_sha: pr.head.sha,
+              status: 'completed',
+              conclusion: conclusion,
+              started_at: new Date().toISOString(),
+              completed_at: new Date().toISOString()
+            });
 


### PR DESCRIPTION
### **User description**
## Summary

- switch normal PR test runs from `pull_request_target` to unprivileged `pull_request`
- keep `workflow_dispatch` support for bot-created PR tests
- move manual check creation into a separate post-test job with `checks: write`
- disable credential persistence when checking out PR code

## Test plan

- `mise exec -- actionlint .github/workflows/pr-tests.yml`

Fixes the checkout refusal seen on fork PR #666.


___

### **Description**
- Switch PR test trigger from `pull_request_target` to unprivileged `pull_request`

- Disable credential persistence during PR checkout to fix fork refusal

- Move manual check creation to separate post-test job with `checks: write`

- Improve check conclusion mapping to handle cancelled and skipped states


___

