### PR TITLE
feat(models): expose catalog pricing tiers

### DIFF
--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -764,12 +764,21 @@ const ModelBehaviorSchema = z.discriminatedUnion('type', [StripAdaptiveThinkingB
 // `overrides` lets users override individual fields per alias. Overridden
 // fields win over catalog values; untouched fields still track the catalog.
 // When `source === 'custom'`, all data comes from overrides (no catalog lookup).
+const MetadataPricingTierSchema = z.object({
+  input_tokens_above: z.number().int().nonnegative(),
+  prompt: z.string().optional(),
+  completion: z.string().optional(),
+  input_cache_read: z.string().optional(),
+  input_cache_write: z.string().optional(),
+});
+
 const MetadataPricingOverridesSchema = z
   .object({
     prompt: z.string().optional(),
     completion: z.string().optional(),
     input_cache_read: z.string().optional(),
     input_cache_write: z.string().optional(),
+    tiers: z.array(MetadataPricingTierSchema).optional(),
   })
   .partial();
 

--- a/packages/backend/src/routes/inference/__tests__/models.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/models.test.ts
@@ -266,6 +266,15 @@ describe('GET /v1/models – with metadata', () => {
     expect(model.context_length).toBe(200000);
     expect(model.pricing.prompt).toBe('0.000003');
     expect(model.pricing.completion).toBe('0.000015');
+    expect(model.pricing.tiers).toEqual([
+      {
+        input_tokens_above: 272000,
+        prompt: '0.000010',
+        completion: '0.000045',
+        input_cache_read: '0.000001',
+        input_cache_write: '0.0000125',
+      },
+    ]);
     expect(model.architecture.input_modalities).toContain('text');
     expect(model.supported_parameters).toContain('temperature');
     expect(model.top_provider.max_completion_tokens).toBe(8192);

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -62,6 +62,13 @@ export interface NormalizedModelMetadata {
     completion?: string;
     input_cache_read?: string;
     input_cache_write?: string;
+    tiers?: Array<{
+      input_tokens_above: number;
+      prompt?: string;
+      completion?: string;
+      input_cache_read?: string;
+      input_cache_write?: string;
+    }>;
   };
   supported_parameters?: string[];
   top_provider?: {
@@ -89,7 +96,23 @@ interface OpenRouterRawModel {
     completion?: string;
     input_cache_read?: string;
     input_cache_write?: string;
-    [key: string]: string | undefined;
+    tiers?: Array<{
+      input_tokens_above: number;
+      prompt?: string;
+      completion?: string;
+      input_cache_read?: string;
+      input_cache_write?: string;
+    }>;
+    [key: string]:
+      | string
+      | Array<{
+          input_tokens_above: number;
+          prompt?: string;
+          completion?: string;
+          input_cache_read?: string;
+          input_cache_write?: string;
+        }>
+      | undefined;
   };
   supported_parameters?: string[];
   top_provider?: {
@@ -193,6 +216,7 @@ function normalizeOpenRouterModel(
           completion: raw.pricing.completion,
           input_cache_read: raw.pricing.input_cache_read,
           input_cache_write: raw.pricing.input_cache_write,
+          tiers: raw.pricing.tiers,
         }
       : undefined,
     supported_parameters: raw.supported_parameters,

--- a/packages/backend/src/utils/__tests__/fixtures/openrouter-metadata-sample.json
+++ b/packages/backend/src/utils/__tests__/fixtures/openrouter-metadata-sample.json
@@ -16,7 +16,16 @@
         "prompt": "0.000003",
         "completion": "0.000015",
         "input_cache_read": "0.0000003",
-        "input_cache_write": "0.00000375"
+        "input_cache_write": "0.00000375",
+        "tiers": [
+          {
+            "input_tokens_above": 272000,
+            "prompt": "0.000010",
+            "completion": "0.000045",
+            "input_cache_read": "0.000001",
+            "input_cache_write": "0.0000125"
+          }
+        ]
       },
       "supported_parameters": ["temperature", "tools", "tool_choice", "max_tokens", "top_p"],
       "top_provider": {


### PR DESCRIPTION
### **User description**
## Summary
- preserve tiered pricing from OpenRouter catalog metadata
- expose tiers through `/v1/models` and support metadata overrides
- cover simple and tiered catalog pricing in the models route

## Validation
- `bun run test`
- `bun run typecheck`


___

### **Description**
- Add `MetadataPricingTierSchema` and `tiers` override support in config schema

- Preserve pricing tiers through `NormalizedModelMetadata` and OpenRouter normalization

- Expose tiers in `/v1/models` response with test coverage and fixture data


___

