### PR TITLE
fix(dispatcher): truncate provider error messages

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
@@ -267,13 +267,56 @@ describe('Dispatcher Failover', () => {
       expect(error.message).toContain('All targets failed');
       expect(error.message).toContain('Invalid Responses API request');
       expect(error.message).not.toContain(largeValidationDetails);
-      expect(error.message.length).toBeLessThan(500);
+      expect(error.message.length).toBeLessThan(650);
       expect(error.routingContext?.providerResponse).toBe(providerBody);
 
       const retryHistory = JSON.parse(error.routingContext?.retryHistory || '[]');
       expect(retryHistory.length).toBeGreaterThanOrEqual(1);
       expect(
         retryHistory.every((attempt: any) => attempt.reason === 'Invalid Responses API request')
+      ).toBe(true);
+    }
+  });
+
+  test('large upstream error messages are capped consistently', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    const largeProviderMessage = `Invalid Responses API request ${'invalid input '.repeat(25_000)}`;
+    const providerBody = JSON.stringify({
+      error: {
+        message: largeProviderMessage,
+        code: 'invalid_prompt',
+      },
+    });
+
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(providerBody, {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('Invalid Responses API request');
+      expect(error.message).toContain('[truncated');
+      expect(error.message).not.toContain(largeProviderMessage);
+      expect(error.message.length).toBeLessThan(650);
+      expect(error.routingContext?.providerResponse).toBe(providerBody);
+
+      const retryHistory = JSON.parse(error.routingContext?.retryHistory || '[]');
+      expect(retryHistory.length).toBeGreaterThanOrEqual(1);
+      expect(
+        retryHistory.every(
+          (attempt: any) =>
+            attempt.reason.startsWith('Invalid Responses API request') &&
+            attempt.reason.includes('[truncated') &&
+            attempt.reason.length < 550
+        )
       ).toBe(true);
     }
   });

