### PR TITLE
feat(debug): add inclusive trace capture targets

### DIFF
--- a/.agents/skills/plexus-management/SKILL.md
+++ b/.agents/skills/plexus-management/SKILL.md
@@ -100,7 +100,11 @@ curl -fsS "$PLEXUS_BASE_URL/v0/management/aliases" \
 ### Review Or Toggle Debug Tracing
 
 - Check state with `GET /v0/management/debug`.
-- Enable globally with `PATCH /v0/management/debug` and `{"enabled":true,"providers":null}` or set `providers` to an array of provider slugs.
+- Debug target state is in-memory only; it resets on process restart except for `DEBUG=true` startup global capture.
+- Enable globally with `PATCH /v0/management/debug` and `{"enabled":true}`.
+- Set inclusive capture targets with `PATCH /v0/management/debug` and any of `keys`, `aliases`, or `providers`, for example `{"enabled":false,"keys":["mobile-app"],"aliases":["gpt-4o-mini"],"providers":["openai"]}`.
+- Capture is inclusive: a request is recorded when any enabled dimension matches the request key, canonical model alias, selected provider, or global flag. Setting `providers` does not filter out global/key/alias capture.
+- Clear a target list by sending `null` or `[]`, for example `{"providers":null}`.
 - Disable with `PATCH /v0/management/debug` and `{"enabled":false}`.
 - List captures with `GET /v0/management/debug/logs?limit=50`.
 - Fetch a full trace with `GET /v0/management/debug/logs/{requestId}`.
@@ -173,4 +177,3 @@ To load the endpoint map, check for the local copy first. If found, read it dire
 
 local: .agents/skills/plexus-management/references/endpoint-map.md
 fallback with curl: "https://raw.githubusercontent.com/mcowger/plexus/refs/heads/main/.agents/skills/plexus-management/references/endpoint-map.md"
-

