### PR TITLE
fix(responses): finish tool calls with tool_calls

### DIFF
--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest';
+import { ResponsesTransformer } from '../responses';
+
+async function transformEvents(events: any[]): Promise<any[]> {
+  const encoder = new TextEncoder();
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(
+          encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+        );
+      }
+      controller.close();
+    },
+  });
+
+  const reader = new ResponsesTransformer().transformStream(source).getReader();
+  const chunks: any[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return chunks;
+    chunks.push(value);
+  }
+}
+
+describe('ResponsesTransformer stream transformation', () => {
+  test('finishes with tool_calls after streaming a function call', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
+      },
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: {
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'get_date',
+          arguments: '',
+        },
+      },
+      {
+        type: 'response.function_call_arguments.delta',
+        output_index: 0,
+        item_id: 'fc_1',
+        delta: '{"timezone":"UTC"}',
+      },
+      {
+        type: 'response.completed',
+        response: { usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } },
+      },
+    ]);
+
+    expect(chunks.find((chunk) => chunk.delta?.tool_calls)?.delta.tool_calls).toEqual([
+      {
+        index: 0,
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'get_date', arguments: '' },
+      },
+    ]);
+    expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('tool_calls');
+  });
+
+  test('finishes with stop when no function call was streamed', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Done' },
+      { type: 'response.completed', response: {} },
+    ]);
+
+    expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('stop');
+  });
+
+  test('recognizes function calls present only in the completed response', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
+      },
+      {
+        type: 'response.completed',
+        response: { output: [{ type: 'function_call' }] },
+      },
+    ]);
+
+    expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('tool_calls');
+  });
+});

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -702,6 +702,7 @@ export class ResponsesTransformer implements Transformer {
     const decoder = new TextDecoder();
     let responseModel = '';
     let responseId = '';
+    let hasFunctionCall = false;
 
     return new ReadableStream({
       async start(controller) {
@@ -743,6 +744,7 @@ export class ResponsesTransformer implements Transformer {
                 });
               } else if (data.type === 'response.function_call_arguments.delta') {
                 // Tool call arguments delta
+                hasFunctionCall = true;
                 controller.enqueue({
                   id: responseId,
                   model: responseModel,
@@ -764,6 +766,7 @@ export class ResponsesTransformer implements Transformer {
                 data.item?.type === 'function_call'
               ) {
                 // Tool call start
+                hasFunctionCall = true;
                 controller.enqueue({
                   id: responseId,
                   model: responseModel,
@@ -784,15 +787,21 @@ export class ResponsesTransformer implements Transformer {
                   finish_reason: null,
                 });
               } else if (data.type === 'response.completed') {
-                // Final chunk with usage data and finish reason
+                // Final chunk with usage data and an OpenAI-compatible finish reason.
+                // `response.completed` includes the full output as a fallback because some
+                // Responses-compatible providers omit intermediate function-call events.
                 const usage = data.response?.usage;
                 const normalizedUsage = usage ? normalizeOpenAIResponsesUsage(usage) : undefined;
+                const completedResponseHasFunctionCall = data.response?.output?.some(
+                  (item: any) => item?.type === 'function_call'
+                );
                 controller.enqueue({
                   id: responseId,
                   model: responseModel,
                   created: Math.floor(Date.now() / 1000),
                   delta: {},
-                  finish_reason: 'stop',
+                  finish_reason:
+                    hasFunctionCall || completedResponseHasFunctionCall ? 'tool_calls' : 'stop',
                   usage: normalizedUsage,
                 });
               }


### PR DESCRIPTION
### **User description**
## Summary
Responses API providers now produce the OpenAI Chat Completions-compatible `tool_calls` terminal finish reason when their streamed response contains function calls. This allows clients to enter their tool-execution loop rather than treating a tool-only response as a normal stop.

## Why / Context
The transformer already translated Responses function-call deltas into Chat Completions tool-call deltas, but it always emitted `stop` for the final chunk.

## Changes
- **Responses stream transformer**: track function-call item and argument-delta events and use `tool_calls` at completion when one was received.
- **Responses stream transformer**: inspect the completed response output as a fallback for compatible providers that omit intermediate function-call events.
- **Tests**: cover streamed function calls, text-only completion, and completed-response-only function calls.

## Testing
- Added focused Responses stream transformer coverage for terminal finish reasons and function-call deltas.

Closes #692


___

### **Description**
- Emit `tool_calls` after Responses function calls

- Detect streamed and completed-response function calls

- Preserve `stop` for non-tool completions

- Add stream transformer finish-reason coverage


___

