### PR TITLE
fix(responses): normalize replayed tool and reasoning items

### DIFF
--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -1,7 +1,11 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { logger } from '../../utils/logger';
 import { Dispatcher } from '../../services/dispatcher';
-import { ResponsesTransformer } from '../../transformers/responses';
+import {
+  ResponsesTransformer,
+  normalizeCompositeResponsesCallIds,
+  normalizeResponsesReasoningContent,
+} from '../../transformers/responses';
 import { UsageStorageService } from '../../services/usage-storage';
 import { ResponsesStorageService } from '../../services/responses-storage';
 import { UsageRecord } from '../../types/usage';
@@ -73,9 +77,11 @@ export async function registerResponsesRoute(
       const transformer = new ResponsesTransformer();
 
       // Helper to normalize input into the standardized array format
-      function normalizeInput(
-        input: unknown
-      ): Array<{ type: string; role: string; content: Array<{ type: string; text: string }> }> {
+      function normalizeInput(input: unknown): Array<{
+        type: string;
+        role: string;
+        content: Array<{ type: string; text: string }>;
+      }> {
         return Array.isArray(input)
           ? (input as any[])
           : [
@@ -130,6 +136,23 @@ export async function registerResponsesRoute(
         body.input = [...conversationItems, ...currentInput];
       }
 
+      // Keep debug capture faithful to the client payload, then repair the
+      // dispatch body so strict Responses providers don't reject composite
+      // tool call IDs observed in replayed Codex CLI conversations.
+      const rawBodyForDebug = JSON.parse(JSON.stringify(body));
+      const normalizedCallIds = normalizeCompositeResponsesCallIds(body);
+      const normalizedReasoningItems = normalizeResponsesReasoningContent(body);
+      if (normalizedCallIds > 0) {
+        logger.warn(
+          `Normalized ${normalizedCallIds} composite Responses call_id value(s) for request ${requestId}`
+        );
+      }
+      if (normalizedReasoningItems > 0) {
+        logger.warn(
+          `Removed plaintext content from ${normalizedReasoningItems} Responses reasoning item(s) for request ${requestId}`
+        );
+      }
+
       let unifiedRequest = await transformer.parseRequest(body);
       unifiedRequest.incomingApiType = 'responses';
       unifiedRequest.originalBody = body;
@@ -164,7 +187,11 @@ export async function registerResponsesRoute(
         };
       }
 
-      DebugManager.getInstance().startLog(requestId, body, sanitizeHeaders(request.headers as any));
+      DebugManager.getInstance().startLog(
+        requestId,
+        rawBodyForDebug,
+        sanitizeHeaders(request.headers as any)
+      );
 
       // Check quota before processing
       if (quotaEnforcer) {

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { ResponsesTransformer } from '../responses';
+import {
+  ResponsesTransformer,
+  normalizeCompositeResponsesCallIds,
+  normalizeResponsesReasoningContent,
+} from '../responses';
 
 /**
  * Round-trip tests for the Responses API transformer.
@@ -17,7 +21,13 @@ import { ResponsesTransformer } from '../responses';
 
 const RESPONSES_REQUEST = {
   model: 'gpt-4o',
-  input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Hello' }] }],
+  input: [
+    {
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: 'Hello' }],
+    },
+  ],
   stream: true,
   max_output_tokens: 1024,
   temperature: 0.7,
@@ -44,6 +54,118 @@ const RESPONSES_REQUEST = {
 };
 
 describe('Responses responses -> responses round-trip preserves native fields', () => {
+  it('normalizes composite call IDs to the model-generated call ID', () => {
+    const body = {
+      input: [
+        {
+          type: 'function_call',
+          name: 'exec_command',
+          call_id:
+            'call_enS4L7YycCRyOiWOg31Xpvwm|fc_0281edd961557cf2016a4b062d87948195968b8fa6c46b8c7a',
+          arguments: '{}',
+        },
+        {
+          type: 'function_call_output',
+          call_id:
+            'call_enS4L7YycCRyOiWOg31Xpvwm|fc_0281edd961557cf2016a4b062d87948195968b8fa6c46b8c7a',
+          output: 'ok',
+        },
+        {
+          type: 'function_call',
+          name: 'exec_command',
+          call_id: 'call_plain',
+          arguments: '{}',
+        },
+        {
+          type: 'function_call',
+          name: 'exec_command',
+          call_id: 'custom|id',
+          arguments: '{}',
+        },
+      ],
+    };
+
+    expect(normalizeCompositeResponsesCallIds(body)).toBe(2);
+    expect(body.input.map((item) => item.call_id)).toEqual([
+      'call_enS4L7YycCRyOiWOg31Xpvwm',
+      'call_enS4L7YycCRyOiWOg31Xpvwm',
+      'call_plain',
+      'custom|id',
+    ]);
+  });
+
+  it('uses normalized call IDs when rebuilding a Responses request', async () => {
+    const transformer = new ResponsesTransformer();
+    const body = {
+      model: 'gpt-4o',
+      input: [
+        {
+          type: 'function_call',
+          name: 'exec_command',
+          call_id:
+            'call_enS4L7YycCRyOiWOg31Xpvwm|fc_0281edd961557cf2016a4b062d87948195968b8fa6c46b8c7a',
+          arguments: '{}',
+        },
+        {
+          type: 'function_call_output',
+          call_id:
+            'call_enS4L7YycCRyOiWOg31Xpvwm|fc_0281edd961557cf2016a4b062d87948195968b8fa6c46b8c7a',
+          output: 'ok',
+        },
+      ],
+    };
+
+    normalizeCompositeResponsesCallIds(body);
+    const unified = await transformer.parseRequest(body);
+    const built = await transformer.transformRequest(unified);
+
+    expect(
+      built.input
+        .filter(
+          (item: any) => item.type === 'function_call' || item.type === 'function_call_output'
+        )
+        .map((item: any) => item.call_id)
+    ).toEqual(['call_enS4L7YycCRyOiWOg31Xpvwm', 'call_enS4L7YycCRyOiWOg31Xpvwm']);
+  });
+
+  it('removes replayed plaintext reasoning content while preserving reasoning metadata', () => {
+    const body = {
+      input: [
+        {
+          id: 'rs_123',
+          type: 'reasoning',
+          status: 'completed',
+          summary: [{ type: 'summary_text', text: 'summary' }],
+          content: [{ type: 'reasoning_text', text: 'private chain of thought' }],
+          encrypted_content: 'encrypted-reasoning',
+        },
+        {
+          type: 'reasoning',
+          summary: [],
+          content: [],
+          encrypted_content: null,
+        },
+        {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'hello' }],
+        },
+      ],
+    };
+
+    expect(normalizeResponsesReasoningContent(body)).toBe(1);
+    expect(body.input[0]).toEqual({
+      id: 'rs_123',
+      type: 'reasoning',
+      status: 'completed',
+      summary: [{ type: 'summary_text', text: 'summary' }],
+      content: [],
+      encrypted_content: 'encrypted-reasoning',
+    });
+    expect(body.input[1]).toMatchObject({ content: [] });
+    expect(body.input[2]).toMatchObject({ content: [{ type: 'input_text', text: 'hello' }] });
+  });
+
   it('preserves top-level user, store, background, service_tier, truncation', async () => {
     const transformer = new ResponsesTransformer();
     const unified = await transformer.parseRequest(RESPONSES_REQUEST);

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -17,6 +17,67 @@ import { encode } from 'eventsource-encoder';
 import { logger } from '../utils/logger';
 import { normalizeOpenAIChatUsage, normalizeOpenAIResponsesUsage } from '../utils/usage-normalizer';
 
+// Some Responses clients have been observed replaying tool calls with composite
+// IDs like "call_...|fc_...". OpenAI-compatible providers validate call_id
+// length and require the model-generated "call_..." ID, so only repair that
+// exact observed shape instead of rewriting arbitrary caller-provided IDs.
+export function normalizeCompositeResponsesCallIds(body: any): number {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.input)) {
+    return 0;
+  }
+
+  let normalizedCount = 0;
+  for (const item of body.input) {
+    if (!item || typeof item !== 'object' || typeof item.call_id !== 'string') {
+      continue;
+    }
+
+    const separatorIndex = item.call_id.indexOf('|');
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const callId = item.call_id.slice(0, separatorIndex);
+    const itemId = item.call_id.slice(separatorIndex + 1);
+    if (!callId.startsWith('call_') || !itemId.startsWith('fc_')) {
+      continue;
+    }
+
+    item.call_id = callId;
+    normalizedCount++;
+  }
+
+  return normalizedCount;
+}
+
+// Reasoning items are valid replay context, but some OpenAI-compatible
+// Responses providers reject replayed plaintext reasoning text with
+// "content max length 0". Drop only the optional plaintext content array while
+// preserving the reasoning item, summary, status, id, and encrypted_content.
+export function normalizeResponsesReasoningContent(body: any): number {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.input)) {
+    return 0;
+  }
+
+  let normalizedCount = 0;
+  for (const item of body.input) {
+    if (
+      !item ||
+      typeof item !== 'object' ||
+      item.type !== 'reasoning' ||
+      !Array.isArray(item.content) ||
+      item.content.length === 0
+    ) {
+      continue;
+    }
+
+    item.content = [];
+    normalizedCount++;
+  }
+
+  return normalizedCount;
+}
+
 /**
  * ResponsesTransformer
  *
@@ -1069,7 +1130,10 @@ export class ResponsesTransformer implements Transformer {
             const { done, value: unifiedChunk } = await reader.read();
             if (done) {
               if (!hasSentCreated) {
-                ensureCreated(controller, { model: responseModel, created: responseCreatedAt });
+                ensureCreated(controller, {
+                  model: responseModel,
+                  created: responseCreatedAt,
+                });
               }
               const outputItems = finalizeOutputItems(controller);
               sendEvent(controller, {


### PR DESCRIPTION
### **User description**
## Summary
- normalize replayed Responses tool call IDs shaped like `call_...|fc_...` to the provider-accepted `call_...` value
- strip plaintext `content` arrays from replayed reasoning input items while preserving reasoning metadata and encrypted content
- keep debug raw request capture faithful to the client payload before dispatch normalization

## Validation
- replayed trace payload c5155409-1076-43df-a2af-dfc9bafc2c00 against local dev and received 200 OK streaming response
- `bun run test src/transformers/__tests__/responses-request-roundtrip.test.ts`
- `bun run typecheck`
- pre-commit hook: backend tests, Biome format/lint, typecheck


___

### **Description**
- Normalize composite `call_...|fc_...` tool call IDs to `call_...` for provider compatibility

- Strip plaintext `content` from replayed reasoning items while preserving metadata

- Keep debug raw request capture faithful to original client payload before normalization

- Add tests for both normalization functions and round-trip request rebuilding


___

