### PR TITLE
fix(logs): include reasoning tokens in E2E throughput

### DIFF
--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -820,6 +820,8 @@ export const Logs = () => {
                   Number(log.tokensCached || 0) +
                   Number(log.tokensCacheWrite || 0) +
                   Number(log.tokensReasoning || 0);
+                const e2eOutputTokens =
+                  Number(log.tokensOutput || 0) + Number(log.tokensReasoning || 0);
                 const status = log.responseStatus || (log.hasError ? 'error' : 'unknown');
                 const statusClass =
                   status === 'success'
@@ -950,11 +952,8 @@ export const Logs = () => {
                         <div className="min-w-0 rounded bg-bg-subtle px-1.5 py-1">
                           <div className="truncate text-text">
                             <span className="text-[9px] uppercase text-text-muted">E2E </span>
-                            {log.durationMs != null &&
-                            log.durationMs > 0 &&
-                            log.tokensOutput &&
-                            log.tokensOutput > 0
-                              ? formatTPS(log.tokensOutput / (log.durationMs / 1000))
+                            {log.durationMs != null && log.durationMs > 0 && e2eOutputTokens > 0
+                              ? formatTPS(e2eOutputTokens / (log.durationMs / 1000))
                               : '-'}
                           </div>
                         </div>
@@ -1496,14 +1495,13 @@ export const Logs = () => {
                                 : null;
                           const liveDuration =
                             rawDurationMs != null ? formatMs(rawDurationMs) : '-';
-                          // End-to-end throughput: total output tokens / full request duration.
+                          const e2eOutputTokens =
+                            Number(log.tokensOutput || 0) + Number(log.tokensReasoning || 0);
+                          // End-to-end throughput: output plus reasoning tokens / full request duration.
                           // Unlike TPS (which excludes the TTFT delay), E2E includes it.
                           const e2e =
-                            log.durationMs != null &&
-                            log.durationMs > 0 &&
-                            log.tokensOutput &&
-                            log.tokensOutput > 0
-                              ? log.tokensOutput / (log.durationMs / 1000)
+                            log.durationMs != null && log.durationMs > 0 && e2eOutputTokens > 0
+                              ? e2eOutputTokens / (log.durationMs / 1000)
                               : null;
                           if (progress) {
                             return (


### PR DESCRIPTION
### **User description**
## Summary
- Include reasoning tokens in the Logs page E2E throughput calculation
- Apply the same calculation in both mobile card and table views

## Validation
- bun run typecheck
- Verified locally in the running UI with a seeded log row showing output + reasoning in E2E


___

### **Description**
- Include reasoning tokens in E2E throughput calculation on Logs page

- Add `e2eOutputTokens` variable combining output and reasoning tokens

- Apply the fix consistently in both mobile card and table views


___

