### PR TITLE
fix(responses): preserve parallel tool call indexes

### DIFF
--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest';
+import { ResponsesTransformer } from '../responses';
+
+function responsesEvent(type: string, data: Record<string, unknown>): string {
+  return `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+}
+
+describe('ResponsesTransformer stream transformation', () => {
+  test('keeps parallel function calls distinct when their argument deltas are interleaved', async () => {
+    const transformer = new ResponsesTransformer();
+    const source = [
+      responsesEvent('response.created', {
+        response: { id: 'resp_1', model: 'gpt-5', created_at: 1234567890 },
+      }),
+      responsesEvent('response.output_item.added', {
+        output_index: 4,
+        item: {
+          id: 'fc_first',
+          type: 'function_call',
+          call_id: 'call_first',
+          name: 'add_task',
+        },
+      }),
+      responsesEvent('response.output_item.added', {
+        output_index: 9,
+        item: {
+          id: 'fc_second',
+          type: 'function_call',
+          call_id: 'call_second',
+          name: 'add_task',
+        },
+      }),
+      responsesEvent('response.function_call_arguments.delta', {
+        output_index: 9,
+        item_id: 'fc_second',
+        delta: '{"title":"second"}',
+      }),
+      responsesEvent('response.function_call_arguments.delta', {
+        output_index: 4,
+        item_id: 'fc_first',
+        delta: '{"title":"first"}',
+      }),
+    ].join('');
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(source));
+        controller.close();
+      },
+    });
+
+    const reader = transformer.transformStream(stream).getReader();
+    const chunks: any[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+
+    const toolCallChunks = chunks.filter((chunk) => chunk.delta.tool_calls);
+    expect(toolCallChunks).toEqual([
+      {
+        id: 'resp_1',
+        model: 'gpt-5',
+        created: expect.any(Number),
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_first',
+              type: 'function',
+              function: { name: 'add_task', arguments: '' },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_1',
+        model: 'gpt-5',
+        created: expect.any(Number),
+        delta: {
+          tool_calls: [
+            {
+              index: 1,
+              id: 'call_second',
+              type: 'function',
+              function: { name: 'add_task', arguments: '' },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_1',
+        model: 'gpt-5',
+        created: expect.any(Number),
+        delta: { tool_calls: [{ index: 1, function: { arguments: '{"title":"second"}' } }] },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_1',
+        model: 'gpt-5',
+        created: expect.any(Number),
+        delta: { tool_calls: [{ index: 0, function: { arguments: '{"title":"first"}' } }] },
+        finish_reason: null,
+      },
+    ]);
+  });
+});

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -702,6 +702,37 @@ export class ResponsesTransformer implements Transformer {
     const decoder = new TextDecoder();
     let responseModel = '';
     let responseId = '';
+    // Responses output indexes identify items in the whole response, whereas
+    // Chat Completions tool call indexes identify only tool calls. Keep a
+    // stable mapping so parallel calls remain independently assemblable even
+    // when their argument deltas are interleaved with other output items.
+    const toolCallIndexByOutputIndex = new Map<number, number>();
+    const toolCallIndexByItemId = new Map<string, number>();
+    let nextToolCallIndex = 0;
+
+    const getToolCallIndex = (data: any): number => {
+      const outputIndex =
+        typeof data.output_index === 'number' ? (data.output_index as number) : undefined;
+      const itemId =
+        typeof data.item_id === 'string'
+          ? data.item_id
+          : typeof data.item?.id === 'string'
+            ? data.item.id
+            : undefined;
+      const index =
+        (outputIndex === undefined ? undefined : toolCallIndexByOutputIndex.get(outputIndex)) ??
+        (itemId === undefined ? undefined : toolCallIndexByItemId.get(itemId)) ??
+        nextToolCallIndex++;
+
+      if (outputIndex !== undefined) {
+        toolCallIndexByOutputIndex.set(outputIndex, index);
+      }
+      if (itemId !== undefined) {
+        toolCallIndexByItemId.set(itemId, index);
+      }
+
+      return index;
+    };
 
     return new ReadableStream({
       async start(controller) {
@@ -750,7 +781,7 @@ export class ResponsesTransformer implements Transformer {
                   delta: {
                     tool_calls: [
                       {
-                        index: 0,
+                        index: getToolCallIndex(data),
                         function: {
                           arguments: data.delta,
                         },
@@ -771,7 +802,7 @@ export class ResponsesTransformer implements Transformer {
                   delta: {
                     tool_calls: [
                       {
-                        index: 0,
+                        index: getToolCallIndex(data),
                         id: data.item.call_id,
                         type: 'function',
                         function: {


### PR DESCRIPTION
### **User description**
## Summary
Responses API streams now preserve distinct Chat Completions tool-call indexes for parallel function calls. Clients can independently assemble interleaved argument deltas rather than concatenating them into a single call.

## Why / Context
Responses-to-Chat-Completions streaming previously emitted `index: 0` for every function call, causing index-based clients to merge parallel calls and produce invalid JSON arguments.

## Changes
- **Responses transformer**: map Responses `output_index` and function-call item IDs to stable sequential Chat Completions tool-call indexes.
- **Streaming regression test**: cover parallel calls with non-contiguous output indexes and interleaved argument deltas.

## Testing
- Added coverage that verifies each interleaved argument delta remains associated with its originating function call.

Closes #691


___

### **Description**
- Preserve distinct indexes for parallel streamed tool calls

- Map Responses output and item identities consistently

- Add interleaved function-argument streaming regression coverage


___

