### PR TITLE
feat(models): automate catalog metadata selection

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -501,6 +501,19 @@ The inline `performanceExplorationRate` / `latencyExplorationRate` / `e2ePerform
 - **`selector` (default)**: Selector picks a provider within each group first, then matches API format.
 - **`api_match`**: Filter targets to those whose provider supports the incoming API format first, then apply the group's selector. Best for tools requiring specific API features (e.g., Claude Code with Anthropic messages).
 
+### Preferred API
+
+For text aliases, when `preferred_api` is omitted, Plexus advertises a recommended API in
+`GET /v1/models` using the canonical target model:
+
+- Anthropic/Claude models: `messages`
+- GPT models: `responses`
+- Gemini models: `gemini`
+- Everything else: `chat_completions`
+
+An explicitly configured `preferred_api` always takes precedence.
+Non-text aliases do not receive an inferred preferred API.
+
 ### Targets
 
 Each target specifies:
@@ -510,7 +523,55 @@ Each target specifies:
 
 ### External Metadata
 
-Link an alias to an external model catalog to return enriched metadata in `GET /v1/models`:
+Model metadata is resolved automatically for every alias and returned by `GET /v1/models`.
+Plexus derives a canonical model identity from, in order:
+
+1. The alias `pi_model` hint.
+2. The target provider's `pi_ai_provider` and model's `pi_ai_model_id` hints.
+3. The enabled target's provider and model names.
+
+It then looks for an exact entry in the configured catalogs. If no exact entry exists,
+Plexus only infers a display name and input/output modalities from the model name. Context
+windows, pricing, and supported parameters are never guessed.
+
+For example, this alias needs no metadata configuration:
+
+```yaml
+models:
+  claude-sonnet:
+    target_groups:
+      - name: default
+        selector: random
+        targets:
+          - provider: anthropic
+            model: claude-sonnet-4-5
+```
+
+Automatic matching is the default. Use `source: auto` only when adding overrides:
+
+```yaml
+metadata:
+  source: auto
+  overrides:
+    context_length: 180000
+```
+
+To pin an alias to a specific catalog entry instead:
+
+```yaml
+metadata:
+  source: models.dev
+  source_path: anthropic.claude-sonnet-4-5
+```
+
+To suppress enriched metadata entirely:
+
+```yaml
+metadata:
+  source: disabled
+```
+
+Available external catalogs:
 
 | Source | URL | Format |
 |--------|-----|--------|
@@ -518,7 +579,8 @@ Link an alias to an external model catalog to return enriched metadata in `GET /
 | `models.dev` | models.dev | `providerid.modelid` |
 | `catwalk` | catwalk.charm.sh | `providerid.modelid` |
 
-Metadata loads at startup. Failures are non-fatal — Plexus operates without enriched data if a source is unavailable.
+Metadata loads at startup. Failures are non-fatal; automatic resolution falls back to the
+safe name-based defaults when no exact catalog entry is available.
 
 ### Direct Model Routing
 

--- a/docs/openapi/components/schemas/AliasConfig.yaml
+++ b/docs/openapi/components/schemas/AliasConfig.yaml
@@ -88,7 +88,10 @@ properties:
     type: array
     description: >
       Advertised in /v1/models to inform clients of the recommended API
-      surface for this alias.
+      surface for this alias. For text aliases, when omitted, Plexus infers
+      `messages` for Anthropic/Claude models, `responses` for GPT models,
+      `gemini` for Gemini models, and `chat_completions` for everything else.
+      Non-text aliases do not receive an inferred value.
     items:
       type: string
       enum:
@@ -131,11 +134,30 @@ properties:
       hit rates.
   metadata:
     description: >
-      Optional reference to an external model catalog entry. When configured,
-      Plexus fetches metadata at startup and includes enriched model
-      information in `GET /v1/models`. All sources support an `overrides`
-      object that wins over catalog values for the specified fields.
+      Model metadata strategy. When omitted or set to `auto`, Plexus derives a
+      canonical identity from the alias targets, looks for an exact catalog
+      entry, and falls back to conservative name and modality heuristics.
+      Catalog sources pin a specific entry, `custom` supplies all fields, and
+      `disabled` suppresses enrichment. Overrides win over resolved values.
     oneOf:
+      - type: object
+        required:
+          - source
+        properties:
+          source:
+            type: string
+            enum: [auto]
+          overrides:
+            $ref: ./MetadataOverrides.yaml
+        additionalProperties: false
+      - type: object
+        required:
+          - source
+        properties:
+          source:
+            type: string
+            enum: [disabled]
+        additionalProperties: false
       - type: object
         required:
           - source

--- a/docs/openapi/components/schemas/MetadataOverrides.yaml
+++ b/docs/openapi/components/schemas/MetadataOverrides.yaml
@@ -1,8 +1,8 @@
 type: object
 description: >
   Override fields for model metadata. Used within alias `metadata` to
-  override individual fields sourced from an external catalog, or to
-  provide all fields when `source` is `custom`.
+  override individual fields resolved automatically or sourced from an
+  external catalog, or to provide all fields when `source` is `custom`.
 properties:
   name:
     type: string

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -442,6 +442,8 @@ paths:
     $ref: paths/v0_management_models_huggingface_{modelId}.yaml
   /v0/management/models/metadata/refresh:
     $ref: paths/v0_management_models_metadata_refresh.yaml
+  /v0/management/models/metadata/resolve:
+    $ref: paths/v0_management_models_metadata_resolve.yaml
   /v0/management/keys:
     $ref: paths/v0_management_keys.yaml
   /v0/management/keys/{name}:

--- a/docs/openapi/paths/v0_management_models_metadata_resolve.yaml
+++ b/docs/openapi/paths/v0_management_models_metadata_resolve.yaml
@@ -1,0 +1,73 @@
+post:
+  operationId: postV0ManagementModelsMetadataResolve
+  tags:
+    - Management — Models
+  summary: Preview automatic model selections (admin only)
+  description: >
+    Resolves an unsaved alias configuration using the same canonical-model,
+    metadata catalog, Pi registry, and preferred API heuristics used by
+    `GET /v1/models`.
+  security:
+    - AdminKey: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: [alias_id, model]
+          properties:
+            alias_id:
+              type: string
+            model:
+              $ref: ../components/schemas/AliasConfig.yaml
+  responses:
+    '200':
+      description: Resolved automatic selections.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [canonical_model, pi_model, metadata, preferred_api]
+            properties:
+              canonical_model:
+                type: object
+                required: [model, basis]
+                properties:
+                  provider:
+                    type: string
+                  model:
+                    type: string
+                  basis:
+                    type: string
+                    enum: [pi_model, target, alias]
+              pi_model:
+                type: [object, 'null']
+                required: [provider, model_id, name]
+                properties:
+                  provider:
+                    type: string
+                  model_id:
+                    type: string
+                  name:
+                    type: string
+              metadata:
+                type: [object, 'null']
+                required: [source, name]
+                properties:
+                  source:
+                    type: string
+                    enum: [openrouter, models.dev, catwalk, heuristic]
+                  source_path:
+                    type: string
+                  name:
+                    type: string
+              preferred_api:
+                type: [array, 'null']
+                items:
+                  type: string
+                  enum: [chat_completions, messages, gemini, responses]
+    '400':
+      description: Invalid alias configuration.
+    '403':
+      description: Admin access required.

