### PR TITLE
fix(oauth): preserve tool name casing

### DIFF
--- a/packages/backend/src/transformers/__tests__/oauth-transformer.test.ts
+++ b/packages/backend/src/transformers/__tests__/oauth-transformer.test.ts
@@ -216,24 +216,32 @@ describe('OAuthTransformer', () => {
     (vi.mocked(piAiModels.stream) as any).mockImplementation(
       (_model: any, _context: any, options: any) => {
         const onPayload = options.onPayload as (payload: any) => any;
-        onPayload({
-          model: 'claude-test',
-          messages: [{ role: 'user', content: [{ type: 'text', text: 'hello world' }] }],
-          tools: [
-            { name: 'github_search_users', input_schema: { type: 'object' } },
-            { name: 'github_list_repos', input_schema: { type: 'object' } },
-            { name: 'github_create_issue', input_schema: { type: 'object' } },
-            { name: 'github_get_issue', input_schema: { type: 'object' } },
-          ],
-        });
-
         return (async function* () {
+          onPayload({
+            model: 'claude-test',
+            messages: [{ role: 'user', content: [{ type: 'text', text: 'hello world' }] }],
+            tools: [
+              {
+                name: 'Read',
+                input_schema: { type: 'object', required: ['path'] },
+              },
+            ],
+          });
           yield {
-            type: 'content_block_start',
-            content_block: {
-              type: 'tool_use',
-              name: 'mcp__github__search_users',
-              input: {},
+            type: 'toolcall_delta',
+            contentIndex: 0,
+            delta: '{}',
+            partial: {
+              provider: 'anthropic',
+              model: 'claude-test',
+              content: [
+                {
+                  type: 'toolCall',
+                  id: 'toolu_test',
+                  name: 'mcp__Read',
+                  arguments: {},
+                },
+              ],
             },
           };
         })() as any;
@@ -242,7 +250,7 @@ describe('OAuthTransformer', () => {
 
     const transformer = new OAuthTransformer();
     const stream = (await transformer.executeRequest(
-      { tools: [], messages: [] },
+      { tools: [{ name: 'read' }], messages: [] },
       'anthropic' as any,
       'claude-test',
       true,
@@ -255,7 +263,7 @@ describe('OAuthTransformer', () => {
     const iterator = stream[Symbol.asyncIterator]();
     const first = await iterator.next();
 
-    expect(first.value.content_block.name).toBe('github_search_users');
+    expect(first.value?.partial.content[0]?.name).toBe('read');
   });
 
   test('transformRequest normalises string assistant content to array blocks (issue #162)', async () => {

--- a/packages/backend/src/transformers/oauth/__tests__/oauth-claude.test.ts
+++ b/packages/backend/src/transformers/oauth/__tests__/oauth-claude.test.ts
@@ -6,6 +6,7 @@ import {
   reverseRemapOAuthToolNamesFromStreamLine,
   injectClaudeCodeSystemPrompt,
   applyClaudeOAuthTransform,
+  restoreOriginalOAuthToolName,
 } from '../oauth-claude';
 
 describe('Claude OAuth', () => {
@@ -113,6 +114,19 @@ describe('Claude OAuth', () => {
       const result = reverseRemapOAuthToolNames(input);
 
       expect(result.content[0].name).toBe('CustomTool');
+    });
+  });
+
+  describe('restoreOriginalOAuthToolName', () => {
+    test('preserves the client-provided tool-name case', () => {
+      const context = {
+        apiKey: 'sk-ant-oat-test-token',
+        isOAuth: true,
+        toolNamesRemapped: true,
+        originalToolNames: new Map([['Read', 'Read']]),
+      };
+
+      expect(restoreOriginalOAuthToolName('Read', context)).toBe('Read');
     });
   });
 

--- a/packages/backend/src/transformers/oauth/oauth-claude.ts
+++ b/packages/backend/src/transformers/oauth/oauth-claude.ts
@@ -57,7 +57,7 @@ function shouldRemapToolName(name: string): boolean {
 /**
  * Remap a single tool name from lowercase to TitleCase.
  */
-function remapToolName(name: string): string {
+export function canonicalizeOAuthToolName(name: string): string {
   const lowerName = name.toLowerCase();
   return OAUTH_TOOL_RENAME_MAP[lowerName] ?? name;
 }
@@ -90,7 +90,7 @@ export function remapOAuthToolNames(body: any): { body: any; renamed: boolean } 
 
       const name = tool.name;
       if (name && shouldRemapToolName(name)) {
-        tool.name = remapToolName(name);
+        tool.name = canonicalizeOAuthToolName(name);
         renamed = true;
       }
     }
@@ -100,7 +100,7 @@ export function remapOAuthToolNames(body: any): { body: any; renamed: boolean } 
   if (result.tool_choice?.type === 'tool' || result.tool_choice?.type === 'function') {
     const tcName = result.tool_choice.name;
     if (tcName && shouldRemapToolName(tcName)) {
-      result.tool_choice.name = remapToolName(tcName);
+      result.tool_choice.name = canonicalizeOAuthToolName(tcName);
       renamed = true;
     }
   }
@@ -115,7 +115,7 @@ export function remapOAuthToolNames(body: any): { body: any; renamed: boolean } 
           case 'tool_use': {
             const name = part.name;
             if (name && shouldRemapToolName(name)) {
-              part.name = remapToolName(name);
+              part.name = canonicalizeOAuthToolName(name);
               renamed = true;
             }
             break;
@@ -124,7 +124,7 @@ export function remapOAuthToolNames(body: any): { body: any; renamed: boolean } 
           case 'tool_reference': {
             const toolName = part.tool_name;
             if (toolName && shouldRemapToolName(toolName)) {
-              part.tool_name = remapToolName(toolName);
+              part.tool_name = canonicalizeOAuthToolName(toolName);
               renamed = true;
             }
             break;
@@ -137,7 +137,7 @@ export function remapOAuthToolNames(body: any): { body: any; renamed: boolean } 
                 if (nested.type === 'tool_reference') {
                   const nestedToolName = nested.tool_name;
                   if (nestedToolName && shouldRemapToolName(nestedToolName)) {
-                    nested.tool_name = remapToolName(nestedToolName);
+                    nested.tool_name = canonicalizeOAuthToolName(nestedToolName);
                     renamed = true;
                   }
                 }
@@ -644,6 +644,11 @@ export interface ClaudeOAuthContext {
   apiKey: string;
   isOAuth: boolean;
   toolNamesRemapped: boolean;
+  originalToolNames?: ReadonlyMap<string, string>;
+}
+
+export function restoreOriginalOAuthToolName(name: string, context: ClaudeOAuthContext): string {
+  return context.originalToolNames?.get(name) ?? name;
 }
 
 /**

--- a/packages/backend/src/transformers/oauth/oauth-transformer.ts
+++ b/packages/backend/src/transformers/oauth/oauth-transformer.ts
@@ -22,7 +22,9 @@ import {
 import { logger } from '../../utils/logger';
 import {
   applyClaudeOAuthTransform,
+  canonicalizeOAuthToolName,
   isClaudeOAuthToken,
+  restoreOriginalOAuthToolName,
   type ClaudeOAuthContext,
 } from './oauth-claude';
 import { CodexVersionService } from '../../services/codex-version-service';
@@ -36,6 +38,17 @@ import {
 import type { RenamePair } from './masking/types';
 
 export { buildThinkingOptions };
+
+const oauthContextSymbol = Symbol('oauthContext');
+
+function attachOAuthContext<T extends object>(value: T, getContext: () => ClaudeOAuthContext): T {
+  Object.defineProperty(value, oauthContextSymbol, { get: getContext });
+  return value;
+}
+
+function getOAuthContext(value: unknown): ClaudeOAuthContext | undefined {
+  return (value as { [oauthContextSymbol]?: ClaudeOAuthContext } | undefined)?.[oauthContextSymbol];
+}
 
 function streamFromAsyncIterable<T>(iterable: AsyncIterable<T>): ReadableStream<T> {
   const iterator = iterable[Symbol.asyncIterator]();
@@ -127,14 +140,41 @@ function reverseToolRenamesInValue<T>(value: T, pairs: readonly RenamePair[]): T
   }
 }
 
-function wrapStreamWithToolRenameReversal<T>(
-  streamInput: ReadableStream<T> | AsyncIterable<T>,
-  pairs: readonly RenamePair[]
-): ReadableStream<T> | AsyncIterable<T> {
-  if (pairs.length === 0) {
-    return streamInput;
+function reverseOAuthToolNamesInStreamValue<T>(value: T, context: ClaudeOAuthContext): T {
+  if (!context.isOAuth || !context.toolNamesRemapped || value == null) {
+    return value;
   }
 
+  const reverseToolCallNames = (input: any): any => {
+    if (Array.isArray(input)) {
+      return input.map(reverseToolCallNames);
+    }
+
+    if (!input || typeof input !== 'object') {
+      return input;
+    }
+
+    const result = Object.fromEntries(
+      Object.entries(input).map(([key, nested]) => [key, reverseToolCallNames(nested)])
+    );
+    if (result.type !== 'toolCall' || typeof result.name !== 'string') {
+      return result;
+    }
+
+    const name = result.name.startsWith('proxy_')
+      ? result.name.slice('proxy_'.length)
+      : result.name;
+    return { ...result, name: restoreOriginalOAuthToolName(name, context) };
+  };
+
+  return reverseToolCallNames(value);
+}
+
+function wrapStreamWithToolRenameReversal<T>(
+  streamInput: ReadableStream<T> | AsyncIterable<T>,
+  getPairs: () => readonly RenamePair[],
+  getContext: () => ClaudeOAuthContext
+): ReadableStream<T> | AsyncIterable<T> {
   if (isReadableStream<T>(streamInput)) {
     const reader = streamInput.getReader();
     return new ReadableStream<T>({
@@ -144,7 +184,12 @@ function wrapStreamWithToolRenameReversal<T>(
           controller.close();
           return;
         }
-        controller.enqueue(reverseToolRenamesInValue(value, pairs));
+        controller.enqueue(
+          reverseOAuthToolNamesInStreamValue(
+            reverseToolRenamesInValue(value, getPairs()),
+            getContext()
+          )
+        );
       },
       cancel(reason) {
         return reader.cancel(reason);
@@ -154,7 +199,10 @@ function wrapStreamWithToolRenameReversal<T>(
 
   return (async function* () {
     for await (const event of streamInput) {
-      yield reverseToolRenamesInValue(event, pairs);
+      yield reverseOAuthToolNamesInStreamValue(
+        reverseToolRenamesInValue(event, getPairs()),
+        getContext()
+      );
     }
   })();
 }
@@ -280,7 +328,12 @@ export class OAuthTransformer implements Transformer {
       error.piAiResponse = piAiError.payload;
       throw error;
     }
-    const unified = piAiMessageToUnified(response, response.provider, response.model);
+    const unified = piAiMessageToUnified(
+      response,
+      response.provider,
+      response.model,
+      getOAuthContext(response)
+    );
 
     logger.debug(`${this.name}: Converted pi-ai response to unified`, {
       hasContent: !!unified.content,
@@ -299,6 +352,7 @@ export class OAuthTransformer implements Transformer {
   }
 
   transformStream(streamInput: ReadableStream | AsyncIterable<any>): ReadableStream {
+    const getStreamOAuthContext = () => getOAuthContext(streamInput);
     const mapped = (async function* () {
       const source = isAsyncIterable<any>(streamInput)
         ? streamInput
@@ -313,7 +367,7 @@ export class OAuthTransformer implements Transformer {
           event.partial?.provider || event.message?.provider || event.error?.provider;
         const eventModel =
           event.partial?.model || event.message?.model || event.error?.model || 'unknown';
-        const chunk = piAiEventToChunk(event, eventModel, provider);
+        const chunk = piAiEventToChunk(event, eventModel, provider, getStreamOAuthContext());
         if (chunk) {
           yield chunk;
         }
@@ -381,6 +435,11 @@ export class OAuthTransformer implements Transformer {
     const usesClaudeCodeOAuthShim =
       provider === 'anthropic' && auth.authMode === 'apiKey' && apiKey.includes('sk-ant-oat');
     const model = { ...this.getPiAiModel(provider, modelId) };
+    const originalToolNames = new Map<string, string>(
+      (context.tools ?? [])
+        .filter((tool: any) => typeof tool?.name === 'string')
+        .map((tool: any) => [canonicalizeOAuthToolName(tool.name), tool.name])
+    );
 
     // GitHub Copilot Business account fix:
     // pi-ai extracts proxy-ep from the token and incorrectly derives api.business.githubcopilot.com
@@ -509,7 +568,7 @@ export class OAuthTransformer implements Transformer {
             oauthMode: true,
           }
         );
-        oauthContext = context;
+        oauthContext = { ...context, originalToolNames };
 
         // Store OAuth context on the model for response transformation
         (model as any).__oauthContext = oauthContext;
@@ -542,7 +601,14 @@ export class OAuthTransformer implements Transformer {
       try {
         const result = await piAiModels.stream(model, context, requestOptions);
         logger.debug(`${this.name}: OAuth stream result type`, describeStreamResult(result));
-        return wrapStreamWithToolRenameReversal(result, toolRenamePairs);
+        return attachOAuthContext(
+          wrapStreamWithToolRenameReversal(
+            result,
+            () => toolRenamePairs,
+            () => oauthContext
+          ),
+          () => oauthContext
+        );
       } catch (error: any) {
         if (error?.name === 'AbortError' || signal?.aborted) {
           const isTimeout = signal?.reason?.name === 'TimeoutError';
@@ -560,7 +626,10 @@ export class OAuthTransformer implements Transformer {
 
     try {
       const result = await piAiModels.complete(model, context, requestOptions);
-      return reverseToolRenamesInValue(result, toolRenamePairs);
+      return attachOAuthContext(
+        reverseToolRenamesInValue(result, toolRenamePairs),
+        () => oauthContext
+      );
     } catch (error: any) {
       if (error?.name === 'AbortError' || signal?.aborted) {
         const isTimeout = signal?.reason?.name === 'TimeoutError';

--- a/packages/backend/src/transformers/oauth/type-mappers.ts
+++ b/packages/backend/src/transformers/oauth/type-mappers.ts
@@ -17,7 +17,7 @@ import type {
   MessageContent,
   UnifiedUsage,
 } from '../../types/unified';
-import type { ClaudeOAuthContext } from './oauth-claude';
+import { restoreOriginalOAuthToolName, type ClaudeOAuthContext } from './oauth-claude';
 export function unifiedToContext(
   request: UnifiedChatRequest,
   provider?: string,
@@ -351,30 +351,7 @@ export function piAiMessageToUnified(
     if (!oauthContext?.isOAuth || !oauthContext?.toolNamesRemapped) {
       return name;
     }
-    // Map of TitleCase Claude Code tool names to lowercase
-    const reverseMap: Record<string, string> = {
-      Bash: 'bash',
-      Read: 'read',
-      Write: 'write',
-      Edit: 'edit',
-      Glob: 'glob',
-      Grep: 'grep',
-      Task: 'task',
-      WebFetch: 'webfetch',
-      TodoWrite: 'todowrite',
-      Question: 'question',
-      Skill: 'skill',
-      LS: 'ls',
-      TodoRead: 'todoread',
-      NotebookEdit: 'notebookedit',
-      AskUserQuestion: 'askuserquestion',
-      EnterPlanMode: 'enterplanmode',
-      ExitPlanMode: 'exitplanmode',
-      KillShell: 'killshell',
-      TaskOutput: 'taskoutput',
-      WebSearch: 'websearch',
-    };
-    return reverseMap[name] ?? name;
+    return restoreOriginalOAuthToolName(name, oauthContext);
   };
 
   // Combined tool name normalizer
@@ -449,29 +426,7 @@ export function piAiEventToChunk(
     if (!oauthContext?.isOAuth || !oauthContext?.toolNamesRemapped) {
       return name;
     }
-    const reverseMap: Record<string, string> = {
-      Bash: 'bash',
-      Read: 'read',
-      Write: 'write',
-      Edit: 'edit',
-      Glob: 'glob',
-      Grep: 'grep',
-      Task: 'task',
-      WebFetch: 'webfetch',
-      TodoWrite: 'todowrite',
-      Question: 'question',
-      Skill: 'skill',
-      LS: 'ls',
-      TodoRead: 'todoread',
-      NotebookEdit: 'notebookedit',
-      AskUserQuestion: 'askuserquestion',
-      EnterPlanMode: 'enterplanmode',
-      ExitPlanMode: 'exitplanmode',
-      KillShell: 'killshell',
-      TaskOutput: 'taskoutput',
-      WebSearch: 'websearch',
-    };
-    return reverseMap[name] ?? name;
+    return restoreOriginalOAuthToolName(name, oauthContext);
   };
 
   // Combined tool name normalizer


### PR DESCRIPTION
### **User description**
## Summary
- preserve each request's original OAuth tool-name casing through Claude Code masking
- restore renamed stream tool calls before dispatcher stream wrappers run
- add regression coverage for lowercase and TitleCase tool names

## Verification
- bun run test -- src/transformers/__tests__/oauth-transformer.test.ts src/transformers/oauth/__tests__/oauth-claude.test.ts
- bun run typecheck
- pre-commit hooks (full backend suite: 2,098 tests)


___

### **Description**
- Preserve original OAuth tool-name casing in responses

- Propagate OAuth remapping context through streams

- Restore tool names before stream chunk conversion

- Add casing regression coverage


___

