### PR TITLE
feat(playground): add streaming API test modes

### DIFF
--- a/packages/backend/drizzle/migrations/0056_add_client_request_id.sql
+++ b/packages/backend/drizzle/migrations/0056_add_client_request_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `request_usage` ADD `client_request_id` text;--> statement-breakpoint
+CREATE INDEX `idx_request_usage_client_request_id` ON `request_usage` (`client_request_id`);

--- a/packages/backend/drizzle/migrations/meta/0056_snapshot.json
+++ b/packages/backend/drizzle/migrations/meta/0056_snapshot.json
@@ -1,0 +1,3357 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c7a549c0-1af1-46bd-9089-1ac80232ff35",
+  "prevId": "7adff97c-3eab-4961-949e-ea72ef6da9e7",
+  "tables": {
+    "meter_snapshots": {
+      "name": "meter_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_type": {
+          "name": "checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_state": {
+          "name": "utilization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_value": {
+          "name": "period_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "period_unit": {
+          "name": "period_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "period_cycle": {
+          "name": "period_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_meter_checker_meter_checked": {
+          "name": "idx_meter_checker_meter_checked",
+          "columns": [
+            "checker_id",
+            "meter_key",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_meter_provider_checked": {
+          "name": "idx_meter_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_meter_checked_at": {
+          "name": "idx_meter_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_usage": {
+      "name": "request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_client_request_id": {
+          "name": "idx_request_usage_client_request_id",
+          "columns": [
+            "client_request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            "api_key",
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            "expiry"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "columns": [
+            "provider",
+            "model"
+          ],
+          "name": "provider_cooldowns_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debug_logs": {
+      "name": "debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inference_errors": {
+      "name": "inference_errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_performance": {
+      "name": "provider_performance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "e2e_tokens_per_sec": {
+          "name": "e2e_tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            "provider",
+            "model",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_snapshots": {
+      "name": "quota_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            "checker_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            "group_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "response_items": {
+      "name": "response_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            "response_id",
+            "item_index"
+          ],
+          "isUnique": false
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "responses": {
+      "name": "responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            "previous_response_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            "server_name"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_state": {
+      "name": "quota_state",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "quota_state_key_name_quota_name_pk": {
+          "columns": [
+            "key_name",
+            "quota_name"
+          ],
+          "name": "quota_state_key_name_quota_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stall_cooldown": {
+          "name": "stall_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gemini_thinking_enabled": {
+          "name": "gemini_thinking_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction": {
+          "name": "compaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_autosync_enabled": {
+          "name": "model_autosync_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_autosync_interval": {
+          "name": "model_autosync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "gpu_profile": {
+          "name": "gpu_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_ram_gb": {
+          "name": "gpu_ram_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_bandwidth_tb_s": {
+          "name": "gpu_bandwidth_tb_s",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_flops_tflop": {
+          "name": "gpu_flops_tflop",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_power_draw_watts": {
+          "name": "gpu_power_draw_watts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_compat": {
+          "name": "auto_compat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_ttfb_ms": {
+          "name": "stall_ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_ttfb_bytes": {
+          "name": "stall_ttfb_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_min_bps": {
+          "name": "stall_min_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_window_ms": {
+          "name": "stall_window_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_grace_period_ms": {
+          "name": "stall_grace_period_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pi_ai_provider": {
+          "name": "pi_ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_models": {
+      "name": "provider_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_compat": {
+          "name": "auto_compat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pi_ai_model_id": {
+          "name": "pi_ai_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "columns": [
+            "provider_id",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_aliases": {
+      "name": "model_aliases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_architecture": {
+          "name": "model_architecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enforce_limits": {
+          "name": "enforce_limits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sticky_session": {
+          "name": "sticky_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "preferred_api": {
+          "name": "preferred_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pi_model": {
+          "name": "pi_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_groups": {
+          "name": "target_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction": {
+          "name": "compaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_alias_targets": {
+      "name": "model_alias_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "columns": [
+            "alias_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_names": {
+          "name": "quota_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_ips": {
+          "name": "allowed_ips",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "beta": {
+          "name": "beta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "columns": [
+            "secret"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "columns": [
+            "secret_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shared": {
+          "name": "shared",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "warn_at": {
+          "name": "warn_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'remote_http'"
+        },
+        "launcher": {
+          "name": "launcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startup_timeout_ms": {
+          "name": "startup_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_settings": {
+      "name": "system_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_credentials": {
+      "name": "oauth_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pi_ai_custom_providers": {
+      "name": "pi_ai_custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pi_ai_custom_providers_name_unique": {
+          "name": "pi_ai_custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pi_ai_custom_models": {
+      "name": "pi_ai_custom_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pi_ai_custom_models_name_unique": {
+          "name": "pi_ai_custom_models_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/backend/drizzle/migrations/meta/_journal.json
+++ b/packages/backend/drizzle/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1783309798440,
       "tag": "0055_add_auto_compat",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "6",
+      "when": 1783698913287,
+      "tag": "0056_add_client_request_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/migrations_pg/0072_add_client_request_id.sql
+++ b/packages/backend/drizzle/migrations_pg/0072_add_client_request_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "request_usage" ADD COLUMN "client_request_id" text;--> statement-breakpoint
+CREATE INDEX "idx_request_usage_client_request_id" ON "request_usage" USING btree ("client_request_id");

--- a/packages/backend/drizzle/migrations_pg/meta/0072_snapshot.json
+++ b/packages/backend/drizzle/migrations_pg/meta/0072_snapshot.json
@@ -1,0 +1,3494 @@
+{
+  "id": "08448576-bbbe-4cf6-a38d-94194f3e2540",
+  "prevId": "5d2976f6-640f-4866-92fd-33f2f016f1fa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_names": {
+          "name": "quota_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_ips": {
+          "name": "allowed_ips",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta": {
+          "name": "beta",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret"
+          ]
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meter_snapshots": {
+      "name": "meter_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_type": {
+          "name": "checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_state": {
+          "name": "utilization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_value": {
+          "name": "period_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_unit": {
+          "name": "period_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_cycle": {
+          "name": "period_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_meter_checker_meter_checked": {
+          "name": "idx_meter_checker_meter_checked",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meter_provider_checked": {
+          "name": "idx_meter_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meter_checked_at": {
+          "name": "idx_meter_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_usage": {
+      "name": "request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_client_request_id": {
+          "name": "idx_request_usage_client_request_id",
+          "columns": [
+            {
+              "expression": "client_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            {
+              "expression": "expiry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "name": "provider_cooldowns_provider_model_pk",
+          "columns": [
+            "provider",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_errors": {
+      "name": "inference_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_performance": {
+      "name": "provider_performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "e2e_tokens_per_sec": {
+          "name": "e2e_tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_snapshots": {
+      "name": "quota_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_items": {
+      "name": "response_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.responses": {
+      "name": "responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            {
+              "expression": "previous_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            {
+              "expression": "server_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_state": {
+      "name": "quota_state",
+      "schema": "",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "quota_state_key_name_quota_name_pk": {
+          "name": "quota_state_key_name_quota_name_pk",
+          "columns": [
+            "key_name",
+            "quota_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stall_cooldown": {
+          "name": "stall_cooldown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gemini_thinking_enabled": {
+          "name": "gemini_thinking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction": {
+          "name": "compaction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "quota_checker_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_autosync_enabled": {
+          "name": "model_autosync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_autosync_interval": {
+          "name": "model_autosync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "gpu_profile": {
+          "name": "gpu_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_ram_gb": {
+          "name": "gpu_ram_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_bandwidth_tb_s": {
+          "name": "gpu_bandwidth_tb_s",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_flops_tflop": {
+          "name": "gpu_flops_tflop",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_power_draw_watts": {
+          "name": "gpu_power_draw_watts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_compat": {
+          "name": "auto_compat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_ttfb_ms": {
+          "name": "stall_ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_ttfb_bytes": {
+          "name": "stall_ttfb_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_min_bps": {
+          "name": "stall_min_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_window_ms": {
+          "name": "stall_window_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_grace_period_ms": {
+          "name": "stall_grace_period_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pi_ai_provider": {
+          "name": "pi_ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_models": {
+      "name": "provider_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "model_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_compat": {
+          "name": "auto_compat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pi_ai_model_id": {
+          "name": "pi_ai_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_aliases": {
+      "name": "model_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "selector_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "alias_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "metadata_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_architecture": {
+          "name": "model_architecture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_limits": {
+          "name": "enforce_limits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sticky_session": {
+          "name": "sticky_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferred_api": {
+          "name": "preferred_api",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pi_model": {
+          "name": "pi_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_groups": {
+          "name": "target_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction": {
+          "name": "compaction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_alias_targets": {
+      "name": "model_alias_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "quota_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "limit_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared": {
+          "name": "shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "warn_at": {
+          "name": "warn_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'remote_http'"
+        },
+        "launcher": {
+          "name": "launcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_timeout_ms": {
+          "name": "startup_timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pi_ai_custom_providers": {
+      "name": "pi_ai_custom_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pi_ai_custom_providers_name_unique": {
+          "name": "pi_ai_custom_providers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pi_ai_custom_models": {
+      "name": "pi_ai_custom_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pi_ai_custom_models_name_unique": {
+          "name": "pi_ai_custom_models_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.oauth_provider_type": {
+      "name": "oauth_provider_type",
+      "schema": "public",
+      "values": [
+        "anthropic",
+        "openai-codex",
+        "github-copilot",
+        "google-gemini-cli",
+        "google-antigravity"
+      ]
+    },
+    "public.quota_checker_type": {
+      "name": "quota_checker_type",
+      "schema": "public",
+      "values": [
+        "naga",
+        "synthetic",
+        "nanogpt",
+        "zai",
+        "moonshot",
+        "minimax",
+        "minimax-coding",
+        "openrouter",
+        "kilo",
+        "openai-codex",
+        "claude-code",
+        "kimi-code",
+        "copilot",
+        "wisdomgate",
+        "apertis",
+        "apertis-coding-plan",
+        "poe",
+        "routing-run",
+        "gemini-cli",
+        "antigravity",
+        "novita",
+        "ollama",
+        "neuralwatt",
+        "zenmux",
+        "devpass",
+        "wafer",
+        "opencode-go",
+        "crof",
+        "exedev",
+        "hyper",
+        "sakana",
+        "cline"
+      ]
+    },
+    "public.model_type": {
+      "name": "model_type",
+      "schema": "public",
+      "values": [
+        "chat",
+        "embeddings",
+        "transcriptions",
+        "speech",
+        "image",
+        "responses"
+      ]
+    },
+    "public.alias_priority": {
+      "name": "alias_priority",
+      "schema": "public",
+      "values": [
+        "selector",
+        "api_match"
+      ]
+    },
+    "public.metadata_source": {
+      "name": "metadata_source",
+      "schema": "public",
+      "values": [
+        "openrouter",
+        "models.dev",
+        "catwalk",
+        "custom"
+      ]
+    },
+    "public.selector_strategy": {
+      "name": "selector_strategy",
+      "schema": "public",
+      "values": [
+        "random",
+        "in_order",
+        "cost",
+        "latency",
+        "usage",
+        "performance"
+      ]
+    },
+    "public.limit_type": {
+      "name": "limit_type",
+      "schema": "public",
+      "values": [
+        "requests",
+        "tokens",
+        "cost"
+      ]
+    },
+    "public.quota_type": {
+      "name": "quota_type",
+      "schema": "public",
+      "values": [
+        "rolling",
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/migrations_pg/meta/_journal.json
+++ b/packages/backend/drizzle/migrations_pg/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1783309798892,
       "tag": "0071_add_auto_compat",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1783698913715,
+      "tag": "0072_add_client_request_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/schema/postgres/request-usage.ts
+++ b/packages/backend/drizzle/schema/postgres/request-usage.ts
@@ -5,6 +5,7 @@ export const requestUsage = pgTable(
   {
     id: serial('id').primaryKey(),
     requestId: text('request_id').notNull().unique(),
+    clientRequestId: text('client_request_id'),
     date: text('date').notNull(),
     sourceIp: text('source_ip'),
     apiKey: text('api_key'),
@@ -61,6 +62,7 @@ export const requestUsage = pgTable(
     dateIdx: index('idx_request_usage_date').on(table.date),
     providerIdx: index('idx_request_usage_provider').on(table.provider),
     requestIdIdx: index('idx_request_usage_request_id').on(table.requestId),
+    clientRequestIdIdx: index('idx_request_usage_client_request_id').on(table.clientRequestId),
     apiKeyIdx: index('idx_request_usage_api_key').on(table.apiKey, table.startTime),
   })
 );

--- a/packages/backend/drizzle/schema/sqlite/request-usage.ts
+++ b/packages/backend/drizzle/schema/sqlite/request-usage.ts
@@ -6,6 +6,7 @@ export const requestUsage = sqliteTable(
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     requestId: text('request_id').notNull().unique(),
+    clientRequestId: text('client_request_id'),
     date: text('date').notNull(),
     sourceIp: text('source_ip'),
     apiKey: text('api_key'),
@@ -62,6 +63,7 @@ export const requestUsage = sqliteTable(
     dateIdx: index('idx_request_usage_date').on(table.date),
     providerIdx: index('idx_request_usage_provider').on(table.provider),
     requestIdIdx: index('idx_request_usage_request_id').on(table.requestId),
+    clientRequestIdIdx: index('idx_request_usage_client_request_id').on(table.clientRequestId),
     apiKeyIdx: index('idx_request_usage_api_key').on(table.apiKey, table.startTime),
   })
 );

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -98,8 +98,15 @@ const fastify = Fastify({
 fastify.register(cors, {
   origin: '*',
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key', 'x-admin-key', 'x-goog-api-key'],
-  exposedHeaders: ['Content-Type'],
+  allowedHeaders: [
+    'Content-Type',
+    'Authorization',
+    'x-api-key',
+    'x-admin-key',
+    'x-goog-api-key',
+    'x-client-request-id',
+  ],
+  exposedHeaders: ['Content-Type', 'x-request-id', 'x-client-request-id'],
 });
 
 // Enable multipart/form-data support for file uploads (audio transcriptions)

--- a/packages/backend/src/routes/inference/__tests__/auth.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/auth.test.ts
@@ -82,6 +82,30 @@ describe('Auth Middleware', () => {
     expect(lastCall[0].apiKey).toBe('test-key-1');
   });
 
+  it('persists and echoes a client request ID separately from the Plexus request ID', async () => {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: {
+        authorization: 'Bearer sk-valid-key',
+        'content-type': 'application/json',
+        'x-client-request-id': 'client-request-123',
+      },
+      payload: {
+        model: 'gpt-4',
+        messages: [],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['x-client-request-id']).toBe('client-request-123');
+    expect(response.headers['x-request-id']).not.toBe('client-request-123');
+
+    const saveRequestCalls = (mockUsageStorage.saveRequest as any).mock.calls;
+    const lastCall = saveRequestCalls[saveRequestCalls.length - 1];
+    expect(lastCall[0].clientRequestId).toBe('client-request-123');
+  });
+
   it('should allow request with x-api-key header', async () => {
     const response = await fastify.inject({
       method: 'POST',

--- a/packages/backend/src/routes/inference/chat.ts
+++ b/packages/backend/src/routes/inference/chat.ts
@@ -14,6 +14,7 @@ import { attachKeyAccessPolicy } from '../../utils/auth';
 import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/timeout';
 import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
 
 export async function registerChatRoute(
   fastify: FastifyInstance,
@@ -29,10 +30,13 @@ export async function registerChatRoute(
    */
   fastify.post('/v1/chat/completions', async (request, reply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType: 'chat',

--- a/packages/backend/src/routes/inference/embeddings.ts
+++ b/packages/backend/src/routes/inference/embeddings.ts
@@ -10,6 +10,7 @@ import { calculateCosts } from '../../utils/calculate-costs';
 import { DebugManager } from '../../services/debug-manager';
 import { attachKeyAccessPolicy } from '../../utils/auth';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
 
 export async function registerEmbeddingsRoute(
   fastify: FastifyInstance,
@@ -23,11 +24,14 @@ export async function registerEmbeddingsRoute(
    */
   fastify.post('/v1/embeddings', async (request, reply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType: 'embeddings',

--- a/packages/backend/src/routes/inference/gemini.ts
+++ b/packages/backend/src/routes/inference/gemini.ts
@@ -14,6 +14,7 @@ import { attachKeyAccessPolicy } from '../../utils/auth';
 import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/timeout';
 import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
 
 export async function registerGeminiRoute(
   fastify: FastifyInstance,
@@ -28,10 +29,13 @@ export async function registerGeminiRoute(
    */
   fastify.post('/v1beta/models/:modelWithAction', async (request, reply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType: 'gemini',

--- a/packages/backend/src/routes/inference/images.ts
+++ b/packages/backend/src/routes/inference/images.ts
@@ -10,6 +10,7 @@ import { DebugManager } from '../../services/debug-manager';
 import { UnifiedImageGenerationRequest, UnifiedImageEditRequest } from '../../types/unified';
 import { attachKeyAccessPolicy } from '../../utils/auth';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
 
 export async function registerImagesRoute(
   fastify: FastifyInstance,
@@ -23,11 +24,14 @@ export async function registerImagesRoute(
    */
   fastify.post('/v1/images/generations', async (request, reply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType: 'images',
@@ -149,11 +153,14 @@ export async function registerImagesRoute(
    */
   fastify.post('/v1/images/edits', async (request, reply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType: 'images',

--- a/packages/backend/src/routes/inference/messages.ts
+++ b/packages/backend/src/routes/inference/messages.ts
@@ -14,6 +14,7 @@ import { attachKeyAccessPolicy } from '../../utils/auth';
 import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/timeout';
 import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
 
 export async function registerMessagesRoute(
   fastify: FastifyInstance,
@@ -27,10 +28,13 @@ export async function registerMessagesRoute(
    */
   fastify.post('/v1/messages', async (request, reply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType: 'messages',

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -19,6 +19,7 @@ import { attachKeyAccessPolicy } from '../../utils/auth';
 import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/timeout';
 import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
 
 export function detectResponsesApiType(
   headers: Record<string, unknown>,
@@ -57,7 +58,9 @@ export async function registerResponsesRoute(
   // Handler for Responses API requests (shared between /v1/responses and /v1/codex/responses)
   const responsesHandler = async (request: FastifyRequest, reply: FastifyReply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
     const incomingApiType = detectResponsesApiType(
       request.headers as Record<string, unknown>,
@@ -65,6 +68,7 @@ export async function registerResponsesRoute(
     );
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType,

--- a/packages/backend/src/routes/inference/speech.ts
+++ b/packages/backend/src/routes/inference/speech.ts
@@ -10,6 +10,7 @@ import { DebugManager } from '../../services/debug-manager';
 import { UnifiedSpeechRequest } from '../../types/unified';
 import { attachKeyAccessPolicy } from '../../utils/auth';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
 
 const VALID_VOICES = [
   'alloy',
@@ -41,11 +42,14 @@ export async function registerSpeechRoute(
    */
   fastify.post('/v1/audio/speech', async (request, reply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType: 'speech',

--- a/packages/backend/src/routes/inference/transcriptions.ts
+++ b/packages/backend/src/routes/inference/transcriptions.ts
@@ -10,6 +10,7 @@ import { DebugManager } from '../../services/debug-manager';
 import { UnifiedTranscriptionRequest } from '../../types/unified';
 import { attachKeyAccessPolicy } from '../../utils/auth';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
 
 export async function registerTranscriptionsRoute(
   fastify: FastifyInstance,
@@ -23,11 +24,14 @@ export async function registerTranscriptionsRoute(
    */
   fastify.post('/v1/audio/transcriptions', async (request, reply) => {
     const requestId = crypto.randomUUID();
+    const clientRequestId = getClientRequestId(request.headers);
     reply.header('x-request-id', requestId);
+    if (clientRequestId) reply.header(CLIENT_REQUEST_ID_HEADER, clientRequestId);
     const startTime = Date.now();
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,
+      clientRequestId,
       date: new Date().toISOString(),
       sourceIp: getClientIp(request),
       incomingApiType: 'transcriptions',

--- a/packages/backend/src/routes/management/usage.ts
+++ b/packages/backend/src/routes/management/usage.ts
@@ -11,6 +11,7 @@ import { isLimited, scopedKeyName } from './_principal';
 
 const USAGE_FIELDS = new Set([
   'requestId',
+  'clientRequestId',
   'date',
   'sourceIp',
   'apiKey',
@@ -84,6 +85,7 @@ export async function registerUsageRoutes(
       startDate: query.startDate,
       endDate: query.endDate,
       requestId: query.requestId,
+      clientRequestId: query.clientRequestId,
       apiKey: query.apiKey,
       incomingApiType: query.incomingApiType,
       provider: query.provider,

--- a/packages/backend/src/services/usage-storage.ts
+++ b/packages/backend/src/services/usage-storage.ts
@@ -24,6 +24,7 @@ export interface ProgressUpdate {
 
 export interface UsageFilters {
   requestId?: string;
+  clientRequestId?: string;
   startDate?: string;
   endDate?: string;
   apiKey?: string;
@@ -204,6 +205,7 @@ export class UsageStorageService extends EventEmitter {
         .insert(this.schema.requestUsage)
         .values({
           requestId: record.requestId!,
+          clientRequestId: record.clientRequestId || null,
           date: record.date || new Date().toISOString(),
           sourceIp: record.sourceIp || null,
           apiKey: record.apiKey || null,
@@ -532,6 +534,9 @@ export class UsageStorageService extends EventEmitter {
     if (filters.requestId) {
       conditions.push(eq(schema.requestUsage.requestId, filters.requestId));
     }
+    if (filters.clientRequestId) {
+      conditions.push(eq(schema.requestUsage.clientRequestId, filters.clientRequestId));
+    }
     if (filters.startDate) {
       conditions.push(gte(schema.requestUsage.date, filters.startDate));
     }
@@ -593,6 +598,7 @@ export class UsageStorageService extends EventEmitter {
       const data = await db
         .select({
           requestId: schema.requestUsage.requestId,
+          clientRequestId: schema.requestUsage.clientRequestId,
           date: schema.requestUsage.date,
           sourceIp: schema.requestUsage.sourceIp,
           apiKey: schema.requestUsage.apiKey,
@@ -648,6 +654,7 @@ export class UsageStorageService extends EventEmitter {
 
       const mappedData: UsageRecord[] = data.map((row: any) => ({
         requestId: row.requestId,
+        clientRequestId: row.clientRequestId,
         date: row.date,
         sourceIp: row.sourceIp,
         apiKey: row.apiKey,

--- a/packages/backend/src/types/usage.ts
+++ b/packages/backend/src/types/usage.ts
@@ -1,5 +1,6 @@
 export interface UsageRecord {
   requestId: string;
+  clientRequestId?: string | null;
   date: string; // ISO string
   sourceIp: string | null;
   apiKey: string | null;

--- a/packages/backend/src/utils/__tests__/client-request-id.test.ts
+++ b/packages/backend/src/utils/__tests__/client-request-id.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'vitest';
+import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../client-request-id';
+
+describe('getClientRequestId', () => {
+  test('returns a trimmed client request ID from the request headers', () => {
+    expect(getClientRequestId({ [CLIENT_REQUEST_ID_HEADER]: '  client-123  ' })).toBe('client-123');
+  });
+
+  test('uses the first value for repeated headers', () => {
+    expect(getClientRequestId({ [CLIENT_REQUEST_ID_HEADER]: ['first', 'second'] })).toBe('first');
+  });
+
+  test('rejects empty and overly long values', () => {
+    expect(getClientRequestId({ [CLIENT_REQUEST_ID_HEADER]: '   ' })).toBeNull();
+    expect(getClientRequestId({ [CLIENT_REQUEST_ID_HEADER]: 'a'.repeat(256) })).toBeNull();
+  });
+});

--- a/packages/backend/src/utils/client-request-id.ts
+++ b/packages/backend/src/utils/client-request-id.ts
@@ -1,0 +1,21 @@
+type Headers = Record<string, string | string[] | undefined>;
+
+const CLIENT_REQUEST_ID_HEADER = 'x-client-request-id';
+const MAX_CLIENT_REQUEST_ID_LENGTH = 255;
+
+/**
+ * Returns the caller's opaque request-correlation ID when one was supplied.
+ * This is intentionally separate from Plexus's server-generated request ID.
+ */
+export function getClientRequestId(headers: Headers): string | null {
+  const value = headers[CLIENT_REQUEST_ID_HEADER];
+  const clientRequestId = Array.isArray(value) ? value[0] : value;
+  if (!clientRequestId) return null;
+
+  const normalized = clientRequestId.trim();
+  return normalized.length > 0 && normalized.length <= MAX_CLIENT_REQUEST_ID_LENGTH
+    ? normalized
+    : null;
+}
+
+export { CLIENT_REQUEST_ID_HEADER };

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -49,9 +49,25 @@ declare module 'deep-chat-react' {
     directConnection?: {
       openAI?: {
         key?: string;
-        completions?: {
+        completions?: true;
+        chat?: {
           model?: string;
+          tools?: unknown;
+          function_handler?: (calls: Array<{ name: string; arguments: string }>) => unknown;
+          parallel_tool_calls?: boolean;
         };
+      };
+      claude?: {
+        key?: string;
+        model?: string;
+        tools?: unknown;
+        function_handler?: (calls: Array<{ name: string; arguments: string }>) => unknown;
+      };
+      gemini?: {
+        key?: string;
+        model?: string;
+        tools?: unknown;
+        function_handler?: (calls: Array<{ name: string; arguments: string }>) => unknown;
       };
     };
     requestInterceptor?: (
@@ -60,9 +76,11 @@ declare module 'deep-chat-react' {
       | DeepChatRequestDetails
       | { error: string }
       | Promise<DeepChatRequestDetails | { error: string }>;
+    responseInterceptor?: (response: unknown) => unknown | Promise<unknown>;
     introMessage?: { text: string } | { html: string } | Array<{ text: string } | { html: string }>;
     auxiliaryStyle?: string;
     history?: DeepChatMessage[];
+    images?: boolean;
     chatStyle?: Record<string, string>;
     inputAreaStyle?: Record<string, string>;
     textInput?: Record<string, unknown>;

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -46,13 +46,20 @@ declare module 'deep-chat-react' {
       additionalBodyProps?: Record<string, unknown>;
       stream?: unknown;
     };
+    directConnection?: {
+      openAI?: {
+        key?: string;
+        completions?: {
+          model?: string;
+        };
+      };
+    };
     requestInterceptor?: (
       details: DeepChatRequestDetails
     ) =>
       | DeepChatRequestDetails
       | { error: string }
       | Promise<DeepChatRequestDetails | { error: string }>;
-    responseInterceptor?: (response: unknown) => DeepChatResponse | Promise<DeepChatResponse>;
     introMessage?: { text: string } | { html: string } | Array<{ text: string } | { html: string }>;
     auxiliaryStyle?: string;
     history?: DeepChatMessage[];

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -505,6 +505,7 @@ export interface Cooldown {
 // Backend Types
 export interface UsageRecord {
   requestId: string;
+  clientRequestId?: string | null;
   date: string;
   sourceIp?: string;
   apiKey?: string;
@@ -596,6 +597,7 @@ interface UsageQueryParams<T extends UsageRecordField> {
   limit?: number;
   offset?: number;
   requestId?: string;
+  clientRequestId?: string;
   startDate?: string;
   endDate?: string;
   incomingApiType?: string;
@@ -839,6 +841,8 @@ const buildUsageQuery = <T extends UsageRecordField>(params: UsageQueryParams<T>
 
   if (params.limit !== undefined) searchParams.set('limit', String(params.limit));
   if (params.offset !== undefined) searchParams.set('offset', String(params.offset));
+  if (params.requestId) searchParams.set('requestId', params.requestId);
+  if (params.clientRequestId) searchParams.set('clientRequestId', params.clientRequestId);
   if (params.startDate) searchParams.set('startDate', params.startDate);
   if (params.endDate) searchParams.set('endDate', params.endDate);
   if (params.incomingApiType) searchParams.set('incomingApiType', params.incomingApiType);

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -53,10 +53,16 @@ const toolParameters = {
       },
     },
   },
-  add_task: {
+  add_tasks: {
     type: 'object',
-    properties: { title: { type: 'string', description: 'The task to add' } },
-    required: ['title'],
+    properties: {
+      titles: {
+        type: 'array',
+        description: 'One or more tasks to add together',
+        items: { type: 'string' },
+      },
+    },
+    required: ['titles'],
   },
   list_tasks: {
     type: 'object',
@@ -66,7 +72,8 @@ const toolParameters = {
 
 const toolDescriptions = {
   get_date: 'Get the current date and time in an optional timezone.',
-  add_task: 'Add a task to this browser-only test task list.',
+  add_tasks:
+    'Add one or more tasks to this browser-only test task list. Use one call with every task in titles.',
   list_tasks: 'List tasks added during this current Playground chat session.',
 };
 
@@ -94,6 +101,12 @@ const geminiTools = [
     })),
   },
 ];
+
+type PlaygroundToolCall = {
+  name: string;
+  arguments: string;
+  result: string;
+};
 
 type RetryAttempt = {
   index?: number;
@@ -258,6 +271,7 @@ type ChatSimulationProps = {
   selectedApi: PlaygroundApi;
   toolMode: ToolMode;
   onRoutingPending: (clientRequestId: string) => void;
+  onToolCalls: (calls: PlaygroundToolCall[]) => void;
 };
 
 const ChatSimulation = memo(
@@ -267,11 +281,12 @@ const ChatSimulation = memo(
     selectedApi,
     toolMode,
     onRoutingPending,
+    onToolCalls,
   }: ChatSimulationProps) => {
     const tasksRef = useRef<string[]>([]);
     const pendingOpenAiToolCallsRef = useRef(false);
-    const runBrowserTools = (calls: BrowserToolCall[]) =>
-      calls.map((call) => {
+    const runBrowserTools = (calls: BrowserToolCall[]) => {
+      const results = calls.map((call) => {
         let args: Record<string, unknown> = {};
         try {
           args = JSON.parse(call.arguments) as Record<string, unknown>;
@@ -293,12 +308,21 @@ const ChatSimulation = memo(
               return { response: JSON.stringify({ error: `Invalid timezone: ${timezone}` }) };
             }
           }
-          case 'add_task': {
-            const title = typeof args.title === 'string' ? args.title.trim() : '';
-            if (!title) return { response: JSON.stringify({ error: 'A task title is required.' }) };
-            tasksRef.current.push(title);
+          case 'add_tasks': {
+            const titles = Array.isArray(args.titles)
+              ? args.titles
+                  .filter((title): title is string => typeof title === 'string')
+                  .map((title) => title.trim())
+                  .filter(Boolean)
+              : [];
+            if (titles.length === 0) {
+              return {
+                response: JSON.stringify({ error: 'At least one task title is required.' }),
+              };
+            }
+            tasksRef.current.push(...titles);
             return {
-              response: JSON.stringify({ added: title, taskCount: tasksRef.current.length }),
+              response: JSON.stringify({ added: titles, taskCount: tasksRef.current.length }),
             };
           }
           case 'list_tasks':
@@ -307,10 +331,28 @@ const ChatSimulation = memo(
             return { response: JSON.stringify({ error: `Unknown browser tool: ${call.name}` }) };
         }
       });
+      window.setTimeout(
+        () =>
+          onToolCalls(
+            calls.map((call, index) => ({
+              name: call.name,
+              arguments: call.arguments,
+              result: results[index]?.response ?? '',
+            }))
+          ),
+        0
+      );
+      return results;
+    };
 
     const requestInterceptor = (details: { body: unknown; headers?: Record<string, string> }) => {
       const clientRequestId = crypto.randomUUID();
-      window.setTimeout(() => onRoutingPending(clientRequestId), 0);
+      const messages =
+        details.body && typeof details.body === 'object' && 'messages' in details.body
+          ? (details.body as { messages?: Array<{ role?: string }> }).messages
+          : undefined;
+      const isToolContinuation = messages?.some((message) => message.role === 'tool') ?? false;
+      if (!isToolContinuation) window.setTimeout(() => onRoutingPending(clientRequestId), 0);
       return {
         ...details,
         headers: {
@@ -555,6 +597,7 @@ export const Playground = () => {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [routingInfo, setRoutingInfo] = useState<RoutingInfo>({ status: 'idle' });
+  const [toolCalls, setToolCalls] = useState<PlaygroundToolCall[]>([]);
   const routingRequestRef = useRef(0);
 
   const selectedKey = useMemo(
@@ -616,6 +659,7 @@ export const Playground = () => {
   const handleRoutingPending = useCallback((clientRequestId: string) => {
     const requestNumber = ++routingRequestRef.current;
     setRoutingInfo({ status: 'pending' });
+    setToolCalls([]);
 
     // Streaming responses do not have a JSON body to carry Playground metadata.
     // The inference route persists its routing decision before it starts SSE,
@@ -669,6 +713,10 @@ export const Playground = () => {
     };
 
     void pollRouting();
+  }, []);
+
+  const handleToolCalls = useCallback((calls: PlaygroundToolCall[]) => {
+    setToolCalls((current) => [...current, ...calls]);
   }, []);
 
   const retryHistory = parseRetryHistory(routingInfo.routing?.retryHistory);
@@ -895,6 +943,7 @@ export const Playground = () => {
                   selectedApi={selectedApi}
                   toolMode={toolMode}
                   onRoutingPending={handleRoutingPending}
+                  onToolCalls={handleToolCalls}
                 />
               </div>
             ) : (
@@ -977,6 +1026,34 @@ export const Playground = () => {
                   <div className="text-text">{routingInfo.routing?.apiType || '-'}</div>
                 </div>
               </div>
+
+              {toolCalls.length > 0 && (
+                <div className="rounded-md border border-border bg-bg-subtle/40 p-3">
+                  <div className="mb-2 font-mono text-[10px] uppercase tracking-wider text-text-muted">
+                    Browser tool calls
+                  </div>
+                  <ol className="space-y-2">
+                    {toolCalls.map((toolCall, index) => (
+                      <li
+                        key={`${toolCall.name}:${toolCall.arguments}:${index}`}
+                        className="rounded border border-border/70 bg-slate-950/30 p-2"
+                      >
+                        <div className="mb-1 font-medium text-text">
+                          {index + 1}. {toolCall.name}
+                        </div>
+                        <div className="font-mono text-[10px] text-text-muted">Arguments</div>
+                        <pre className="mt-0.5 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded bg-slate-950/60 p-1.5 font-mono text-[10px] text-text-secondary">
+                          {toolCall.arguments}
+                        </pre>
+                        <div className="mt-2 font-mono text-[10px] text-text-muted">Result</div>
+                        <pre className="mt-0.5 max-h-24 overflow-auto whitespace-pre-wrap break-words rounded bg-slate-950/60 p-1.5 font-mono text-[10px] text-text-secondary">
+                          {toolCall.result}
+                        </pre>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
+              )}
 
               {attemptedProviders.length > 0 && (
                 <div className="rounded-md border border-border bg-bg-subtle/40 p-3">

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -24,6 +24,77 @@ type ModelListResponse = {
   data?: Array<{ id?: string }>;
 };
 
+type PlaygroundApi = 'openai-completions' | 'openai-responses' | 'anthropic-messages' | 'gemini';
+type ToolMode = 'off' | 'sample-tools';
+type BrowserToolCall = { name: string; arguments: string };
+
+const playgroundApiOptions: Array<{ value: PlaygroundApi; label: string }> = [
+  { value: 'openai-completions', label: 'OpenAI Chat Completions' },
+  { value: 'openai-responses', label: 'OpenAI Responses' },
+  { value: 'anthropic-messages', label: 'Anthropic Messages' },
+  { value: 'gemini', label: 'Gemini Generate Content' },
+];
+
+const playgroundApiLabel = (apiType: PlaygroundApi) =>
+  playgroundApiOptions.find((option) => option.value === apiType)?.label ?? apiType;
+
+const toolModeOptions: Array<{ value: ToolMode; label: string }> = [
+  { value: 'off', label: 'No tools' },
+  { value: 'sample-tools', label: 'Sample browser tools' },
+];
+
+const toolParameters = {
+  get_date: {
+    type: 'object',
+    properties: {
+      timezone: {
+        type: 'string',
+        description: 'Optional IANA timezone, such as America/Los_Angeles',
+      },
+    },
+  },
+  add_task: {
+    type: 'object',
+    properties: { title: { type: 'string', description: 'The task to add' } },
+    required: ['title'],
+  },
+  list_tasks: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+const toolDescriptions = {
+  get_date: 'Get the current date and time in an optional timezone.',
+  add_task: 'Add a task to this browser-only test task list.',
+  list_tasks: 'List tasks added during this current Playground chat session.',
+};
+
+const openAiTools = Object.entries(toolParameters).map(([name, parameters]) => ({
+  type: 'function',
+  function: {
+    name,
+    description: toolDescriptions[name as keyof typeof toolDescriptions],
+    parameters,
+  },
+}));
+
+const claudeTools = Object.entries(toolParameters).map(([name, input_schema]) => ({
+  name,
+  description: toolDescriptions[name as keyof typeof toolDescriptions],
+  input_schema,
+}));
+
+const geminiTools = [
+  {
+    functionDeclarations: Object.entries(toolParameters).map(([name, parameters]) => ({
+      name,
+      description: toolDescriptions[name as keyof typeof toolDescriptions],
+      parameters,
+    })),
+  },
+];
+
 type RetryAttempt = {
   index?: number;
   provider?: string;
@@ -101,6 +172,44 @@ const deepChatAuxiliaryStyle = `
     color: #64748b !important;
   }
 
+  #file-attachment-container {
+    box-sizing: border-box !important;
+    width: calc(100% - 2px) !important;
+    height: 3.6em !important;
+    top: -3.6em !important;
+    left: 1px !important;
+    padding: 4px !important;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+    background: #0b1324 !important;
+    border: 1px solid #334155 !important;
+    border-bottom: 0 !important;
+    border-radius: 0.625rem 0.625rem 0 0 !important;
+  }
+
+  .file-attachment {
+    margin: 0 0.5em 0 0 !important;
+    background: #020617 !important;
+    border: 1px solid #334155 !important;
+    border-radius: 0.375rem !important;
+  }
+
+  .border-bound-attachment {
+    width: 100% !important;
+    height: 100% !important;
+    border: 0 !important;
+    border-radius: 0.3125rem !important;
+  }
+
+  .image-attachment {
+    border-radius: 0.3125rem !important;
+  }
+
+  .remove-file-attachment-button {
+    border-color: #64748b !important;
+    background: #0f172a !important;
+  }
+
   #messages::-webkit-scrollbar {
     width: 8px;
   }
@@ -146,11 +255,59 @@ const formatRoute = (provider?: string | null, model?: string | null) =>
 type ChatSimulationProps = {
   selectedKey: KeyConfig;
   selectedModel: string;
+  selectedApi: PlaygroundApi;
+  toolMode: ToolMode;
   onRoutingPending: (clientRequestId: string) => void;
 };
 
 const ChatSimulation = memo(
-  ({ selectedKey, selectedModel, onRoutingPending }: ChatSimulationProps) => {
+  ({
+    selectedKey,
+    selectedModel,
+    selectedApi,
+    toolMode,
+    onRoutingPending,
+  }: ChatSimulationProps) => {
+    const tasksRef = useRef<string[]>([]);
+    const pendingOpenAiToolCallsRef = useRef(false);
+    const runBrowserTools = (calls: BrowserToolCall[]) =>
+      calls.map((call) => {
+        let args: Record<string, unknown> = {};
+        try {
+          args = JSON.parse(call.arguments) as Record<string, unknown>;
+        } catch {
+          // The adapter validates tool calls; this is a final defensive fallback.
+        }
+
+        switch (call.name) {
+          case 'get_date': {
+            const timezone = typeof args.timezone === 'string' ? args.timezone : undefined;
+            try {
+              return {
+                response: JSON.stringify({
+                  datetime: new Date().toLocaleString('en-US', { timeZone: timezone }),
+                  timezone: timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+                }),
+              };
+            } catch {
+              return { response: JSON.stringify({ error: `Invalid timezone: ${timezone}` }) };
+            }
+          }
+          case 'add_task': {
+            const title = typeof args.title === 'string' ? args.title.trim() : '';
+            if (!title) return { response: JSON.stringify({ error: 'A task title is required.' }) };
+            tasksRef.current.push(title);
+            return {
+              response: JSON.stringify({ added: title, taskCount: tasksRef.current.length }),
+            };
+          }
+          case 'list_tasks':
+            return { response: JSON.stringify({ tasks: tasksRef.current }) };
+          default:
+            return { response: JSON.stringify({ error: `Unknown browser tool: ${call.name}` }) };
+        }
+      });
+
     const requestInterceptor = (details: { body: unknown; headers?: Record<string, string> }) => {
       const clientRequestId = crypto.randomUUID();
       window.setTimeout(() => onRoutingPending(clientRequestId), 0);
@@ -159,26 +316,122 @@ const ChatSimulation = memo(
         headers: {
           ...details.headers,
           'x-client-request-id': clientRequestId,
+          ...(selectedApi === 'gemini' ? { 'x-goog-api-key': selectedKey.secret } : {}),
         },
       };
     };
 
+    const responseInterceptor = (response: unknown) => {
+      // Deep Chat 2.4.x starts its browser-side tool continuation only when the
+      // terminal OpenAI chunk says `tool_calls`. Plexus-compatible streams may
+      // validly finish with `stop` after emitting tool deltas, so normalize that
+      // one compatibility detail locally without changing the gateway response.
+      if (selectedApi !== 'openai-completions' || toolMode !== 'sample-tools') return response;
+      if (!response || typeof response !== 'object' || !('choices' in response)) return response;
+
+      const choice = (response as { choices?: Array<Record<string, unknown>> }).choices?.[0];
+      if (!choice) return response;
+      const delta = choice.delta as { tool_calls?: unknown[] } | undefined;
+      if (delta?.tool_calls?.length) {
+        pendingOpenAiToolCallsRef.current = true;
+        return response;
+      }
+      if (pendingOpenAiToolCallsRef.current && choice.finish_reason === 'stop') {
+        pendingOpenAiToolCallsRef.current = false;
+        return {
+          ...(response as Record<string, unknown>),
+          choices: [{ ...choice, finish_reason: 'tool_calls' }],
+        };
+      }
+      return response;
+    };
+
+    const connection = (() => {
+      const baseUrl = window.location.origin;
+      const enableTools = toolMode === 'sample-tools';
+      switch (selectedApi) {
+        case 'openai-responses':
+          return {
+            connect: { url: `${baseUrl}/v1/responses`, stream: true },
+            directConnection: {
+              openAI: {
+                key: selectedKey.secret,
+                chat: {
+                  model: selectedModel,
+                  ...(enableTools
+                    ? {
+                        tools: openAiTools,
+                        function_handler: runBrowserTools,
+                        // Keep browser-only sample tools sequential until parallel
+                        // Responses-to-Chat-Completions translation is fixed.
+                        parallel_tool_calls: false,
+                      }
+                    : {}),
+                },
+              },
+            },
+          };
+        case 'anthropic-messages':
+          return {
+            connect: { url: `${baseUrl}/v1/messages`, stream: true },
+            directConnection: {
+              claude: {
+                key: selectedKey.secret,
+                model: selectedModel,
+                ...(enableTools ? { tools: claudeTools, function_handler: runBrowserTools } : {}),
+              },
+            },
+          };
+        case 'gemini':
+          return {
+            connect: {
+              url: `${baseUrl}/v1beta/models/${encodeURIComponent(selectedModel)}:streamGenerateContent?alt=sse`,
+              stream: true,
+            },
+            directConnection: {
+              gemini: {
+                key: selectedKey.secret,
+                model: selectedModel,
+                ...(enableTools ? { tools: geminiTools, function_handler: runBrowserTools } : {}),
+              },
+            },
+          };
+        case 'openai-completions':
+        default:
+          return {
+            connect: { url: `${baseUrl}/v1/chat/completions`, stream: true },
+            directConnection: {
+              openAI: {
+                key: selectedKey.secret,
+                // Deep Chat 2.4.x selects its Chat Completions service from
+                // `completions`, but reads its model configuration from `chat`.
+                completions: true as const,
+                chat: {
+                  model: selectedModel,
+                  ...(enableTools
+                    ? {
+                        tools: openAiTools,
+                        function_handler: runBrowserTools,
+                        // Keep browser-only sample tools sequential until parallel
+                        // Responses-to-Chat-Completions translation is fixed.
+                        parallel_tool_calls: false,
+                      }
+                    : {}),
+                },
+              },
+            },
+          };
+      }
+    })();
+
     return (
       <DeepChat
-        key={`${selectedKey.key}:${selectedModel}`}
-        // Deep Chat's OpenAI Completions adapter natively builds and parses
-        // the Plexus-compatible Chat Completions streaming protocol.
-        connect={{
-          url: `${window.location.origin}/v1/chat/completions`,
-          stream: true,
-        }}
-        directConnection={{
-          openAI: {
-            key: selectedKey.secret,
-            completions: { model: selectedModel },
-          },
-        }}
+        key={`${selectedKey.key}:${selectedModel}:${selectedApi}:${toolMode}`}
+        connect={connection.connect}
+        directConnection={connection.directConnection}
         requestInterceptor={requestInterceptor}
+        responseInterceptor={responseInterceptor}
+        images={true}
         introMessage={{
           text: `Simulation active using key "${selectedKey.key}" and model "${selectedModel}".`,
         }}
@@ -296,6 +549,8 @@ export const Playground = () => {
   const [selectedKeyName, setSelectedKeyName] = useState('');
   const [models, setModels] = useState<string[]>([]);
   const [selectedModel, setSelectedModel] = useState('');
+  const [selectedApi, setSelectedApi] = useState<PlaygroundApi>('openai-completions');
+  const [toolMode, setToolMode] = useState<ToolMode>('off');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -499,6 +754,22 @@ export const Playground = () => {
               className="h-9 truncate text-xs sm:text-sm"
             />
 
+            <Select
+              label="Request API"
+              value={selectedApi}
+              onChange={(value) => setSelectedApi(value as PlaygroundApi)}
+              options={playgroundApiOptions}
+              className="h-9 truncate text-xs sm:text-sm"
+            />
+
+            <Select
+              label="Tool Mode"
+              value={toolMode}
+              onChange={(value) => setToolMode(value as ToolMode)}
+              options={toolModeOptions}
+              className="h-9 truncate text-xs sm:text-sm"
+            />
+
             <div className="min-w-0 rounded-md border border-border bg-bg-subtle/60 p-2">
               <div className="mb-1 flex items-center gap-1 font-mono text-[9px] uppercase tracking-wider text-text-muted sm:text-[10px]">
                 <Key className="h-3 w-3" />
@@ -609,7 +880,9 @@ export const Playground = () => {
             extra={
               <div className="flex items-center gap-2 text-xs text-text-muted">
                 <SlidersHorizontal className="h-3.5 w-3.5" />
-                {selectedModel || 'No model selected'}
+                {selectedModel
+                  ? `${playgroundApiLabel(selectedApi)} · ${toolMode === 'sample-tools' ? 'tools on · ' : ''}${selectedModel}`
+                  : 'No model selected'}
               </div>
             }
             flush
@@ -619,6 +892,8 @@ export const Playground = () => {
                 <ChatSimulation
                   selectedKey={selectedKey}
                   selectedModel={selectedModel}
+                  selectedApi={selectedApi}
+                  toolMode={toolMode}
                   onRoutingPending={handleRoutingPending}
                 />
               </div>

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -351,7 +351,10 @@ const ChatSimulation = memo(
         details.body && typeof details.body === 'object' && 'messages' in details.body
           ? (details.body as { messages?: Array<{ role?: string }> }).messages
           : undefined;
-      const isToolContinuation = messages?.some((message) => message.role === 'tool') ?? false;
+      const isToolContinuation =
+        messages !== undefined &&
+        messages.length > 0 &&
+        messages[messages.length - 1]?.role === 'tool';
       if (!isToolContinuation) window.setTimeout(() => onRoutingPending(clientRequestId), 0);
       return {
         ...details,

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DeepChat } from 'deep-chat-react';
 import {
   CheckCircle2,
@@ -22,16 +22,6 @@ import { Badge } from '../components/ui/Badge';
 
 type ModelListResponse = {
   data?: Array<{ id?: string }>;
-};
-
-type DeepChatRequestDetails = {
-  body: unknown;
-  headers?: Record<string, string>;
-};
-
-type OpenAiMessage = {
-  role: 'system' | 'user' | 'assistant' | 'tool';
-  content: string;
 };
 
 type RetryAttempt = {
@@ -63,8 +53,6 @@ type PlaygroundRouting = {
   allAttemptedProviders?: string;
   retryHistory?: string;
 };
-
-const CHAT_COMPLETIONS_ENDPOINT = '/v1/chat/completions';
 
 const deepChatAuxiliaryStyle = `
   :host {
@@ -130,92 +118,6 @@ const deepChatAuxiliaryStyle = `
 const formatList = (items?: string[], emptyLabel = 'All') =>
   items && items.length > 0 ? items.join(', ') : emptyLabel;
 
-const deepChatRoleToOpenAiRole = (role?: string): OpenAiMessage['role'] => {
-  if (role === 'ai' || role === 'assistant') return 'assistant';
-  if (role === 'system' || role === 'tool') return role;
-  return 'user';
-};
-
-const stringifyContent = (content: unknown): string => {
-  if (typeof content === 'string') return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((item) => {
-        if (typeof item === 'string') return item;
-        if (item && typeof item === 'object' && 'text' in item) {
-          return String((item as { text?: unknown }).text ?? '');
-        }
-        return '';
-      })
-      .filter(Boolean)
-      .join('\n');
-  }
-  return '';
-};
-
-const extractMessages = (body: unknown): OpenAiMessage[] => {
-  if (!body || typeof body !== 'object' || !('messages' in body)) return [];
-  const messages = (body as { messages?: unknown }).messages;
-  if (!Array.isArray(messages)) return [];
-
-  return messages
-    .map((message): OpenAiMessage | null => {
-      if (!message || typeof message !== 'object') return null;
-      const record = message as { role?: string; text?: unknown; content?: unknown };
-      const content = stringifyContent(record.content ?? record.text);
-      if (!content.trim()) return null;
-      return {
-        role: deepChatRoleToOpenAiRole(record.role),
-        content,
-      };
-    })
-    .filter((message): message is OpenAiMessage => message !== null);
-};
-
-const extractResponseText = (content: unknown): string => {
-  const directText = stringifyContent(content);
-  if (directText) return directText;
-
-  if (content && typeof content === 'object' && 'message' in content) {
-    const message = (content as { message?: { content?: unknown } }).message;
-    return stringifyContent(message?.content);
-  }
-
-  return '';
-};
-
-const responseToMessage = (response: unknown) => {
-  if (response && typeof response === 'object' && 'error' in response) {
-    const error = (response as { error?: string | { message?: string } }).error;
-    return { error: typeof error === 'string' ? error : error?.message || 'Request failed' };
-  }
-
-  const choices =
-    response && typeof response === 'object' && 'choices' in response
-      ? (response as { choices?: unknown[] }).choices
-      : undefined;
-  const firstChoice = Array.isArray(choices) ? choices[0] : undefined;
-  if (firstChoice && typeof firstChoice === 'object') {
-    const choice = firstChoice as {
-      message?: { content?: unknown };
-      delta?: { content?: unknown };
-      text?: unknown;
-    };
-    const text =
-      extractResponseText(choice.message?.content) ||
-      extractResponseText(choice.delta?.content) ||
-      extractResponseText(choice.text);
-    if (text) return { text };
-  }
-
-  if (response && typeof response === 'object' && 'text' in response) {
-    const text = extractResponseText((response as { text?: unknown }).text);
-    if (text) return { text };
-  }
-
-  return { error: 'Plexus returned an unsupported response shape.' };
-};
-
 const parseRetryHistory = (value?: string | null): RetryAttempt[] => {
   if (!value) return [];
   try {
@@ -244,61 +146,39 @@ const formatRoute = (provider?: string | null, model?: string | null) =>
 type ChatSimulationProps = {
   selectedKey: KeyConfig;
   selectedModel: string;
-  adminKey: string;
-  onRoutingPending: () => void;
-  onRoutingResponse: (routing: PlaygroundRouting | null, error?: string) => void;
+  onRoutingPending: (clientRequestId: string) => void;
 };
 
 const ChatSimulation = memo(
-  ({
-    selectedKey,
-    selectedModel,
-    adminKey,
-    onRoutingPending,
-    onRoutingResponse,
-  }: ChatSimulationProps) => {
-    const requestInterceptor = (details: DeepChatRequestDetails) => {
-      window.setTimeout(onRoutingPending, 0);
-      const body = details.body && typeof details.body === 'object' ? details.body : {};
+  ({ selectedKey, selectedModel, onRoutingPending }: ChatSimulationProps) => {
+    const requestInterceptor = (details: { body: unknown; headers?: Record<string, string> }) => {
+      const clientRequestId = crypto.randomUUID();
+      window.setTimeout(() => onRoutingPending(clientRequestId), 0);
       return {
         ...details,
-        body: {
-          ...body,
-          model: selectedModel,
-          stream: false,
-          messages: extractMessages(body),
+        headers: {
+          ...details.headers,
+          'x-client-request-id': clientRequestId,
         },
       };
-    };
-
-    const responseInterceptor = (response: unknown) => {
-      const routing =
-        response && typeof response === 'object' && 'plexus' in response
-          ? ((response as { plexus?: PlaygroundRouting }).plexus ?? null)
-          : null;
-      const message = responseToMessage(response);
-      window.setTimeout(() => onRoutingResponse(routing, message.error), 0);
-      return message;
     };
 
     return (
       <DeepChat
         key={`${selectedKey.key}:${selectedModel}`}
+        // Deep Chat's OpenAI Completions adapter natively builds and parses
+        // the Plexus-compatible Chat Completions streaming protocol.
         connect={{
-          url: CHAT_COMPLETIONS_ENDPOINT,
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${selectedKey.secret}`,
-            'x-plexus-playground': 'true',
-            'x-admin-key': adminKey,
-          },
-          additionalBodyProps: {
-            model: selectedModel,
-            stream: false,
+          url: `${window.location.origin}/v1/chat/completions`,
+          stream: true,
+        }}
+        directConnection={{
+          openAI: {
+            key: selectedKey.secret,
+            completions: { model: selectedModel },
           },
         }}
         requestInterceptor={requestInterceptor}
-        responseInterceptor={responseInterceptor}
         introMessage={{
           text: `Simulation active using key "${selectedKey.key}" and model "${selectedModel}".`,
         }}
@@ -420,7 +300,7 @@ export const Playground = () => {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [routingInfo, setRoutingInfo] = useState<RoutingInfo>({ status: 'idle' });
-  const adminKey = useMemo(() => localStorage.getItem('plexus_admin_key') ?? '', []);
+  const routingRequestRef = useRef(0);
 
   const selectedKey = useMemo(
     () => keys.find((key) => key.key === selectedKeyName) ?? null,
@@ -478,26 +358,62 @@ export const Playground = () => {
     loadData();
   };
 
-  const handleRoutingPending = useCallback(() => {
+  const handleRoutingPending = useCallback((clientRequestId: string) => {
+    const requestNumber = ++routingRequestRef.current;
     setRoutingInfo({ status: 'pending' });
-  }, []);
 
-  const handleRoutingResponse = useCallback((routing: PlaygroundRouting | null, error?: string) => {
-    if (routing) {
-      setRoutingInfo({
-        status: error ? 'error' : 'complete',
-        routing,
-        error,
-      });
-    } else if (error) {
-      setRoutingInfo({ status: 'error', error });
-    } else {
-      setRoutingInfo({
-        status: 'error',
-        error:
-          'Routing metadata was not returned. Verify admin access and use a unary JSON request.',
-      });
-    }
+    // Streaming responses do not have a JSON body to carry Playground metadata.
+    // The inference route persists its routing decision before it starts SSE,
+    // allowing this authenticated management request to retrieve it separately.
+    const pollRouting = async (attempt = 0): Promise<void> => {
+      try {
+        const result = await api.getLogs(1, 0, { clientRequestId });
+        const record = result.data[0];
+        if (routingRequestRef.current !== requestNumber) return;
+
+        if (record?.provider || record?.selectedModelName) {
+          const isComplete = record.responseStatus !== 'pending';
+          setRoutingInfo({
+            // The initial record contains the selected provider/model, but the
+            // API type and retry trail are written when the stream finishes.
+            status: isComplete
+              ? record.responseStatus === 'error'
+                ? 'error'
+                : 'complete'
+              : 'pending',
+            error: record.responseStatus === 'error' ? 'The request failed.' : undefined,
+            routing: {
+              requestId: record.requestId,
+              provider: record.provider ?? undefined,
+              model: record.selectedModelName ?? undefined,
+              apiType: record.outgoingApiType ?? undefined,
+              canonicalModel: record.canonicalModelName ?? undefined,
+              attemptCount: record.attemptCount ?? undefined,
+              finalAttemptProvider: record.finalAttemptProvider ?? record.provider ?? undefined,
+              finalAttemptModel: record.finalAttemptModel ?? record.selectedModelName ?? undefined,
+              allAttemptedProviders: record.allAttemptedProviders ?? undefined,
+              retryHistory: record.retryHistory ?? undefined,
+            },
+          });
+          if (isComplete) return;
+        }
+      } catch {
+        // The pending record is inserted asynchronously; retry below.
+      }
+
+      if (attempt >= 20) {
+        if (routingRequestRef.current === requestNumber) {
+          setRoutingInfo({
+            status: 'error',
+            error: 'Routing metadata was not available for this request.',
+          });
+        }
+        return;
+      }
+      window.setTimeout(() => void pollRouting(attempt + 1), 250);
+    };
+
+    void pollRouting();
   }, []);
 
   const retryHistory = parseRetryHistory(routingInfo.routing?.retryHistory);
@@ -703,9 +619,7 @@ export const Playground = () => {
                 <ChatSimulation
                   selectedKey={selectedKey}
                   selectedModel={selectedModel}
-                  adminKey={adminKey}
                   onRoutingPending={handleRoutingPending}
-                  onRoutingResponse={handleRoutingResponse}
                 />
               </div>
             ) : (
@@ -839,7 +753,7 @@ export const Playground = () => {
                   </ol>
                 ) : (
                   <div className="text-[11px] text-text-muted">
-                    Routing details appear after the next unary playground request.
+                    Routing details appear once the next playground request is routed.
                   </div>
                 )}
               </div>


### PR DESCRIPTION
### **User description**
## Summary
- add generic client request ID correlation and usage lookup support
- stream Playground requests through Deep Chat's OpenAI-compatible integrations
- add request API selection, image attachments, sample browser tools, and tool-call detail display

## Validation
- bun run test
- bun run typecheck
- browser-tested Playground streaming, tool execution, and tool-call details


___

### **Description**
- Stream Playground requests across four provider APIs

- Add browser-only sample tools and call details

- Correlate requests using persisted client request IDs

- Poll usage logs for streaming routing metadata


___

