### PR TITLE
feat(oauth): support GPT-5.6 model variants

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
       "name": "plexus-backend",
       "version": "1.0.0",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.80.3",
+        "@earendil-works/pi-ai": "0.80.5",
         "@fastify/bearer-auth": "^10.1.2",
         "@fastify/cors": "^11.3.0",
         "@fastify/multipart": "^10.1.0",
@@ -178,7 +178,7 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.5", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-+7UODYKu4o/X8sxTHG8HEV3+O+dOYKg5MeO3MJIFQ+wu65pIWDhjZGc759uWsRr79AhV7MSJEe4GWnFn4l68gw=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.5.4", "", {}, "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "lint:migrations": "cd ../.. && bun run scripts/lint-migrations.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.80.3",
+    "@earendil-works/pi-ai": "0.80.5",
     "@fastify/bearer-auth": "^10.1.2",
     "@fastify/cors": "^11.3.0",
     "@fastify/multipart": "^10.1.0",

--- a/packages/backend/src/filters/__tests__/pi-ai-request-filters.test.ts
+++ b/packages/backend/src/filters/__tests__/pi-ai-request-filters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { filterPiAiRequestOptions } from '../pi-ai-request-filters';
+
+describe('filterPiAiRequestOptions', () => {
+  it.each([
+    ['github-copilot', 'gpt-5.6-luna'],
+    ['github-copilot', 'gpt-5.6-sol'],
+    ['github-copilot', 'gpt-5.6-terra'],
+    ['openai-codex', 'gpt-5.6-luna'],
+    ['openai-codex', 'gpt-5.6-sol'],
+    ['openai-codex', 'gpt-5.6-terra'],
+  ])('strips temperature for %s %s', (provider, id) => {
+    const result = filterPiAiRequestOptions({ temperature: 0.7, maxTokens: 256 }, {
+      id,
+      provider,
+    } as any);
+
+    expect(result).toEqual({
+      filteredOptions: { maxTokens: 256 },
+      strippedParameters: ['temperature'],
+    });
+  });
+
+  it('does not apply a GPT-5.6 rule to the invalid bare Copilot model name', () => {
+    const result = filterPiAiRequestOptions({ temperature: 0.7, maxTokens: 256 }, {
+      id: 'gpt-5.6',
+      provider: 'github-copilot',
+    } as any);
+
+    expect(result).toEqual({
+      filteredOptions: { temperature: 0.7, maxTokens: 256 },
+      strippedParameters: [],
+    });
+  });
+});

--- a/packages/backend/src/filters/pi-ai-request-filter-rules.ts
+++ b/packages/backend/src/filters/pi-ai-request-filter-rules.ts
@@ -21,6 +21,24 @@ export const PI_AI_REQUEST_FILTERS: PiAiRequestFilterRule[] = [
   },
   {
     provider: 'github-copilot',
+    model: 'gpt-5.6-luna',
+    strippedParameters: ['temperature'],
+    comment: 'GitHub Copilot rejects temperature for this model.',
+  },
+  {
+    provider: 'github-copilot',
+    model: 'gpt-5.6-sol',
+    strippedParameters: ['temperature'],
+    comment: 'GitHub Copilot rejects temperature for this model.',
+  },
+  {
+    provider: 'github-copilot',
+    model: 'gpt-5.6-terra',
+    strippedParameters: ['temperature'],
+    comment: 'GitHub Copilot rejects temperature for this model.',
+  },
+  {
+    provider: 'github-copilot',
     model: 'gpt-5.2-codex',
     strippedParameters: ['temperature'],
     comment: 'GitHub Copilot rejects temperature for this model.',
@@ -52,6 +70,24 @@ export const PI_AI_REQUEST_FILTERS: PiAiRequestFilterRule[] = [
   {
     provider: 'openai-codex',
     model: 'gpt-5.5',
+    strippedParameters: ['temperature'],
+    comment: 'Codex OAuth rejects temperature for this model.',
+  },
+  {
+    provider: 'openai-codex',
+    model: 'gpt-5.6-luna',
+    strippedParameters: ['temperature'],
+    comment: 'Codex OAuth rejects temperature for this model.',
+  },
+  {
+    provider: 'openai-codex',
+    model: 'gpt-5.6-sol',
+    strippedParameters: ['temperature'],
+    comment: 'Codex OAuth rejects temperature for this model.',
+  },
+  {
+    provider: 'openai-codex',
+    model: 'gpt-5.6-terra',
     strippedParameters: ['temperature'],
     comment: 'Codex OAuth rejects temperature for this model.',
   },

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -15,7 +15,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
### **User description**
## Summary
- update pi-ai to 0.80.5 for GPT-5.6 model metadata
- strip unsupported temperature for GPT-5.6 Luna, Sol, and Terra on GitHub Copilot and OpenAI Codex
- remove the obsolete frontend TypeScript baseUrl option for TypeScript 7 compatibility

## Validation
- bun run test
- bun run typecheck
- bun run format:check


___

### **Description**
- Add temperature filter rules for GPT-5.6 Luna, Sol, Terra on Copilot and Codex

- Add unit tests for GPT-5.6 request filter rules and edge cases

- Bump `@earendil-works/pi-ai` from 0.80.3 to 0.80.5

- Remove obsolete `baseUrl` from frontend tsconfig for TypeScript 7


___

