### PR TITLE
feat(dev): frontend-testing skill and dev:agent launcher

### DIFF
--- a/.agents/skills/frontend-testing/SKILL.md
+++ b/.agents/skills/frontend-testing/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: frontend-testing
+description: >-
+  See, screenshot, or confirm the behavior of any Plexus admin-UI screen in the actually
+  running app. This skill boots the worktree-safe dev stack (`bun run dev:full`), auto-logs
+  into the admin panel, and drives it with a real browser — the port, credentials, and
+  auto-login that raw browser automation doesn't know how to do on its own. Reach for it
+  whenever you need eyes on the running Plexus frontend: after you edit anything under
+  `packages/frontend/src` (React `.tsx`/`.jsx`, routes, forms, buttons, tables, modals,
+  Tailwind/CSS, layout, the login page, dashboards) and want to confirm it renders and
+  behaves before calling the work done, OR whenever the user asks to look at or verify a
+  screen — e.g. "screenshot the dashboard", "does the new tab show up in the sidebar", "did
+  my routing change work", "confirm clicking delete removes the row", "make sure the page
+  renders instead of a blank/white screen", "check the sidebar still collapses in the running
+  app", "verify the UI change", "does the button actually work", or a reported visual or
+  interaction bug to reproduce. Prefer actually rendering and clicking the page over reading
+  the component source to guess whether it works — if the user changed a component or route
+  and "hasn't looked at it yet", boot the app and look. Prefer this skill over the generic
+  agent-browser skill for anything targeting the local Plexus frontend, since only this one
+  knows the dev-stack port, credentials, and auto-login. Don't hand frontend work back
+  unverified and don't ask the user to check for you — you can verify it yourself.
+---
+
+# Frontend testing (verify your own UI work)
+
+The point of this skill is self-verification: after you change something in the Plexus
+frontend, don't hand it back unverified. Boot the app, look at it through a real browser,
+interact with it the way a user would, and confirm it renders and works. This catches the
+class of mistakes that typecheck and unit tests miss — a component that throws on mount, a
+button wired to nothing, a layout that collapses, a form that never submits.
+
+You already have every piece you need:
+
+- **`bun run dev:full`** — starts a fully-seeded, worktree-safe dev stack (backend + frontend watcher).
+- **`bun run dev:get:port`** — tells you which port this worktree uses.
+- **agent-browser** — drives a real Chromium browser (load its `core` skill for command syntax).
+- **plexus-management** skill — inspects/seeds backend state through the management API when you need to set up or confirm data behind the UI.
+
+This skill wires them together. Follow the steps in order the first time; on later runs you
+can skip straight to browsing if the instance is already up.
+
+## Step 0 — Preflight (once per environment)
+
+agent-browser needs a Chromium binary, which may not be installed yet. Install it once; it's
+a no-op if already present:
+
+```bash
+bunx agent-browser install --with-deps   # --with-deps pulls Linux browser libs; drop it on macOS
+```
+
+Note the `bunx` prefix: agent-browser is a dev dependency here, not a global binary, so run
+every command as `bunx agent-browser ...`.
+
+## Step 1 — Start or reuse the instance
+
+Use the agent launcher — it does the right thing in one blocking call:
+
+```bash
+bun run dev:agent
+```
+
+`dev:agent` starts the full stack **detached**, waits until the server is healthy, then returns
+while the stack keeps running in the background. Do **not** use `bun run dev:full` directly for
+this — it runs in the foreground under a file watcher and never returns, so it will hang your
+session. `dev:agent` is also idempotent: if an instance is already up on this worktree's port it
+just reports it and exits immediately.
+
+It prints everything you need — capture it:
+
+```
+PORT=17508
+ADMIN_KEY=password
+URL=http://localhost:17508/ui/login?token=password
+LOG=/tmp/plexus-dev-<worktree>.log
+```
+
+The stack is keyed to the worktree directory name, so each worktree gets its own stable port and
+its own database — parallel worktrees never collide. Health is a single sufficient readiness gate
+for the whole stack: the backend embeds the built frontend at startup, so it can't report healthy
+until the frontend has been built. On the very first boot of a fresh worktree the stack also seeds
+data via `prep-dev` and restarts once, so that first `dev:agent` call takes longer than later ones.
+
+If `dev:agent` reports it never became healthy, read the `LOG` path it printed — a common cause is
+a real error in the code you just changed (the backend `--watch` crash-loops on a broken import or
+a component that fails to build). Another is missing dependencies — run `bun install` first.
+
+## Step 2 — Log in automatically
+
+The remaining steps use `$PORT` and `$ADMIN_KEY`. Set them from the values `dev:agent` printed
+(or re-derive the port — it's deterministic per worktree):
+
+```bash
+PORT=$(bun run dev:get:port)
+ADMIN_KEY="${ADMIN_KEY:-password}"   # dev default is "password" unless you set ADMIN_KEY
+```
+
+Skip the login form entirely. The login page accepts the admin key as a `?token=` query
+parameter and authenticates on load, so navigate straight there:
+
+```bash
+bunx agent-browser open "http://localhost:$PORT/ui/login?token=$ADMIN_KEY"
+bunx agent-browser wait --load networkidle
+bunx agent-browser snapshot -i        # confirm you've landed in the app, not back on the login form
+```
+
+If the snapshot still shows a key input / "Log in" heading, the token was rejected — double-check
+`ADMIN_KEY` matches what the running server used (see the `ADMIN_KEY:` line in the dev log at
+`/tmp/plexus-dev-<worktree>.log`).
+
+## Step 3 — Drive and inspect the UI
+
+Now exercise whatever you changed. For the exact agent-browser command syntax — snapshots,
+element refs, clicking, filling, waiting, screenshots — load its core skill once and follow it;
+don't guess flags:
+
+```bash
+bunx agent-browser skills get core
+```
+
+The essential loop is: `snapshot -i` to see interactive elements and their `@eN` refs → act on a
+ref (`click`, `fill`, `type`, `select`) → **re-snapshot**, because refs go stale the instant the
+page changes (navigation, submit, re-render, modal open).
+
+Navigate directly to the route you touched rather than clicking through the whole app, e.g.
+`bunx agent-browser open "http://localhost:$PORT/ui/<route>"`. Then verify the specific thing you
+changed:
+
+- Does the page render without an error boundary / blank screen? (`snapshot -i` should show real content.)
+- Does the element you added/changed appear, with the right text and state?
+- Does the interaction you wired up actually do something? Click it, then re-snapshot and confirm the expected change.
+- Capture a screenshot as evidence (see below).
+
+## Step 4 — Confirm backend state when the UI writes data
+
+If your UI change creates, edits, or deletes something (a provider, key, alias, quota, setting),
+don't trust the optimistic UI alone — confirm the change actually persisted. Use the
+**plexus-management** skill for this, pointed at your local instance:
+
+```bash
+export PLEXUS_BASE_URL="http://localhost:$PORT"
+export PLEXUS_ADMIN_KEY="$ADMIN_KEY"
+```
+
+Then follow the plexus-management skill to read back the relevant resource (e.g. list providers
+after your form submits and check the new one is there). You can also use it in the other
+direction — to seed data the UI needs before you test a read/display change.
+
+## Screenshots
+
+Capture a screenshot as evidence of what you verified. Let agent-browser save it to its own
+default screenshot directory and use the path it prints in its output — don't fight it with a
+custom path (a bare relative path is parsed as a CSS *selector*, not a filename, and a leading
+`./` is easy to forget):
+
+```bash
+bunx agent-browser screenshot            # prints e.g. "Screenshot saved to /home/.../screenshot-<ts>.png"
+```
+
+When you report results, quote that printed path and state plainly what the screenshot shows.
+
+## When you're done
+
+Leave the instance running — it's meant to persist, and reusing it makes your next check instant
+(and `dev:agent` will just reuse it). Note in your summary that it's still up on
+`http://localhost:$PORT/ui/`. You don't need to close the browser between checks, but
+`bunx agent-browser close` frees it. To tear the stack down for this worktree, run
+`bun run dev:stop`.
+
+## After editing frontend code mid-session
+
+Both watchers rebuild automatically when you save a file, and the backend `--watch` restarts to
+re-embed the rebuilt frontend. So after a further change, give it a moment, re-run
+`bun run dev:agent` (it returns as soon as health is stable again), then reload in the browser
+(`bunx agent-browser open` the same URL, or a hard reload) before re-checking — otherwise you may
+be looking at the pre-change build.
+
+## Troubleshooting
+
+- **`dev:agent` reports never-healthy** → read the dev log at the `LOG` path it printed (`/tmp/plexus-dev-<worktree>.log`). Two common causes: (a) the change you made broke the build or crashes the backend on start; (b) dependencies aren't installed — a `Could not resolve: "react"` (or similar) crash-loop means the worktree needs `bun install` before the stack can boot.
+- **`prep-dev` fails / DB looks empty** → the stack only seeds if a data source exists (saved local data or `PLEXUS_STAGING_URL`/`PLEXUS_STAGING_ADMIN_KEY`). Without one, the server still runs fine on an empty DB — seed what you need for the test via the plexus-management skill.
+- **Stuck/old process on the port** → `bun run dev:stop` tears down this worktree's stack, then `bun run dev:agent` to start fresh.
+- **agent-browser can't launch a browser** → run `bunx agent-browser install --with-deps`. In headless/CI-like environments this can fail two ways: the downloaded Chrome binary may lack the execute bit (`chmod +x ~/.agent-browser/browsers/*/chrome`), and `--with-deps` needs `sudo` to `apt-get install` system libs. Diagnose missing libs with `ldd ~/.agent-browser/browsers/*/chrome | grep 'not found'` and install the matching packages.
+- **Login snapshot still shows the form** → the `?token=` key didn't match the server's `ADMIN_KEY`; confirm from the dev log.
+- **UI looks stale after an edit** → the watcher hadn't finished; wait for `/health`, then hard-reload.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,11 +77,23 @@ Rules:
 - Import assets with ES6 imports only.
 - Do not use dynamic asset paths.
 
+### If the task changes the frontend UI
+
+After editing anything a user sees in the browser (React `.tsx`/`.jsx`, routes, forms,
+Tailwind/CSS, layout, or any file under `packages/frontend/src`), verify it yourself
+instead of handing it back unchecked:
+
+1. Read the **`frontend-testing`** skill.
+2. Boot the worktree-safe dev stack, auto-log into the UI, and drive it with a real
+   browser to confirm your change renders and behaves correctly.
+
 ## Canonical project commands
 
 Use these commands exactly:
 
 - Dev server: `bun run dev`
+- Dev stack for agents (background, worktree-safe): `bun run dev:agent`
+- Stop the agent dev stack: `bun run dev:stop`
 - Dev port: `PORT=$(bun run dev:get:port)`
 - Dev DB path: `DB_PATH=$(bun run dev:get:db_path)`
 - Tests: `bun run test`
@@ -91,6 +103,7 @@ Use these commands exactly:
 
 Notes:
 - `bun run dev` derives the backend port from the worktree name and runs the frontend watcher.
+- `bun run dev:agent` boots the full stack detached and returns once healthy (unlike `dev:full`, which runs in the foreground and never returns); use it when an agent needs a running instance to test against.
 - `bun test` is intentionally blocked. Use `bun run test`.
 
 ## Project overview

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "profile": "bun run dev --profile",
     "dev:pglite": "bun run scripts/dev.ts --pglite",
     "dev:full": "bun run scripts/dev.ts --full",
+    "dev:agent": "bun run scripts/dev-agent.ts",
+    "dev:stop": "bun run scripts/dev-agent.ts stop",
     "dev:get:port": "bun run scripts/dev-config.ts port",
     "dev:get:db_path": "bun run scripts/dev-config.ts db_path",
     "build:frontend": "cd packages/frontend && bun run build",

--- a/scripts/dev-agent.ts
+++ b/scripts/dev-agent.ts
@@ -1,0 +1,131 @@
+/**
+ * dev-agent.ts
+ *
+ * Agent-friendly launcher for the full dev stack. Unlike `bun run dev:full`
+ * (which runs in the foreground under a file watcher and never returns), this
+ * starts the stack detached, waits only until the server is healthy, then exits
+ * 0 while the stack keeps running in the background. This lets an agent boot the
+ * app and immediately move on to driving it, without managing backgrounding.
+ *
+ * Usage:
+ *   bun run dev:agent            # start (or reuse) and block until healthy, then return
+ *   bun run dev:agent --no-wait  # start detached and return immediately (don't wait for health)
+ *   bun run dev:agent stop       # stop the background dev stack for this worktree
+ *
+ * Worktree-safe: the port, log path, and pid file are all derived from the
+ * worktree directory name, matching scripts/dev.ts.
+ */
+
+import { basename, join } from 'path';
+import { tmpdir } from 'os';
+import { openSync, existsSync, readFileSync } from 'fs';
+import { spawn } from 'child_process';
+
+const dirName = basename(process.cwd());
+
+function derivePort(): string {
+  if (process.env.PORT) return process.env.PORT;
+  let hash = 5381;
+  for (let i = 0; i < dirName.length; i++) {
+    hash = (hash * 33) ^ dirName.charCodeAt(i);
+  }
+  return String(10000 + (Math.abs(hash) % 10000));
+}
+
+const PORT = derivePort();
+const ADMIN_KEY = process.env.ADMIN_KEY ?? 'password';
+const BASE = `http://localhost:${PORT}`;
+const LOGIN_URL = `${BASE}/ui/login?token=${encodeURIComponent(ADMIN_KEY)}`;
+const LOG_FILE = join(tmpdir(), `plexus-dev-${dirName}.log`);
+const PID_FILE = join(tmpdir(), `plexus-${dirName}.pid`);
+
+const READY_TIMEOUT_MS = 180_000; // first boot also seeds data + restarts
+const CONSECUTIVE_OK = 3; // require stable health to ride out the post-seed restart
+
+async function isHealthy(): Promise<boolean> {
+  try {
+    const res = await fetch(`${BASE}/health`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForHealthy(timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  let ok = 0;
+  while (Date.now() - start < timeoutMs) {
+    if (await isHealthy()) {
+      if (++ok >= CONSECUTIVE_OK) return true;
+    } else {
+      ok = 0;
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return false;
+}
+
+function printReady(prefix: string) {
+  console.log(prefix);
+  console.log(`PORT=${PORT}`);
+  console.log(`ADMIN_KEY=${ADMIN_KEY}`);
+  console.log(`URL=${LOGIN_URL}`);
+  console.log(`LOG=${LOG_FILE}`);
+}
+
+const subcommand = process.argv[2];
+
+if (subcommand === 'stop') {
+  if (existsSync(PID_FILE)) {
+    const pid = parseInt(readFileSync(PID_FILE, 'utf8').trim(), 10);
+    try {
+      process.kill(pid, 'SIGTERM');
+      console.log(`Stopped dev stack for "${dirName}" (pid ${pid}).`);
+    } catch {
+      console.log(`No live dev stack for "${dirName}" (stale pid file).`);
+    }
+  } else {
+    console.log(`No dev stack running for "${dirName}".`);
+  }
+  process.exit(0);
+}
+
+// --- start (default) ---
+
+if (await isHealthy()) {
+  printReady('Dev stack already running — reusing it.');
+  process.exit(0);
+}
+
+const noWait = process.argv.includes('--no-wait');
+const logFd = openSync(LOG_FILE, 'a');
+
+const child = spawn('bun', ['run', 'scripts/dev.ts', '--full', '--no-open'], {
+  cwd: process.cwd(),
+  env: { ...process.env, PORT, ADMIN_KEY },
+  detached: true, // own session — survives after this launcher exits
+  stdio: ['ignore', logFd, logFd],
+});
+child.unref();
+
+console.log(`Starting Plexus dev stack in background (logs: ${LOG_FILE})...`);
+
+if (noWait) {
+  console.log(`PORT=${PORT}`);
+  console.log(`Poll ${BASE}/health until ready, then log in at ${LOGIN_URL}`);
+  process.exit(0);
+}
+
+if (await waitForHealthy(READY_TIMEOUT_MS)) {
+  printReady('Ready.');
+  process.exit(0);
+}
+
+console.error(`Server did not become healthy within ${READY_TIMEOUT_MS / 1000}s. Recent log:`);
+try {
+  console.error(readFileSync(LOG_FILE, 'utf8').split('\n').slice(-25).join('\n'));
+} catch {}
+console.error(
+  `\nThe stack may still be starting — inspect ${LOG_FILE} or stop it with: bun run dev:stop`
+);
+process.exit(1);


### PR DESCRIPTION
### **User description**
## Summary

Adds a **`frontend-testing`** skill that lets an agent verify its own UI work end-to-end, plus a **`bun run dev:agent`** launcher that makes booting the dev stack agent-friendly.

### `frontend-testing` skill
Ties together the existing pieces so an agent can check the frontend it just changed:
- Boots the worktree-safe dev stack via `bun run dev:agent`.
- Auto-logs into the admin UI using the `?token=` login URL (no form-filling).
- Drives the UI with `agent-browser` (defers to its `core` skill for command syntax).
- Confirms persisted backend state via the `plexus-management` skill when the UI writes data.
- Documents the real environment snags (browser install/libs, `bun install`, empty-DB seeding).

### `dev:agent` / `dev:stop` (`scripts/dev-agent.ts`)
- `dev:agent` starts the full stack **detached**, blocks only until `/health` is stable, then returns while the stack keeps running — unlike `dev:full`, which runs in the foreground under a watcher and never returns (a common way for agents to hang). Idempotent: reuses a live instance.
- `dev:stop` tears down the worktree's stack via its PID file.
- Worktree-safe (port/log/pid derived from the directory name).

### AGENTS.md
- New "If the task changes the frontend UI" trigger pointing at the skill.
- `dev:agent` / `dev:stop` added to canonical commands.

## Validation
- **Triggering probe** (real installed skill, 20 realistic queries): precision 100% (clean separation from `plexus-management`, `gh-cli`, `db-schema-migrations`, `vitest`, WebFetch); the should-trigger set that didn't fire immediately was orienting via `git diff` first, not mis-routing.
- **Cold subagent tests** (no prior context, server down): fresh agent triggered the skill, booted via `dev:agent`, auto-logged in, navigated and exercised the Providers/Keys screens, and screenshotted — end-to-end success.

## Notes
- Pre-commit hooks (biome format/lint, typecheck, no-migrations) pass.
- No schema/migration changes.


___

### **Description**
- Add `dev:agent` and `dev:stop` scripts for detached, worktree-safe dev stack management

- Add `frontend-testing` skill for end-to-end UI verification via browser automation

- Update `AGENTS.md` with frontend UI verification trigger and new canonical commands


___

