### PR TITLE
feat(playground): show routing decisions

### DIFF
--- a/packages/backend/src/routes/management/usage.ts
+++ b/packages/backend/src/routes/management/usage.ts
@@ -83,6 +83,7 @@ export async function registerUsageRoutes(
     const filters: any = {
       startDate: query.startDate,
       endDate: query.endDate,
+      requestId: query.requestId,
       apiKey: query.apiKey,
       incomingApiType: query.incomingApiType,
       provider: query.provider,

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -446,6 +446,13 @@ export async function handleResponse(
     return reply.send(pipeline);
   } else {
     // --- Scenario B: Non-Streaming (Unary) Response ---
+    const includePlaygroundRouting = request.headers?.['x-plexus-playground'] === 'true';
+    const playgroundRouting = includePlaygroundRouting
+      ? {
+          requestId: usageRecord.requestId,
+          ...unifiedResponse.plexus,
+        }
+      : undefined;
 
     // Remove internal plexus metadata before sending to client
     if (unifiedResponse.plexus) {
@@ -458,6 +465,9 @@ export async function handleResponse(
     } else {
       // Re-format the unified JSON body to match the client's expected API format
       responseBody = await clientTransformer.formatResponse(unifiedResponse);
+    }
+    if (playgroundRouting && responseBody && typeof responseBody === 'object') {
+      responseBody.plexus = playgroundRouting;
     }
 
     // Capture transformed response for debugging

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -1,4 +1,5 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
+import crypto from 'node:crypto';
 import { UnifiedChatResponse } from '../types/unified';
 import { Transformer } from '../types/transformer';
 import { UsageRecord } from '../types/usage';
@@ -18,6 +19,24 @@ import type { GpuParams } from '@plexus/shared';
 import { QuotaEnforcer } from '../services/quota/quota-enforcer';
 import { recordQuotaUsage, buildQuotaHeaders } from '../services/quota/quota-middleware';
 import { CooldownManager } from './cooldown-manager';
+
+function getHeaderValue(request: FastifyRequest, headerName: string): string | undefined {
+  const value = request.headers?.[headerName];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function hasValidAdminKey(request: FastifyRequest): boolean {
+  const adminKey = process.env.ADMIN_KEY;
+  const providedKey = getHeaderValue(request, 'x-admin-key');
+  if (!adminKey || !providedKey) return false;
+  const adminKeyHash = crypto.createHash('sha256').update(adminKey).digest();
+  const providedKeyHash = crypto.createHash('sha256').update(providedKey).digest();
+  return crypto.timingSafeEqual(adminKeyHash, providedKeyHash);
+}
+
+function shouldIncludePlaygroundRouting(request: FastifyRequest): boolean {
+  return getHeaderValue(request, 'x-plexus-playground') === 'true' && hasValidAdminKey(request);
+}
 /**
  * handleResponse
  *
@@ -446,7 +465,7 @@ export async function handleResponse(
     return reply.send(pipeline);
   } else {
     // --- Scenario B: Non-Streaming (Unary) Response ---
-    const includePlaygroundRouting = request.headers?.['x-plexus-playground'] === 'true';
+    const includePlaygroundRouting = shouldIncludePlaygroundRouting(request);
     const playgroundRouting = includePlaygroundRouting
       ? {
           requestId: usageRecord.requestId,

--- a/packages/backend/src/services/usage-storage.ts
+++ b/packages/backend/src/services/usage-storage.ts
@@ -23,6 +23,7 @@ export interface ProgressUpdate {
 // ModelArchitecture is now imported from @plexus/shared
 
 export interface UsageFilters {
+  requestId?: string;
   startDate?: string;
   endDate?: string;
   apiKey?: string;
@@ -528,6 +529,9 @@ export class UsageStorageService extends EventEmitter {
     const schema = this.schema!;
     const conditions = [];
 
+    if (filters.requestId) {
+      conditions.push(eq(schema.requestUsage.requestId, filters.requestId));
+    }
     if (filters.startDate) {
       conditions.push(gte(schema.requestUsage.date, filters.startDate));
     }

--- a/packages/backend/src/utils/__tests__/response-handler.test.ts
+++ b/packages/backend/src/utils/__tests__/response-handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { handleResponse } from '../../services/response-handler';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { UsageStorageService } from '../../services/usage-storage';
@@ -7,6 +7,8 @@ import { UnifiedChatResponse } from '../../types/unified';
 import { UsageRecord } from '../../types/usage';
 
 describe('handleResponse', () => {
+  const originalAdminKey = process.env.ADMIN_KEY;
+
   const mockStorage = {
     saveRequest: vi.fn(),
     saveError: vi.fn(),
@@ -38,6 +40,19 @@ describe('handleResponse', () => {
   const mockRequest = {
     id: 'test-req-id',
   } as unknown as FastifyRequest;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_KEY = originalAdminKey;
+  });
+
+  afterEach(() => {
+    if (originalAdminKey === undefined) {
+      delete process.env.ADMIN_KEY;
+    } else {
+      process.env.ADMIN_KEY = originalAdminKey;
+    }
+  });
 
   test('should process non-streaming response correctly', async () => {
     const unifiedResponse: UnifiedChatResponse = {
@@ -90,6 +105,126 @@ describe('handleResponse', () => {
     const result = lastCall[0];
     expect(result.plexus).toBeUndefined();
     expect(result.formatted).toBe(true);
+  });
+
+  test('includes playground routing metadata only with a valid admin key', async () => {
+    process.env.ADMIN_KEY = 'correct-admin-key';
+    const unifiedResponse: UnifiedChatResponse = {
+      id: 'resp-playground',
+      model: 'model-1',
+      content: 'Hello',
+      plexus: {
+        provider: 'provider-1',
+        model: 'model-orig',
+        canonicalModel: 'model-canonical',
+        apiType: 'chat',
+        attemptCount: 2,
+      },
+    };
+    const usageRecord: Partial<UsageRecord> = {
+      requestId: 'req-playground',
+    };
+    const request = {
+      headers: {
+        'x-plexus-playground': 'true',
+        'x-admin-key': 'correct-admin-key',
+      },
+    } as unknown as FastifyRequest;
+
+    await handleResponse(
+      request,
+      mockReply,
+      unifiedResponse,
+      mockTransformer,
+      usageRecord,
+      mockStorage,
+      Date.now(),
+      'chat'
+    );
+
+    const lastCall = (mockReply.send as any).mock.calls.at(-1);
+    const result = lastCall[0];
+    expect(result.plexus).toEqual({
+      requestId: 'req-playground',
+      provider: 'provider-1',
+      model: 'model-orig',
+      canonicalModel: 'model-canonical',
+      apiType: 'chat',
+      attemptCount: 2,
+    });
+  });
+
+  test('does not include playground routing metadata without an admin key', async () => {
+    process.env.ADMIN_KEY = 'correct-admin-key';
+    const unifiedResponse: UnifiedChatResponse = {
+      id: 'resp-no-admin',
+      model: 'model-1',
+      content: 'Hello',
+      plexus: {
+        provider: 'provider-1',
+        model: 'model-orig',
+        apiType: 'chat',
+      },
+    };
+    const usageRecord: Partial<UsageRecord> = {
+      requestId: 'req-no-admin',
+    };
+    const request = {
+      headers: {
+        'x-plexus-playground': 'true',
+      },
+    } as unknown as FastifyRequest;
+
+    await handleResponse(
+      request,
+      mockReply,
+      unifiedResponse,
+      mockTransformer,
+      usageRecord,
+      mockStorage,
+      Date.now(),
+      'chat'
+    );
+
+    const lastCall = (mockReply.send as any).mock.calls.at(-1);
+    expect(lastCall[0].plexus).toBeUndefined();
+  });
+
+  test('does not include playground routing metadata with the wrong admin key', async () => {
+    process.env.ADMIN_KEY = 'correct-admin-key';
+    const unifiedResponse: UnifiedChatResponse = {
+      id: 'resp-wrong-admin',
+      model: 'model-1',
+      content: 'Hello',
+      plexus: {
+        provider: 'provider-1',
+        model: 'model-orig',
+        apiType: 'chat',
+      },
+    };
+    const usageRecord: Partial<UsageRecord> = {
+      requestId: 'req-wrong-admin',
+    };
+    const request = {
+      headers: {
+        'x-plexus-playground': 'true',
+        'x-admin-key': 'wrong-admin-key',
+      },
+    } as unknown as FastifyRequest;
+
+    await handleResponse(
+      request,
+      mockReply,
+      unifiedResponse,
+      mockTransformer,
+      usageRecord,
+      mockStorage,
+      Date.now(),
+      'chat'
+    );
+
+    const lastCall = (mockReply.send as any).mock.calls.at(-1);
+    expect(lastCall[0].plexus).toBeUndefined();
   });
 
   test('should fallback to unifiedResponse.model if plexus.model missing', async () => {

--- a/packages/backend/src/utils/__tests__/sanitize-headers.test.ts
+++ b/packages/backend/src/utils/__tests__/sanitize-headers.test.ts
@@ -18,6 +18,13 @@ describe('sanitizeHeaders', () => {
     expect(result['x-auth-token']).toBe('toke...cdef');
   });
 
+  test('masks admin key header', () => {
+    const result = sanitizeHeaders({
+      'x-admin-key': 'correct-admin-key',
+    });
+    expect(result['x-admin-key']).toBe('corr...-key');
+  });
+
   test('masks x-api-key header', () => {
     const result = sanitizeHeaders({
       'x-api-key': 'my-long-api-key-value',

--- a/packages/backend/src/utils/sanitize-headers.ts
+++ b/packages/backend/src/utils/sanitize-headers.ts
@@ -1,5 +1,6 @@
 const SENSITIVE_HEADERS = [
   'authorization',
+  'x-admin-key',
   'x-auth-token',
   'x-api-key',
   'x-goog-api-key',

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -503,7 +503,11 @@ export interface UsageRecord {
   incomingApiType?: string;
   provider?: string;
   incomingModelAlias?: string;
+  canonicalModelName?: string | null;
   selectedModelName?: string;
+  finalAttemptProvider?: string | null;
+  finalAttemptModel?: string | null;
+  allAttemptedProviders?: string | null;
   outgoingApiType?: string;
   tokensInput?: number;
   tokensOutput?: number;
@@ -582,6 +586,7 @@ type UsageRecordField = keyof UsageRecord;
 interface UsageQueryParams<T extends UsageRecordField> {
   limit?: number;
   offset?: number;
+  requestId?: string;
   startDate?: string;
   endDate?: string;
   incomingApiType?: string;

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -1,12 +1,16 @@
-import { useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { DeepChat } from 'deep-chat-react';
 import {
+  CheckCircle2,
+  Clock,
   FlaskConical,
   Key,
   LockKeyhole,
   RefreshCw,
+  Route,
   ShieldAlert,
   SlidersHorizontal,
+  XCircle,
 } from 'lucide-react';
 import { api, KeyConfig } from '../lib/api';
 import { PageContainer } from '../components/layout/PageContainer';
@@ -28,6 +32,36 @@ type DeepChatRequestDetails = {
 type OpenAiMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content: string;
+};
+
+type RetryAttempt = {
+  index?: number;
+  provider?: string;
+  model?: string;
+  apiType?: string;
+  status?: 'success' | 'failed' | 'skipped';
+  reason?: string;
+  statusCode?: number;
+  retryable?: boolean;
+};
+
+type RoutingInfo = {
+  status: 'idle' | 'pending' | 'complete' | 'error';
+  error?: string;
+  routing?: PlaygroundRouting;
+};
+
+type PlaygroundRouting = {
+  requestId?: string;
+  provider?: string;
+  model?: string;
+  apiType?: string;
+  canonicalModel?: string;
+  attemptCount?: number;
+  finalAttemptProvider?: string;
+  finalAttemptModel?: string;
+  allAttemptedProviders?: string;
+  retryHistory?: string;
 };
 
 const CHAT_COMPLETIONS_ENDPOINT = '/v1/chat/completions';
@@ -182,6 +216,193 @@ const responseToMessage = (response: unknown) => {
   return { error: 'Plexus returned an unsupported response shape.' };
 };
 
+const parseRetryHistory = (value?: string | null): RetryAttempt[] => {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const parseAttemptedProviders = (value?: string | null): string[] => {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const formatRoute = (provider?: string | null, model?: string | null) =>
+  provider && model ? `${provider}/${model}` : provider || model || 'Pending';
+
+type ChatSimulationProps = {
+  selectedKey: KeyConfig;
+  selectedModel: string;
+  onRoutingPending: () => void;
+  onRoutingResponse: (routing: PlaygroundRouting | null, error?: string) => void;
+};
+
+const ChatSimulation = memo(
+  ({ selectedKey, selectedModel, onRoutingPending, onRoutingResponse }: ChatSimulationProps) => {
+    const requestInterceptor = (details: DeepChatRequestDetails) => {
+      window.setTimeout(onRoutingPending, 0);
+      const body = details.body && typeof details.body === 'object' ? details.body : {};
+      return {
+        ...details,
+        body: {
+          ...body,
+          model: selectedModel,
+          stream: false,
+          messages: extractMessages(body),
+        },
+      };
+    };
+
+    const responseInterceptor = (response: unknown) => {
+      const routing =
+        response && typeof response === 'object' && 'plexus' in response
+          ? ((response as { plexus?: PlaygroundRouting }).plexus ?? null)
+          : null;
+      const message = responseToMessage(response);
+      window.setTimeout(() => onRoutingResponse(routing, message.error), 0);
+      return message;
+    };
+
+    return (
+      <DeepChat
+        key={`${selectedKey.key}:${selectedModel}`}
+        connect={{
+          url: CHAT_COMPLETIONS_ENDPOINT,
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${selectedKey.secret}`,
+            'x-plexus-playground': 'true',
+          },
+          additionalBodyProps: {
+            model: selectedModel,
+            stream: false,
+          },
+        }}
+        requestInterceptor={requestInterceptor}
+        responseInterceptor={responseInterceptor}
+        introMessage={{
+          text: `Simulation active using key "${selectedKey.key}" and model "${selectedModel}".`,
+        }}
+        textInput={{
+          placeholder: {
+            text: 'Send a test prompt through Plexus...',
+            style: { color: '#64748b' },
+          },
+          styles: {
+            container: {
+              backgroundColor: '#020617',
+              border: '1px solid #334155',
+              borderRadius: '0.625rem',
+              boxShadow: 'none',
+            },
+            text: {
+              color: '#f8fafc',
+            },
+            focus: {
+              border: '1px solid #f59e0b',
+              boxShadow: '0 0 0 3px rgba(245, 158, 11, 0.18)',
+            },
+          },
+        }}
+        errorMessages={{ displayServiceErrorMessages: true }}
+        auxiliaryStyle={deepChatAuxiliaryStyle}
+        style={{
+          border: '1px solid rgb(30 41 59)',
+          borderRadius: '0.625rem',
+          height: '100%',
+          width: '100%',
+          background: 'rgb(15 23 42)',
+          boxShadow: 'none',
+          color: '#f8fafc',
+          fontFamily: 'var(--font-body)',
+          overflow: 'hidden',
+        }}
+        chatStyle={{
+          backgroundColor: 'transparent',
+          paddingTop: '0.75rem',
+          paddingBottom: '0.75rem',
+        }}
+        inputAreaStyle={{
+          backgroundColor: '#0b1324',
+          borderTop: '1px solid #1e293b',
+        }}
+        messageStyles={{
+          default: {
+            shared: {
+              bubble: {
+                borderRadius: '0.625rem',
+                fontSize: '0.8125rem',
+                lineHeight: '1.35',
+                boxShadow: 'none',
+              },
+            },
+            user: {
+              bubble: {
+                backgroundColor: '#f59e0b',
+                color: '#1a1006',
+              },
+            },
+            ai: {
+              bubble: {
+                backgroundColor: '#1e293b',
+                color: '#f8fafc',
+                border: '1px solid #334155',
+              },
+            },
+          },
+          intro: {
+            bubble: {
+              backgroundColor: '#111a30',
+              color: '#e2e8f0',
+              border: '1px solid #334155',
+            },
+          },
+          error: {
+            bubble: {
+              backgroundColor: 'rgba(239, 68, 68, 0.12)',
+              color: '#fecaca',
+              border: '1px solid rgba(239, 68, 68, 0.28)',
+            },
+          },
+        }}
+        submitButtonStyles={{
+          submit: {
+            container: {
+              default: {
+                backgroundColor: '#f59e0b',
+                borderRadius: '0.5rem',
+              },
+              hover: {
+                backgroundColor: '#fbbf24',
+              },
+            },
+            svg: {
+              styles: {
+                default: {
+                  filter: 'brightness(0) saturate(100%)',
+                },
+              },
+            },
+          },
+        }}
+      />
+    );
+  }
+);
+
+ChatSimulation.displayName = 'ChatSimulation';
+
 export const Playground = () => {
   const [keys, setKeys] = useState<KeyConfig[]>([]);
   const [selectedKeyName, setSelectedKeyName] = useState('');
@@ -190,6 +411,7 @@ export const Playground = () => {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [routingInfo, setRoutingInfo] = useState<RoutingInfo>({ status: 'idle' });
 
   const selectedKey = useMemo(
     () => keys.find((key) => key.key === selectedKeyName) ?? null,
@@ -247,18 +469,28 @@ export const Playground = () => {
     loadData();
   };
 
-  const requestInterceptor = (details: DeepChatRequestDetails) => {
-    const body = details.body && typeof details.body === 'object' ? details.body : {};
-    return {
-      ...details,
-      body: {
-        ...body,
-        model: selectedModel,
-        stream: false,
-        messages: extractMessages(body),
-      },
-    };
-  };
+  const handleRoutingPending = useCallback(() => {
+    setRoutingInfo({ status: 'pending' });
+  }, []);
+
+  const handleRoutingResponse = useCallback((routing: PlaygroundRouting | null, error?: string) => {
+    if (routing) {
+      setRoutingInfo({
+        status: error ? 'error' : 'complete',
+        routing,
+        error,
+      });
+    } else if (error) {
+      setRoutingInfo({ status: 'error', error });
+    }
+  }, []);
+
+  const retryHistory = parseRetryHistory(routingInfo.routing?.retryHistory);
+  const attemptedProviders = parseAttemptedProviders(routingInfo.routing?.allAttemptedProviders);
+  const finalRoute = formatRoute(
+    routingInfo.routing?.finalAttemptProvider || routingInfo.routing?.provider,
+    routingInfo.routing?.finalAttemptModel || routingInfo.routing?.model
+  );
 
   if (loading) {
     return (
@@ -439,7 +671,7 @@ export const Playground = () => {
           )}
         </Card>
 
-        <div className="grid grid-cols-1 gap-4">
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
           <Card
             className="min-h-0"
             title="Chat Simulation"
@@ -452,127 +684,12 @@ export const Playground = () => {
             flush
           >
             {selectedKey && selectedModel ? (
-              <div className="h-[calc(100dvh-15rem)] min-h-[20rem] overflow-hidden p-3 sm:h-[calc(100dvh-13rem)] sm:min-h-[32rem] sm:p-4 xl:h-[42.5rem]">
-                <DeepChat
-                  key={`${selectedKey.key}:${selectedModel}`}
-                  connect={{
-                    url: CHAT_COMPLETIONS_ENDPOINT,
-                    method: 'POST',
-                    headers: {
-                      Authorization: `Bearer ${selectedKey.secret}`,
-                    },
-                    additionalBodyProps: {
-                      model: selectedModel,
-                      stream: false,
-                    },
-                  }}
-                  requestInterceptor={requestInterceptor}
-                  responseInterceptor={responseToMessage}
-                  introMessage={{
-                    text: `Simulation active using key "${selectedKey.key}" and model "${selectedModel}".`,
-                  }}
-                  textInput={{
-                    placeholder: {
-                      text: 'Send a test prompt through Plexus...',
-                      style: { color: '#64748b' },
-                    },
-                    styles: {
-                      container: {
-                        backgroundColor: '#020617',
-                        border: '1px solid #334155',
-                        borderRadius: '0.625rem',
-                        boxShadow: 'none',
-                      },
-                      text: {
-                        color: '#f8fafc',
-                      },
-                      focus: {
-                        border: '1px solid #f59e0b',
-                        boxShadow: '0 0 0 3px rgba(245, 158, 11, 0.18)',
-                      },
-                    },
-                  }}
-                  errorMessages={{ displayServiceErrorMessages: true }}
-                  auxiliaryStyle={deepChatAuxiliaryStyle}
-                  style={{
-                    border: '1px solid rgb(30 41 59)',
-                    borderRadius: '0.625rem',
-                    height: '100%',
-                    width: '100%',
-                    background: 'rgb(15 23 42)',
-                    boxShadow: 'none',
-                    color: '#f8fafc',
-                    fontFamily: 'var(--font-body)',
-                    overflow: 'hidden',
-                  }}
-                  chatStyle={{
-                    backgroundColor: 'transparent',
-                    paddingTop: '0.75rem',
-                    paddingBottom: '0.75rem',
-                  }}
-                  inputAreaStyle={{
-                    backgroundColor: '#0b1324',
-                    borderTop: '1px solid #1e293b',
-                  }}
-                  messageStyles={{
-                    default: {
-                      shared: {
-                        bubble: {
-                          borderRadius: '0.625rem',
-                          fontSize: '0.8125rem',
-                          lineHeight: '1.35',
-                          boxShadow: 'none',
-                        },
-                      },
-                      user: {
-                        bubble: {
-                          backgroundColor: '#f59e0b',
-                          color: '#1a1006',
-                        },
-                      },
-                      ai: {
-                        bubble: {
-                          backgroundColor: '#1e293b',
-                          color: '#f8fafc',
-                          border: '1px solid #334155',
-                        },
-                      },
-                    },
-                    intro: {
-                      bubble: {
-                        backgroundColor: '#111a30',
-                        color: '#e2e8f0',
-                        border: '1px solid #334155',
-                      },
-                    },
-                    error: {
-                      bubble: {
-                        backgroundColor: 'rgba(239, 68, 68, 0.12)',
-                        color: '#fecaca',
-                        border: '1px solid rgba(239, 68, 68, 0.28)',
-                      },
-                    },
-                  }}
-                  submitButtonStyles={{
-                    submit: {
-                      container: {
-                        default: {
-                          backgroundColor: '#f59e0b',
-                          borderRadius: '0.5rem',
-                        },
-                        hover: {
-                          backgroundColor: '#fbbf24',
-                        },
-                      },
-                      svg: {
-                        styles: {
-                          default: {
-                            filter: 'brightness(0) saturate(100%)',
-                          },
-                        },
-                      },
-                    },
-                  }}
+              <div className="h-[clamp(18rem,calc(100dvh-22rem),42.5rem)] overflow-hidden p-3 sm:p-4">
+                <ChatSimulation
+                  selectedKey={selectedKey}
+                  selectedModel={selectedModel}
+                  onRoutingPending={handleRoutingPending}
+                  onRoutingResponse={handleRoutingResponse}
                 />
               </div>
             ) : (
@@ -583,6 +700,140 @@ export const Playground = () => {
                 </span>
               </div>
             )}
+          </Card>
+
+          <Card
+            className="min-h-0"
+            title="Routing Decision"
+            extra={
+              <div className="flex items-center gap-2 text-xs text-text-muted">
+                {routingInfo.status === 'pending' ? (
+                  <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                ) : routingInfo.status === 'complete' ? (
+                  <CheckCircle2 className="h-3.5 w-3.5 text-success" />
+                ) : routingInfo.status === 'error' ? (
+                  <XCircle className="h-3.5 w-3.5 text-danger" />
+                ) : (
+                  <Route className="h-3.5 w-3.5" />
+                )}
+                {routingInfo.status === 'idle'
+                  ? 'Waiting'
+                  : routingInfo.status === 'pending'
+                    ? 'Resolving'
+                    : routingInfo.status === 'complete'
+                      ? 'Routed'
+                      : 'Failed'}
+              </div>
+            }
+            dense
+          >
+            <div className="space-y-3 text-xs text-text-secondary">
+              <div className="rounded-md border border-border bg-bg-subtle/60 p-3">
+                <div className="mb-1 font-mono text-[10px] uppercase tracking-wider text-text-muted">
+                  Final route
+                </div>
+                <div className="break-words text-sm font-medium text-text">{finalRoute}</div>
+                <div className="mt-1 break-all font-mono text-[10px] text-text-muted">
+                  {routingInfo.routing?.requestId || 'Send a prompt to inspect routing.'}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <div className="rounded-md bg-slate-950/30 p-2">
+                  <div className="mb-0.5 font-mono text-[9px] uppercase tracking-wider text-text-muted">
+                    Alias
+                  </div>
+                  <div className="truncate text-text" title={selectedModel}>
+                    {selectedModel || '-'}
+                  </div>
+                </div>
+                <div className="rounded-md bg-slate-950/30 p-2">
+                  <div className="mb-0.5 font-mono text-[9px] uppercase tracking-wider text-text-muted">
+                    Canonical
+                  </div>
+                  <div
+                    className="truncate text-text"
+                    title={routingInfo.routing?.canonicalModel || undefined}
+                  >
+                    {routingInfo.routing?.canonicalModel || '-'}
+                  </div>
+                </div>
+                <div className="rounded-md bg-slate-950/30 p-2">
+                  <div className="mb-0.5 font-mono text-[9px] uppercase tracking-wider text-text-muted">
+                    Attempts
+                  </div>
+                  <div className="text-text">{routingInfo.routing?.attemptCount ?? '-'}</div>
+                </div>
+                <div className="rounded-md bg-slate-950/30 p-2">
+                  <div className="mb-0.5 flex items-center gap-1 font-mono text-[9px] uppercase tracking-wider text-text-muted">
+                    <Clock className="h-3 w-3" />
+                    API
+                  </div>
+                  <div className="text-text">{routingInfo.routing?.apiType || '-'}</div>
+                </div>
+              </div>
+
+              {attemptedProviders.length > 0 && (
+                <div className="rounded-md border border-border bg-bg-subtle/40 p-3">
+                  <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-text-muted">
+                    Candidate path
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {attemptedProviders.map((attempted) => (
+                      <Badge key={attempted} status="neutral">
+                        {attempted}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="rounded-md border border-border bg-bg-subtle/40 p-3">
+                <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-text-muted">
+                  Decision trail
+                </div>
+                {retryHistory.length > 0 ? (
+                  <ol className="space-y-2">
+                    {retryHistory.map((attempt, index) => (
+                      <li
+                        key={`${attempt.provider}:${attempt.model}:${index}`}
+                        className="rounded-md bg-slate-950/40 p-2"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="min-w-0 truncate font-medium text-text">
+                            {formatRoute(attempt.provider, attempt.model)}
+                          </span>
+                          <Badge
+                            status={
+                              attempt.status === 'success'
+                                ? 'success'
+                                : attempt.status === 'failed'
+                                  ? 'danger'
+                                  : 'neutral'
+                            }
+                          >
+                            {attempt.status || 'attempt'}
+                          </Badge>
+                        </div>
+                        <div className="mt-1 line-clamp-3 text-[11px] text-text-muted">
+                          {attempt.reason || 'No decision reason recorded'}
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <div className="text-[11px] text-text-muted">
+                    Routing details appear after the next playground request.
+                  </div>
+                )}
+              </div>
+
+              {routingInfo.error && (
+                <div className="rounded-md border border-danger/30 bg-danger/10 p-3 text-danger">
+                  {routingInfo.error}
+                </div>
+              )}
+            </div>
           </Card>
         </div>
       </PageContainer>

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -244,12 +244,19 @@ const formatRoute = (provider?: string | null, model?: string | null) =>
 type ChatSimulationProps = {
   selectedKey: KeyConfig;
   selectedModel: string;
+  adminKey: string;
   onRoutingPending: () => void;
   onRoutingResponse: (routing: PlaygroundRouting | null, error?: string) => void;
 };
 
 const ChatSimulation = memo(
-  ({ selectedKey, selectedModel, onRoutingPending, onRoutingResponse }: ChatSimulationProps) => {
+  ({
+    selectedKey,
+    selectedModel,
+    adminKey,
+    onRoutingPending,
+    onRoutingResponse,
+  }: ChatSimulationProps) => {
     const requestInterceptor = (details: DeepChatRequestDetails) => {
       window.setTimeout(onRoutingPending, 0);
       const body = details.body && typeof details.body === 'object' ? details.body : {};
@@ -283,6 +290,7 @@ const ChatSimulation = memo(
           headers: {
             Authorization: `Bearer ${selectedKey.secret}`,
             'x-plexus-playground': 'true',
+            'x-admin-key': adminKey,
           },
           additionalBodyProps: {
             model: selectedModel,
@@ -412,6 +420,7 @@ export const Playground = () => {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [routingInfo, setRoutingInfo] = useState<RoutingInfo>({ status: 'idle' });
+  const adminKey = useMemo(() => localStorage.getItem('plexus_admin_key') ?? '', []);
 
   const selectedKey = useMemo(
     () => keys.find((key) => key.key === selectedKeyName) ?? null,
@@ -482,6 +491,12 @@ export const Playground = () => {
       });
     } else if (error) {
       setRoutingInfo({ status: 'error', error });
+    } else {
+      setRoutingInfo({
+        status: 'error',
+        error:
+          'Routing metadata was not returned. Verify admin access and use a unary JSON request.',
+      });
     }
   }, []);
 
@@ -688,6 +703,7 @@ export const Playground = () => {
                 <ChatSimulation
                   selectedKey={selectedKey}
                   selectedModel={selectedModel}
+                  adminKey={adminKey}
                   onRoutingPending={handleRoutingPending}
                   onRoutingResponse={handleRoutingResponse}
                 />
@@ -823,7 +839,7 @@ export const Playground = () => {
                   </ol>
                 ) : (
                   <div className="text-[11px] text-text-muted">
-                    Routing details appear after the next playground request.
+                    Routing details appear after the next unary playground request.
                   </div>
                 )}
               </div>


### PR DESCRIPTION
### **User description**
## Summary
- add an opt-in playground routing metadata response for unary chat completions
- show final route, alias/canonical model, attempt count, candidate path, and retry decision trail in the playground
- keep the chat transcript stable while routing metadata updates beside it

## Verification
- bun run format:check
- bun run typecheck
- pre-commit hook: backend-tests, biome-format, biome-lint, frontend-build, no-migrations, typecheck
- Browser-tested playground routing panel and chat transcript
- Screenshot: /home/matt.cowger/.agent-browser/tmp/screenshots/screenshot-1783380612672.png


___

### **Description**
- Add routing decision panel to playground showing final route, canonical model, attempts, and retry trail

- Inject `plexus` routing metadata into non-streaming responses via `x-plexus-playground` header

- Extract `ChatSimulation` into memoized component with routing callback handlers

- Add `requestId` filter support to usage queries and `UsageRecord` type fields


___

