### PR TITLE
fix(models): correct embedding output modality

### DIFF
--- a/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
+++ b/packages/backend/src/services/__tests__/model-metadata-manager.test.ts
@@ -753,6 +753,56 @@ describe('resolveModelMetadata', () => {
     expect(resolved?.metadata.context_length).toBe(200000);
   });
 
+  test('overrides catalog text output for embeddings aliases', async () => {
+    ModelMetadataManager.resetForTesting();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              openai: {
+                id: 'openai',
+                models: {
+                  'text-embedding-3-small': {
+                    id: 'text-embedding-3-small',
+                    name: 'Text Embedding 3 Small',
+                    modalities: { input: ['text', 'image'], output: ['text'] },
+                  },
+                },
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+      )
+    );
+    const manager = ModelMetadataManager.getInstance();
+    await manager.loadAll({
+      openrouter: '/dev/null-nonexistent',
+      modelsDev: 'https://example.com/models.json',
+      catwalk: '/dev/null-nonexistent',
+    });
+    const modelConfig = {
+      type: 'embeddings',
+      target_groups: [
+        {
+          name: 'default',
+          selector: 'random',
+          targets: [{ provider: 'openai', model: 'text-embedding-3-small' }],
+        },
+      ],
+    } as unknown as ModelConfig;
+
+    const resolved = resolveModelMetadata('text-embedding-3-small', modelConfig, {}, manager);
+
+    expect(resolved?.source).toBe('models.dev');
+    expect(resolved?.metadata.architecture).toMatchObject({
+      modality: 'text+image->embeddings',
+      input_modalities: ['text', 'image'],
+      output_modalities: ['embeddings'],
+    });
+  });
+
   test('falls back to conservative name and modality heuristics', () => {
     ModelMetadataManager.resetForTesting();
     const modelConfig = {

--- a/packages/backend/src/services/model-metadata-manager.ts
+++ b/packages/backend/src/services/model-metadata-manager.ts
@@ -913,6 +913,24 @@ function inferArchitecture(
   }
 }
 
+function applyConfiguredModelType(
+  metadata: NormalizedModelMetadata,
+  configuredType?: ModelConfig['type']
+): NormalizedModelMetadata {
+  if (configuredType !== 'embeddings') return metadata;
+
+  const inputModalities = metadata.architecture?.input_modalities ?? ['text'];
+  return {
+    ...metadata,
+    architecture: {
+      ...metadata.architecture,
+      modality: `${inputModalities.join('+')}->embeddings`,
+      input_modalities: inputModalities,
+      output_modalities: ['embeddings'],
+    },
+  };
+}
+
 function getProviderModelConfig(
   provider: ProviderConfig | undefined,
   model: string
@@ -999,7 +1017,9 @@ export function resolveModelMetadata(
 
   if (configured?.source === 'custom') {
     const metadata = mergeOverrides(undefined, configured.overrides);
-    return metadata ? { metadata, source: 'heuristic' } : undefined;
+    return metadata
+      ? { metadata: applyConfiguredModelType(metadata, modelConfig.type), source: 'heuristic' }
+      : undefined;
   }
 
   if (
@@ -1010,7 +1030,11 @@ export function resolveModelMetadata(
     const catalog = manager.getMetadata(configured.source, configured.source_path);
     const metadata = catalog ? mergeOverrides(catalog, configured.overrides) : undefined;
     return metadata
-      ? { metadata, source: configured.source, sourcePath: configured.source_path }
+      ? {
+          metadata: applyConfiguredModelType(metadata, modelConfig.type),
+          source: configured.source,
+          sourcePath: configured.source_path,
+        }
       : undefined;
   }
 
@@ -1020,7 +1044,9 @@ export function resolveModelMetadata(
     : undefined;
   if (exact) {
     const metadata = mergeOverrides(exact.metadata, configured?.overrides);
-    return metadata ? { ...exact, metadata } : undefined;
+    return metadata
+      ? { ...exact, metadata: applyConfiguredModelType(metadata, modelConfig.type) }
+      : undefined;
   }
 
   const heuristic: NormalizedModelMetadata = {
@@ -1029,7 +1055,9 @@ export function resolveModelMetadata(
     architecture: inferArchitecture(identity.model, modelConfig.type),
   };
   const metadata = mergeOverrides(heuristic, configured?.overrides);
-  return metadata ? { metadata, source: 'heuristic' } : undefined;
+  return metadata
+    ? { metadata: applyConfiguredModelType(metadata, modelConfig.type), source: 'heuristic' }
+    : undefined;
 }
 
 export function resolvePreferredApi(


### PR DESCRIPTION
### **User description**
## Summary
- force embeddings aliases to advertise embeddings output when catalog metadata is incorrect
- preserve catalog input modalities while rebuilding the architecture modality
- add regression coverage for text-embedding-3-small catalog metadata

## Verification
- bun run test src/services/__tests__/model-metadata-manager.test.ts
- bun run typecheck
- bun run format:check


___

### **Description**
- Correct embedding alias output modality metadata

- Preserve catalog-provided input modalities

- Apply correction across metadata resolution paths

- Add catalog metadata regression coverage


___

