### PR TITLE
feat: add xAI SuperGrok / X Premium+ OAuth provider

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -143,6 +143,7 @@ Plexus supports OAuth-backed providers via the [pi-ai](https://www.npmjs.com/pac
 - OpenAI Codex
 - Gemini CLI
 - Antigravity
+- xAI Grok (SuperGrok / X Premium+ subscription via device-code OAuth; inference uses the xAI Responses API)
 - OpenAI o1-pro
 
 **Configuration:**

--- a/docs/openapi/components/schemas/ProviderConfig.yaml
+++ b/docs/openapi/components/schemas/ProviderConfig.yaml
@@ -43,6 +43,7 @@ properties:
       - github-copilot
       - google-gemini-cli
       - google-antigravity
+      - xai
     description: >
       OAuth provider identifier. Required when `api_base_url` uses an
       `oauth://` URI. Determines which OAuth flow is used to obtain

--- a/packages/backend/drizzle/schema/postgres/enums.ts
+++ b/packages/backend/drizzle/schema/postgres/enums.ts
@@ -6,6 +6,7 @@ export const oauthProviderTypeEnum = pgEnum('oauth_provider_type', [
   'github-copilot',
   'google-gemini-cli',
   'google-antigravity',
+  'xai',
 ]);
 
 export const quotaCheckerTypeEnum = pgEnum('quota_checker_type', [

--- a/packages/backend/drizzle/schema/sqlite/oauth-credentials.ts
+++ b/packages/backend/drizzle/schema/sqlite/oauth-credentials.ts
@@ -4,7 +4,7 @@ export const oauthCredentials = sqliteTable(
   'oauth_credentials',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
-    oauthProviderType: text('oauth_provider_type').notNull(), // 'anthropic' | 'openai-codex' | 'github-copilot' | 'google-gemini-cli' | 'google-antigravity'
+    oauthProviderType: text('oauth_provider_type').notNull(), // 'anthropic' | 'openai-codex' | 'github-copilot' | 'google-gemini-cli' | 'google-antigravity' | 'xai'
     accountId: text('account_id').notNull(),
     accessToken: text('access_token').notNull(),
     refreshToken: text('refresh_token').notNull(),

--- a/packages/backend/drizzle/schema/sqlite/providers.ts
+++ b/packages/backend/drizzle/schema/sqlite/providers.ts
@@ -9,7 +9,7 @@ export const providers = sqliteTable(
     displayName: text('display_name'),
     apiBaseUrl: text('api_base_url'), // JSON: string URL or {"chat":"...","messages":"..."}
     apiKey: text('api_key'),
-    oauthProviderType: text('oauth_provider_type'), // 'anthropic' | 'openai-codex' | 'github-copilot' | 'google-gemini-cli' | 'google-antigravity'
+    oauthProviderType: text('oauth_provider_type'), // 'anthropic' | 'openai-codex' | 'github-copilot' | 'google-gemini-cli' | 'google-antigravity' | 'xai'
     oauthCredentialId: integer('oauth_credential_id').references(() => oauthCredentials.id, {
       onDelete: 'set null',
     }),

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -207,6 +207,7 @@ const OAuthProviderSchema = z.enum([
   'github-copilot',
   'google-gemini-cli',
   'google-antigravity',
+  'xai',
 ]);
 
 const NagaQuotaCheckerOptionsSchema = z.object({

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -49,6 +49,7 @@ import { SelectorFactory } from './services/selectors/factory';
 import { QuotaScheduler } from './services/quota/quota-scheduler';
 import { ResponsesStorageService } from './services/responses-storage';
 import { OAuthAuthManager } from './services/oauth-auth-manager';
+import { registerXaiOAuthProvider } from './services/oauth/xai-oauth-provider';
 import { requestLogger } from './middleware/log';
 import { registerManagementRoutes } from './routes/management';
 import { registerInferenceRoutes } from './routes/inference';
@@ -170,6 +171,9 @@ try {
 
   // One-time migration: rewrite legacy model_type 'chat'/'responses' → 'text'.
   await configService.migrateModelTypes();
+
+  // Register custom OAuth providers (not built into pi-ai) before auth init.
+  registerXaiOAuthProvider();
 
   // Eagerly initialize OAuth auth manager so auth.json schema migration
   // runs during startup (instead of waiting for first OAuth request).

--- a/packages/backend/src/services/dispatcher.ts
+++ b/packages/backend/src/services/dispatcher.ts
@@ -29,6 +29,7 @@ import { EmbeddingsTransformerFactory } from './embeddings-transformer-factory';
 import { resolveAdapters } from './adapter-resolver';
 import type { ResolvedAdapter } from '../types/provider-adapter';
 import { getBuiltinModels } from '@earendil-works/pi-ai/providers/all';
+import { getXaiOAuthExtraModelIds } from './oauth/xai-oauth-provider';
 import { buildGenerationOptions, resolvePiAiModel } from './pi-ai/registry';
 import type { GenerationIntent } from './pi-ai/generation';
 import { normalizeVerbosity } from './pi-ai/generation';
@@ -2859,17 +2860,17 @@ export class Dispatcher {
   }
 
   private assertOAuthModelSupported(oauthProvider: string, modelId: string) {
-    const supportedModels = getBuiltinModels(oauthProvider as any);
-    if (!supportedModels || supportedModels.length === 0) {
+    const supportedModels = getBuiltinModels(oauthProvider as any) ?? [];
+    // SuperGrok OAuth extras (e.g. grok-4.5) are not in pi-ai's generated catalog yet.
+    const extraIds = oauthProvider === 'xai' ? getXaiOAuthExtraModelIds() : [];
+    const knownIds = new Set([...supportedModels.map((model) => model.id), ...extraIds]);
+
+    if (knownIds.size === 0) {
       throw new Error(`OAuth provider '${oauthProvider}' has no known models.`);
     }
 
-    const isSupported = supportedModels.some((model) => model.id === modelId);
-    if (!isSupported) {
-      const modelList = supportedModels
-        .map((model) => model.id)
-        .sort()
-        .join(', ');
+    if (!knownIds.has(modelId)) {
+      const modelList = Array.from(knownIds).sort().join(', ');
       throw new Error(
         `OAuth model '${modelId}' is not supported for provider '${oauthProvider}'. ` +
           `Supported models: ${modelList}`

--- a/packages/backend/src/services/oauth/__tests__/xai-oauth-provider.test.ts
+++ b/packages/backend/src/services/oauth/__tests__/xai-oauth-provider.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  applyXaiOAuthModelTransport,
+  assertXaiOAuthEndpoint,
+  credentialsFromTokenPayload,
+  ensureXaiProviderSupportsResponses,
+  expiresAtFromAccessToken,
+  getXaiOAuthExtraModel,
+  getXaiOAuthExtraModelIds,
+  loginXaiOAuth,
+  refreshXaiOAuthToken,
+  registerXaiOAuthProvider,
+  XAI_INFERENCE_BASE_URL,
+  XAI_OAUTH_EXTRA_MODELS,
+  XAI_OAUTH_MODEL_API,
+  xaiOAuthProvider,
+} from '../xai-oauth-provider';
+import { getOAuthProvider } from '@earendil-works/pi-ai/oauth';
+import { piAiModels } from '../../pi-ai/registry';
+
+function jwtWithExp(expSeconds: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString('base64url');
+  return `${header}.${payload}.sig`;
+}
+
+describe('xai oauth provider helpers', () => {
+  test('assertXaiOAuthEndpoint accepts auth.x.ai HTTPS URLs', () => {
+    expect(assertXaiOAuthEndpoint('https://auth.x.ai/oauth/token', 'token_endpoint')).toBe(
+      'https://auth.x.ai/oauth/token'
+    );
+  });
+
+  test('assertXaiOAuthEndpoint rejects non-x.ai hosts', () => {
+    expect(() => assertXaiOAuthEndpoint('https://evil.example/token', 'token_endpoint')).toThrow(
+      /not an x\.ai domain/
+    );
+  });
+
+  test('assertXaiOAuthEndpoint rejects non-HTTPS', () => {
+    expect(() => assertXaiOAuthEndpoint('http://auth.x.ai/token', 'token_endpoint')).toThrow(
+      /must use HTTPS/
+    );
+  });
+
+  test('expiresAtFromAccessToken reads JWT exp', () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const expires = expiresAtFromAccessToken(jwtWithExp(exp));
+    expect(expires).toBe(exp * 1000);
+  });
+
+  test('credentialsFromTokenPayload requires refresh_token', () => {
+    expect(() => credentialsFromTokenPayload({ access_token: 'access-only' })).toThrow(
+      /missing refresh_token/
+    );
+  });
+
+  test('credentialsFromTokenPayload reuses previous refresh on rotate-only access', () => {
+    const exp = Math.floor(Date.now() / 1000) + 120;
+    const creds = credentialsFromTokenPayload(
+      { access_token: jwtWithExp(exp), expires_in: 120 },
+      'prev-refresh'
+    );
+    expect(creds.access).toContain('.');
+    expect(creds.refresh).toBe('prev-refresh');
+    expect(creds.expires).toBe(exp * 1000);
+  });
+});
+
+describe('xai oauth login/refresh', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test('loginXaiOAuth completes device-code flow', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    let tokenPolls = 0;
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('openid-configuration')) {
+        return new Response(
+          JSON.stringify({
+            authorization_endpoint: 'https://auth.x.ai/oauth/authorize',
+            token_endpoint: 'https://auth.x.ai/oauth/token',
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.includes('/oauth2/device/code')) {
+        return new Response(
+          JSON.stringify({
+            device_code: 'dev-code',
+            user_code: 'ABCD-1234',
+            verification_uri: 'https://auth.x.ai/device',
+            verification_uri_complete: 'https://auth.x.ai/device?user_code=ABCD-1234',
+            expires_in: 600,
+            interval: 1,
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.includes('/oauth/token') && init?.method === 'POST') {
+        tokenPolls += 1;
+        if (tokenPolls < 2) {
+          return new Response(JSON.stringify({ error: 'authorization_pending' }), {
+            status: 400,
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            access_token: jwtWithExp(exp),
+            refresh_token: 'refresh-1',
+            expires_in: 3600,
+            token_type: 'Bearer',
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response('unexpected', { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const onDeviceCode = vi.fn();
+    const onProgress = vi.fn();
+
+    const loginPromise = loginXaiOAuth({ onDeviceCode, onProgress });
+    const creds = await loginPromise;
+
+    expect(onDeviceCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userCode: 'ABCD-1234',
+        verificationUri: 'https://auth.x.ai/device?user_code=ABCD-1234',
+      })
+    );
+    expect(creds.refresh).toBe('refresh-1');
+    expect(creds.access).toBe(jwtWithExp(exp));
+    expect(creds.expires).toBe(exp * 1000);
+  });
+
+  test('refreshXaiOAuthToken exchanges refresh_token', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 7200;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('openid-configuration')) {
+        return new Response(
+          JSON.stringify({
+            authorization_endpoint: 'https://auth.x.ai/oauth/authorize',
+            token_endpoint: 'https://auth.x.ai/oauth/token',
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.includes('/oauth/token')) {
+        return new Response(
+          JSON.stringify({
+            access_token: jwtWithExp(exp),
+            refresh_token: 'refresh-2',
+            expires_in: 7200,
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response('unexpected', { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const creds = await refreshXaiOAuthToken('refresh-1');
+    expect(creds.refresh).toBe('refresh-2');
+    expect(creds.access).toBe(jwtWithExp(exp));
+  });
+});
+
+describe('xai oauth extra models', () => {
+  test('includes SuperGrok-only catalog entries', () => {
+    const ids = getXaiOAuthExtraModelIds();
+    expect(ids).toEqual(
+      expect.arrayContaining(['grok-4.5', 'grok-composer-2.5-fast', 'grok-4.20-multi-agent-0309'])
+    );
+
+    const flagship = getXaiOAuthExtraModel('grok-4.5');
+    expect(flagship?.contextWindow).toBe(500_000);
+    expect(flagship?.reasoning).toBe(true);
+
+    const composer = getXaiOAuthExtraModel('grok-composer-2.5-fast');
+    expect(composer?.name).toContain('Composer');
+    expect(composer?.contextWindow).toBe(200_000);
+    expect(composer?.reasoning).toBe(false);
+
+    const multiAgent = getXaiOAuthExtraModel('grok-4.20-multi-agent-0309');
+    expect(multiAgent?.contextWindow).toBe(2_000_000);
+    expect(multiAgent?.reasoning).toBe(true);
+
+    expect(XAI_OAUTH_EXTRA_MODELS.every((m) => m.provider === 'xai')).toBe(true);
+  });
+});
+
+describe('xai oauth responses transport', () => {
+  test('applyXaiOAuthModelTransport rewrites api to openai-responses', () => {
+    const base = {
+      id: 'grok-4.3',
+      name: 'Grok 4.3',
+      api: 'openai-completions' as const,
+      provider: 'xai' as const,
+      baseUrl: XAI_INFERENCE_BASE_URL,
+      reasoning: true,
+      input: ['text'] as ('text' | 'image')[],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 8192,
+    };
+    const rewritten = applyXaiOAuthModelTransport(base as any);
+    expect(rewritten.api).toBe(XAI_OAUTH_MODEL_API);
+    expect(rewritten.baseUrl).toBe(XAI_INFERENCE_BASE_URL);
+    expect(rewritten.id).toBe('grok-4.3');
+  });
+
+  test('applyXaiOAuthModelTransport leaves non-xai models unchanged', () => {
+    const base = {
+      id: 'gpt-4o',
+      name: 'GPT-4o',
+      api: 'openai-responses' as const,
+      provider: 'openai' as const,
+      baseUrl: 'https://api.openai.com/v1',
+      reasoning: false,
+      input: ['text'] as ('text' | 'image')[],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 8192,
+    };
+    expect(applyXaiOAuthModelTransport(base as any)).toBe(base);
+  });
+});
+
+describe('xai oauth registration', () => {
+  test('registerXaiOAuthProvider exposes provider to pi-ai OAuth registry', () => {
+    registerXaiOAuthProvider();
+    const provider = getOAuthProvider('xai');
+    expect(provider?.id).toBe('xai');
+    expect(provider?.name).toContain('SuperGrok');
+    expect(xaiOAuthProvider.getApiKey({ access: 'tok', refresh: 'r', expires: 1 })).toBe('tok');
+    // Under the global pi-ai vitest mock there is no real xAI provider to rebind.
+    // Production uses the real builtinModels() registry (see ensureXaiProviderSupportsResponses).
+    expect(typeof ensureXaiProviderSupportsResponses).toBe('function');
+    expect(piAiModels.getProvider?.('xai')).toBeUndefined();
+  });
+});

--- a/packages/backend/src/services/oauth/xai-oauth-provider.ts
+++ b/packages/backend/src/services/oauth/xai-oauth-provider.ts
@@ -320,8 +320,11 @@ export const xaiOAuthProvider: OAuthProviderInterface = {
  * the OAuth path rewrites to openai-responses via applyXaiOAuthModelTransport.
  *
  * Metadata sources:
- * - Grok 4.5: xAI docs ($2/$6 per 1M, 500K ctx, reasoning low|medium|high)
+ * - Grok 4.5: xAI docs ($2/$6 per 1M, 500K ctx, reasoning low|medium|high default high;
+ *   Responses + Chat Completions; recommend prompt_cache_key / x-grok-conv-id)
  * - Composer / multi-agent: Hermes + pi-xai-oauth curated SuperGrok lists
+ *
+ * OAuth inference always rewrites api → openai-responses (Responses API).
  */
 export const XAI_OAUTH_EXTRA_MODELS: PiAiModel<'openai-completions'>[] = [
   {
@@ -335,6 +338,7 @@ export const XAI_OAUTH_EXTRA_MODELS: PiAiModel<'openai-completions'>[] = [
       supportsDeveloperRole: false,
       supportsReasoningEffort: true,
     },
+    // Default reasoning is high per xAI docs when effort is requested.
     reasoning: true,
     input: ['text', 'image'],
     cost: {

--- a/packages/backend/src/services/oauth/xai-oauth-provider.ts
+++ b/packages/backend/src/services/oauth/xai-oauth-provider.ts
@@ -1,0 +1,497 @@
+/**
+ * xAI SuperGrok / X Premium+ OAuth (device-code flow).
+ *
+ * Ported from NousResearch/hermes-agent (hermes_cli/auth.py) constants and
+ * device-code exchange. Registered into pi-ai via registerOAuthProvider so
+ * Plexus can reuse OAuthAuthManager + Admin UI login sessions.
+ *
+ * SuperGrok OAuth inference uses the xAI Responses API (`openai-responses`
+ * at https://api.x.ai/v1), matching Hermes' codex_responses transport. The
+ * built-in pi-ai xAI provider only ships completions, so we re-register it
+ * with both API implementations and rewrite model.api on the OAuth path.
+ */
+import { createProvider, type Model as PiAiModel } from '@earendil-works/pi-ai';
+import { openAICompletionsApi } from '@earendil-works/pi-ai/api/openai-completions.lazy';
+import { openAIResponsesApi } from '@earendil-works/pi-ai/api/openai-responses.lazy';
+import {
+  pollOAuthDeviceCodeFlow,
+  registerOAuthProvider,
+  type OAuthCredentials,
+  type OAuthLoginCallbacks,
+  type OAuthProviderInterface,
+} from '@earendil-works/pi-ai/oauth';
+import { piAiModels } from '../pi-ai/registry';
+import { logger } from '../../utils/logger';
+
+const XAI_OAUTH_ISSUER = 'https://auth.x.ai';
+const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+const XAI_OAUTH_CLIENT_ID = 'b1a00492-073a-47ea-816f-4c329264a828';
+const XAI_OAUTH_SCOPE = 'openid profile email offline_access grok-cli:access api:access';
+const XAI_OAUTH_DEVICE_CODE_URL = `${XAI_OAUTH_ISSUER}/oauth2/device/code`;
+/** Public xAI OpenAI-compatible base (Responses + Completions). */
+export const XAI_INFERENCE_BASE_URL = 'https://api.x.ai/v1';
+/** Wire protocol used for SuperGrok / X Premium+ OAuth inference. */
+export const XAI_OAUTH_MODEL_API = 'openai-responses' as const;
+const DEFAULT_ACCESS_TTL_MS = 6 * 60 * 60 * 1000;
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : undefined;
+}
+
+function requireString(record: JsonRecord, key: string): string {
+  const value = record[key];
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`xAI OAuth response missing string field '${key}'`);
+  }
+  return value.trim();
+}
+
+/** Only allow auth endpoints under auth.x.ai / *.x.ai over HTTPS. */
+export function assertXaiOAuthEndpoint(url: string, field: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`xAI OAuth ${field} is not a valid URL`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`xAI OAuth ${field} must use HTTPS`);
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (host !== 'auth.x.ai' && host !== 'x.ai' && !host.endsWith('.x.ai')) {
+    throw new Error(`xAI OAuth ${field} host is not an x.ai domain: ${host}`);
+  }
+  return parsed.href;
+}
+
+export function expiresAtFromAccessToken(accessToken: string, expiresInSeconds?: number): number {
+  const parts = accessToken.split('.');
+  if (parts.length >= 2 && parts[1]) {
+    try {
+      const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+      const json = Buffer.from(padded, 'base64').toString('utf8');
+      const payload = JSON.parse(json) as { exp?: number };
+      if (typeof payload.exp === 'number' && Number.isFinite(payload.exp)) {
+        return payload.exp * 1000;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  if (typeof expiresInSeconds === 'number' && expiresInSeconds > 0) {
+    return Date.now() + expiresInSeconds * 1000;
+  }
+  return Date.now() + DEFAULT_ACCESS_TTL_MS;
+}
+
+export function credentialsFromTokenPayload(
+  payload: JsonRecord,
+  previousRefresh?: string
+): OAuthCredentials {
+  const access = requireString(payload, 'access_token');
+  const refreshRaw = payload.refresh_token;
+  const refresh =
+    typeof refreshRaw === 'string' && refreshRaw.trim()
+      ? refreshRaw.trim()
+      : (previousRefresh?.trim() ?? '');
+  if (!refresh) {
+    throw new Error('xAI OAuth response missing refresh_token');
+  }
+  const expiresIn =
+    typeof payload.expires_in === 'number' && Number.isFinite(payload.expires_in)
+      ? payload.expires_in
+      : undefined;
+  return {
+    access,
+    refresh,
+    expires: expiresAtFromAccessToken(access, expiresIn),
+  };
+}
+
+async function fetchJson(url: string, init: RequestInit, errorPrefix: string): Promise<JsonRecord> {
+  const response = await fetch(url, init);
+  const text = await response.text().catch(() => '');
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { raw: text };
+  }
+  if (!response.ok) {
+    const detail = text.trim() ? ` ${text.trim().slice(0, 400)}` : '';
+    throw new Error(`${errorPrefix} (HTTP ${response.status}).${detail}`);
+  }
+  const record = asRecord(body);
+  if (!record) {
+    throw new Error(`${errorPrefix}: expected JSON object`);
+  }
+  return record;
+}
+
+async function discoverTokenEndpoint(signal?: AbortSignal): Promise<string> {
+  const payload = await fetchJson(
+    XAI_OAUTH_DISCOVERY_URL,
+    { method: 'GET', headers: { Accept: 'application/json' }, signal },
+    'xAI OIDC discovery failed'
+  );
+  return assertXaiOAuthEndpoint(requireString(payload, 'token_endpoint'), 'token_endpoint');
+}
+
+type DeviceCodeStart = {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  intervalSeconds: number;
+  expiresInSeconds: number;
+};
+
+async function requestDeviceCode(signal?: AbortSignal): Promise<DeviceCodeStart> {
+  const payload = await fetchJson(
+    XAI_OAUTH_DEVICE_CODE_URL,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        client_id: XAI_OAUTH_CLIENT_ID,
+        scope: XAI_OAUTH_SCOPE,
+      }),
+      signal,
+    },
+    'xAI device-code request failed'
+  );
+
+  const verificationUri = assertXaiOAuthEndpoint(
+    String(payload.verification_uri_complete || payload.verification_uri || ''),
+    'verification_uri'
+  );
+  const interval =
+    typeof payload.interval === 'number' && payload.interval > 0 ? payload.interval : 5;
+  const expiresIn =
+    typeof payload.expires_in === 'number' && payload.expires_in > 0 ? payload.expires_in : 900;
+
+  return {
+    deviceCode: requireString(payload, 'device_code'),
+    userCode: requireString(payload, 'user_code'),
+    verificationUri,
+    intervalSeconds: interval,
+    expiresInSeconds: expiresIn,
+  };
+}
+
+export async function loginXaiOAuth(
+  callbacks: Pick<OAuthLoginCallbacks, 'onDeviceCode' | 'onProgress' | 'signal'>
+): Promise<OAuthCredentials> {
+  const signal = callbacks.signal;
+  callbacks.onProgress?.('Discovering xAI OAuth endpoints…');
+  const tokenEndpoint = await discoverTokenEndpoint(signal);
+
+  callbacks.onProgress?.('Requesting device code…');
+  const device = await requestDeviceCode(signal);
+
+  callbacks.onDeviceCode({
+    userCode: device.userCode,
+    verificationUri: device.verificationUri,
+    intervalSeconds: device.intervalSeconds,
+    expiresInSeconds: device.expiresInSeconds,
+  });
+  callbacks.onProgress?.(
+    `Open ${device.verificationUri} and enter code ${device.userCode} if prompted`
+  );
+
+  const tokenPayload = await pollOAuthDeviceCodeFlow<JsonRecord>({
+    intervalSeconds: device.intervalSeconds,
+    expiresInSeconds: device.expiresInSeconds,
+    signal,
+    poll: async () => {
+      const response = await fetch(tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          client_id: XAI_OAUTH_CLIENT_ID,
+          device_code: device.deviceCode,
+        }),
+        signal,
+      });
+
+      if (response.ok) {
+        const payload = asRecord(await response.json());
+        if (!payload) {
+          return { status: 'failed', message: 'xAI token response was not JSON' };
+        }
+        return { status: 'complete', value: payload };
+      }
+
+      const rawText = await response.text().catch(() => '');
+      let errorCode = '';
+      let description = '';
+      try {
+        const errBody = asRecord(rawText ? JSON.parse(rawText) : {});
+        errorCode = String(errBody?.error || '');
+        description = String(errBody?.error_description || errBody?.error || '');
+      } catch {
+        description = rawText;
+      }
+
+      if (errorCode === 'authorization_pending') {
+        return { status: 'pending' };
+      }
+      if (errorCode === 'slow_down') {
+        return { status: 'slow_down' };
+      }
+      if (errorCode === 'expired_token' || errorCode === 'access_denied') {
+        return {
+          status: 'failed',
+          message: description || `xAI device authorization failed: ${errorCode}`,
+        };
+      }
+      return {
+        status: 'failed',
+        message: `xAI device-code token polling failed (HTTP ${response.status})${
+          description ? `: ${description.slice(0, 300)}` : ''
+        }`,
+      };
+    },
+  });
+
+  callbacks.onProgress?.('xAI OAuth login complete');
+  return credentialsFromTokenPayload(tokenPayload);
+}
+
+export async function refreshXaiOAuthToken(
+  refreshToken: string,
+  signal?: AbortSignal
+): Promise<OAuthCredentials> {
+  if (!refreshToken.trim()) {
+    throw new Error('xAI OAuth is missing refresh_token. Re-authenticate.');
+  }
+  const tokenEndpoint = await discoverTokenEndpoint(signal);
+  const payload = await fetchJson(
+    tokenEndpoint,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: XAI_OAUTH_CLIENT_ID,
+        refresh_token: refreshToken,
+      }),
+      signal,
+    },
+    'xAI token refresh failed'
+  );
+  return credentialsFromTokenPayload(payload, refreshToken);
+}
+
+export const xaiOAuthProvider: OAuthProviderInterface = {
+  id: 'xai',
+  name: 'xAI Grok (SuperGrok / X Premium+)',
+  usesCallbackServer: false,
+
+  async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+    return loginXaiOAuth(callbacks);
+  },
+
+  async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+    return refreshXaiOAuthToken(credentials.refresh);
+  },
+
+  getApiKey(credentials: OAuthCredentials): string {
+    return credentials.access;
+  },
+};
+
+/**
+ * Models available via SuperGrok OAuth that are not yet in pi-ai's generated
+ * xAI catalog (pi-ai 0.80.x). Catalog entries still declare openai-completions;
+ * the OAuth path rewrites to openai-responses via applyXaiOAuthModelTransport.
+ *
+ * Metadata sources:
+ * - Grok 4.5: xAI docs ($2/$6 per 1M, 500K ctx, reasoning low|medium|high)
+ * - Composer / multi-agent: Hermes + pi-xai-oauth curated SuperGrok lists
+ */
+export const XAI_OAUTH_EXTRA_MODELS: PiAiModel<'openai-completions'>[] = [
+  {
+    id: 'grok-4.5',
+    name: 'Grok 4.5',
+    api: 'openai-completions',
+    provider: 'xai',
+    baseUrl: XAI_INFERENCE_BASE_URL,
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: true,
+    },
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: {
+      input: 2,
+      output: 6,
+      cacheRead: 0.5,
+      cacheWrite: 0,
+    },
+    contextWindow: 500_000,
+    maxTokens: 30_000,
+  },
+  {
+    // Cursor Composer 2.5 via SuperGrok / Grok Build OAuth surface.
+    id: 'grok-composer-2.5-fast',
+    name: 'Grok Composer 2.5 Fast',
+    api: 'openai-completions',
+    provider: 'xai',
+    baseUrl: XAI_INFERENCE_BASE_URL,
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    },
+    // No configurable reasoning_effort on this model (Hermes/pi-xai-oauth).
+    reasoning: false,
+    input: ['text', 'image'],
+    cost: {
+      input: 1,
+      output: 2,
+      cacheRead: 0.2,
+      cacheWrite: 0,
+    },
+    contextWindow: 200_000,
+    maxTokens: 30_000,
+  },
+  {
+    id: 'grok-4.20-multi-agent-0309',
+    name: 'Grok 4.20 Multi-Agent',
+    api: 'openai-completions',
+    provider: 'xai',
+    baseUrl: XAI_INFERENCE_BASE_URL,
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: true,
+    },
+    reasoning: true,
+    input: ['text', 'image'],
+    cost: {
+      input: 1.25,
+      output: 2.5,
+      cacheRead: 0.2,
+      cacheWrite: 0,
+    },
+    contextWindow: 2_000_000,
+    maxTokens: 30_000,
+  },
+];
+
+/** Extra model ids not present in getBuiltinModels('xai'). */
+export function getXaiOAuthExtraModelIds(): string[] {
+  return XAI_OAUTH_EXTRA_MODELS.map((m) => m.id);
+}
+
+/** Resolve an OAuth-only extra model definition (e.g. grok-4.5). */
+export function getXaiOAuthExtraModel(modelId: string): PiAiModel<any> | undefined {
+  return XAI_OAUTH_EXTRA_MODELS.find((m) => m.id === modelId);
+}
+
+/**
+ * SuperGrok OAuth must hit xAI's Responses API. Built-in catalog models still
+ * declare openai-completions; rewrite on the OAuth request path only.
+ */
+export function applyXaiOAuthModelTransport<T extends PiAiModel<any>>(model: T): T {
+  if (model.provider !== 'xai') return model;
+  return {
+    ...model,
+    api: XAI_OAUTH_MODEL_API,
+    baseUrl: model.baseUrl?.trim() || XAI_INFERENCE_BASE_URL,
+  };
+}
+
+function mergeXaiCatalogModels(builtin: readonly PiAiModel<any>[]): PiAiModel<any>[] {
+  const merged = [...builtin];
+  const ids = new Set(merged.map((m) => m.id));
+  for (const extra of XAI_OAUTH_EXTRA_MODELS) {
+    if (!ids.has(extra.id)) {
+      merged.push(extra);
+      ids.add(extra.id);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Built-in xAI provider only implements openai-completions. Re-register with
+ * both completions (API-key / catalog default) and responses (OAuth path),
+ * and inject SuperGrok-only models missing from the pi-ai catalog.
+ *
+ * Returns false when the runtime registry is a test stub / missing xAI (so
+ * unit tests under the global pi-ai mock still exercise OAuth login helpers).
+ */
+export function ensureXaiProviderSupportsResponses(): boolean {
+  const models = piAiModels as {
+    getProvider?: (id: string) =>
+      | {
+          id: string;
+          name: string;
+          baseUrl?: string;
+          headers?: Record<string, string>;
+          auth: unknown;
+          getModels?: () => readonly PiAiModel<any>[];
+        }
+      | undefined;
+    setProvider?: (provider: unknown) => void;
+  };
+
+  if (typeof models.getProvider !== 'function' || typeof models.setProvider !== 'function') {
+    logger.debug('xAI OAuth: piAiModels registry is not mutable; skipping Responses rebind');
+    return false;
+  }
+
+  const existing = models.getProvider('xai');
+  if (!existing || typeof existing.getModels !== 'function') {
+    logger.debug('xAI OAuth: built-in xAI provider missing; skipping Responses rebind');
+    return false;
+  }
+
+  // createProvider is not present on the global vitest pi-ai mock.
+  if (typeof createProvider !== 'function') {
+    logger.debug('xAI OAuth: createProvider unavailable; skipping Responses rebind');
+    return false;
+  }
+
+  models.setProvider(
+    createProvider({
+      id: existing.id,
+      name: existing.name,
+      baseUrl: existing.baseUrl ?? XAI_INFERENCE_BASE_URL,
+      headers: existing.headers,
+      auth: existing.auth as any,
+      models: mergeXaiCatalogModels(existing.getModels()),
+      api: {
+        'openai-completions': openAICompletionsApi(),
+        'openai-responses': openAIResponsesApi(),
+      },
+    })
+  );
+  return true;
+}
+
+let registered = false;
+
+/** Idempotent: OAuth login provider + dual-API xAI inference registration. */
+export function registerXaiOAuthProvider(): void {
+  if (registered) return;
+  registerOAuthProvider(xaiOAuthProvider);
+  ensureXaiProviderSupportsResponses();
+  registered = true;
+}

--- a/packages/backend/src/services/provider-model-discovery.ts
+++ b/packages/backend/src/services/provider-model-discovery.ts
@@ -1,6 +1,7 @@
 import { getBuiltinModels } from '@earendil-works/pi-ai/providers/all';
 import { getProviderTypes, type ProviderConfig } from '../config';
 import { logger } from '../utils/logger';
+import { XAI_OAUTH_EXTRA_MODELS } from './oauth/xai-oauth-provider';
 
 export interface DiscoveredModel {
   id: string;
@@ -119,7 +120,11 @@ export async function fetchModelsFromUrl(
 }
 
 export function getOAuthProviderModels(providerId: string): DiscoveredModel[] {
-  return getBuiltinModels(providerId as any).map((model) => ({
+  const builtin = getBuiltinModels(providerId as any) ?? [];
+  // SuperGrok OAuth: merge models not yet in pi-ai's generated xAI catalog.
+  const models = providerId === 'xai' ? mergeModelsById(builtin, XAI_OAUTH_EXTRA_MODELS) : builtin;
+
+  return models.map((model) => ({
     id: model.id,
     name: model.name,
     context_length: model.contextWindow,
@@ -130,6 +135,21 @@ export function getOAuthProviderModels(providerId: string): DiscoveredModel[] {
         }
       : undefined,
   }));
+}
+
+function mergeModelsById<T extends { id: string }>(
+  builtin: readonly T[],
+  extras: readonly T[]
+): T[] {
+  const merged = [...builtin];
+  const ids = new Set(merged.map((m) => m.id));
+  for (const extra of extras) {
+    if (!ids.has(extra.id)) {
+      merged.push(extra);
+      ids.add(extra.id);
+    }
+  }
+  return merged;
 }
 
 export function deriveModelsUrl(provider: ProviderConfig): string | null {

--- a/packages/backend/src/transformers/oauth/oauth-transformer.ts
+++ b/packages/backend/src/transformers/oauth/oauth-transformer.ts
@@ -252,8 +252,19 @@ export class OAuthTransformer implements Transformer {
         )
       );
     }
-    if (request.prompt_cache_key) {
-      options.sessionId = request.prompt_cache_key;
+    // xAI (and OpenAI-compatible Responses) sticky routing for prompt cache hits:
+    // - Responses body: prompt_cache_key (mapped to pi-ai sessionId)
+    // - Chat Completions header: x-grok-conv-id (see xAI prompt-caching docs)
+    const clientGrokConvId =
+      clientHeaders && typeof clientHeaders['x-grok-conv-id'] === 'string'
+        ? clientHeaders['x-grok-conv-id'].trim()
+        : '';
+    const promptCacheKey =
+      (typeof request.prompt_cache_key === 'string' && request.prompt_cache_key.trim()) ||
+      clientGrokConvId ||
+      '';
+    if (promptCacheKey) {
+      options.sessionId = promptCacheKey;
     }
     if (Array.isArray(request.include) && request.include.length > 0) {
       options.include = request.include;
@@ -417,12 +428,26 @@ export class OAuthTransformer implements Transformer {
       userAgent = codexVersionService.getUserAgent();
     }
 
+    const sessionAffinityKey =
+      typeof (filteredOptions as any).sessionId === 'string'
+        ? String((filteredOptions as any).sessionId).trim()
+        : typeof clientHeaders?.['x-grok-conv-id'] === 'string'
+          ? String(clientHeaders['x-grok-conv-id']).trim()
+          : '';
+
     const baseHeaders: Record<string, string> = {
       ...((filteredOptions as any).headers as Record<string, string>),
       ...(codexVersion ? { Version: codexVersion } : {}),
       ...(provider === 'anthropic' && auth.authMode === 'apiKey' ? { 'x-api-key': rawApiKey } : {}),
       ...(userAgent ? { 'User-Agent': userAgent } : {}),
+      // xAI sticky routing for multi-turn cache hits (Chat Completions path + dual signal).
+      // Responses also gets prompt_cache_key via pi-ai from options.sessionId.
+      ...(provider === 'xai' && sessionAffinityKey ? { 'x-grok-conv-id': sessionAffinityKey } : {}),
     };
+
+    if (provider === 'xai' && sessionAffinityKey && !requestOptions.sessionId) {
+      requestOptions.sessionId = sessionAffinityKey;
+    }
 
     requestOptions.headers = baseHeaders;
     const isClaudeCodeAgent =

--- a/packages/backend/src/transformers/oauth/oauth-transformer.ts
+++ b/packages/backend/src/transformers/oauth/oauth-transformer.ts
@@ -6,6 +6,10 @@ import type {
 } from '../../types/unified';
 import type { Model as PiAiModel } from '@earendil-works/pi-ai';
 import { piAiModels } from '../../services/pi-ai/registry';
+import {
+  applyXaiOAuthModelTransport,
+  getXaiOAuthExtraModel,
+} from '../../services/oauth/xai-oauth-provider';
 import type { OAuthProvider } from '@earendil-works/pi-ai/oauth';
 import {
   applyClaudeCodeToolProxy,
@@ -165,11 +169,16 @@ export class OAuthTransformer implements Transformer {
   readonly defaultModel = 'gpt-5-mini';
 
   protected getPiAiModel(provider: OAuthProvider, modelId: string): PiAiModel<any> {
-    const model = piAiModels.getModel(provider as any, modelId);
+    let model = piAiModels.getModel(provider as any, modelId);
+    // SuperGrok-only models (e.g. grok-4.5) may not be in pi-ai's generated catalog.
+    if (!model && provider === 'xai') {
+      model = getXaiOAuthExtraModel(modelId);
+    }
     if (!model) {
       throw new Error(`Model '${modelId}' not found for provider '${provider}'`);
     }
-    return model;
+    // SuperGrok / X Premium+ OAuth uses xAI Responses API (not chat completions).
+    return applyXaiOAuthModelTransport(model);
   }
 
   private async resolveApiKey(

--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -24,6 +24,7 @@ export const OAUTH_PROVIDERS = [
   { value: 'google-gemini-cli', label: 'Google Cloud Code Assist (Gemini CLI)' },
   { value: 'google-antigravity', label: 'Antigravity (Gemini 3, Claude, GPT-OSS)' },
   { value: 'openai-codex', label: 'ChatGPT Plus/Pro (Codex Subscription)' },
+  { value: 'xai', label: 'xAI Grok (SuperGrok / X Premium+)' },
 ];
 
 const getOAuthCheckerType = (oauthProvider?: string): string | null => {


### PR DESCRIPTION
## Summary

Adds SuperGrok / X Premium+ OAuth support so Plexus can use subscription-backed Grok models without an `XAI_API_KEY`.

- **Device-code OAuth** against `auth.x.ai` (same flow as Hermes Agent), registered into pi-ai via `registerOAuthProvider`
- **Inference** via xAI **Responses API** (`openai-responses` at `https://api.x.ai/v1`)
- **Admin UI**: OAuth provider entry for xAI
- **Schema**: `xai` added to `oauth_provider_type` enum (Postgres) — migration SQL intentionally **not** included; CI generates it after merge to `main`
- **Extra SuperGrok models** missing from pi-ai 0.80.x catalog:
  - `grok-4.5`
  - `grok-composer-2.5-fast`
  - `grok-4.20-multi-agent-0309`

## Configuration

```json
{
  "api_base_url": "oauth://",
  "api_key": "oauth",
  "oauth_provider": "xai",
  "oauth_account": "personal",
  "models": {
    "grok-4.5": { "type": "text" },
    "grok-composer-2.5-fast": { "type": "text" },
    "grok-build-0.1": { "type": "text" }
  }
}
```

Log in from the Admin UI (device code: URL + user code). Tokens are stored in `oauth_credentials` and auto-refreshed.

## Notes / risks

- Uses the shared public Grok CLI OAuth client id (same approach as Hermes / OpenClaw).
- Some SuperGrok tiers may still get HTTP 403 from xAI’s OAuth API allowlist; API-key path remains available.
- No SuperGrok quota checker yet (no stable public usage endpoint).

## Test plan

- [x] Unit tests for device-code login/refresh helpers and extra models (`xai-oauth-provider.test.ts`)
- [x] Local Admin UI login with SuperGrok subscription
- [x] Inference with `grok-4.5` / Responses path
- [ ] CI green
- [ ] Postgres enum migration generated by CI after merge