### PR TITLE
fix(responses): only normalize oversized replay fields

### DIFF
--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -60,6 +60,12 @@ describe('Responses responses -> responses round-trip preserves native fields', 
         {
           type: 'function_call',
           name: 'exec_command',
+          call_id: 'call_short|fc_short',
+          arguments: '{}',
+        },
+        {
+          type: 'function_call',
+          name: 'exec_command',
           call_id:
             'call_enS4L7YycCRyOiWOg31Xpvwm|fc_0281edd961557cf2016a4b062d87948195968b8fa6c46b8c7a',
           arguments: '{}',
@@ -87,6 +93,7 @@ describe('Responses responses -> responses round-trip preserves native fields', 
 
     expect(normalizeCompositeResponsesCallIds(body)).toBe(2);
     expect(body.input.map((item) => item.call_id)).toEqual([
+      'call_short|fc_short',
       'call_enS4L7YycCRyOiWOg31Xpvwm',
       'call_enS4L7YycCRyOiWOg31Xpvwm',
       'call_plain',

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -17,10 +17,14 @@ import { encode } from 'eventsource-encoder';
 import { logger } from '../utils/logger';
 import { normalizeOpenAIChatUsage, normalizeOpenAIResponsesUsage } from '../utils/usage-normalizer';
 
+const OPENAI_RESPONSES_CALL_ID_MAX_LENGTH = 64;
+const OPENAI_RESPONSES_REASONING_CONTENT_MAX_ITEMS = 0;
+
 // Some Responses clients have been observed replaying tool calls with composite
 // IDs like "call_...|fc_...". OpenAI-compatible providers validate call_id
-// length and require the model-generated "call_..." ID, so only repair that
-// exact observed shape instead of rewriting arbitrary caller-provided IDs.
+// length and require the model-generated "call_..." ID when the composite ID is
+// too long, so only repair that exact observed shape once it violates the
+// OpenAI limit instead of rewriting arbitrary caller-provided IDs.
 export function normalizeCompositeResponsesCallIds(body: any): number {
   if (!body || typeof body !== 'object' || !Array.isArray(body.input)) {
     return 0;
@@ -29,6 +33,10 @@ export function normalizeCompositeResponsesCallIds(body: any): number {
   let normalizedCount = 0;
   for (const item of body.input) {
     if (!item || typeof item !== 'object' || typeof item.call_id !== 'string') {
+      continue;
+    }
+
+    if (item.call_id.length <= OPENAI_RESPONSES_CALL_ID_MAX_LENGTH) {
       continue;
     }
 
@@ -52,8 +60,9 @@ export function normalizeCompositeResponsesCallIds(body: any): number {
 
 // Reasoning items are valid replay context, but some OpenAI-compatible
 // Responses providers reject replayed plaintext reasoning text with
-// "content max length 0". Drop only the optional plaintext content array while
-// preserving the reasoning item, summary, status, id, and encrypted_content.
+// "content max length 0". Drop only the optional plaintext content array once
+// it violates that limit while preserving the reasoning item, summary, status,
+// id, and encrypted_content.
 export function normalizeResponsesReasoningContent(body: any): number {
   if (!body || typeof body !== 'object' || !Array.isArray(body.input)) {
     return 0;
@@ -66,7 +75,7 @@ export function normalizeResponsesReasoningContent(body: any): number {
       typeof item !== 'object' ||
       item.type !== 'reasoning' ||
       !Array.isArray(item.content) ||
-      item.content.length === 0
+      item.content.length <= OPENAI_RESPONSES_REASONING_CONTENT_MAX_ITEMS
     ) {
       continue;
     }


### PR DESCRIPTION
### **User description**
## Summary
- Keep replayed Responses composite call IDs intact when they fit within OpenAI limits
- Normalize only oversized observed call_id composites to their model-generated call ID
- Add regression coverage for valid short composite IDs

## Verification
- bun run test src/transformers/__tests__/responses-request-roundtrip.test.ts
- bun run typecheck
- pre-commit: bun run test, biome format/lint, typecheck


___

### **Description**
- Only normalize composite `call_id` values that exceed OpenAI's 64-char limit

- Preserve valid short composite call IDs during Responses round-trip replay

- Extract length/limit constants for `call_id` and reasoning content thresholds

- Add regression test for short composite call IDs left intact


___