--- a/.agents/skills/plexus-management/evals/evals.json
+++ b/.agents/skills/plexus-management/evals/evals.json
@@ -21,8 +21,8 @@
     },
     {
       "id": 4,
-      "prompt": "Temporarily enable global debug tracing for the dev system, restricted to the first configured provider if a provider exists. First record the current debug state, apply the change, verify it, then restore the exact original debug state before finishing. Use PLEXUS_BASE_URL and PLEXUS_ADMIN_KEY.",
-      "expected_output": "Reads current debug state, lists providers, PATCHes /v0/management/debug with a provider filter, verifies state, restores the previous state exactly, and reports both before/after states.",
+      "prompt": "Temporarily enable debug tracing for the dev system for the first configured provider if a provider exists, without enabling global tracing. First record the current debug state, apply the provider capture target, verify it, then restore the exact original debug state before finishing. Use PLEXUS_BASE_URL and PLEXUS_ADMIN_KEY.",
+      "expected_output": "Reads current debug state, lists providers, PATCHes /v0/management/debug with an inclusive provider capture target, verifies state, restores the previous state exactly, and reports both before/after states.",
       "files": []
     },
     {

--- a/.agents/skills/plexus-management/references/endpoint-map.md
+++ b/.agents/skills/plexus-management/references/endpoint-map.md
@@ -37,7 +37,7 @@ Useful usage query params include `limit`, `offset`, `sortBy`, `sortDir`, `start
 | Action | Method | Path |
 | --- | --- | --- |
 | Get debug state | `GET` | `/v0/management/debug` |
-| Update global debug state | `PATCH` | `/v0/management/debug` |
+| Update in-memory debug state | `PATCH` | `/v0/management/debug` |
 | Toggle current key debug | `POST` | `/v0/management/self/debug/toggle` |
 | List debug logs | `GET` | `/v0/management/debug/logs` |
 | Get one debug log | `GET` | `/v0/management/debug/logs/{requestId}` |
@@ -47,10 +47,16 @@ Useful usage query params include `limit`, `offset`, `sortBy`, `sortDir`, `start
 Debug state body examples:
 
 ```json
-{"enabled":true,"providers":null}
-{"enabled":true,"providers":["openai","anthropic"]}
+{"enabled":true}
+{"enabled":false,"keys":["mobile-app"],"aliases":["gpt-4o-mini"],"providers":["openai","anthropic"]}
+{"keys":null,"aliases":null,"providers":null}
 {"enabled":false}
 ```
+
+Debug target state is in-memory only. Capture is inclusive: a request is
+recorded when any enabled dimension matches the request key, canonical model
+alias, selected provider, or global flag. `providers` is a provider target list,
+not a filter that suppresses global/key/alias capture.
 
 ## Providers And Provider Quotas
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -60,6 +60,8 @@ For programmatic configuration, use the Management API (`/v0/management/*`). All
 | `GET /v0/management/keys` | List all API keys |
 | `PUT /v0/management/keys/{name}` | Create/update key |
 | `DELETE /v0/management/keys/{name}` | Remove key |
+| `GET /v0/management/debug` | Read in-memory debug capture state |
+| `PATCH /v0/management/debug` | Update in-memory global/key/alias/provider debug capture targets |
 | `GET /v0/management/user-quotas` | List quota definitions |
 | `PUT /v0/management/user-quotas/{name}` | Create/update quota |
 | `DELETE /v0/management/user-quotas/{name}` | Remove quota |
@@ -67,6 +69,25 @@ For programmatic configuration, use the Management API (`/v0/management/*`). All
 | `PUT /v0/management/config` | Import config (replace all) |
 
 See the [API Reference](/docs/openapi/openapi.yaml) for complete endpoint documentation.
+
+### Debug Trace Capture
+
+Debug trace targeting is runtime-only. `GET /v0/management/debug` returns the
+current in-memory state, and `PATCH /v0/management/debug` can update:
+
+```json
+{
+  "enabled": false,
+  "keys": ["mobile-app"],
+  "aliases": ["gpt-4o-mini"],
+  "providers": ["openai"]
+}
+```
+
+Capture is inclusive: a request is recorded when any enabled dimension matches
+the request key, canonical model alias, selected provider, or global flag. Setting
+`providers` does not filter out global/key/alias capture. `keys`, `aliases`, and
+`providers` can be set to `null` or `[]` to clear that target list.
 
 ---
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -83,7 +83,7 @@ All normal responses redact sensitive fields (API keys, secrets, tokens, cookies
 | `plexus_quota` | `list`, `get`, `put`, `create`, `update`, `delete` | Inspect and manage user quota definitions. |
 | `plexus_quota_checker` | `types`, `list`, `get` | Inspect upstream quota checker configuration. |
 | `plexus_usage` | `list`, `summary`, `delete`, `delete_all` | Review request logs and usage summaries; delete individual or bulk usage logs. |
-| `plexus_debug` | `state`, `update`, `logs`, `get_log`, `delete_log`, `delete_all_logs` | Inspect and manage debug tracing and stored debug logs. |
+| `plexus_debug` | `state`, `update`, `logs`, `get_log`, `delete_log`, `delete_all_logs` | Inspect and manage in-memory debug tracing targets (`enabled`, `keys`, `aliases`, `providers`) and stored debug logs. |
 | `plexus_mcp_gateway` | `servers_list`, `list`, `get`, `put`, `create`, `update`, `delete` | Inspect and manage upstream MCP gateway server configuration. |
 | `plexus_settings` | `get` | Get settings by category (failover, cooldown, timeout, stall, exploration, etc.) |
 | `plexus_system_logs` | `recent`, `level`, `set_level`, `reset_level` | Inspect recent in-memory Plexus system logs from the bounded ring buffer and control the runtime logging level. |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -210,7 +210,7 @@ tags:
       | `defined` | Explicit pricing ranges from `pricing.range` in model config. |
       | `per_request` | Flat fee per call; full amount in `costInput`, others zero. |
   - name: Management — Debug
-    description: Per-request debug capture toggles and logs.
+    description: In-memory debug capture targets and stored debug trace logs.
   - name: Management — Errors
     description: Inference error log storage.
   - name: Management — MCP Logs

--- a/docs/openapi/paths/v0_management_debug.yaml
+++ b/docs/openapi/paths/v0_management_debug.yaml
@@ -3,7 +3,16 @@ get:
     - Management — Debug
   summary: Get debug-mode state
   description: |
-    Returns the current debug capture configuration.
+    Returns the current in-memory debug capture configuration.
+
+    Debug target state is intentionally runtime-only. It is not written to the
+    database and is reset when the process restarts, except `DEBUG=true`, which
+    enables global capture at startup.
+
+    Capture is inclusive: a trace is persisted when any enabled dimension
+    matches the request (`enabledGlobal`, key, model alias, provider), or when
+    capture-on-error force-persistence applies. Provider targets do not filter
+    or suppress global, key, or alias capture.
 
     ## Response shapes
 
@@ -14,6 +23,8 @@ get:
       "enabled": true,
       "enabledGlobal": false,
       "enabledKeys": ["sk-alpha", "sk-beta"],
+      "keys": ["sk-alpha", "sk-beta"],
+      "aliases": ["gpt-4o-mini"],
       "providers": ["openai", "anthropic"]
     }
     ```
@@ -24,15 +35,20 @@ get:
     {
       "enabled": true,
       "enabledGlobal": false,
-      "enabledForKey": true
+      "enabledForKey": true,
+      "keys": ["sk-alpha"],
+      "aliases": ["gpt-4o-mini"],
+      "providers": ["openai"]
     }
     ```
 
-    - **enabled** — Global debug enable (overrides per-key settings).
+    - **enabled** — For admins, global debug enable. For limited principals, whether their requests are captured by global or per-key debug.
     - **enabledGlobal** — True if global debug is on.
-    - **enabledKeys** — (admin only) List of keys with per-key debug enabled.
+    - **enabledKeys** — (admin only) Backward-compatible alias for `keys`.
+    - **keys** — In-memory key-name capture targets.
+    - **aliases** — In-memory canonical model-alias capture targets. Requests made through additional aliases are matched after routing to the canonical alias.
+    - **providers** — In-memory provider-slug capture targets.
     - **enabledForKey** — (limited only) Whether debug is on for this key.
-    - **providers** — Provider filter; `null` means capture for all providers.
   security:
     - AdminKey: []
   responses:
@@ -55,14 +71,24 @@ get:
                 type: array
                 items:
                   type: string
-                description: Only present for admins. Per-key opt-in list.
+                description: Only present for admins. Backward-compatible alias for `keys`.
+              keys:
+                type: array
+                items:
+                  type: string
+                description: In-memory key-name capture targets.
+              aliases:
+                type: array
+                items:
+                  type: string
+                description: In-memory canonical model-alias capture targets.
               providers:
                 type:
                   - array
                   - 'null'
                 items:
                   type: string
-                description: Filter; `null` means capture for all providers.
+                description: In-memory provider-slug capture targets; `null` means no provider targets are enabled.
     '401':
       description: Authentication required or invalid credentials.
   operationId: getV0ManagementDebug
@@ -71,14 +97,19 @@ patch:
     - Management — Debug
   summary: Update debug-mode state (admin only)
   description: |
-    Update global debug capture settings.
+    Update in-memory debug capture settings.
 
     **Admin only** — limited principals receive 403. Limited users must
     use `POST /v0/management/self/debug/toggle` to enable debug for their key.
 
     - **enabled** — Toggle global debug on/off.
-    - **providers** — Optional filter to only capture for specific providers.
-      `null` = capture for all providers.
+    - **keys** — Replace the in-memory key-name capture target list. `null` or `[]` clears it.
+    - **aliases** — Replace the in-memory canonical model-alias capture target list. `null` or `[]` clears it.
+    - **providers** — Replace the in-memory provider-slug capture target list. `null` or `[]` clears it.
+
+    Capture is inclusive: a trace is persisted when any enabled dimension
+    matches the request. Setting `providers` does not restrict global, key, or
+    alias capture.
   security:
     - AdminKey: []
   requestBody:
@@ -96,6 +127,18 @@ patch:
                 - 'null'
               items:
                 type: string
+            keys:
+              type:
+                - array
+                - 'null'
+              items:
+                type: string
+            aliases:
+              type:
+                - array
+                - 'null'
+              items:
+                type: string
   responses:
     '200':
       description: New state.
@@ -104,6 +147,29 @@ patch:
           schema:
             type: object
             additionalProperties: true
+            properties:
+              enabled:
+                type: boolean
+              enabledGlobal:
+                type: boolean
+              enabledKeys:
+                type: array
+                items:
+                  type: string
+              keys:
+                type: array
+                items:
+                  type: string
+              aliases:
+                type: array
+                items:
+                  type: string
+              providers:
+                type:
+                  - array
+                  - 'null'
+                items:
+                  type: string
     '401':
       description: Authentication required or invalid credentials.
   operationId: patchV0ManagementDebug

--- a/packages/backend/src/routes/management/__tests__/admin-auth.test.ts
+++ b/packages/backend/src/routes/management/__tests__/admin-auth.test.ts
@@ -94,6 +94,8 @@ describe('GET /v0/management/auth/verify', () => {
   beforeEach(async () => {
     process.env.ADMIN_KEY = 'correct-admin-key';
     setConfigForTesting(BASE_CONFIG);
+    DebugManager.getInstance().resetForTesting();
+    DebugManager.getInstance().setEnabled(false);
     fastify = Fastify();
     const { mockUsageStorage, mockDispatcher, mockProbeService } = makeMockDeps();
     await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher, mockProbeService);
@@ -102,6 +104,8 @@ describe('GET /v0/management/auth/verify', () => {
 
   afterEach(async () => {
     await closeFastify(fastify);
+    DebugManager.getInstance().resetForTesting();
+    DebugManager.getInstance().setEnabled(false);
   });
 
   it('returns 200 with admin principal info when the correct admin key is provided', async () => {
@@ -252,6 +256,8 @@ describe('Management route protection', () => {
   beforeEach(async () => {
     process.env.ADMIN_KEY = 'correct-admin-key';
     setConfigForTesting(BASE_CONFIG);
+    DebugManager.getInstance().resetForTesting();
+    DebugManager.getInstance().setEnabled(false);
     fastify = Fastify();
     const { mockUsageStorage, mockDispatcher, mockProbeService } = makeMockDeps();
     await registerManagementRoutes(fastify, mockUsageStorage, mockDispatcher, mockProbeService);
@@ -260,6 +266,8 @@ describe('Management route protection', () => {
 
   afterEach(async () => {
     await closeFastify(fastify);
+    DebugManager.getInstance().resetForTesting();
+    DebugManager.getInstance().setEnabled(false);
   });
 
   it('rejects GET /v0/management/cooldowns without admin key', async () => {
@@ -308,6 +316,65 @@ describe('Management route protection', () => {
     });
 
     expect(res.statusCode).toBe(200);
+  });
+
+  it('round-trips in-memory debug capture targets', async () => {
+    const patchRes = await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/debug',
+      headers: { 'x-admin-key': 'correct-admin-key' },
+      payload: {
+        enabled: false,
+        keys: ['mobile-app'],
+        aliases: ['gpt-4o-mini'],
+        providers: ['openai'],
+      },
+    });
+
+    expect(patchRes.statusCode).toBe(200);
+    expect(patchRes.json()).toMatchObject({
+      enabled: false,
+      enabledGlobal: false,
+      enabledKeys: ['mobile-app'],
+      keys: ['mobile-app'],
+      aliases: ['gpt-4o-mini'],
+      providers: ['openai'],
+    });
+
+    const getRes = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/debug',
+      headers: { 'x-admin-key': 'correct-admin-key' },
+    });
+
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json()).toMatchObject({
+      enabled: false,
+      enabledGlobal: false,
+      enabledKeys: ['mobile-app'],
+      keys: ['mobile-app'],
+      aliases: ['gpt-4o-mini'],
+      providers: ['openai'],
+    });
+
+    const clearRes = await fastify.inject({
+      method: 'PATCH',
+      url: '/v0/management/debug',
+      headers: { 'x-admin-key': 'correct-admin-key' },
+      payload: {
+        keys: null,
+        aliases: null,
+        providers: null,
+      },
+    });
+
+    expect(clearRes.statusCode).toBe(200);
+    expect(clearRes.json()).toMatchObject({
+      enabledKeys: [],
+      keys: [],
+      aliases: [],
+      providers: null,
+    });
   });
 });
 

--- a/packages/backend/src/routes/management/debug.ts
+++ b/packages/backend/src/routes/management/debug.ts
@@ -7,6 +7,8 @@ import { isLimited, scopedKeyName } from './_principal';
 const patchDebugSchema = z.object({
   enabled: z.boolean().optional(),
   providers: z.array(z.string()).nullable().optional(),
+  keys: z.array(z.string()).nullable().optional(),
+  aliases: z.array(z.string()).nullable().optional(),
 });
 
 export async function registerDebugRoutes(
@@ -30,6 +32,8 @@ export async function registerDebugRoutes(
         enabledGlobal,
         enabledForKey,
         providers: debugManager.getProviderFilter(),
+        keys: [scopeKey].filter((key) => debugManager.isKeyDimensionEnabled(key)),
+        aliases: debugManager.getEnabledAliases(),
       });
     }
     return reply.send({
@@ -37,6 +41,8 @@ export async function registerDebugRoutes(
       enabledGlobal: debugManager.isEnabled(),
       enabledKeys: debugManager.getEnabledKeys(),
       providers: debugManager.getProviderFilter(),
+      keys: debugManager.getEnabledKeys(),
+      aliases: debugManager.getEnabledAliases(),
     });
   });
 
@@ -60,12 +66,20 @@ export async function registerDebugRoutes(
     if (parsed.data.providers !== undefined) {
       debugManager.setProviderFilter(parsed.data.providers);
     }
+    if (parsed.data.keys !== undefined) {
+      debugManager.setEnabledKeys(parsed.data.keys);
+    }
+    if (parsed.data.aliases !== undefined) {
+      debugManager.setEnabledAliases(parsed.data.aliases);
+    }
 
     return reply.send({
       enabled: debugManager.isEnabled(),
       enabledGlobal: debugManager.isEnabled(),
       enabledKeys: debugManager.getEnabledKeys(),
       providers: debugManager.getProviderFilter(),
+      keys: debugManager.getEnabledKeys(),
+      aliases: debugManager.getEnabledAliases(),
     });
   });
 

--- a/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
@@ -128,8 +128,8 @@ describe('Plexus management MCP routes', () => {
   });
 
   beforeEach(() => {
+    DebugManager.getInstance().resetForTesting();
     DebugManager.getInstance().setEnabled(false);
-    DebugManager.getInstance().setProviderFilter(null);
     mockLogLevel = 'info';
     registerSpy(fastify, 'inject').mockImplementation(async (options: any) => {
       const request = typeof options === 'string' ? { url: options, method: 'GET' } : options;
@@ -425,6 +425,8 @@ describe('Plexus management MCP routes', () => {
           enabled: DebugManager.getInstance().isEnabled(),
           enabledGlobal: DebugManager.getInstance().isEnabled(),
           enabledKeys: DebugManager.getInstance().getEnabledKeys(),
+          keys: DebugManager.getInstance().getEnabledKeys(),
+          aliases: DebugManager.getInstance().getEnabledAliases(),
           providers: DebugManager.getInstance().getProviderFilter(),
         });
       }
@@ -433,10 +435,15 @@ describe('Plexus management MCP routes', () => {
         if (typeof body.enabled === 'boolean') DebugManager.getInstance().setEnabled(body.enabled);
         if (body.providers !== undefined)
           DebugManager.getInstance().setProviderFilter(body.providers ?? null);
+        if (body.keys !== undefined) DebugManager.getInstance().setEnabledKeys(body.keys ?? null);
+        if (body.aliases !== undefined)
+          DebugManager.getInstance().setEnabledAliases(body.aliases ?? null);
         return json({
           enabled: DebugManager.getInstance().isEnabled(),
           enabledGlobal: DebugManager.getInstance().isEnabled(),
           enabledKeys: DebugManager.getInstance().getEnabledKeys(),
+          keys: DebugManager.getInstance().getEnabledKeys(),
+          aliases: DebugManager.getInstance().getEnabledAliases(),
           providers: DebugManager.getInstance().getProviderFilter(),
         });
       }

--- a/packages/backend/src/routes/mcp/plexus.ts
+++ b/packages/backend/src/routes/mcp/plexus.ts
@@ -1407,7 +1407,7 @@ function getToolDescription(toolName: string) {
     case 'plexus_usage':
       return 'Review request logs and summaries. Operations: list, summary, delete, delete_all.';
     case 'plexus_debug':
-      return 'Review and manage debug tracing. Operations: state, update, logs, get_log, delete_log, delete_all_logs.';
+      return 'Review and manage debug tracing. Operations: state, update, logs, get_log, delete_log, delete_all_logs. Debug capture targets are in-memory and inclusive: update body may include enabled, keys, aliases, and providers; a request is captured when any enabled dimension matches.';
     case 'plexus_mcp_gateway':
       return 'Inspect and manage Plexus upstream MCP gateway configuration. Operations: servers_list, list, get, put, create, update, delete, status, start, stop, restart, logs.';
     case 'plexus_settings':

--- a/packages/backend/src/services/__tests__/debug-manager-targets.test.ts
+++ b/packages/backend/src/services/__tests__/debug-manager-targets.test.ts
@@ -47,21 +47,44 @@ describe('DebugManager target capture', () => {
   test('persists when routing resolves an alternate alias to an enabled canonical alias', () => {
     debugManager.enableForAlias('canonical-alias');
 
-    debugManager.startLog('req-canonical-alias', { model: 'alternate-alias' });
-    debugManager.setModelAliasForRequest('req-canonical-alias', 'canonical-alias');
+    const rawRequest = { model: 'alternate-alias', messages: [{ role: 'user', content: 'hello' }] };
+    const requestHeaders = { 'x-test': 'yes' };
+
+    debugManager.startLog('req-canonical-alias', rawRequest, requestHeaders);
+    expect(debugManager.getPendingLog('req-canonical-alias')).toMatchObject({
+      requestId: 'req-canonical-alias',
+      modelAlias: 'alternate-alias',
+      deferPayloadCapture: true,
+    });
+    expect(debugManager.getPendingLog('req-canonical-alias')?.rawRequest).toBeUndefined();
+
+    debugManager.setModelAliasForRequest(
+      'req-canonical-alias',
+      'canonical-alias',
+      rawRequest,
+      requestHeaders
+    );
     debugManager.flush('req-canonical-alias');
 
     expect(saveDebugLog).toHaveBeenCalledTimes(1);
     expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
       requestId: 'req-canonical-alias',
       modelAlias: 'canonical-alias',
+      rawRequest,
+      requestHeaders,
     });
   });
 
   test('persists when the selected provider is enabled', () => {
     debugManager.setEnabledProviders(['tracked-provider']);
 
-    debugManager.startLog('req-provider', { model: 'untracked-alias' });
+    const rawRequest = { model: 'untracked-alias', messages: [{ role: 'user', content: 'hello' }] };
+
+    debugManager.startLog('req-provider', rawRequest);
+    expect(debugManager.getPendingLog('req-provider')).toMatchObject({
+      requestId: 'req-provider',
+      rawRequest,
+    });
     debugManager.setProviderForRequest('req-provider', 'tracked-provider');
     debugManager.flush('req-provider');
 
@@ -98,6 +121,34 @@ describe('DebugManager target capture', () => {
       debugManager.flush('req-drop');
     });
 
+    expect(saveDebugLog).not.toHaveBeenCalled();
+  });
+
+  test('does not buffer full payloads when only unmatched aliases are enabled', () => {
+    debugManager.setEnabledAliases(['tracked-alias']);
+
+    const rawRequest = { model: 'other-alias', messages: [{ role: 'user', content: 'hello' }] };
+    debugManager.startLog('req-unmatched-alias', rawRequest, { 'x-test': 'yes' });
+    debugManager.addTransformedRequest('req-unmatched-alias', {
+      model: 'provider-model',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+    debugManager.addResponseMeta('req-unmatched-alias', 200, {
+      'content-type': 'application/json',
+    });
+
+    const pendingLog = debugManager.getPendingLog('req-unmatched-alias');
+    expect(pendingLog).toMatchObject({
+      requestId: 'req-unmatched-alias',
+      modelAlias: 'other-alias',
+      deferPayloadCapture: true,
+    });
+    expect(pendingLog?.rawRequest).toBeUndefined();
+    expect(pendingLog?.requestHeaders).toBeUndefined();
+    expect(pendingLog?.transformedRequest).toBeUndefined();
+    expect(pendingLog?.responseHeaders).toBeUndefined();
+
+    debugManager.flush('req-unmatched-alias');
     expect(saveDebugLog).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/services/__tests__/debug-manager-targets.test.ts
+++ b/packages/backend/src/services/__tests__/debug-manager-targets.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { DebugManager } from '../debug-manager';
+import { runInRequestContext } from '../request-context';
+import type { UsageStorageService } from '../usage-storage';
+
+describe('DebugManager target capture', () => {
+  let debugManager: DebugManager;
+  let saveDebugLog: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    debugManager = DebugManager.getInstance();
+    debugManager.resetForTesting();
+    debugManager.setEnabled(false);
+    saveDebugLog = vi.fn();
+    debugManager.setStorage({ saveDebugLog } as unknown as UsageStorageService);
+  });
+
+  test('persists when the request key is enabled', () => {
+    debugManager.enableForKey('test-key');
+
+    runInRequestContext({ keyName: 'test-key' }, () => {
+      debugManager.startLog('req-key', { model: 'untracked-alias' });
+      debugManager.flush('req-key');
+    });
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+    expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
+      requestId: 'req-key',
+      apiKey: 'test-key',
+      modelAlias: 'untracked-alias',
+    });
+  });
+
+  test('persists when the incoming alias is enabled', () => {
+    debugManager.enableForAlias('tracked-alias');
+
+    debugManager.startLog('req-alias', { model: 'tracked-alias' });
+    debugManager.flush('req-alias');
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+    expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
+      requestId: 'req-alias',
+      modelAlias: 'tracked-alias',
+    });
+  });
+
+  test('persists when routing resolves an alternate alias to an enabled canonical alias', () => {
+    debugManager.enableForAlias('canonical-alias');
+
+    debugManager.startLog('req-canonical-alias', { model: 'alternate-alias' });
+    debugManager.setModelAliasForRequest('req-canonical-alias', 'canonical-alias');
+    debugManager.flush('req-canonical-alias');
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+    expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
+      requestId: 'req-canonical-alias',
+      modelAlias: 'canonical-alias',
+    });
+  });
+
+  test('persists when the selected provider is enabled', () => {
+    debugManager.setEnabledProviders(['tracked-provider']);
+
+    debugManager.startLog('req-provider', { model: 'untracked-alias' });
+    debugManager.setProviderForRequest('req-provider', 'tracked-provider');
+    debugManager.flush('req-provider');
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+    expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
+      requestId: 'req-provider',
+      provider: 'tracked-provider',
+    });
+  });
+
+  test('global capture persists regardless of unmatched provider target', () => {
+    debugManager.setEnabled(true);
+    debugManager.setEnabledProviders(['other-provider']);
+
+    debugManager.startLog('req-global', { model: 'untracked-alias' });
+    debugManager.setProviderForRequest('req-global', 'untracked-provider');
+    debugManager.flush('req-global');
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+    expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
+      requestId: 'req-global',
+      provider: 'untracked-provider',
+    });
+  });
+
+  test('drops traces when no enabled dimension matches', () => {
+    debugManager.setEnabledProviders(['tracked-provider']);
+    debugManager.setEnabledAliases(['tracked-alias']);
+    debugManager.setEnabledKeys(['tracked-key']);
+
+    runInRequestContext({ keyName: 'other-key' }, () => {
+      debugManager.startLog('req-drop', { model: 'other-alias' });
+      debugManager.setProviderForRequest('req-drop', 'other-provider');
+      debugManager.flush('req-drop');
+    });
+
+    expect(saveDebugLog).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/services/debug-manager.ts
+++ b/packages/backend/src/services/debug-manager.ts
@@ -19,6 +19,7 @@ export interface DebugLogRecord {
   responseStatus?: number;
   provider?: string;
   createdAt?: number;
+  deferPayloadCapture?: boolean;
   /**
    * When true, this log is persisted on flush even if debug capture is not
    * otherwise enabled for its key. Set by the "capture trace on error" mode
@@ -191,10 +192,20 @@ export class DebugManager {
     }
   }
 
-  setModelAliasForRequest(requestId: string, modelAlias: string | null | undefined) {
+  setModelAliasForRequest(
+    requestId: string,
+    modelAlias: string | null | undefined,
+    rawRequest?: any,
+    requestHeaders?: Record<string, string | string[]>
+  ) {
     const log = this.pendingLogs.get(requestId);
     if (log && modelAlias) {
       log.modelAlias = modelAlias;
+      if (log.deferPayloadCapture && this.isAliasDimensionEnabled(modelAlias)) {
+        log.deferPayloadCapture = false;
+        log.rawRequest = rawRequest;
+        log.requestHeaders = requestHeaders;
+      }
     }
   }
 
@@ -203,17 +214,21 @@ export class DebugManager {
     // Seed the request id into the async-local context so the cooldown path
     // (which lacks a requestId) can force-persist this request's trace.
     setCurrentRequestId(requestId);
-    if (!this.isCaptureEnabled()) return;
+    const modelAlias = this.getRequestModelAlias(rawRequest);
+    const shouldCapturePayload = this.shouldCapturePayloadAtStart(modelAlias);
+    const shouldDeferAliasCapture =
+      !shouldCapturePayload && this.enabledAliases.size > 0 && this.enabledProviders.size === 0;
+
+    if (!shouldCapturePayload && !shouldDeferAliasCapture) return;
+
     this.pendingLogs.set(requestId, {
       requestId,
       apiKey: getCurrentKeyName() ?? null,
-      modelAlias:
-        rawRequest && typeof rawRequest === 'object' && typeof rawRequest.model === 'string'
-          ? rawRequest.model
-          : null,
-      rawRequest,
-      requestHeaders,
+      modelAlias,
+      rawRequest: shouldCapturePayload ? rawRequest : undefined,
+      requestHeaders: shouldCapturePayload ? requestHeaders : undefined,
       createdAt: Date.now(),
+      deferPayloadCapture: shouldDeferAliasCapture,
     });
 
     // Auto-cleanup after 5 minutes to prevent memory leaks if streams hang or fail to flush
@@ -226,6 +241,27 @@ export class DebugManager {
       },
       5 * 60 * 1000
     );
+  }
+
+  private getRequestModelAlias(rawRequest: any): string | null {
+    return rawRequest && typeof rawRequest === 'object' && typeof rawRequest.model === 'string'
+      ? rawRequest.model
+      : null;
+  }
+
+  private shouldCapturePayloadAtStart(modelAlias: string | null): boolean {
+    return (
+      this.captureOnError ||
+      this.enabledGlobal ||
+      this.isKeyDimensionEnabled(getCurrentKeyName() ?? null) ||
+      this.enabledProviders.size > 0 ||
+      this.isAliasDimensionEnabled(modelAlias)
+    );
+  }
+
+  private shouldCapturePayloadForRequest(requestId: string): boolean {
+    const log = this.pendingLogs.get(requestId);
+    return !log?.deferPayloadCapture;
   }
 
   private ensureLog(requestId: string): DebugLogRecord {
@@ -243,12 +279,14 @@ export class DebugManager {
 
   addTransformedRequest(requestId: string, payload: any) {
     if (!this.isCaptureEnabled()) return;
+    if (!this.shouldCapturePayloadForRequest(requestId)) return;
     const log = this.ensureLog(requestId);
     log.transformedRequest = payload;
   }
 
   addRawResponse(requestId: string, payload: any) {
     if (!this.isCaptureEnabled()) return;
+    if (!this.shouldCapturePayloadForRequest(requestId)) return;
     const log = this.ensureLog(requestId);
     log.rawResponse = payload;
   }
@@ -263,6 +301,7 @@ export class DebugManager {
   addTransformedResponse(requestId: string, payload: any) {
     // Only save full response bodies if debug mode is enabled (for DB persistence)
     if (!this.isCaptureEnabled()) return;
+    if (!this.shouldCapturePayloadForRequest(requestId)) return;
     const log = this.ensureLog(requestId);
     log.transformedResponse = payload;
   }
@@ -275,6 +314,7 @@ export class DebugManager {
 
   addResponseMeta(requestId: string, status: number, headers: Record<string, string>) {
     if (!this.isCaptureEnabled()) return;
+    if (!this.shouldCapturePayloadForRequest(requestId)) return;
     const log = this.ensureLog(requestId);
     log.responseStatus = status;
     log.responseHeaders = headers;

--- a/packages/backend/src/services/debug-manager.ts
+++ b/packages/backend/src/services/debug-manager.ts
@@ -7,6 +7,7 @@ import { getCurrentKeyName, setCurrentRequestId } from './request-context';
 export interface DebugLogRecord {
   requestId: string;
   apiKey?: string | null;
+  modelAlias?: string | null;
   rawRequest?: any;
   transformedRequest?: any;
   rawResponse?: any;
@@ -32,7 +33,8 @@ export class DebugManager {
   private enabledGlobal: boolean = false;
   private captureOnError: boolean = false;
   private enabledKeys: Set<string> = new Set();
-  private providerFilter: string[] | null = null;
+  private enabledAliases: Set<string> = new Set();
+  private enabledProviders: Set<string> = new Set();
   private pendingLogs: Map<string, DebugLogRecord> = new Map();
   private ephemeralRequests: Set<string> = new Set();
 
@@ -89,6 +91,11 @@ export class DebugManager {
     return this.enabledKeys.has(keyName);
   }
 
+  isKeyDimensionEnabled(keyName: string | null | undefined): boolean {
+    if (!keyName) return false;
+    return this.enabledKeys.has(keyName);
+  }
+
   /**
    * Whether ANY capture should happen for the current async context.
    * Reads the key name from the request context when one is available.
@@ -96,36 +103,98 @@ export class DebugManager {
   isCaptureEnabled(): boolean {
     // Capture-on-error mode buffers every request so a trace exists to persist
     // if the request later errors or triggers a cooldown.
-    return this.captureOnError || this.isEnabledForKey(getCurrentKeyName() ?? null);
+    return (
+      this.captureOnError ||
+      this.enabledGlobal ||
+      this.isKeyDimensionEnabled(getCurrentKeyName() ?? null) ||
+      this.enabledAliases.size > 0 ||
+      this.enabledProviders.size > 0
+    );
   }
 
   getEnabledKeys(): string[] {
     return Array.from(this.enabledKeys).sort();
   }
 
+  setEnabledKeys(keys: string[] | null | undefined): void {
+    this.enabledKeys = new Set((keys ?? []).map((key) => key.trim()).filter(Boolean));
+    logger.warn(
+      `Debug key capture ${this.enabledKeys.size > 0 ? 'set to: ' + this.getEnabledKeys().join(', ') : 'cleared'}`
+    );
+  }
+
+  // ─── Per-alias toggle ───────────────────────────────────────────
+  enableForAlias(alias: string): void {
+    this.enabledAliases.add(alias);
+    logger.warn(`Debug mode enabled for alias '${alias}'`);
+  }
+
+  disableForAlias(alias: string): void {
+    this.enabledAliases.delete(alias);
+    logger.warn(`Debug mode disabled for alias '${alias}'`);
+  }
+
+  setEnabledAliases(aliases: string[] | null | undefined): void {
+    this.enabledAliases = new Set((aliases ?? []).map((alias) => alias.trim()).filter(Boolean));
+    logger.warn(
+      `Debug alias capture ${this.enabledAliases.size > 0 ? 'set to: ' + this.getEnabledAliases().join(', ') : 'cleared'}`
+    );
+  }
+
+  getEnabledAliases(): string[] {
+    return Array.from(this.enabledAliases).sort();
+  }
+
+  isEnabledForAlias(alias: string | null | undefined): boolean {
+    if (this.enabledGlobal) return true;
+    return this.isAliasDimensionEnabled(alias);
+  }
+
+  isAliasDimensionEnabled(alias: string | null | undefined): boolean {
+    if (!alias) return false;
+    return this.enabledAliases.has(alias);
+  }
+
   // ─── Provider filter ────────────────────────────────────────────
   setProviderFilter(providers: string[] | null) {
-    this.providerFilter = providers;
+    this.setEnabledProviders(providers);
+  }
+
+  setEnabledProviders(providers: string[] | null | undefined) {
+    this.enabledProviders = new Set(
+      (providers ?? []).map((provider) => provider.trim()).filter(Boolean)
+    );
     logger.warn(
-      `Debug provider filter ${providers ? 'set to: ' + providers.join(', ') : 'cleared'}`
+      `Debug provider capture ${this.enabledProviders.size > 0 ? 'set to: ' + this.getProviderFilter()?.join(', ') : 'cleared'}`
     );
   }
 
   getProviderFilter(): string[] | null {
-    return this.providerFilter;
+    const providers = Array.from(this.enabledProviders).sort();
+    return providers.length > 0 ? providers : null;
   }
 
   shouldLogProvider(provider: string): boolean {
-    if (!this.providerFilter || this.providerFilter.length === 0) {
-      return true; // No filter set, log all providers
-    }
-    return this.providerFilter.includes(provider);
+    if (this.enabledGlobal) return true;
+    return this.isProviderDimensionEnabled(provider);
+  }
+
+  isProviderDimensionEnabled(provider: string | null | undefined): boolean {
+    if (!provider) return false;
+    return this.enabledProviders.has(provider);
   }
 
   setProviderForRequest(requestId: string, provider: string) {
     const log = this.pendingLogs.get(requestId);
     if (log) {
       log.provider = provider;
+    }
+  }
+
+  setModelAliasForRequest(requestId: string, modelAlias: string | null | undefined) {
+    const log = this.pendingLogs.get(requestId);
+    if (log && modelAlias) {
+      log.modelAlias = modelAlias;
     }
   }
 
@@ -138,6 +207,10 @@ export class DebugManager {
     this.pendingLogs.set(requestId, {
       requestId,
       apiKey: getCurrentKeyName() ?? null,
+      modelAlias:
+        rawRequest && typeof rawRequest === 'object' && typeof rawRequest.model === 'string'
+          ? rawRequest.model
+          : null,
       rawRequest,
       requestHeaders,
       createdAt: Date.now(),
@@ -218,24 +291,28 @@ export class DebugManager {
     const log = this.pendingLogs.get(requestId);
     if (!log) return;
 
-    // Persist if debug mode is enabled for this request's key, or if the
+    const enabledByGlobal = this.enabledGlobal;
+    const enabledByKey = this.isKeyDimensionEnabled(log.apiKey ?? null);
+    const enabledByAlias = this.isAliasDimensionEnabled(log.modelAlias ?? null);
+    const enabledByProvider = this.isProviderDimensionEnabled(log.provider ?? null);
+
+    // Persist when any debug dimension matches this request, or when the
     // request was flagged for forced persistence (capture-on-error mode).
-    if (!this.isEnabledForKey(log.apiKey ?? null) && !log.forcePersist) {
+    if (
+      !enabledByGlobal &&
+      !enabledByKey &&
+      !enabledByAlias &&
+      !enabledByProvider &&
+      !log.forcePersist
+    ) {
       logger.debug(
-        `Skipping flush for ${requestId} - debug mode not enabled for key '${log.apiKey ?? '(none)'}'`
+        `Skipping flush for ${requestId} - debug mode not enabled for key '${log.apiKey ?? '(none)'}', alias '${log.modelAlias ?? '(none)'}', provider '${log.provider ?? '(none)'}'`
       );
       this.pendingLogs.delete(requestId);
       return;
     }
 
     if (!this.storage) return;
-
-    // Check provider filter
-    if (log.provider && !this.shouldLogProvider(log.provider)) {
-      logger.debug(`Skipping flush for ${requestId} - provider '${log.provider}' not in filter`);
-      this.pendingLogs.delete(requestId);
-      return;
-    }
 
     logger.debug(`Flushing debug log for ${requestId}`);
     if (typeof this.storage.saveDebugLog === 'function') {
@@ -293,6 +370,10 @@ export class DebugManager {
   resetForTesting(): void {
     this.pendingLogs.clear();
     this.ephemeralRequests.clear();
+    this.enabledKeys.clear();
+    this.enabledAliases.clear();
+    this.enabledProviders.clear();
+    this.captureOnError = false;
   }
 
   getPendingLog(requestId: string): DebugLogRecord | undefined {

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -18,6 +18,7 @@ import type { GpuParams } from '@plexus/shared';
 import { QuotaEnforcer } from '../services/quota/quota-enforcer';
 import { recordQuotaUsage, buildQuotaHeaders } from '../services/quota/quota-middleware';
 import { CooldownManager } from './cooldown-manager';
+import { sanitizeHeaders } from '../utils/sanitize-headers';
 /**
  * handleResponse
  *
@@ -63,7 +64,9 @@ export async function handleResponse(
   }
   DebugManager.getInstance().setModelAliasForRequest(
     usageRecord.requestId!,
-    usageRecord.canonicalModelName || usageRecord.incomingModelAlias || null
+    usageRecord.canonicalModelName || usageRecord.incomingModelAlias || null,
+    originalRequest,
+    sanitizeHeaders((request.headers ?? {}) as any)
   );
   usageRecord.attemptCount = unifiedResponse.plexus?.attemptCount || 1;
   usageRecord.retryHistory = unifiedResponse.plexus?.retryHistory || null;

--- a/packages/backend/src/services/response-handler.ts
+++ b/packages/backend/src/services/response-handler.ts
@@ -61,6 +61,10 @@ export async function handleResponse(
   if (usageRecord.provider) {
     DebugManager.getInstance().setProviderForRequest(usageRecord.requestId!, usageRecord.provider);
   }
+  DebugManager.getInstance().setModelAliasForRequest(
+    usageRecord.requestId!,
+    usageRecord.canonicalModelName || usageRecord.incomingModelAlias || null
+  );
   usageRecord.attemptCount = unifiedResponse.plexus?.attemptCount || 1;
   usageRecord.retryHistory = unifiedResponse.plexus?.retryHistory || null;
   usageRecord.finalAttemptProvider =

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -2254,29 +2254,60 @@ export const api = {
     }
   },
 
-  getDebugMode: async (): Promise<{ enabled: boolean; providers: string[] | null }> => {
+  getDebugMode: async (): Promise<{
+    enabled: boolean;
+    enabledGlobal?: boolean;
+    enabledKeys?: string[];
+    providers: string[] | null;
+    keys: string[] | null;
+    aliases: string[] | null;
+  }> => {
     try {
       const res = await fetchWithAuth(`${API_BASE}/v0/management/debug`);
       if (!res.ok) throw new Error('Failed to fetch debug status');
       const json = await res.json();
       return {
         enabled: !!json.enabled,
+        enabledGlobal: json.enabledGlobal === undefined ? undefined : !!json.enabledGlobal,
+        enabledKeys: Array.isArray(json.enabledKeys) ? json.enabledKeys : undefined,
         providers: json.providers || null,
+        keys: json.keys || json.enabledKeys || null,
+        aliases: json.aliases || null,
       };
     } catch (e) {
       console.error('API Error getDebugMode', e);
-      return { enabled: false, providers: null };
+      return { enabled: false, providers: null, keys: null, aliases: null };
     }
   },
 
   setDebugMode: async (
     enabled: boolean,
-    providers?: string[] | null
-  ): Promise<{ enabled: boolean; providers: string[] | null }> => {
+    providers?: string[] | null,
+    keys?: string[] | null,
+    aliases?: string[] | null
+  ): Promise<{
+    enabled: boolean;
+    enabledGlobal?: boolean;
+    enabledKeys?: string[];
+    providers: string[] | null;
+    keys: string[] | null;
+    aliases: string[] | null;
+  }> => {
     try {
-      const body: { enabled: boolean; providers?: string[] | null } = { enabled };
+      const body: {
+        enabled: boolean;
+        providers?: string[] | null;
+        keys?: string[] | null;
+        aliases?: string[] | null;
+      } = { enabled };
       if (providers !== undefined) {
         body.providers = providers;
+      }
+      if (keys !== undefined) {
+        body.keys = keys;
+      }
+      if (aliases !== undefined) {
+        body.aliases = aliases;
       }
       const res = await fetchWithAuth(`${API_BASE}/v0/management/debug`, {
         method: 'PATCH',
@@ -2287,7 +2318,11 @@ export const api = {
       const json = await res.json();
       return {
         enabled: !!json.enabled,
+        enabledGlobal: json.enabledGlobal === undefined ? undefined : !!json.enabledGlobal,
+        enabledKeys: Array.isArray(json.enabledKeys) ? json.enabledKeys : undefined,
         providers: json.providers || null,
+        keys: json.keys || json.enabledKeys || null,
+        aliases: json.aliases || null,
       };
     } catch (e) {
       console.error('API Error setDebugMode', e);

--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -248,13 +248,13 @@ export const Debug: React.FC = () => {
   };
 
   const clearCaptureTargets = async () => {
-    setSelectedProviders([]);
-    setSelectedKeys([]);
-    setSelectedAliases([]);
     try {
-      await api.setDebugMode(debugEnabled, null, null, null);
+      const next = await api.setDebugMode(debugEnabled, null, null, null);
+      setSelectedProviders(next.providers || []);
+      setSelectedKeys(next.keys || next.enabledKeys || []);
+      setSelectedAliases(next.aliases || []);
     } catch (e) {
-      console.error('Failed to clear capture targets', e);
+      console.error('Failed to apply capture targets', e);
     }
   };
 

--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -22,7 +22,7 @@ import { Switch } from '../components/ui/Switch';
 import { Modal } from '../components/ui/Modal';
 import { PageHeader } from '../components/layout/PageHeader';
 import { useLocation } from 'react-router-dom';
-import type { Provider } from '../lib/api';
+import type { Alias, KeyConfig, Provider } from '../lib/api';
 import { isClipboardAvailable, copyToClipboard } from '../lib/clipboard';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -53,13 +53,17 @@ export const Debug: React.FC = () => {
   const [loadingDetail, setLoadingDetail] = useState(false);
   const [copiedAll, setCopiedAll] = useState(false);
 
-  // Provider filter state
+  // Debug capture target state
   const [providers, setProviders] = useState<Provider[]>([]);
+  const [keys, setKeys] = useState<KeyConfig[]>([]);
+  const [aliases, setAliases] = useState<Alias[]>([]);
   const [debugEnabled, setDebugEnabled] = useState(false);
   const [captureTraceOnError, setCaptureTraceOnError] = useState(false);
   const [captureTraceLoaded, setCaptureTraceLoaded] = useState(false);
   const [captureTraceSaving, setCaptureTraceSaving] = useState(false);
   const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [selectedAliases, setSelectedAliases] = useState<string[]>([]);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
 
   // Delete Modal State
@@ -152,19 +156,25 @@ export const Debug: React.FC = () => {
     setCopiedAll(false);
   }, [detail?.requestId]);
 
-  // Fetch providers and debug status
+  // Fetch capture dimensions and debug status
   useEffect(() => {
     const fetchProvidersAndStatus = async () => {
       try {
-        const [providersData, debugStatus] = await Promise.all([
+        const [providersData, keysData, aliasesData, debugStatus] = await Promise.all([
           api.getProviders(),
+          isAdmin ? api.getKeys() : Promise.resolve([]),
+          isAdmin ? api.getAliases() : Promise.resolve([]),
           api.getDebugMode(),
         ]);
         setProviders(providersData);
+        setKeys(keysData);
+        setAliases(aliasesData);
         setDebugEnabled(debugStatus.enabled);
         setSelectedProviders(debugStatus.providers || []);
+        setSelectedKeys(debugStatus.keys || debugStatus.enabledKeys || []);
+        setSelectedAliases(debugStatus.aliases || []);
       } catch (e) {
-        console.error('Failed to fetch providers or debug status', e);
+        console.error('Failed to fetch capture targets or debug status', e);
       }
       // Capture-trace-on-error is an admin-only persisted setting.
       if (isAdmin) {
@@ -210,32 +220,46 @@ export const Debug: React.FC = () => {
     }
   }, [isFilterOpen]);
 
-  const handleProviderToggle = (providerId: string) => {
-    setSelectedProviders((prev) => {
-      const newSelection = prev.includes(providerId)
-        ? prev.filter((id) => id !== providerId)
-        : [...prev, providerId];
-      return newSelection;
-    });
+  const toggleSelection = (
+    value: string,
+    setter: React.Dispatch<React.SetStateAction<string[]>>
+  ) => {
+    setter((prev) =>
+      prev.includes(value) ? prev.filter((entry) => entry !== value) : [...prev, value]
+    );
   };
 
-  const applyProviderFilter = async () => {
+  const applyCaptureTargets = async () => {
     try {
-      await api.setDebugMode(debugEnabled, selectedProviders.length > 0 ? selectedProviders : null);
+      const next = await api.setDebugMode(
+        debugEnabled,
+        selectedProviders.length > 0 ? selectedProviders : null,
+        selectedKeys.length > 0 ? selectedKeys : null,
+        selectedAliases.length > 0 ? selectedAliases : null
+      );
+      setDebugEnabled(next.enabledGlobal ?? next.enabled);
+      setSelectedProviders(next.providers || []);
+      setSelectedKeys(next.keys || next.enabledKeys || []);
+      setSelectedAliases(next.aliases || []);
       setIsFilterOpen(false);
     } catch (e) {
-      console.error('Failed to apply provider filter', e);
+      console.error('Failed to apply capture targets', e);
     }
   };
 
-  const clearProviderFilter = async () => {
+  const clearCaptureTargets = async () => {
     setSelectedProviders([]);
+    setSelectedKeys([]);
+    setSelectedAliases([]);
     try {
-      await api.setDebugMode(debugEnabled, null);
+      await api.setDebugMode(debugEnabled, null, null, null);
     } catch (e) {
-      console.error('Failed to clear provider filter', e);
+      console.error('Failed to clear capture targets', e);
     }
   };
+
+  const selectedCaptureTargetCount =
+    selectedProviders.length + selectedKeys.length + selectedAliases.length;
 
   const formatContent = (content: any) => {
     if (!content) return '';
@@ -344,33 +368,33 @@ export const Debug: React.FC = () => {
                   />
                 </label>
               )}
-              {/* Provider Filter — admin-only: the global filter affects all users. */}
+              {/* Capture targets — admin-only, in-memory DebugManager state. */}
               {isAdmin && (
                 <div className="relative provider-filter-dropdown">
                   <Button
                     variant="secondary"
                     className={clsx(
                       'flex items-center gap-2',
-                      selectedProviders.length > 0 && 'border-primary'
+                      selectedCaptureTargetCount > 0 && 'border-primary'
                     )}
                     onClick={() => setIsFilterOpen(!isFilterOpen)}
                     leftIcon={<Filter size={14} />}
                   >
-                    Filter
-                    {selectedProviders.length > 0 && (
+                    Targets
+                    {selectedCaptureTargetCount > 0 && (
                       <span className="ml-1 px-1.5 py-0.5 text-xs bg-primary text-white rounded-full">
-                        {selectedProviders.length}
+                        {selectedCaptureTargetCount}
                       </span>
                     )}
                   </Button>
 
                   {isFilterOpen && (
-                    <div className="absolute left-0 top-full z-50 mt-2 w-[calc(100vw-2rem)] max-w-72 rounded-lg border border-border-glass bg-bg-surface p-4 shadow-lg sm:left-auto sm:right-0">
+                    <div className="absolute left-0 top-full z-50 mt-2 w-[calc(100vw-2rem)] max-w-[34rem] rounded-lg border border-border-glass bg-bg-surface p-4 shadow-lg sm:left-auto sm:right-0">
                       <div className="flex items-center justify-between mb-3">
-                        <span className="text-sm font-medium text-text">Provider Filter</span>
-                        {selectedProviders.length > 0 && (
+                        <span className="text-sm font-medium text-text">Trace Capture Targets</span>
+                        {selectedCaptureTargetCount > 0 && (
                           <button
-                            onClick={clearProviderFilter}
+                            onClick={clearCaptureTargets}
                             className="text-xs text-text-muted hover:text-text transition-colors flex items-center gap-1"
                           >
                             <X size={12} />
@@ -379,25 +403,93 @@ export const Debug: React.FC = () => {
                         )}
                       </div>
                       <p className="text-xs text-text-muted mb-3">
-                        Only log requests for selected providers
+                        Capture traces when any selected key, alias, provider, or global mode
+                        matches.
                       </p>
-                      <div className="max-h-64 overflow-y-auto space-y-1">
-                        {providers.map((provider) => (
-                          <label
-                            key={provider.id}
-                            className="flex items-center gap-2 p-2 rounded hover:bg-bg-hover cursor-pointer"
-                          >
-                            <input
-                              type="checkbox"
-                              checked={selectedProviders.includes(provider.id)}
-                              onChange={() => handleProviderToggle(provider.id)}
-                              className="rounded border-border-glass text-primary focus:ring-primary"
-                            />
-                            <span className="text-sm text-text">
-                              {provider.name || provider.id}
-                            </span>
-                          </label>
-                        ))}
+                      <div className="grid max-h-80 grid-cols-1 gap-4 overflow-y-auto md:grid-cols-3">
+                        <div>
+                          <div className="mb-2 text-xs font-medium uppercase text-text-muted">
+                            Keys
+                          </div>
+                          <div className="space-y-1">
+                            {keys.length === 0 ? (
+                              <div className="p-2 text-xs text-text-muted">No keys</div>
+                            ) : (
+                              keys.map((key) => (
+                                <label
+                                  key={key.key}
+                                  className="flex items-center gap-2 rounded p-2 hover:bg-bg-hover cursor-pointer"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={selectedKeys.includes(key.key)}
+                                    onChange={() => toggleSelection(key.key, setSelectedKeys)}
+                                    className="rounded border-border-glass text-primary focus:ring-primary"
+                                  />
+                                  <span className="min-w-0 truncate text-sm text-text">
+                                    {key.key}
+                                  </span>
+                                </label>
+                              ))
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="mb-2 text-xs font-medium uppercase text-text-muted">
+                            Aliases
+                          </div>
+                          <div className="space-y-1">
+                            {aliases.length === 0 ? (
+                              <div className="p-2 text-xs text-text-muted">No aliases</div>
+                            ) : (
+                              aliases.map((alias) => (
+                                <label
+                                  key={alias.id}
+                                  className="flex items-center gap-2 rounded p-2 hover:bg-bg-hover cursor-pointer"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={selectedAliases.includes(alias.id)}
+                                    onChange={() => toggleSelection(alias.id, setSelectedAliases)}
+                                    className="rounded border-border-glass text-primary focus:ring-primary"
+                                  />
+                                  <span className="min-w-0 truncate text-sm text-text">
+                                    {alias.id}
+                                  </span>
+                                </label>
+                              ))
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="mb-2 text-xs font-medium uppercase text-text-muted">
+                            Providers
+                          </div>
+                          <div className="space-y-1">
+                            {providers.length === 0 ? (
+                              <div className="p-2 text-xs text-text-muted">No providers</div>
+                            ) : (
+                              providers.map((provider) => (
+                                <label
+                                  key={provider.id}
+                                  className="flex items-center gap-2 rounded p-2 hover:bg-bg-hover cursor-pointer"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={selectedProviders.includes(provider.id)}
+                                    onChange={() =>
+                                      toggleSelection(provider.id, setSelectedProviders)
+                                    }
+                                    className="rounded border-border-glass text-primary focus:ring-primary"
+                                  />
+                                  <span className="min-w-0 truncate text-sm text-text">
+                                    {provider.name || provider.id}
+                                  </span>
+                                </label>
+                              ))
+                            )}
+                          </div>
+                        </div>
                       </div>
                       <div className="flex gap-2 mt-4 pt-3 border-t border-border-glass">
                         <Button
@@ -410,7 +502,7 @@ export const Debug: React.FC = () => {
                         <Button
                           variant="primary"
                           className="flex-1 text-xs"
-                          onClick={applyProviderFilter}
+                          onClick={applyCaptureTargets}
                         >
                           Apply
                         </Button>


### PR DESCRIPTION
### **User description**
## Summary
- Add in-memory debug capture targets for keys, canonical aliases, and providers with inclusive matching alongside global capture
- Expose key/alias/provider target state through the management API and admin Traces UI
- Update OpenAPI, docs, MCP tool guidance, and plexus-management skill references

## Validation
- bun run format:check
- bun run typecheck
- bun run lint:openapi
- bun run test src/services/__tests__/debug-manager-targets.test.ts src/routes/management/__tests__/admin-auth.test.ts src/routes/mcp/__tests__/plexus-mcp-routes.test.ts
- pre-commit hook: backend tests, frontend build, OpenAPI lint, typecheck

## Notes
- bun run sync:openapi still reports pre-existing unrelated undocumented endpoints; /v0/management/debug is documented and OpenAPI lint passes.


___

### **Description**
- Add inclusive in-memory debug capture targets for keys, aliases, and providers

- Refactor `DebugManager` to persist traces when any enabled dimension matches

- Expose `keys` and `aliases` in management API, frontend UI, and MCP tool

- Update OpenAPI, docs, skill references, and add target capture tests


___