--- a/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
@@ -226,7 +226,7 @@ describe('Dispatcher Failover', () => {
       await dispatcher.dispatch({ ...makeChatRequest(), requestId: 'req-malformed-json' });
       throw new Error('expected dispatch to fail');
     } catch (error: any) {
-      expect(error.message).toContain(invalidJson);
+      expect(error.message).toContain(invalidJson.trim());
       expect(error.routingContext?.attemptCount).toBe(1);
       expect(error.routingContext?.rawResponseText).toBe(invalidJson);
       expect(error.routingContext?.providerResponse).toBe(invalidJson);
@@ -234,6 +234,47 @@ describe('Dispatcher Failover', () => {
       const retryHistory = JSON.parse(error.routingContext?.retryHistory || '[]');
       expect(retryHistory).toHaveLength(1);
       expect(retryHistory[0]?.reason).toContain('{"broken":');
+    }
+  });
+
+  test('large upstream validation bodies are not echoed into client-facing error messages', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    const largeValidationDetails = 'invalid input '.repeat(25_000);
+    const providerBody = JSON.stringify({
+      error: {
+        message: 'Invalid Responses API request',
+        code: 'invalid_prompt',
+      },
+      metadata: {
+        raw: largeValidationDetails,
+      },
+    });
+
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(providerBody, {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+      expect(error.message).toContain('Invalid Responses API request');
+      expect(error.message).not.toContain(largeValidationDetails);
+      expect(error.message.length).toBeLessThan(500);
+      expect(error.routingContext?.providerResponse).toBe(providerBody);
+
+      const retryHistory = JSON.parse(error.routingContext?.retryHistory || '[]');
+      expect(retryHistory.length).toBeGreaterThanOrEqual(1);
+      expect(
+        retryHistory.every((attempt: any) => attempt.reason === 'Invalid Responses API request')
+      ).toBe(true);
     }
   });
 

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -70,7 +70,7 @@ interface RetryHistoryLikeEntry {
 
 type ResolveTimeoutMs = (timeoutMs?: number | null) => number;
 
-const CLIENT_ERROR_MESSAGE_LIMIT = 1000;
+const PROVIDER_ERROR_SUMMARY_LIMIT = 500;
 
 /**
  * Request-level API types (e.g. embeddings, transcriptions) share base URLs
@@ -413,19 +413,21 @@ function stripTrailingApiVersion(url: string): string {
 export class Dispatcher {
   private usageStorage?: UsageStorageService;
 
-  private compactClientErrorMessage(value: unknown): string {
-    const text = String(value || 'Unknown provider error').trim();
+  private compactProviderErrorSummary(value: unknown): string {
+    const raw = typeof value === 'string' ? value : value == null ? '' : String(value);
+    const text = raw.trim() || 'Unknown provider error';
+    const chars = Array.from(text);
 
-    if (text.length <= CLIENT_ERROR_MESSAGE_LIMIT) {
+    if (chars.length <= PROVIDER_ERROR_SUMMARY_LIMIT) {
       return text;
     }
 
-    return `${text.slice(0, CLIENT_ERROR_MESSAGE_LIMIT)}... [truncated ${text.length - CLIENT_ERROR_MESSAGE_LIMIT} chars]`;
+    return `${chars.slice(0, PROVIDER_ERROR_SUMMARY_LIMIT).join('')}... [truncated ${chars.length - PROVIDER_ERROR_SUMMARY_LIMIT} chars]`;
   }
 
   private formatClientProviderError(statusCode: number, errorText: string): string {
     const reason = this.extractFailureReason(errorText) || errorText || 'Unknown provider error';
-    return `Provider failed: ${statusCode} ${this.compactClientErrorMessage(reason)}`;
+    return `Provider failed: ${statusCode} ${this.compactProviderErrorSummary(reason)}`;
   }
 
   private extractFailureReason(value: unknown): string | undefined {
@@ -508,10 +510,10 @@ export class Dispatcher {
     const statusCode = error?.routingContext?.statusCode ?? error?.status ?? error?.statusCode;
 
     if (includeStatusCode && typeof statusCode === 'number') {
-      return `HTTP ${statusCode}: ${extracted}`.slice(0, 500);
+      return this.compactProviderErrorSummary(`HTTP ${statusCode}: ${extracted}`);
     }
 
-    return String(extracted).slice(0, 500);
+    return this.compactProviderErrorSummary(extracted);
   }
 
   private async recordAttemptMetric(
@@ -1812,7 +1814,7 @@ export class Dispatcher {
     retryHistory: RetryAttemptRecord[] = []
   ): Error {
     const summary = attemptedProviders.length > 0 ? attemptedProviders.join(', ') : 'none';
-    const baseMessage = this.compactClientErrorMessage(
+    const baseMessage = this.compactProviderErrorSummary(
       this.formatFailureReason(lastError) || lastError?.message || 'Unknown provider error'
     );
     const enriched = new Error(`All targets failed: ${summary}. Last error: ${baseMessage}`) as any;
@@ -3316,7 +3318,10 @@ export class Dispatcher {
         route.provider,
         route.model,
         cooldownDuration,
-        `HTTP ${response.status}: ${errorText.slice(0, 500)}`
+        this.formatFailureReason(
+          { routingContext: { providerResponse: errorText, statusCode: response.status } },
+          true
+        )
       );
     }
 

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -70,6 +70,8 @@ interface RetryHistoryLikeEntry {
 
 type ResolveTimeoutMs = (timeoutMs?: number | null) => number;
 
+const CLIENT_ERROR_MESSAGE_LIMIT = 1000;
+
 /**
  * Request-level API types (e.g. embeddings, transcriptions) share base URLs
  * with their provider-level counterparts (e.g. chat, gemini). This map defines
@@ -410,6 +412,21 @@ function stripTrailingApiVersion(url: string): string {
 
 export class Dispatcher {
   private usageStorage?: UsageStorageService;
+
+  private compactClientErrorMessage(value: unknown): string {
+    const text = String(value || 'Unknown provider error').trim();
+
+    if (text.length <= CLIENT_ERROR_MESSAGE_LIMIT) {
+      return text;
+    }
+
+    return `${text.slice(0, CLIENT_ERROR_MESSAGE_LIMIT)}... [truncated ${text.length - CLIENT_ERROR_MESSAGE_LIMIT} chars]`;
+  }
+
+  private formatClientProviderError(statusCode: number, errorText: string): string {
+    const reason = this.extractFailureReason(errorText) || errorText || 'Unknown provider error';
+    return `Provider failed: ${statusCode} ${this.compactClientErrorMessage(reason)}`;
+  }
 
   private extractFailureReason(value: unknown): string | undefined {
     if (typeof value === 'string') {
@@ -1795,7 +1812,9 @@ export class Dispatcher {
     retryHistory: RetryAttemptRecord[] = []
   ): Error {
     const summary = attemptedProviders.length > 0 ? attemptedProviders.join(', ') : 'none';
-    const baseMessage = lastError?.message || 'Unknown provider error';
+    const baseMessage = this.compactClientErrorMessage(
+      this.formatFailureReason(lastError) || lastError?.message || 'Unknown provider error'
+    );
     const enriched = new Error(`All targets failed: ${summary}. Last error: ${baseMessage}`) as any;
 
     enriched.cause = lastError;
@@ -3302,7 +3321,7 @@ export class Dispatcher {
     }
 
     // Create enriched error with routing context
-    const error = new Error(`Provider failed: ${response.status} ${errorText}`) as any;
+    const error = new Error(this.formatClientProviderError(response.status, errorText)) as any;
     error.routingContext = {
       provider: route.provider,
       targetModel: route.model,


### PR DESCRIPTION
### **User description**
## Summary
- truncate provider error text used in client-facing dispatcher error messages
- keep full upstream provider responses in routing context/debug logs for diagnosis
- add regression coverage for large upstream validation bodies

## Validation
- bun run test src/services/__tests__/dispatcher-failover.test.ts
- bun run typecheck
- bun run format:check
- pre-commit: bun run test, biome format/lint, no-migrations, typecheck


___

### **Description**
- Add `compactClientErrorMessage` and `formatClientProviderError` to truncate provider errors at 1000 chars

- Update `buildAllTargetsFailedError` to use compacted, extracted failure reasons

- Add regression test ensuring large upstream validation bodies are not echoed to clients

- Update existing malformed-JSON test to assert trimmed error text


___