--- a/packages/backend/src/__tests__/config-model-metadata.test.ts
+++ b/packages/backend/src/__tests__/config-model-metadata.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { validateConfig } from '../config';
+
+function configWithMetadata(metadata: unknown): string {
+  return JSON.stringify({
+    providers: {
+      p1: {
+        api_base_url: 'https://p1.example.com/v1',
+        api_key: 'k',
+        models: { 'model-1': {} },
+      },
+    },
+    models: {
+      'test-alias': {
+        target_groups: [
+          {
+            name: 'default',
+            selector: 'random',
+            targets: [{ provider: 'p1', model: 'model-1' }],
+          },
+        ],
+        metadata,
+      },
+    },
+    keys: {},
+  });
+}
+
+describe('ModelConfigSchema metadata modes', () => {
+  it('accepts automatic metadata with partial overrides', () => {
+    const config = validateConfig(
+      configWithMetadata({ source: 'auto', overrides: { context_length: 32000 } })
+    );
+
+    expect(config.models['test-alias']?.metadata).toEqual({
+      source: 'auto',
+      overrides: { context_length: 32000 },
+    });
+  });
+
+  it('accepts disabled metadata without a source path', () => {
+    const config = validateConfig(configWithMetadata({ source: 'disabled' }));
+
+    expect(config.models['test-alias']?.metadata).toEqual({ source: 'disabled' });
+  });
+});

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -809,6 +809,13 @@ const MetadataOverridesSchema = z.object({
 
 const ModelMetadataSchema = z.discriminatedUnion('source', [
   z.object({
+    source: z.literal('auto'),
+    overrides: MetadataOverridesSchema.optional(),
+  }),
+  z.object({
+    source: z.literal('disabled'),
+  }),
+  z.object({
     source: z.literal('openrouter'),
     // Path within the source catalog (e.g., "openai/gpt-4.1-nano")
     source_path: z.string().min(1),
@@ -855,8 +862,8 @@ export const ModelConfigSchema = z
     // in the alias targets). Tracked in-memory only; see
     // services/sticky-session-manager.ts.
     sticky_session: z.boolean().default(true),
-    // Advertised in GET /v1/models to inform clients of the preferred API surface(s)
-    // for this alias, even if plexus can translate between them.
+    // Advertised in GET /v1/models to inform clients of the preferred API surface(s).
+    // When omitted for text aliases, the model family determines the default.
     preferred_api: z
       .array(z.enum(['chat_completions', 'messages', 'gemini', 'responses']))
       .optional(),

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -837,6 +837,8 @@ export class ConfigRepository {
   async saveAlias(slug: string, config: ModelConfig): Promise<void> {
     const schema = this.schema();
     const timestamp = now();
+    const metadataSourcePath =
+      config.metadata && 'source_path' in config.metadata ? config.metadata.source_path : undefined;
 
     const aliasData = {
       slug,
@@ -846,7 +848,7 @@ export class ConfigRepository {
       additionalAliases: config.additional_aliases ? toJson(config.additional_aliases) : null,
       advanced: config.advanced ? toJson(config.advanced) : null,
       metadataSource: config.metadata?.source ?? null,
-      metadataSourcePath: config.metadata?.source_path ?? null,
+      metadataSourcePath: metadataSourcePath ?? null,
       useImageFallthrough: fromBool(config.use_image_fallthrough === true),
       // Model architecture override for inference energy calculation
       modelArchitecture: config.model_architecture ? toJson(config.model_architecture) : null,
@@ -919,7 +921,8 @@ export class ConfigRepository {
         .delete(schema.aliasMetadataOverrides)
         .where(eq(schema.aliasMetadataOverrides.aliasId, aliasId));
 
-      const overrides = config.metadata?.overrides;
+      const overrides =
+        config.metadata && 'overrides' in config.metadata ? config.metadata.overrides : undefined;
       if (overrides && hasAnyOverrideField(overrides)) {
         await tx.insert(schema.aliasMetadataOverrides).values({
           aliasId,
@@ -1004,7 +1007,14 @@ export class ConfigRepository {
 
     if (row.metadataSource) {
       const overrides = overrideRow ? overrideRowToOverrides(overrideRow) : undefined;
-      if (row.metadataSource === 'custom') {
+      if (row.metadataSource === 'disabled') {
+        result.metadata = { source: 'disabled' };
+      } else if (row.metadataSource === 'auto') {
+        result.metadata = {
+          source: 'auto',
+          ...(overrides && Object.keys(overrides).length > 0 ? { overrides } : {}),
+        };
+      } else if (row.metadataSource === 'custom') {
         // Custom sources always carry overrides (possibly empty if no row found).
         result.metadata = {
           source: 'custom',

--- a/packages/backend/src/routes/inference/__tests__/models.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/models.test.ts
@@ -75,7 +75,33 @@ describe('GET /v1/models', () => {
     expect(modelIds).toEqual(['simple-model']);
   });
 
-  it('should return base fields for aliases without metadata config', async () => {
+  it('should infer preferred APIs from model families while preserving explicit values', async () => {
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+
+    setConfigForTesting({
+      models: {
+        'claude-sonnet-4-5': { targets: [] },
+        'gpt-5.2': { targets: [] },
+        'gemini-2.5-pro': { targets: [] },
+        'gemini-embedding-001': { targets: [], type: 'embeddings' },
+        'mistral-large': { targets: [] },
+        'gpt-explicit': { targets: [], preferred_api: ['chat_completions'] },
+      },
+    } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({ method: 'GET', url: '/v1/models' });
+    const models = new Map(response.json().data.map((model: any) => [model.id, model]));
+
+    expect((models.get('claude-sonnet-4-5') as any).preferred_api).toEqual(['messages']);
+    expect((models.get('gpt-5.2') as any).preferred_api).toEqual(['responses']);
+    expect((models.get('gemini-2.5-pro') as any).preferred_api).toEqual(['gemini']);
+    expect((models.get('gemini-embedding-001') as any).preferred_api).toBeUndefined();
+    expect((models.get('mistral-large') as any).preferred_api).toEqual(['chat_completions']);
+    expect((models.get('gpt-explicit') as any).preferred_api).toEqual(['chat_completions']);
+  });
+
+  it('should infer safe metadata defaults for aliases without metadata config', async () => {
     const fastify = Fastify();
     await registerModelsRoute(fastify);
 
@@ -93,10 +119,28 @@ describe('GET /v1/models', () => {
     expect(model.object).toBe('model');
     expect(model.owned_by).toBe('plexus');
     expect(typeof model.created).toBe('number');
-    // Should NOT have enriched fields
-    expect(model.name).toBeUndefined();
+    expect(model.name).toBe('Plain Model');
+    expect(model.architecture.input_modalities).toEqual(['text']);
+    expect(model.architecture.output_modalities).toEqual(['text']);
     expect(model.context_length).toBeUndefined();
     expect(model.pricing).toBeUndefined();
+  });
+
+  it('should return only base fields when metadata enrichment is disabled', async () => {
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+
+    setConfigForTesting({
+      models: {
+        'plain-model': { targets: [], metadata: { source: 'disabled' } },
+      },
+    } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({ method: 'GET', url: '/v1/models' });
+    const model = response.json().data[0];
+    expect(model.id).toBe('plain-model');
+    expect(model.name).toBeUndefined();
+    expect(model.architecture).toBeUndefined();
   });
 });
 
@@ -124,7 +168,8 @@ describe('GET /v1/models – vision fallthrough modalities', () => {
 
     expect(vfModel.architecture.input_modalities).toEqual(['text', 'image']);
     expect(vfModel.architecture.output_modalities).toEqual(['text']);
-    expect(noVfModel.architecture).toBeUndefined();
+    expect(noVfModel.architecture.input_modalities).toEqual(['text']);
+    expect(noVfModel.architecture.output_modalities).toEqual(['text']);
   });
 
   it('should not add image when vision_fallthrough is not configured globally', async () => {
@@ -141,7 +186,8 @@ describe('GET /v1/models – vision fallthrough modalities', () => {
     expect(response.statusCode).toBe(200);
 
     const model = response.json().data[0];
-    expect(model.architecture).toBeUndefined();
+    expect(model.architecture.input_modalities).toEqual(['text']);
+    expect(model.architecture.output_modalities).toEqual(['text']);
   });
 
   it('should inject image into existing modalities when metadata is present', async () => {

--- a/packages/backend/src/routes/inference/models.ts
+++ b/packages/backend/src/routes/inference/models.ts
@@ -1,7 +1,12 @@
 import { FastifyInstance } from 'fastify';
 import { getConfig } from '../../config';
 import { PricingManager } from '../../services/pricing-manager';
-import { ModelMetadataManager, mergeOverrides } from '../../services/model-metadata-manager';
+import {
+  ModelMetadataManager,
+  resolveAutomaticModelIdentity,
+  resolveModelMetadata,
+  resolvePreferredApi,
+} from '../../services/model-metadata-manager';
 import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
 
 export async function registerModelsRoute(fastify: FastifyInstance) {
@@ -10,9 +15,8 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
    * Returns a list of available model aliases configured in the database,
    * following the OpenRouter/OpenAI model list format.
    *
-   * When an alias has a `metadata` block configured, the response includes
-   * enriched fields (name, description, context_length, architecture, pricing,
-   * supported_parameters, top_provider) sourced from the configured catalog.
+   * Metadata is resolved automatically from each alias's canonical target by
+   * default. Explicit catalog links and per-field overrides remain supported.
    *
    * Note: Direct provider/model syntax (e.g., "stima/gemini-2.5-flash") is NOT
    * included in this list, as it's intended for debugging only.
@@ -25,11 +29,32 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
     const hasVisionFallthrough = !!config.vision_fallthrough;
 
     const models = Object.entries(config.models).map(([aliasId, modelConfig]) => {
-      const metaConfig = modelConfig?.metadata;
-      const piModelConfig = modelConfig?.pi_model;
+      const automaticIdentity = resolveAutomaticModelIdentity(
+        aliasId,
+        modelConfig,
+        config.providers
+      );
+      let piModelConfig = modelConfig?.pi_model;
+      const preferredApi = resolvePreferredApi(aliasId, modelConfig, config.providers);
 
       // Look up pi compat options if a pi model reference is configured.
       let piOptions: Record<string, unknown> | undefined;
+      if (!piModelConfig && automaticIdentity.provider) {
+        try {
+          const inferred = getBuiltinModel(
+            automaticIdentity.provider as any,
+            automaticIdentity.model as any
+          );
+          if (inferred) {
+            piModelConfig = {
+              provider: automaticIdentity.provider,
+              model_id: automaticIdentity.model,
+            };
+          }
+        } catch {
+          // No Pi registry match — metadata and preferred API inference still apply.
+        }
+      }
       if (piModelConfig) {
         try {
           const piModel = getBuiltinModel(
@@ -49,41 +74,18 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
         object: 'model' as const,
         created,
         owned_by: 'plexus',
-        ...(modelConfig?.preferred_api !== undefined && {
-          preferred_api: modelConfig.preferred_api,
-        }),
+        ...(preferredApi !== undefined && { preferred_api: preferredApi }),
         ...(piModelConfig && { pi_provider: piModelConfig.provider }),
         ...(piModelConfig && { pi_model: piModelConfig.model_id }),
         ...(piOptions !== undefined && { pi_options: piOptions }),
       };
 
-      if (!metaConfig) {
-        if (hasVisionFallthrough && modelConfig.use_image_fallthrough) {
-          return {
-            ...base,
-            architecture: {
-              input_modalities: ['text', 'image'],
-              output_modalities: ['text'],
-            },
-          };
-        }
-        return base;
-      }
-
-      // Look up enriched metadata from the appropriate source. Custom sources
-      // skip the catalog entirely and derive everything from overrides. For
-      // catalog-backed sources, a missing catalog hit is treated as a miss —
-      // we don't silently synthesize a partial record from overrides alone,
-      // because that would hide typos in source_path or unloaded sources.
-      let enriched: ReturnType<typeof mergeOverrides> = undefined;
-      if (metaConfig.source === 'custom') {
-        enriched = mergeOverrides(undefined, metaConfig.overrides);
-      } else {
-        const catalog = metadataManager.getMetadata(metaConfig.source, metaConfig.source_path);
-        if (catalog) {
-          enriched = mergeOverrides(catalog, metaConfig.overrides);
-        }
-      }
+      const enriched = resolveModelMetadata(
+        aliasId,
+        modelConfig,
+        config.providers,
+        metadataManager
+      )?.metadata;
       if (!enriched) {
         if (hasVisionFallthrough && modelConfig.use_image_fallthrough) {
           return {

--- a/packages/backend/src/routes/management/__tests__/models.test.ts
+++ b/packages/backend/src/routes/management/__tests__/models.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { registerSpy } from '../../../../test/test-utils';
 import { registerModelRoutes } from '../models';
 import { ModelMetadataManager } from '../../../services/model-metadata-manager';
+import { setConfigForTesting, type PlexusConfig } from '../../../config';
 
 describe('management model routes', () => {
   let fastify: ReturnType<typeof Fastify>;
@@ -51,5 +52,59 @@ describe('management model routes', () => {
         catwalk: { count: 3 },
       },
     });
+  });
+
+  test('POST /v0/management/models/metadata/resolve previews automatic selections', async () => {
+    setConfigForTesting({ providers: {}, models: {}, keys: {} } as PlexusConfig);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/v0/management/models/metadata/resolve',
+      payload: {
+        alias_id: 'company-assistant',
+        model: {
+          target_groups: [
+            {
+              name: 'default',
+              selector: 'random',
+              targets: [{ provider: 'company-proxy', model: 'gpt-5.2' }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      canonical_model: { provider: 'openai', model: 'gpt-5.2', basis: 'target' },
+      pi_model: { provider: 'openai', model_id: 'gpt-5.2', name: 'gpt-5.2' },
+      metadata: { source: 'heuristic', name: 'GPT 5 2' },
+      preferred_api: ['responses'],
+    });
+  });
+
+  test('does not infer a preferred API for non-text models', async () => {
+    setConfigForTesting({ providers: {}, models: {}, keys: {} } as PlexusConfig);
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/v0/management/models/metadata/resolve',
+      payload: {
+        alias_id: 'embeddings',
+        model: {
+          type: 'embeddings',
+          target_groups: [
+            {
+              name: 'default',
+              selector: 'random',
+              targets: [{ provider: 'google', model: 'gemini-embedding-001' }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().preferred_api).toBeNull();
   });
 });

--- a/packages/backend/src/routes/management/models.ts
+++ b/packages/backend/src/routes/management/models.ts
@@ -1,8 +1,18 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { logger } from '../../utils/logger';
 import { HuggingFaceModelFetcher } from '../../services/huggingface-model-fetcher';
-import { ModelMetadataManager } from '../../services/model-metadata-manager';
-import { getBuiltinModels, getBuiltinProviders } from '@earendil-works/pi-ai/providers/all';
+import {
+  ModelMetadataManager,
+  resolveAutomaticModelIdentity,
+  resolveModelMetadata,
+  resolvePreferredApi,
+} from '../../services/model-metadata-manager';
+import { getConfig, ModelConfigSchema } from '../../config';
+import {
+  getBuiltinModel,
+  getBuiltinModels,
+  getBuiltinProviders,
+} from '@earendil-works/pi-ai/providers/all';
 
 interface FetchModelRequest {
   Params: {
@@ -14,6 +24,51 @@ export async function registerModelRoutes(fastify: FastifyInstance) {
   fastify.post('/v0/management/models/metadata/refresh', async (_request, reply) => {
     const result = await ModelMetadataManager.getInstance().refreshAll(undefined, 'manual');
     return reply.send(result);
+  });
+
+  fastify.post('/v0/management/models/metadata/resolve', async (request, reply) => {
+    const body = request.body as { alias_id?: unknown; model?: unknown } | null;
+    if (!body || typeof body.alias_id !== 'string') {
+      return reply.code(400).send({ error: 'alias_id is required' });
+    }
+
+    const parsed = ModelConfigSchema.safeParse(body.model);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Validation failed', details: parsed.error.issues });
+    }
+
+    const providers = getConfig().providers;
+    const identity = resolveAutomaticModelIdentity(body.alias_id, parsed.data, providers);
+    const resolved = resolveModelMetadata(
+      body.alias_id,
+      parsed.data,
+      providers,
+      ModelMetadataManager.getInstance()
+    );
+    let piModel: { provider: string; model_id: string; name: string } | null = null;
+    if (identity.provider) {
+      try {
+        const match = getBuiltinModel(identity.provider as any, identity.model as any);
+        if (match) {
+          piModel = { provider: identity.provider, model_id: identity.model, name: match.name };
+        }
+      } catch {
+        // A catalog match can exist without a corresponding Pi registry entry.
+      }
+    }
+
+    return reply.send({
+      canonical_model: identity,
+      pi_model: piModel,
+      metadata: resolved
+        ? {
+            source: resolved.source,
+            source_path: resolved.sourcePath,
+            name: resolved.metadata.name,
+          }
+        : null,
+      preferred_api: resolvePreferredApi(body.alias_id, parsed.data, providers) ?? null,
+    });
   });
 
   // Fetch model architecture from Hugging Face

--- a/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
+++ b/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import path from 'path';
-import { ModelMetadataManager, mergeOverrides } from '../model-metadata-manager';
+import {
+  ModelMetadataManager,
+  mergeOverrides,
+  resolveModelMetadata,
+} from '../model-metadata-manager';
 import type { NormalizedModelMetadata } from '../model-metadata-manager';
-import type { MetadataOverrides } from '../../config';
+import type { MetadataOverrides, ModelConfig, ProviderConfig } from '../../config';
 
 const FIXTURES = path.join(__dirname, '../../utils/__tests__/fixtures');
 
@@ -383,6 +387,44 @@ describe('ModelMetadataManager – Catwalk source', () => {
   });
 });
 
+describe('ModelMetadataManager – limit normalization', () => {
+  test('omits non-positive catalog limits instead of producing invalid overrides', async () => {
+    ModelMetadataManager.resetForTesting();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              openai: {
+                id: 'openai',
+                models: {
+                  'gpt-4o-mini-tts': {
+                    id: 'gpt-4o-mini-tts',
+                    name: 'GPT-4o Mini TTS',
+                    limit: { context: 0, output: 0 },
+                  },
+                },
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+      )
+    );
+    const manager = ModelMetadataManager.getInstance();
+
+    await manager.loadAll({
+      openrouter: '/dev/null-nonexistent',
+      modelsDev: 'https://example.com/models.json',
+      catwalk: '/dev/null-nonexistent',
+    });
+
+    const metadata = manager.getMetadata('models.dev', 'openai.gpt-4o-mini-tts');
+    expect(metadata?.context_length).toBeUndefined();
+    expect(metadata?.top_provider).toBeUndefined();
+  });
+});
+
 // ─── Error handling ─────────────────────────────────────────
 
 describe('ModelMetadataManager – error handling', () => {
@@ -670,5 +712,110 @@ describe('mergeOverrides', () => {
       architecture: { tokenizer: 'custom' },
     });
     expect(base).toEqual(snapshot);
+  });
+});
+
+describe('resolveModelMetadata', () => {
+  test('automatically resolves an exact catalog entry from provider canonical hints', async () => {
+    ModelMetadataManager.resetForTesting();
+    const manager = ModelMetadataManager.getInstance();
+    await manager.loadAll({
+      openrouter: '/dev/null-nonexistent',
+      modelsDev: modelsDevFixture,
+      catwalk: '/dev/null-nonexistent',
+    });
+
+    const modelConfig = {
+      target_groups: [
+        {
+          name: 'default',
+          selector: 'random',
+          targets: [{ provider: 'company-proxy', model: 'sonnet' }],
+        },
+      ],
+    } as unknown as ModelConfig;
+    const providers = {
+      'company-proxy': {
+        pi_ai_provider: 'anthropic',
+        models: {
+          sonnet: {
+            pi_ai_model_id: 'claude-3-5-haiku-20241022',
+            pricing: { source: 'simple', input: 0, output: 0 },
+          },
+        },
+      },
+    } as unknown as Record<string, ProviderConfig>;
+
+    const resolved = resolveModelMetadata('claude', modelConfig, providers, manager);
+
+    expect(resolved?.source).toBe('models.dev');
+    expect(resolved?.sourcePath).toBe('anthropic.claude-3-5-haiku-20241022');
+    expect(resolved?.metadata.context_length).toBe(200000);
+  });
+
+  test('falls back to conservative name and modality heuristics', () => {
+    ModelMetadataManager.resetForTesting();
+    const modelConfig = {
+      target_groups: [
+        {
+          name: 'default',
+          selector: 'random',
+          targets: [{ provider: 'openai', model: 'text-embedding-3-small' }],
+        },
+      ],
+    } as unknown as ModelConfig;
+
+    const resolved = resolveModelMetadata('embeddings', modelConfig);
+
+    expect(resolved?.source).toBe('heuristic');
+    expect(resolved?.metadata.name).toBe('Text Embedding 3 Small');
+    expect(resolved?.metadata.architecture?.input_modalities).toEqual(['text']);
+    expect(resolved?.metadata.architecture?.output_modalities).toEqual(['embeddings']);
+    expect(resolved?.metadata.context_length).toBeUndefined();
+    expect(resolved?.metadata.pricing).toBeUndefined();
+  });
+
+  test('normalizes Pi provider IDs to catalog vendors', async () => {
+    ModelMetadataManager.resetForTesting();
+    const manager = ModelMetadataManager.getInstance();
+    await manager.loadAll({
+      openrouter: '/dev/null-nonexistent',
+      modelsDev: modelsDevFixture,
+      catwalk: '/dev/null-nonexistent',
+    });
+    const modelConfig = {
+      target_groups: [],
+      pi_model: { provider: 'openai-codex', model_id: 'gpt-4.1-nano' },
+    } as unknown as ModelConfig;
+
+    const resolved = resolveModelMetadata('codex', modelConfig, {}, manager);
+
+    expect(resolved?.source).toBe('models.dev');
+    expect(resolved?.sourcePath).toBe('openai.gpt-4.1-nano');
+  });
+
+  test('applies auto overrides after inferred defaults', () => {
+    const modelConfig = {
+      target_groups: [],
+      metadata: {
+        source: 'auto',
+        overrides: { name: 'Internal Model', context_length: 32000 },
+      },
+    } as unknown as ModelConfig;
+
+    const resolved = resolveModelMetadata('internal-chat', modelConfig);
+
+    expect(resolved?.metadata.name).toBe('Internal Model');
+    expect(resolved?.metadata.context_length).toBe(32000);
+    expect(resolved?.metadata.architecture?.output_modalities).toEqual(['text']);
+  });
+
+  test('returns no metadata when automatic enrichment is disabled', () => {
+    const modelConfig = {
+      target_groups: [],
+      metadata: { source: 'disabled' },
+    } as unknown as ModelConfig;
+
+    expect(resolveModelMetadata('internal-chat', modelConfig)).toBeUndefined();
   });
 });

--- a/packages/backend/src/services/enforce-limits.ts
+++ b/packages/backend/src/services/enforce-limits.ts
@@ -1,9 +1,9 @@
 import type { Context } from '@earendil-works/pi-ai';
-import type { ModelConfig } from '../config';
+import { getConfig, type ModelConfig } from '../config';
 import type { UnifiedChatRequest } from '../types/unified';
 import { estimateContextTokens, estimateInputTokens } from '../utils/estimate-tokens';
 import { logger } from '../utils/logger';
-import { ModelMetadataManager, mergeOverrides } from './model-metadata-manager';
+import { resolveModelMetadata } from './model-metadata-manager';
 
 // Heuristic estimator has ±20–30% variance; inflate the estimate by 10% so we
 // err on the side of rejecting a borderline-oversized request rather than
@@ -13,6 +13,18 @@ const ESTIMATE_SAFETY_MULTIPLIER = 1.1;
 // Fallback reservation when we have no metadata max_completion_tokens and the
 // caller didn't specify max_tokens. Matches a common default completion budget.
 const DEFAULT_OUTPUT_RESERVATION = 4096;
+
+function resolveMetadata(aliasConfig: ModelConfig, aliasSlug = '') {
+  let providers = {};
+  if (!aliasConfig.metadata || aliasConfig.metadata.source === 'auto') {
+    try {
+      providers = getConfig().providers;
+    } catch {
+      // Provider hints improve automatic matching but are not required for safe fallback.
+    }
+  }
+  return resolveModelMetadata(aliasSlug, aliasConfig, providers)?.metadata;
+}
 
 export interface ContextLengthExceededDetails {
   statusCode: 400;
@@ -43,17 +55,6 @@ export class ContextLengthExceededError extends Error {
  * overrides on top of the catalog entry. Returns undefined when no context
  * length is known from either source — callers should fail open.
  */
-function resolveMetadata(aliasConfig: ModelConfig) {
-  const metadata = aliasConfig.metadata;
-  if (!metadata) return undefined;
-
-  let base;
-  if (metadata.source !== 'custom') {
-    base = ModelMetadataManager.getInstance().getMetadata(metadata.source, metadata.source_path);
-  }
-  return mergeOverrides(base, metadata.overrides);
-}
-
 /**
  * Enforces the incoming-context-size limit for an alias that has
  * `enforce_limits` enabled. Fast path: one JSON.stringify + one linear
@@ -69,7 +70,7 @@ export function enforceContextLimit(
   aliasConfig: ModelConfig,
   aliasSlug: string
 ): void {
-  const merged = resolveMetadata(aliasConfig);
+  const merged = resolveMetadata(aliasConfig, aliasSlug);
 
   // Prefer top_provider.context_length (per-deployment) over the model-wide
   // context_length when both are present.
@@ -126,8 +127,8 @@ export function enforceContextLimit(
  * Returns undefined when no context_length is known — callers should fail open.
  * The executor (Task 3) uses this to resolve the per-candidate context window.
  */
-export function resolveContextLength(aliasConfig: ModelConfig): number | undefined {
-  const merged = resolveMetadata(aliasConfig);
+export function resolveContextLength(aliasConfig: ModelConfig, aliasSlug = ''): number | undefined {
+  const merged = resolveMetadata(aliasConfig, aliasSlug);
   const ctx = merged?.top_provider?.context_length ?? merged?.context_length;
   return ctx && ctx > 0 ? ctx : undefined;
 }
@@ -162,7 +163,9 @@ export function enforceContextLimitForRoute(
 ): void {
   if (!aliasConfig?.enforce_limits || !route.canonicalModel) return;
   enforceContextLimitForContext(context, aliasConfig, route.canonicalModel, {
-    contextLength: route.modelArchitecture?.context_length ?? resolveContextLength(aliasConfig),
+    contextLength:
+      route.modelArchitecture?.context_length ??
+      resolveContextLength(aliasConfig, route.canonicalModel),
     maxTokens,
     apiType,
   });
@@ -179,7 +182,7 @@ export function enforceContextLimitForContext(
   aliasSlug: string,
   opts: ContextLimitOptions = {}
 ): void {
-  const merged = resolveMetadata(aliasConfig);
+  const merged = resolveMetadata(aliasConfig, aliasSlug);
   const contextLength =
     opts.contextLength ?? merged?.top_provider?.context_length ?? merged?.context_length;
   if (!contextLength || contextLength <= 0) {

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -1,5 +1,10 @@
 import { logger } from '../utils/logger';
-import type { MetadataOverrides } from '../config';
+import type {
+  MetadataOverrides,
+  ModelConfig,
+  ModelProviderConfig,
+  ProviderConfig,
+} from '../config';
 
 type MetadataSourceId = 'openrouter' | 'models.dev' | 'catwalk';
 
@@ -75,6 +80,12 @@ export interface NormalizedModelMetadata {
     context_length?: number;
     max_completion_tokens?: number;
   };
+}
+
+export interface ResolvedModelMetadata {
+  metadata: NormalizedModelMetadata;
+  source: MetadataSourceId | 'heuristic';
+  sourcePath?: string;
 }
 
 // ─── Source-specific raw shapes ──────────────────────────
@@ -179,6 +190,23 @@ interface CatwalkProvider {
 }
 
 // ─── Normalizers ───────────────────────────────────────
+function positiveNumber(value?: number): number | undefined {
+  return value !== undefined && value > 0 ? value : undefined;
+}
+
+function normalizeTopProvider(
+  contextLength?: number,
+  maxCompletionTokens?: number
+): NormalizedModelMetadata['top_provider'] {
+  const normalized = {
+    context_length: positiveNumber(contextLength),
+    max_completion_tokens: positiveNumber(maxCompletionTokens),
+  };
+  return normalized.context_length !== undefined || normalized.max_completion_tokens !== undefined
+    ? normalized
+    : undefined;
+}
+
 function inferOpenRouterArchitecture(
   raw: OpenRouterRawModel,
   kind: OpenRouterCatalogKind
@@ -208,7 +236,7 @@ function normalizeOpenRouterModel(
     id: raw.id,
     name: raw.name ?? raw.id,
     description: raw.description,
-    context_length: raw.context_length,
+    context_length: positiveNumber(raw.context_length),
     architecture,
     pricing: raw.pricing
       ? {
@@ -220,7 +248,10 @@ function normalizeOpenRouterModel(
         }
       : undefined,
     supported_parameters: raw.supported_parameters,
-    top_provider: raw.top_provider,
+    top_provider: normalizeTopProvider(
+      raw.top_provider?.context_length,
+      raw.top_provider?.max_completion_tokens
+    ),
   };
 }
 
@@ -248,7 +279,7 @@ function normalizeModelsDevModel(
   return {
     id: `${providerId}.${modelId}`,
     name: raw.name ?? raw.id ?? modelId,
-    context_length: raw.limit?.context,
+    context_length: positiveNumber(raw.limit?.context),
     architecture: {
       modality:
         inputModalities?.length || outputModalities?.length
@@ -267,13 +298,7 @@ function normalizeModelsDevModel(
           }
         : undefined,
     supported_parameters: params.length > 0 ? params : undefined,
-    top_provider:
-      raw.limit?.output != null
-        ? {
-            max_completion_tokens: raw.limit.output,
-            context_length: raw.limit.context,
-          }
-        : undefined,
+    top_provider: normalizeTopProvider(raw.limit?.context, raw.limit?.output),
   };
 }
 
@@ -294,7 +319,7 @@ function normalizeCatwalkModel(providerId: string, raw: CatwalkModel): Normalize
   return {
     id: `${providerId}.${raw.id}`,
     name: raw.name ?? raw.id,
-    context_length: raw.context_window,
+    context_length: positiveNumber(raw.context_window),
     architecture: {
       modality: `${inputModalities.join('+')}->${outputModalities.join('+')}`,
       input_modalities: inputModalities,
@@ -309,10 +334,7 @@ function normalizeCatwalkModel(providerId: string, raw: CatwalkModel): Normalize
           }
         : undefined,
     supported_parameters: params,
-    top_provider: {
-      context_length: raw.context_window,
-      max_completion_tokens: raw.default_max_tokens,
-    },
+    top_provider: normalizeTopProvider(raw.context_window, raw.default_max_tokens),
   };
 }
 
@@ -669,6 +691,21 @@ export class ModelMetadataManager {
     return this.getMap(source).get(sourcePath);
   }
 
+  public findExactMetadata(provider: string, model: string): ResolvedModelMetadata | undefined {
+    const candidates: Array<{ source: MetadataSourceId; sourcePath: string }> = [
+      { source: 'models.dev', sourcePath: `${provider}.${model}` },
+      { source: 'openrouter', sourcePath: `${provider}/${model}` },
+      { source: 'catwalk', sourcePath: `${provider}.${model}` },
+    ];
+
+    for (const candidate of candidates) {
+      const metadata = this.getMap(candidate.source).get(candidate.sourcePath);
+      if (metadata) return { ...candidate, metadata };
+    }
+
+    return undefined;
+  }
+
   /**
    * Search models within a source by substring match on id or name.
    * Returns lightweight { id, name } objects suitable for autocomplete.
@@ -803,4 +840,212 @@ export function mergeOverrides(
   }
 
   return merged;
+}
+
+const DISPLAY_TOKEN_OVERRIDES: Record<string, string> = {
+  ai: 'AI',
+  api: 'API',
+  gpt: 'GPT',
+  llm: 'LLM',
+  tts: 'TTS',
+};
+
+function humanizeModelName(model: string): string {
+  const modelId = model.split('/').at(-1) ?? model;
+  return modelId
+    .split(/[-_.]+/)
+    .filter(Boolean)
+    .map(
+      (token) =>
+        DISPLAY_TOKEN_OVERRIDES[token.toLowerCase()] ??
+        `${token[0]?.toUpperCase()}${token.slice(1)}`
+    )
+    .join(' ');
+}
+
+function inferModelType(model: string, configuredType?: ModelConfig['type']): ModelConfig['type'] {
+  if (configuredType) return configuredType;
+  const normalized = model.toLowerCase();
+  if (/embed|embedding/.test(normalized)) return 'embeddings';
+  if (/whisper|transcri|speech[-_.]?to[-_.]?text|(?:^|[-_.])stt(?:$|[-_.])/.test(normalized)) {
+    return 'transcriptions';
+  }
+  if (/(?:^|[-_.])tts(?:$|[-_.])|text[-_.]?to[-_.]?speech/.test(normalized)) return 'speech';
+  if (/dall[-_.]?e|(?:^|[/_.-])(flux|imagen)(?:$|[/_.-])/.test(normalized)) return 'image';
+  return 'text';
+}
+
+function inferArchitecture(
+  model: string,
+  configuredType?: ModelConfig['type']
+): NonNullable<NormalizedModelMetadata['architecture']> {
+  switch (inferModelType(model, configuredType)) {
+    case 'embeddings':
+      return {
+        modality: 'text->embeddings',
+        input_modalities: ['text'],
+        output_modalities: ['embeddings'],
+      };
+    case 'transcriptions':
+      return {
+        modality: 'audio->text',
+        input_modalities: ['audio'],
+        output_modalities: ['text'],
+      };
+    case 'speech':
+      return {
+        modality: 'text->audio',
+        input_modalities: ['text'],
+        output_modalities: ['audio'],
+      };
+    case 'image':
+      return {
+        modality: 'text->image',
+        input_modalities: ['text'],
+        output_modalities: ['image'],
+      };
+    default:
+      return {
+        modality: 'text->text',
+        input_modalities: ['text'],
+        output_modalities: ['text'],
+      };
+  }
+}
+
+function getProviderModelConfig(
+  provider: ProviderConfig | undefined,
+  model: string
+): ModelProviderConfig | undefined {
+  if (!provider?.models || Array.isArray(provider.models)) return undefined;
+  return provider.models[model];
+}
+
+function inferProviderFromModel(model: string): string | undefined {
+  const normalized = (model.split('/').at(-1) ?? model).toLowerCase();
+  if (normalized.includes('claude')) return 'anthropic';
+  if (/^(gpt|o[134](?:-|$)|text-embedding|dall-e)/.test(normalized)) return 'openai';
+  if (normalized.includes('gemini') || normalized.includes('imagen')) return 'google';
+  if (normalized.includes('mistral') || normalized.includes('codestral')) return 'mistralai';
+  return undefined;
+}
+
+function normalizeCatalogProvider(provider: string, model: string): string {
+  switch (provider) {
+    case 'openai-codex':
+      return 'openai';
+    case 'google-antigravity':
+    case 'google-gemini-cli':
+      return 'google';
+    case 'github-copilot':
+      return inferProviderFromModel(model) ?? provider;
+    default:
+      return provider;
+  }
+}
+
+export interface AutomaticModelIdentity {
+  provider?: string;
+  model: string;
+  basis: 'pi_model' | 'target' | 'alias';
+}
+
+export function resolveAutomaticModelIdentity(
+  aliasId: string,
+  modelConfig: ModelConfig,
+  providers: Record<string, ProviderConfig>
+): AutomaticModelIdentity {
+  if (modelConfig.pi_model) {
+    return {
+      provider: normalizeCatalogProvider(
+        modelConfig.pi_model.provider,
+        modelConfig.pi_model.model_id
+      ),
+      model: modelConfig.pi_model.model_id,
+      basis: 'pi_model',
+    };
+  }
+
+  const targets = (modelConfig.target_groups ?? [])
+    .flatMap((group) => group.targets)
+    .filter((target) => target.enabled !== false);
+  const identities = targets.map((target) => {
+    const provider = providers[target.provider];
+    const providerModel = getProviderModelConfig(provider, target.model);
+    const model = providerModel?.pi_ai_model_id ?? target.model;
+    const providerId = provider?.pi_ai_provider ?? inferProviderFromModel(model) ?? target.provider;
+    return { provider: normalizeCatalogProvider(providerId, model), model };
+  });
+
+  const unique = new Map(
+    identities.map((identity) => [
+      `${identity.provider.toLowerCase()}\0${identity.model.toLowerCase()}`,
+      identity,
+    ])
+  );
+  if (unique.size === 1) return { ...[...unique.values()][0]!, basis: 'target' };
+
+  return { provider: inferProviderFromModel(aliasId), model: aliasId, basis: 'alias' };
+}
+
+export function resolveModelMetadata(
+  aliasId: string,
+  modelConfig: ModelConfig,
+  providers: Record<string, ProviderConfig> = {},
+  manager = ModelMetadataManager.getInstance()
+): ResolvedModelMetadata | undefined {
+  const configured = modelConfig.metadata;
+  if (configured?.source === 'disabled') return undefined;
+
+  if (configured?.source === 'custom') {
+    const metadata = mergeOverrides(undefined, configured.overrides);
+    return metadata ? { metadata, source: 'heuristic' } : undefined;
+  }
+
+  if (
+    configured?.source === 'openrouter' ||
+    configured?.source === 'models.dev' ||
+    configured?.source === 'catwalk'
+  ) {
+    const catalog = manager.getMetadata(configured.source, configured.source_path);
+    const metadata = catalog ? mergeOverrides(catalog, configured.overrides) : undefined;
+    return metadata
+      ? { metadata, source: configured.source, sourcePath: configured.source_path }
+      : undefined;
+  }
+
+  const identity = resolveAutomaticModelIdentity(aliasId, modelConfig, providers);
+  const exact = identity.provider
+    ? manager.findExactMetadata(identity.provider, identity.model)
+    : undefined;
+  if (exact) {
+    const metadata = mergeOverrides(exact.metadata, configured?.overrides);
+    return metadata ? { ...exact, metadata } : undefined;
+  }
+
+  const heuristic: NormalizedModelMetadata = {
+    id: identity.model,
+    name: humanizeModelName(identity.model),
+    architecture: inferArchitecture(identity.model, modelConfig.type),
+  };
+  const metadata = mergeOverrides(heuristic, configured?.overrides);
+  return metadata ? { metadata, source: 'heuristic' } : undefined;
+}
+
+export function resolvePreferredApi(
+  aliasId: string,
+  modelConfig: ModelConfig,
+  providers: Record<string, ProviderConfig> = {}
+): ModelConfig['preferred_api'] {
+  if (modelConfig.preferred_api !== undefined) return modelConfig.preferred_api;
+  if (modelConfig.type !== undefined && modelConfig.type !== 'text') return undefined;
+
+  const identity = resolveAutomaticModelIdentity(aliasId, modelConfig, providers);
+  const provider = identity.provider?.toLowerCase() ?? '';
+  const model = (identity.model.split('/').at(-1) ?? identity.model).toLowerCase();
+
+  if (provider.includes('anthropic') || model.includes('claude')) return ['messages'];
+  if (/^gpt(?:-|$)/.test(model)) return ['responses'];
+  if (/^gemini(?:-|$)/.test(model)) return ['gemini'];
+  return ['chat_completions'];
 }

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -1045,7 +1045,7 @@ export function resolvePreferredApi(
   const model = (identity.model.split('/').at(-1) ?? identity.model).toLowerCase();
 
   if (provider.includes('anthropic') || model.includes('claude')) return ['messages'];
-  if (/^gpt(?:-|$)/.test(model)) return ['responses'];
+  if (/^(gpt|o[134])(?:-|$)/.test(model)) return ['responses'];
   if (/^gemini(?:-|$)/.test(model)) return ['gemini'];
   return ['chat_completions'];
 }

--- a/packages/frontend/src/components/models/MetadataOverrideForm.tsx
+++ b/packages/frontend/src/components/models/MetadataOverrideForm.tsx
@@ -85,7 +85,7 @@ export function MetadataOverrideForm({
 }: Props) {
   const helperText = isCustom
     ? 'All fields below come from your manual entry — no catalog is consulted.'
-    : 'Fields left blank fall back to the catalog value.';
+    : 'Fields left blank use the automatically resolved or catalog value.';
 
   return (
     <div

--- a/packages/frontend/src/components/models/ModelBehaviorsEditor.tsx
+++ b/packages/frontend/src/components/models/ModelBehaviorsEditor.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Switch } from '../ui/Switch';
 import { Badge } from '../ui/Badge';
 import { DebouncedInput } from '../ui/DebouncedInput';
@@ -98,18 +98,6 @@ export function ModelBehaviorsEditor({ editingAlias, setEditingAlias }: Props) {
                   of max_tokens and the model&apos;s max completion for the response. Requires a
                   known context_length in metadata (override or catalog).
                 </p>
-                {editingAlias.enforce_limits &&
-                  !editingAlias.metadata?.overrides?.context_length &&
-                  !editingAlias.metadata?.overrides?.top_provider?.context_length && (
-                    <p
-                      className="font-body text-[11px] mt-1 flex items-center gap-1"
-                      style={{ color: 'var(--color-warning)' }}
-                    >
-                      <AlertTriangle size={12} />
-                      No context_length found in metadata - this toggle will have no effect until a
-                      metadata source with a known context_length is configured.
-                    </p>
-                  )}
               </div>
               <Switch
                 checked={editingAlias.enforce_limits || false}

--- a/packages/frontend/src/components/models/ModelMetadataEditor.tsx
+++ b/packages/frontend/src/components/models/ModelMetadataEditor.tsx
@@ -1,17 +1,27 @@
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { BookOpen, ChevronDown, ChevronRight, CheckCircle, X, Loader2 } from 'lucide-react';
+import {
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  CheckCircle,
+  X,
+  Loader2,
+  RotateCcw,
+} from 'lucide-react';
 import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
 import { Switch } from '../ui/Switch';
 import { MetadataOverrideForm } from './MetadataOverrideForm';
 import { useMetadataEditor } from '../../hooks/useMetadataEditor';
 import { api } from '../../lib/api';
+import { useToast } from '../../contexts/ToastContext';
 import type {
   Alias,
   AliasMetadata,
   MetadataSource,
   MetadataOverrides,
+  ModelResolutionPreview,
   PreferredApiValue,
 } from '../../lib/api';
 
@@ -22,7 +32,9 @@ interface Props {
 }
 
 export function ModelMetadataEditor({ editingAlias, setEditingAlias, isModalOpen }: Props) {
+  const toast = useToast();
   const [isOpen, setIsOpen] = useState(false);
+  const [showAdvancedMetadata, setShowAdvancedMetadata] = useState(false);
   const {
     isOverrideOpen,
     setIsOverrideOpen,
@@ -52,6 +64,11 @@ export function ModelMetadataEditor({ editingAlias, setEditingAlias, isModalOpen
     Array<{ id: string; name: string; api: string; custom: boolean }>
   >([]);
   const [piModelsLoading, setPiModelsLoading] = useState(false);
+  const [automaticResolution, setAutomaticResolution] = useState<ModelResolutionPreview | null>(
+    null
+  );
+  const [isResolvingAutomatically, setIsResolvingAutomatically] = useState(false);
+  const [automaticResolutionFailed, setAutomaticResolutionFailed] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -75,6 +92,116 @@ export function ModelMetadataEditor({ editingAlias, setEditingAlias, isModalOpen
       .finally(() => setPiModelsLoading(false));
   }, [editingAlias.pi_model?.provider]);
 
+  const metadataSource = editingAlias.metadata?.source ?? 'auto';
+  const isCatalogSource =
+    metadataSource === 'openrouter' ||
+    metadataSource === 'models.dev' ||
+    metadataSource === 'catwalk';
+  const catalogMetadata =
+    editingAlias.metadata?.source === 'openrouter' ||
+    editingAlias.metadata?.source === 'models.dev' ||
+    editingAlias.metadata?.source === 'catwalk'
+      ? editingAlias.metadata
+      : undefined;
+  const metadataOverrides =
+    editingAlias.metadata && editingAlias.metadata.source !== 'disabled'
+      ? editingAlias.metadata.overrides
+      : undefined;
+  const hasManualMetadataSelections =
+    metadataSource !== 'auto' ||
+    !!editingAlias.pi_model ||
+    !!editingAlias.preferred_api?.length ||
+    !!(metadataOverrides && Object.keys(metadataOverrides).length > 0);
+  const metadataStatus =
+    metadataSource === 'auto'
+      ? {
+          label: 'Automatic metadata enabled',
+          description: 'Selections update automatically when enabled targets change.',
+        }
+      : metadataSource === 'disabled'
+        ? {
+            label: 'Metadata disabled',
+            description: 'This alias only exposes the basic OpenAI model-list fields.',
+          }
+        : metadataSource === 'custom'
+          ? {
+              label: 'Custom metadata',
+              description: 'This alias uses manually configured metadata fields.',
+            }
+          : {
+              label: `Pinned to ${metadataSource}`,
+              description: catalogMetadata?.source_path
+                ? `Using ${catalogMetadata.source_path}.`
+                : 'Choose the catalog model in Advanced settings.',
+            };
+
+  useEffect(() => {
+    if (isModalOpen) setShowAdvancedMetadata(false);
+  }, [isModalOpen, editingAlias.id]);
+
+  useEffect(() => {
+    const hasInput =
+      editingAlias.id.trim().length > 0 ||
+      !!editingAlias.pi_model?.model_id ||
+      editingAlias.target_groups.some((group) =>
+        group.targets.some((target) => target.enabled !== false && target.model.trim().length > 0)
+      );
+    if (!isOpen || metadataSource !== 'auto' || !hasInput) {
+      setAutomaticResolution(null);
+      setIsResolvingAutomatically(false);
+      setAutomaticResolutionFailed(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsResolvingAutomatically(true);
+    setAutomaticResolutionFailed(false);
+    const timer = setTimeout(() => {
+      api
+        .previewModelResolution(editingAlias)
+        .then((resolution) => {
+          if (!cancelled) setAutomaticResolution(resolution);
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setAutomaticResolution(null);
+            setAutomaticResolutionFailed(true);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setIsResolvingAutomatically(false);
+        });
+    }, 200);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [isOpen, metadataSource, editingAlias]);
+
+  const resetToAutomatic = async () => {
+    const confirmed = await toast.confirm({
+      title: 'Reset to Automatic?',
+      message:
+        'This removes the pinned metadata source, Pi model, preferred API, and all metadata overrides. Plexus will derive them again from enabled targets.',
+      confirmLabel: 'Reset to Automatic',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+
+    clearMetadata();
+    setEditingAlias((current) => {
+      const {
+        metadata: _metadata,
+        pi_model: _piModel,
+        preferred_api: _preferredApi,
+        ...automatic
+      } = current;
+      return automatic as Alias;
+    });
+    setShowAdvancedMetadata(false);
+  };
+
   return (
     <>
       <div className="border border-border-glass rounded-sm overflow-hidden">
@@ -86,11 +213,9 @@ export function ModelMetadataEditor({ editingAlias, setEditingAlias, isModalOpen
           <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
             <BookOpen size={13} className="text-text-muted" />
             <span className="font-body text-[13px] font-medium text-text-secondary">Metadata</span>
-            {editingAlias.metadata && (
-              <span className="inline-flex items-center rounded px-2 py-0.5 text-[10px] font-medium border border-border-glass text-primary bg-bg-hover">
-                {editingAlias.metadata.source}
-              </span>
-            )}
+            <span className="inline-flex items-center rounded px-2 py-0.5 text-[10px] font-medium border border-border-glass text-primary bg-bg-hover">
+              {metadataSource === 'auto' ? 'automatic' : metadataSource}
+            </span>
           </div>
           {isOpen ? (
             <ChevronDown size={14} className="text-text-muted" />
@@ -104,411 +229,569 @@ export function ModelMetadataEditor({ editingAlias, setEditingAlias, isModalOpen
             className="px-3 py-3 border-t border-border-glass"
             style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
           >
-            <p className="font-body text-[11px] text-text-muted">
-              Link this alias to a model in an external catalog. When configured, Plexus includes
-              enriched metadata (name, context length, pricing, supported parameters) in the{' '}
-              <code className="text-primary">GET /v1/models</code> response.
-            </p>
-
-            {/* Source selector */}
-            <div>
-              <label
-                className="font-body text-[12px] font-medium text-text-secondary"
-                style={{ display: 'block', marginBottom: '4px' }}
-              >
-                Source
-              </label>
-              <select
-                className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                style={{ padding: '5px 8px', height: '30px' }}
-                value={editingAlias.metadata?.source ?? 'openrouter'}
-                onChange={(e) => {
-                  const source = e.target.value as MetadataSource;
-                  const prevSource = editingAlias.metadata?.source;
-                  const existingOverrides = editingAlias.metadata?.overrides;
-                  const existingSourcePath = editingAlias.metadata?.source_path;
-                  const carryPath = prevSource === source || source === 'custom';
-                  const carriedSourcePath = carryPath ? existingSourcePath : undefined;
-                  let next: AliasMetadata;
-                  if (source === 'custom') {
-                    const defaults = buildCustomDefaults(editingAlias.id);
-                    const existing = existingOverrides ?? {};
-                    const mergedOverrides = {
-                      ...defaults,
-                      ...existing,
-                      ...(defaults.pricing || existing.pricing
-                        ? { pricing: { ...(defaults.pricing ?? {}), ...(existing.pricing ?? {}) } }
-                        : {}),
-                      ...(defaults.architecture || existing.architecture
-                        ? {
-                            architecture: {
-                              ...(defaults.architecture ?? {}),
-                              ...(existing.architecture ?? {}),
-                            },
-                          }
-                        : {}),
-                      ...(defaults.top_provider || existing.top_provider
-                        ? {
-                            top_provider: {
-                              ...(defaults.top_provider ?? {}),
-                              ...(existing.top_provider ?? {}),
-                            },
-                          }
-                        : {}),
-                    } as MetadataOverrides & { name: string };
-                    next = {
-                      source: 'custom',
-                      ...(carriedSourcePath ? { source_path: carriedSourcePath } : {}),
-                      overrides: mergedOverrides,
-                    };
-                    setIsOverrideOpen(true);
-                  } else {
-                    next = {
-                      source,
-                      source_path: carriedSourcePath ?? '',
-                      ...(existingOverrides ? { overrides: existingOverrides } : {}),
-                    };
-                  }
-                  setEditingAlias({ ...editingAlias, metadata: next });
-                  // Kill any pending search from the prior source.
-                  if (prevSource !== source) {
-                    // The source change handler in useMetadataEditor handles
-                    // debounce cancellation via state resets.
-                  }
-                }}
-              >
-                <option value="openrouter">OpenRouter</option>
-                <option value="models.dev">models.dev</option>
-                <option value="catwalk">Catwalk (Charm)</option>
-                <option value="custom">Custom (manual entry)</option>
-              </select>
-            </div>
-
-            {/* Search / source_path */}
-            {editingAlias.metadata?.source !== 'custom' && (
-              <div style={{ position: 'relative' }}>
-                <label
-                  className="font-body text-[12px] font-medium text-text-secondary"
-                  style={{ display: 'block', marginBottom: '4px' }}
-                >
-                  Model
-                  {editingAlias.metadata?.source_path && (
-                    <span className="ml-2 font-normal text-text-muted">
-                      ({editingAlias.metadata.source_path})
-                    </span>
-                  )}
-                </label>
-                <div style={{ position: 'relative', display: 'flex', gap: '4px' }}>
-                  <div ref={metadataInputWrapperRef} style={{ position: 'relative', flex: 1 }}>
-                    <Input
-                      value={metadataQuery}
-                      onChange={(e) => {
-                        const src = editingAlias.metadata?.source ?? 'openrouter';
-                        handleMetadataSearch(e.target.value, src);
-                        if (metadataInputWrapperRef.current) {
-                          const r = metadataInputWrapperRef.current.getBoundingClientRect();
-                          setDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width });
-                        }
-                      }}
-                      onFocus={() => {
-                        if (metadataResults.length > 0) {
-                          if (metadataInputWrapperRef.current) {
-                            const r = metadataInputWrapperRef.current.getBoundingClientRect();
-                            setDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width });
-                          }
-                          setShowMetadataDropdown(true);
-                        }
-                      }}
-                      placeholder={`Search ${editingAlias.metadata?.source ?? 'openrouter'} catalog...`}
-                      style={{
-                        width: '100%',
-                        paddingRight: isMetadataSearching ? '28px' : undefined,
-                      }}
-                      onBlur={() => setShowMetadataDropdown(false)}
-                    />
-                    {isMetadataSearching && (
-                      <Loader2
-                        size={14}
-                        className="animate-spin text-text-muted"
-                        style={{
-                          position: 'absolute',
-                          right: '8px',
-                          top: '50%',
-                          transform: 'translateY(-50%)',
-                        }}
-                      />
-                    )}
-                  </div>
-                  {editingAlias.metadata && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={clearMetadata}
-                      style={{ color: 'var(--color-danger)', padding: '4px', minHeight: 'auto' }}
-                      title="Remove metadata"
-                    >
-                      <X size={14} />
-                    </Button>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {/* Selected metadata preview */}
-            {editingAlias.metadata &&
-              (editingAlias.metadata.source === 'custom' ||
-                editingAlias.metadata.source_path ||
-                editingAlias.metadata.overrides) && (
+            <div
+              className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-3"
+              style={{ display: 'flex', justifyContent: 'space-between', gap: '12px' }}
+            >
+              <div>
                 <div
-                  className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-2"
-                  style={{ fontSize: '11px', color: 'var(--color-text-secondary)' }}
+                  className="font-body text-[12px] font-medium text-text-secondary"
+                  style={{ display: 'flex', alignItems: 'center', gap: '6px' }}
                 >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                    <CheckCircle size={12} className="text-success" />
-                    <span>
-                      {editingAlias.metadata.source === 'custom' ? (
-                        <>
-                          Custom metadata
-                          {editingAlias.metadata.source_path && (
-                            <>
-                              :{' '}
-                              <code className="text-primary">
-                                {editingAlias.metadata.source_path}
-                              </code>
-                            </>
-                          )}
-                        </>
-                      ) : (
-                        <>
-                          Metadata assigned from <strong>{editingAlias.metadata.source}</strong>
-                          {editingAlias.metadata.source_path && (
-                            <>
-                              :{' '}
-                              <code className="text-primary">
-                                {editingAlias.metadata.source_path}
-                              </code>
-                            </>
-                          )}
-                        </>
-                      )}
-                      {countOverrides(editingAlias.metadata) > 0 && (
-                        <span className="ml-2 text-text-muted">
-                          + {countOverrides(editingAlias.metadata)} field
-                          {countOverrides(editingAlias.metadata) === 1 ? '' : 's'} overridden
-                        </span>
-                      )}
-                    </span>
-                  </div>
+                  <CheckCircle size={13} className="text-success" />
+                  {metadataStatus.label}
                 </div>
-              )}
-
-            {/* Pi model */}
-            <div>
-              <label
-                className="font-body text-[12px] font-medium text-text-secondary"
-                style={{ display: 'block', marginBottom: '4px' }}
-              >
-                Pi model
-              </label>
-              <p className="font-body text-[11px] text-text-muted" style={{ marginBottom: '6px' }}>
-                Link to a pi-ai model to include its compatibility options as{' '}
-                <code className="text-primary">pi_options</code> in{' '}
-                <code className="text-primary">GET /v1/models</code>.
-              </p>
-              <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-                {/* Provider dropdown */}
-                <select
-                  className="font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                  style={{
-                    padding: '5px 8px',
-                    height: '30px',
-                    flex: '0 0 auto',
-                    maxWidth: '160px',
-                  }}
-                  value={editingAlias.pi_model?.provider ?? ''}
-                  onChange={(e) => {
-                    const provider = e.target.value;
-                    if (!provider) {
-                      const { pi_model: _removed, ...rest } = editingAlias;
-                      setEditingAlias(rest as Alias);
-                    } else {
-                      setEditingAlias({ ...editingAlias, pi_model: { provider, model_id: '' } });
-                    }
-                  }}
-                >
-                  <option value="">None</option>
-                  {piProviders.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-
-                {/* Model dropdown */}
-                {editingAlias.pi_model?.provider && (
-                  <div style={{ position: 'relative', flex: 1 }}>
-                    <select
-                      className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                      style={{
-                        padding: '5px 8px',
-                        height: '30px',
-                        paddingRight: piModelsLoading ? '28px' : undefined,
-                      }}
-                      value={editingAlias.pi_model?.model_id ?? ''}
-                      onChange={(e) => {
-                        const model_id = e.target.value;
-                        setEditingAlias({
-                          ...editingAlias,
-                          pi_model: { provider: editingAlias.pi_model!.provider, model_id },
-                        });
-                      }}
-                    >
-                      <option value="">Select model...</option>
-                      {piModels.map((m) => (
-                        <option key={m.id} value={m.id} title={m.api}>
-                          {m.name} ({m.id}){m.custom ? ' — custom' : ''}
-                        </option>
-                      ))}
-                    </select>
-                    {piModelsLoading && (
-                      <Loader2
-                        size={14}
-                        className="animate-spin text-text-muted"
-                        style={{
-                          position: 'absolute',
-                          right: '8px',
-                          top: '50%',
-                          transform: 'translateY(-50%)',
-                          pointerEvents: 'none',
-                        }}
-                      />
+                <p className="font-body text-[11px] text-text-muted mt-1">
+                  {metadataStatus.description}
+                </p>
+                {metadataSource === 'auto' && (
+                  <div
+                    className="font-body text-[11px] text-text-muted mt-2"
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                      columnGap: '12px',
+                      rowGap: '4px',
+                    }}
+                  >
+                    {isResolvingAutomatically ? (
+                      <span>Resolving automatic selections…</span>
+                    ) : automaticResolutionFailed ? (
+                      <span className="text-danger">Could not preview automatic selections.</span>
+                    ) : automaticResolution ? (
+                      <>
+                        <span>
+                          Model:{' '}
+                          <code className="text-primary">
+                            {automaticResolution.canonical_model.provider
+                              ? `${automaticResolution.canonical_model.provider} / `
+                              : ''}
+                            {automaticResolution.canonical_model.model}
+                          </code>
+                        </span>
+                        <span>
+                          Pi model:{' '}
+                          {automaticResolution.pi_model ? (
+                            <code className="text-primary">
+                              {automaticResolution.pi_model.provider} /{' '}
+                              {automaticResolution.pi_model.model_id}
+                            </code>
+                          ) : (
+                            'No registry match'
+                          )}
+                        </span>
+                        <span>
+                          Metadata:{' '}
+                          {automaticResolution.metadata?.source === 'heuristic'
+                            ? 'Safe name and modality defaults'
+                            : automaticResolution.metadata
+                              ? `${automaticResolution.metadata.source} · ${automaticResolution.metadata.source_path}`
+                              : 'Disabled'}
+                        </span>
+                        <span>
+                          Preferred API:{' '}
+                          {automaticResolution.preferred_api ? (
+                            <code className="text-primary">
+                              {automaticResolution.preferred_api[0]}
+                            </code>
+                          ) : (
+                            'Not applicable'
+                          )}
+                        </span>
+                      </>
+                    ) : (
+                      <span>Add an alias name or enabled target to preview selections.</span>
                     )}
                   </div>
                 )}
-
-                {/* Clear pi model */}
-                {editingAlias.pi_model?.model_id && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      const { pi_model: _removed, ...rest } = editingAlias;
-                      setEditingAlias(rest as Alias);
-                    }}
-                    style={{
-                      color: 'var(--color-danger)',
-                      padding: '4px',
-                      minHeight: 'auto',
-                      flex: '0 0 auto',
-                    }}
-                    title="Remove pi model"
-                  >
-                    <X size={14} />
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '6px',
+                  flex: '0 0 auto',
+                  alignSelf: 'center',
+                }}
+              >
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowAdvancedMetadata((current) => !current)}
+                >
+                  {showAdvancedMetadata ? 'Hide settings' : 'Advanced settings'}
+                </Button>
+                {hasManualMetadataSelections && (
+                  <Button variant="danger" size="sm" onClick={resetToAutomatic}>
+                    <RotateCcw size={12} />
+                    Reset to Automatic
                   </Button>
                 )}
               </div>
-
-              {/* Confirmation badge */}
-              {editingAlias.pi_model?.model_id && (
-                <div
-                  className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-2"
-                  style={{
-                    fontSize: '11px',
-                    color: 'var(--color-text-secondary)',
-                    marginTop: '6px',
-                  }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                    <CheckCircle size={12} className="text-success" />
-                    <span>
-                      Pi model: <strong>{editingAlias.pi_model.provider}</strong>
-                      {' / '}
-                      <code className="text-primary">{editingAlias.pi_model.model_id}</code>
-                    </span>
-                  </div>
-                </div>
-              )}
             </div>
 
-            {/* Preferred API */}
-            <div>
-              <label
-                className="font-body text-[12px] font-medium text-text-secondary"
-                style={{ display: 'block', marginBottom: '4px' }}
+            {showAdvancedMetadata && (
+              <div
+                className="border-t border-border-glass pt-3"
+                style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
               >
-                Preferred API
-              </label>
-              <p className="font-body text-[11px] text-text-muted" style={{ marginBottom: '6px' }}>
-                Advertised in <code className="text-primary">/v1/models</code> to inform clients of
-                the recommended API surface for this alias.
-              </p>
-              <select
-                className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
-                style={{ padding: '5px 8px', height: '30px' }}
-                value={(editingAlias.preferred_api ?? [])[0] ?? ''}
-                onChange={(e) => {
-                  const val = e.target.value as PreferredApiValue | '';
-                  setEditingAlias({
-                    ...editingAlias,
-                    preferred_api: val ? [val] : undefined,
-                  });
-                }}
-              >
-                <option value="">None</option>
-                <option value="chat_completions">Chat Completions (/v1/chat/completions)</option>
-                <option value="messages">Messages (/v1/messages)</option>
-                <option value="gemini">Gemini (Google Gemini API)</option>
-                <option value="responses">Responses (/v1/responses)</option>
-              </select>
-            </div>
-
-            {/* Override toggle + editable form */}
-            {editingAlias.metadata && (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                {editingAlias.metadata.source !== 'custom' && (
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
+                {/* Source selector */}
+                <div>
+                  <label
+                    className="font-body text-[12px] font-medium text-text-secondary"
+                    style={{ display: 'block', marginBottom: '4px' }}
+                  >
+                    Source
+                  </label>
+                  <select
+                    className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                    style={{ padding: '5px 8px', height: '30px' }}
+                    value={metadataSource}
+                    onChange={(e) => {
+                      const source = e.target.value as MetadataSource;
+                      const prevSource = editingAlias.metadata?.source;
+                      const existingOverrides = metadataOverrides;
+                      const existingSourcePath =
+                        editingAlias.metadata && 'source_path' in editingAlias.metadata
+                          ? editingAlias.metadata.source_path
+                          : undefined;
+                      const carryPath = prevSource === source || source === 'custom';
+                      const carriedSourcePath = carryPath ? existingSourcePath : undefined;
+                      let next: AliasMetadata;
+                      if (source === 'auto') {
+                        next = {
+                          source: 'auto',
+                          ...(existingOverrides ? { overrides: existingOverrides } : {}),
+                        };
+                      } else if (source === 'disabled') {
+                        next = { source: 'disabled' };
+                        setIsOverrideOpen(false);
+                      } else if (source === 'custom') {
+                        const defaults = buildCustomDefaults(editingAlias.id);
+                        const existing = existingOverrides ?? {};
+                        const mergedOverrides = {
+                          ...defaults,
+                          ...existing,
+                          ...(defaults.pricing || existing.pricing
+                            ? {
+                                pricing: {
+                                  ...(defaults.pricing ?? {}),
+                                  ...(existing.pricing ?? {}),
+                                },
+                              }
+                            : {}),
+                          ...(defaults.architecture || existing.architecture
+                            ? {
+                                architecture: {
+                                  ...(defaults.architecture ?? {}),
+                                  ...(existing.architecture ?? {}),
+                                },
+                              }
+                            : {}),
+                          ...(defaults.top_provider || existing.top_provider
+                            ? {
+                                top_provider: {
+                                  ...(defaults.top_provider ?? {}),
+                                  ...(existing.top_provider ?? {}),
+                                },
+                              }
+                            : {}),
+                        } as MetadataOverrides & { name: string };
+                        next = {
+                          source: 'custom',
+                          ...(carriedSourcePath ? { source_path: carriedSourcePath } : {}),
+                          overrides: mergedOverrides,
+                        };
+                        setIsOverrideOpen(true);
+                      } else {
+                        next = {
+                          source,
+                          source_path: carriedSourcePath ?? '',
+                          ...(existingOverrides ? { overrides: existingOverrides } : {}),
+                        };
+                      }
+                      setEditingAlias({ ...editingAlias, metadata: next });
+                      // Kill any pending search from the prior source.
+                      if (prevSource !== source) {
+                        // The source change handler in useMetadataEditor handles
+                        // debounce cancellation via state resets.
+                      }
                     }}
                   >
+                    <option value="auto">Automatic (recommended)</option>
+                    <option value="openrouter">OpenRouter</option>
+                    <option value="models.dev">models.dev</option>
+                    <option value="catwalk">Catwalk (Charm)</option>
+                    <option value="custom">Custom (manual entry)</option>
+                    <option value="disabled">Disabled</option>
+                  </select>
+                </div>
+
+                {/* Search / source_path */}
+                {isCatalogSource && (
+                  <div style={{ position: 'relative' }}>
                     <label
                       className="font-body text-[12px] font-medium text-text-secondary"
-                      style={{ marginBottom: 0 }}
+                      style={{ display: 'block', marginBottom: '4px' }}
                     >
-                      Override catalog fields
+                      Model
+                      {catalogMetadata?.source_path && (
+                        <span className="ml-2 font-normal text-text-muted">
+                          ({catalogMetadata.source_path})
+                        </span>
+                      )}
                     </label>
-                    <Switch
-                      checked={isOverrideOpen}
-                      onChange={(v) => {
-                        setIsOverrideOpen(v);
-                        if (!v) {
-                          const current = editingAlias.metadata;
-                          if (current) {
-                            const { overrides: _o, ...rest } = current;
-                            setEditingAlias({ ...editingAlias, metadata: rest as AliasMetadata });
-                          }
-                        } else {
-                          const cur = editingAlias.metadata;
-                          if (cur && cur.source !== 'custom' && cur.source_path) {
-                            populateOverridesFromCatalog(cur.source, cur.source_path);
-                          }
-                        }
-                      }}
-                    />
+                    <div style={{ position: 'relative', display: 'flex', gap: '4px' }}>
+                      <div ref={metadataInputWrapperRef} style={{ position: 'relative', flex: 1 }}>
+                        <Input
+                          value={metadataQuery}
+                          onChange={(e) => {
+                            const src = catalogMetadata?.source ?? 'openrouter';
+                            handleMetadataSearch(e.target.value, src);
+                            if (metadataInputWrapperRef.current) {
+                              const r = metadataInputWrapperRef.current.getBoundingClientRect();
+                              setDropdownRect({ top: r.bottom + 2, left: r.left, width: r.width });
+                            }
+                          }}
+                          onFocus={() => {
+                            if (metadataResults.length > 0) {
+                              if (metadataInputWrapperRef.current) {
+                                const r = metadataInputWrapperRef.current.getBoundingClientRect();
+                                setDropdownRect({
+                                  top: r.bottom + 2,
+                                  left: r.left,
+                                  width: r.width,
+                                });
+                              }
+                              setShowMetadataDropdown(true);
+                            }
+                          }}
+                          placeholder={`Search ${catalogMetadata?.source ?? 'openrouter'} catalog...`}
+                          style={{
+                            width: '100%',
+                            paddingRight: isMetadataSearching ? '28px' : undefined,
+                          }}
+                          onBlur={() => setShowMetadataDropdown(false)}
+                        />
+                        {isMetadataSearching && (
+                          <Loader2
+                            size={14}
+                            className="animate-spin text-text-muted"
+                            style={{
+                              position: 'absolute',
+                              right: '8px',
+                              top: '50%',
+                              transform: 'translateY(-50%)',
+                            }}
+                          />
+                        )}
+                      </div>
+                      {editingAlias.metadata && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={clearMetadata}
+                          style={{
+                            color: 'var(--color-danger)',
+                            padding: '4px',
+                            minHeight: 'auto',
+                          }}
+                          title="Return to automatic metadata"
+                        >
+                          <X size={14} />
+                        </Button>
+                      )}
+                    </div>
                   </div>
                 )}
 
-                {(isOverrideOpen || editingAlias.metadata.source === 'custom') && (
-                  <MetadataOverrideForm
-                    overrides={editingAlias.metadata.overrides ?? {}}
-                    isCustom={editingAlias.metadata.source === 'custom'}
-                    onSetField={setOverrideField}
-                    onSetPricing={setPricingField}
-                    onSetArchitecture={setArchitectureField}
-                    onSetTopProvider={setTopProviderField}
-                  />
+                {/* Selected metadata preview */}
+                {editingAlias.metadata &&
+                  editingAlias.metadata.source !== 'auto' &&
+                  editingAlias.metadata.source !== 'disabled' &&
+                  (editingAlias.metadata.source === 'custom' ||
+                    ('source_path' in editingAlias.metadata && editingAlias.metadata.source_path) ||
+                    editingAlias.metadata.overrides) && (
+                    <div
+                      className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-2"
+                      style={{ fontSize: '11px', color: 'var(--color-text-secondary)' }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                        <CheckCircle size={12} className="text-success" />
+                        <span>
+                          {editingAlias.metadata.source === 'custom' ? (
+                            <>
+                              Custom metadata
+                              {editingAlias.metadata.source_path && (
+                                <>
+                                  :{' '}
+                                  <code className="text-primary">
+                                    {editingAlias.metadata.source_path}
+                                  </code>
+                                </>
+                              )}
+                            </>
+                          ) : (
+                            <>
+                              Metadata assigned from <strong>{editingAlias.metadata.source}</strong>
+                              {editingAlias.metadata.source_path && (
+                                <>
+                                  :{' '}
+                                  <code className="text-primary">
+                                    {editingAlias.metadata.source_path}
+                                  </code>
+                                </>
+                              )}
+                            </>
+                          )}
+                          {countOverrides(editingAlias.metadata) > 0 && (
+                            <span className="ml-2 text-text-muted">
+                              + {countOverrides(editingAlias.metadata)} field
+                              {countOverrides(editingAlias.metadata) === 1 ? '' : 's'} overridden
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+
+                {/* Pi model */}
+                <div>
+                  <label
+                    className="font-body text-[12px] font-medium text-text-secondary"
+                    style={{ display: 'block', marginBottom: '4px' }}
+                  >
+                    Pi model
+                  </label>
+                  <p
+                    className="font-body text-[11px] text-text-muted"
+                    style={{ marginBottom: '6px' }}
+                  >
+                    Automatic derives the model from enabled targets. Choose a pi-ai model only to
+                    override that match and advertise its{' '}
+                    <code className="text-primary">pi_options</code>.
+                  </p>
+                  <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                    {/* Provider dropdown */}
+                    <select
+                      className="font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                      style={{
+                        padding: '5px 8px',
+                        height: '30px',
+                        flex: '0 0 auto',
+                        maxWidth: '160px',
+                      }}
+                      value={editingAlias.pi_model?.provider ?? ''}
+                      onChange={(e) => {
+                        const provider = e.target.value;
+                        if (!provider) {
+                          const { pi_model: _removed, ...rest } = editingAlias;
+                          setEditingAlias(rest as Alias);
+                        } else {
+                          setEditingAlias({
+                            ...editingAlias,
+                            pi_model: { provider, model_id: '' },
+                          });
+                        }
+                      }}
+                    >
+                      <option value="">Automatic (from targets)</option>
+                      {piProviders.map((p) => (
+                        <option key={p} value={p}>
+                          {p}
+                        </option>
+                      ))}
+                    </select>
+
+                    {/* Model dropdown */}
+                    {editingAlias.pi_model?.provider && (
+                      <div style={{ position: 'relative', flex: 1 }}>
+                        <select
+                          className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                          style={{
+                            padding: '5px 8px',
+                            height: '30px',
+                            paddingRight: piModelsLoading ? '28px' : undefined,
+                          }}
+                          value={editingAlias.pi_model?.model_id ?? ''}
+                          onChange={(e) => {
+                            const model_id = e.target.value;
+                            setEditingAlias({
+                              ...editingAlias,
+                              pi_model: { provider: editingAlias.pi_model!.provider, model_id },
+                            });
+                          }}
+                        >
+                          <option value="">Select model...</option>
+                          {piModels.map((m) => (
+                            <option key={m.id} value={m.id} title={m.api}>
+                              {m.name} ({m.id}){m.custom ? ' — custom' : ''}
+                            </option>
+                          ))}
+                        </select>
+                        {piModelsLoading && (
+                          <Loader2
+                            size={14}
+                            className="animate-spin text-text-muted"
+                            style={{
+                              position: 'absolute',
+                              right: '8px',
+                              top: '50%',
+                              transform: 'translateY(-50%)',
+                              pointerEvents: 'none',
+                            }}
+                          />
+                        )}
+                      </div>
+                    )}
+
+                    {/* Clear pi model */}
+                    {editingAlias.pi_model?.model_id && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          const { pi_model: _removed, ...rest } = editingAlias;
+                          setEditingAlias(rest as Alias);
+                        }}
+                        style={{
+                          color: 'var(--color-danger)',
+                          padding: '4px',
+                          minHeight: 'auto',
+                          flex: '0 0 auto',
+                        }}
+                        title="Return to automatic Pi model matching"
+                      >
+                        <X size={14} />
+                      </Button>
+                    )}
+                  </div>
+
+                  {/* Confirmation badge */}
+                  {editingAlias.pi_model?.model_id && (
+                    <div
+                      className="rounded-sm border border-border-glass bg-bg-subtle px-3 py-2"
+                      style={{
+                        fontSize: '11px',
+                        color: 'var(--color-text-secondary)',
+                        marginTop: '6px',
+                      }}
+                    >
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                        <CheckCircle size={12} className="text-success" />
+                        <span>
+                          Pi model: <strong>{editingAlias.pi_model.provider}</strong>
+                          {' / '}
+                          <code className="text-primary">{editingAlias.pi_model.model_id}</code>
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Preferred API */}
+                {((editingAlias.type ?? 'text') === 'text' ||
+                  !!editingAlias.preferred_api?.length) && (
+                  <div>
+                    <label
+                      className="font-body text-[12px] font-medium text-text-secondary"
+                      style={{ display: 'block', marginBottom: '4px' }}
+                    >
+                      Preferred API
+                    </label>
+                    <p
+                      className="font-body text-[11px] text-text-muted"
+                      style={{ marginBottom: '6px' }}
+                    >
+                      Advertised in <code className="text-primary">/v1/models</code>. Automatic uses
+                      Messages for Claude, Responses for GPT, Gemini for Gemini models, and Chat
+                      Completions for everything else.
+                    </p>
+                    <select
+                      className="w-full font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none transition-all duration-200 backdrop-blur-md focus:border-primary"
+                      style={{ padding: '5px 8px', height: '30px' }}
+                      value={(editingAlias.preferred_api ?? [])[0] ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value as PreferredApiValue | '';
+                        setEditingAlias({
+                          ...editingAlias,
+                          preferred_api: val ? [val] : undefined,
+                        });
+                      }}
+                    >
+                      <option value="">Automatic (inferred)</option>
+                      <option value="chat_completions">
+                        Chat Completions (/v1/chat/completions)
+                      </option>
+                      <option value="messages">Messages (/v1/messages)</option>
+                      <option value="gemini">Gemini (Google Gemini API)</option>
+                      <option value="responses">Responses (/v1/responses)</option>
+                    </select>
+                  </div>
+                )}
+
+                {/* Override toggle + editable form */}
+                {metadataSource !== 'disabled' && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                    {metadataSource !== 'custom' && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                        }}
+                      >
+                        <label
+                          className="font-body text-[12px] font-medium text-text-secondary"
+                          style={{ marginBottom: 0 }}
+                        >
+                          Override metadata fields
+                        </label>
+                        <Switch
+                          checked={isOverrideOpen}
+                          onChange={(v) => {
+                            setIsOverrideOpen(v);
+                            if (!v) {
+                              const current = editingAlias.metadata;
+                              if (current && current.source !== 'disabled') {
+                                const { overrides: _o, ...rest } = current;
+                                setEditingAlias({
+                                  ...editingAlias,
+                                  metadata: rest as AliasMetadata,
+                                });
+                              }
+                            } else {
+                              const cur = editingAlias.metadata;
+                              if (!cur) {
+                                setEditingAlias({
+                                  ...editingAlias,
+                                  metadata: { source: 'auto', overrides: {} },
+                                });
+                              } else if (
+                                cur.source !== 'auto' &&
+                                cur.source !== 'disabled' &&
+                                cur.source !== 'custom' &&
+                                cur.source_path
+                              ) {
+                                populateOverridesFromCatalog(cur.source, cur.source_path);
+                              }
+                            }
+                          }}
+                        />
+                      </div>
+                    )}
+
+                    {(isOverrideOpen || metadataSource === 'custom') && (
+                      <MetadataOverrideForm
+                        overrides={metadataOverrides ?? {}}
+                        isCustom={metadataSource === 'custom'}
+                        onSetField={setOverrideField}
+                        onSetPricing={setPricingField}
+                        onSetArchitecture={setArchitectureField}
+                        onSetTopProvider={setTopProviderField}
+                      />
+                    )}
+                  </div>
                 )}
               </div>
             )}

--- a/packages/frontend/src/hooks/useMetadataEditor.ts
+++ b/packages/frontend/src/hooks/useMetadataEditor.ts
@@ -3,6 +3,7 @@ import {
   api,
   Alias,
   AliasMetadata,
+  CatalogMetadataSource,
   MetadataOverrides,
   MetadataSource,
   NormalizedModelMetadata,
@@ -70,7 +71,9 @@ export function useMetadataEditor(
     const out: MetadataOverrides = {};
     if (meta.name) out.name = meta.name;
     if (meta.description !== undefined) out.description = meta.description;
-    if (meta.context_length !== undefined) out.context_length = meta.context_length;
+    if (meta.context_length !== undefined && meta.context_length > 0) {
+      out.context_length = meta.context_length;
+    }
     if (meta.pricing) {
       const p: NonNullable<MetadataOverrides['pricing']> = {};
       if (meta.pricing.prompt !== undefined) p.prompt = meta.pricing.prompt;
@@ -94,9 +97,12 @@ export function useMetadataEditor(
       out.supported_parameters = [...meta.supported_parameters];
     if (meta.top_provider) {
       const tp: NonNullable<MetadataOverrides['top_provider']> = {};
-      if (meta.top_provider.context_length !== undefined)
+      if (meta.top_provider.context_length !== undefined && meta.top_provider.context_length > 0)
         tp.context_length = meta.top_provider.context_length;
-      if (meta.top_provider.max_completion_tokens !== undefined)
+      if (
+        meta.top_provider.max_completion_tokens !== undefined &&
+        meta.top_provider.max_completion_tokens > 0
+      )
         tp.max_completion_tokens = meta.top_provider.max_completion_tokens;
       if (Object.keys(tp).length > 0) out.top_provider = tp;
     }
@@ -106,6 +112,7 @@ export function useMetadataEditor(
   /** Return `current` with overrides replaced, preserving custom's name invariant. */
   const withOverrides = useCallback(
     (current: AliasMetadata, overrides: MetadataOverrides): AliasMetadata => {
+      if (current.source === 'disabled') return current;
       if (current.source === 'custom') {
         return {
           ...current,
@@ -161,7 +168,7 @@ export function useMetadataEditor(
    * user-typed overrides (user values win on conflict).
    */
   const populateOverridesFromCatalog = useCallback(
-    async (source: Exclude<MetadataSource, 'custom'>, sourcePath: string) => {
+    async (source: CatalogMetadataSource, sourcePath: string) => {
       if (!sourcePath) return;
       const priorCatalog = catalogReference ?? null;
       try {
@@ -210,7 +217,7 @@ export function useMetadataEditor(
 
   const handleMetadataSearch = useCallback(
     (query: string, source: MetadataSource) => {
-      if (source === 'custom') {
+      if (source === 'auto' || source === 'disabled' || source === 'custom') {
         cancelMetadataDebounce();
         setMetadataQuery(query);
         setMetadataResults([]);
@@ -246,14 +253,18 @@ export function useMetadataEditor(
     (result: { id: string; name: string }) => {
       const current = aliasRef.current;
       const meta = current.metadata;
-      const source: Exclude<MetadataSource, 'custom'> =
-        meta?.source && meta.source !== 'custom' ? meta.source : 'openrouter';
+      const source: CatalogMetadataSource =
+        meta?.source === 'openrouter' || meta?.source === 'models.dev' || meta?.source === 'catwalk'
+          ? meta.source
+          : 'openrouter';
       setEditingAlias({
         ...current,
         metadata: {
           source,
           source_path: result.id,
-          ...(meta?.overrides ? { overrides: meta.overrides } : {}),
+          ...(meta && meta.source !== 'disabled' && meta.overrides
+            ? { overrides: meta.overrides }
+            : {}),
         },
       });
       setMetadataQuery(result.name);
@@ -283,7 +294,7 @@ export function useMetadataEditor(
   const setOverrideField = useCallback(
     <K extends keyof MetadataOverrides>(key: K, value: MetadataOverrides[K] | undefined) => {
       const current = aliasRef.current.metadata;
-      if (!current) return;
+      if (!current || current.source === 'disabled') return;
       const nextOverrides: MetadataOverrides = { ...(current.overrides ?? {}) };
       if (value === undefined) {
         if (current.source === 'custom' && key === 'name') {
@@ -302,7 +313,7 @@ export function useMetadataEditor(
   const setPricingField = useCallback(
     (key: keyof NonNullable<MetadataOverrides['pricing']>, value: string | undefined) => {
       const current = aliasRef.current.metadata;
-      if (!current) return;
+      if (!current || current.source === 'disabled') return;
       const pricing = { ...(current.overrides?.pricing ?? {}) };
       if (value === undefined || value === '') delete pricing[key];
       else pricing[key] = value;
@@ -320,7 +331,7 @@ export function useMetadataEditor(
       value: string | string[] | undefined
     ) => {
       const current = aliasRef.current.metadata;
-      if (!current) return;
+      if (!current || current.source === 'disabled') return;
       const arch = { ...(current.overrides?.architecture ?? {}) };
       if (value === undefined || (Array.isArray(value) && value.length === 0) || value === '')
         delete arch[key];
@@ -336,7 +347,7 @@ export function useMetadataEditor(
   const setTopProviderField = useCallback(
     (key: keyof NonNullable<MetadataOverrides['top_provider']>, value: number | undefined) => {
       const current = aliasRef.current.metadata;
-      if (!current) return;
+      if (!current || current.source === 'disabled') return;
       const tp = { ...(current.overrides?.top_provider ?? {}) };
       if (value === undefined) delete tp[key];
       else tp[key] = value;
@@ -350,11 +361,13 @@ export function useMetadataEditor(
 
   const countOverrides = useCallback(
     (metadata?: AliasMetadata): number => {
-      if (!metadata?.overrides) return 0;
+      if (!metadata || metadata.source === 'disabled' || !metadata.overrides) return 0;
       const o = metadata.overrides;
       let ref: MetadataOverrides;
       if (metadata.source === 'custom') {
         ref = buildCustomDefaults(aliasRef.current.id);
+      } else if (metadata.source === 'auto') {
+        ref = {};
       } else if (catalogReference === undefined) {
         return 0;
       } else {
@@ -429,8 +442,10 @@ export function useMetadataEditor(
     if (!isModalOpen) return;
     cancelMetadataDebounce();
     const meta = editingAlias.metadata;
-    setIsOverrideOpen(!!meta && (meta.source === 'custom' || !!meta.overrides));
-    setMetadataQuery(meta?.source_path ?? '');
+    setIsOverrideOpen(
+      !!meta && meta.source !== 'disabled' && (meta.source === 'custom' || !!meta.overrides)
+    );
+    setMetadataQuery(meta && 'source_path' in meta ? (meta.source_path ?? '') : '');
     setShowMetadataDropdown(false);
     setMetadataResults([]);
     setIsMetadataSearching(false);
@@ -440,7 +455,13 @@ export function useMetadataEditor(
   // Keep catalogReference in sync with the selected catalog (source, source_path).
   useEffect(() => {
     const meta = editingAlias.metadata;
-    if (!meta || meta.source === 'custom' || !meta.source_path) {
+    if (
+      !meta ||
+      meta.source === 'auto' ||
+      meta.source === 'disabled' ||
+      meta.source === 'custom' ||
+      !meta.source_path
+    ) {
       setCatalogReference(undefined);
       return;
     }
@@ -459,7 +480,12 @@ export function useMetadataEditor(
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editingAlias.metadata?.source, editingAlias.metadata?.source_path]);
+  }, [
+    editingAlias.metadata?.source,
+    editingAlias.metadata && 'source_path' in editingAlias.metadata
+      ? editingAlias.metadata.source_path
+      : undefined,
+  ]);
 
   return {
     // State

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -338,7 +338,8 @@ export interface StripAdaptiveThinkingBehavior {
 
 export type AliasBehavior = StripAdaptiveThinkingBehavior; // | NextBehavior | ...
 
-export type MetadataSource = 'openrouter' | 'models.dev' | 'catwalk' | 'custom';
+export type CatalogMetadataSource = 'openrouter' | 'models.dev' | 'catwalk';
+export type MetadataSource = CatalogMetadataSource | 'auto' | 'disabled' | 'custom';
 
 export interface MetadataOverrides {
   name?: string;
@@ -391,7 +392,7 @@ export interface NormalizedModelMetadata {
 }
 
 export interface ModelMetadataRefreshSourceSummary {
-  source: Exclude<MetadataSource, 'custom'>;
+  source: CatalogMetadataSource;
   initialized: boolean;
   count: number;
   error?: string;
@@ -417,9 +418,16 @@ export interface ModelMetadataRefreshResult {
 // an overrides blob with a non-empty `name` (there is no catalog fallback).
 export type AliasMetadata =
   | {
-      source: Exclude<MetadataSource, 'custom'>;
+      source: CatalogMetadataSource;
       source_path: string;
       overrides?: MetadataOverrides;
+    }
+  | {
+      source: 'auto';
+      overrides?: MetadataOverrides;
+    }
+  | {
+      source: 'disabled';
     }
   | {
       source: 'custom';
@@ -1092,6 +1100,49 @@ export interface CompactionSettings {
   protectRecent?: number;
   native?: { maxArrayItems?: number; maxStringChars?: number };
   headroom?: { baseUrl?: string; apiKey?: string; targetRatio?: number | null; timeoutMs?: number };
+}
+
+export interface ModelResolutionPreview {
+  canonical_model: {
+    provider?: string;
+    model: string;
+    basis: 'pi_model' | 'target' | 'alias';
+  };
+  pi_model: { provider: string; model_id: string; name: string } | null;
+  metadata: {
+    source: CatalogMetadataSource | 'heuristic';
+    source_path?: string;
+    name: string;
+  } | null;
+  preferred_api: PreferredApiValue[] | null;
+}
+
+function aliasToConfigPayload(alias: Alias): Record<string, unknown> {
+  return {
+    priority: alias.priority || 'selector',
+    additional_aliases: alias.aliases,
+    use_image_fallthrough: alias.use_image_fallthrough || false,
+    enforce_limits: alias.enforce_limits || false,
+    sticky_session: alias.sticky_session ?? true,
+    ...(alias.preferred_api?.length ? { preferred_api: alias.preferred_api } : {}),
+    ...(alias.type && { type: alias.type }),
+    ...(alias.advanced?.length ? { advanced: alias.advanced } : {}),
+    ...(alias.metadata && { metadata: alias.metadata }),
+    ...(alias.pi_model && { pi_model: alias.pi_model }),
+    ...(alias.model_architecture && { model_architecture: alias.model_architecture }),
+    ...(alias.extraBody && Object.keys(alias.extraBody).length > 0
+      ? { extraBody: alias.extraBody }
+      : {}),
+    target_groups: alias.target_groups.map((group) => ({
+      name: group.name,
+      selector: group.selector,
+      targets: group.targets.map((target) => ({
+        provider: target.provider,
+        model: target.model,
+        ...(target.enabled === false && { enabled: false }),
+      })),
+    })),
+  };
 }
 
 export const api = {
@@ -1992,34 +2043,7 @@ export const api = {
   },
 
   saveAlias: async (alias: Alias, oldId?: string): Promise<void> => {
-    const body: any = {
-      priority: alias.priority || 'selector',
-      additional_aliases: alias.aliases,
-      use_image_fallthrough: alias.use_image_fallthrough || false,
-      enforce_limits: alias.enforce_limits || false,
-      sticky_session: alias.sticky_session ?? true,
-      ...(alias.preferred_api &&
-        alias.preferred_api.length > 0 && {
-          preferred_api: alias.preferred_api,
-        }),
-      ...(alias.type && { type: alias.type }),
-      ...(alias.advanced && alias.advanced.length > 0 && { advanced: alias.advanced }),
-      ...(alias.metadata && { metadata: alias.metadata }),
-      ...(alias.pi_model && { pi_model: alias.pi_model }),
-      // Model architecture override for inference energy calculation
-      ...(alias.model_architecture && { model_architecture: alias.model_architecture }),
-      ...(alias.extraBody &&
-        Object.keys(alias.extraBody).length > 0 && { extraBody: alias.extraBody }),
-      target_groups: alias.target_groups.map((g) => ({
-        name: g.name,
-        selector: g.selector,
-        targets: g.targets.map((t) => ({
-          provider: t.provider,
-          model: t.model,
-          ...(t.enabled === false && { enabled: false }),
-        })),
-      })),
-    };
+    const body = aliasToConfigPayload(alias);
 
     const res = await fetchWithAuth(
       `${API_BASE}/v0/management/aliases/${encodeURIComponent(alias.id)}`,
@@ -2038,6 +2062,16 @@ export const api = {
     if (oldId && oldId !== alias.id) {
       await api.deleteAlias(oldId);
     }
+  },
+
+  previewModelResolution: async (alias: Alias): Promise<ModelResolutionPreview> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/models/metadata/resolve`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ alias_id: alias.id, model: aliasToConfigPayload(alias) }),
+    });
+    if (!res.ok) throw new Error('Failed to resolve automatic model selections');
+    return res.json();
   },
 
   getModels: async (): Promise<Model[]> => {
@@ -2662,7 +2696,7 @@ export const api = {
    * @param limit  - max results (default 50)
    */
   searchModelMetadata: async (
-    source: Exclude<MetadataSource, 'custom'>,
+    source: CatalogMetadataSource,
     query?: string,
     limit?: number
   ): Promise<{ data: { id: string; name: string }[]; count: number }> => {
@@ -2684,7 +2718,7 @@ export const api = {
    * can gracefully fall back to leaving the form blank.
    */
   getModelMetadata: async (
-    source: Exclude<MetadataSource, 'custom'>,
+    source: CatalogMetadataSource,
     sourcePath: string
   ): Promise<NormalizedModelMetadata | null> => {
     const params = new URLSearchParams({ source, source_path: sourcePath });


### PR DESCRIPTION
### **User description**
## Summary
- resolve model metadata automatically from Pi hints and enabled targets, with exact catalog matches and conservative fallbacks
- infer verified Pi models and text-only preferred APIs while preserving explicit overrides
- simplify the metadata editor with live resolution previews, advanced overrides, reset-to-automatic, and zero-limit sanitization
- document and test the new metadata modes and resolution preview API

## Verification
- `bun run test`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:openapi`
- browser-verified automatic, pinned, reset, speech, and embeddings flows


___

### **Description**
- Add automatic metadata resolution from canonical model identity, exact catalog matching, and conservative heuristic fallbacks

- Infer preferred API from model families (Claude→messages, GPT→responses, Gemini→gemini) while preserving explicit overrides

- Add `auto` and `disabled` metadata source modes with schema, DB repository, and config validation support

- Add resolution preview API endpoint and live preview UI with advanced settings toggle and reset-to-automatic

- Sanitize zero/negative catalog limits and update documentation for new metadata modes


___

