### PR TITLE
feat: upgrade pi-ai(0.80.5) and add gpt-5.6 filters

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "lint:migrations": "cd ../.. && bun run scripts/lint-migrations.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.80.3",
+    "@earendil-works/pi-ai": "0.80.5",
     "@fastify/bearer-auth": "^10.1.2",
     "@fastify/cors": "^11.3.0",
     "@fastify/multipart": "^10.1.0",

--- a/packages/backend/src/filters/pi-ai-request-filter-rules.ts
+++ b/packages/backend/src/filters/pi-ai-request-filter-rules.ts
@@ -79,4 +79,22 @@ export const PI_AI_REQUEST_FILTERS: PiAiRequestFilterRule[] = [
     strippedParameters: ['temperature'],
     comment: 'Codex OAuth rejects temperature for this model.',
   },
+  {
+    provider: 'openai-codex',
+    model: 'gpt-5.6-sol',
+    strippedParameters: ['temperature'],
+    comment: 'Codex OAuth rejects temperature for this model.',
+  },
+  {
+    provider: 'openai-codex',
+    model: 'gpt-5.6-tera',
+    strippedParameters: ['temperature'],
+    comment: 'Codex OAuth rejects temperature for this model.',
+  },
+  {
+    provider: 'openai-codex',
+    model: 'gpt-5.6-luna',
+    strippedParameters: ['temperature'],
+    comment: 'Codex OAuth rejects temperature for this model.',
+  },
 ];


### PR DESCRIPTION
### **Description**
- Upgrade `@earendil-works/pi-ai` from `0.80.3` to `0.80.5`

- Add temperature-stripping filter rules for new Codex models
  - `gpt-5.6-sol`, `gpt-5.6-tera`, `gpt-5.6-luna`


___

