### PR TITLE
fix(playground): format Responses API tools correctly

### DIFF
--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -124,6 +124,15 @@ const openAiTools = Object.entries(toolParameters).map(([name, parameters]) => (
   },
 }));
 
+// Chat Completions expects function definitions nested under `function`, while
+// Responses defines the same fields directly on the tool object.
+const responsesTools = Object.entries(toolParameters).map(([name, parameters]) => ({
+  type: 'function',
+  name,
+  description: toolDescriptions[name as keyof typeof toolDescriptions],
+  parameters,
+}));
+
 const claudeTools = Object.entries(toolParameters).map(([name, input_schema]) => ({
   name,
   description: toolDescriptions[name as keyof typeof toolDescriptions],
@@ -443,7 +452,7 @@ const ChatSimulation = memo(
                   model: selectedModel,
                   ...(enableTools
                     ? {
-                        tools: openAiTools,
+                        tools: responsesTools,
                         function_handler: runBrowserTools,
                         // Keep browser-only sample tools sequential until parallel
                         // Responses-to-Chat-Completions translation is fixed.


### PR DESCRIPTION
### **User description**
## Summary
Fixes the Playground's OpenAI Responses tool definitions so sample browser tools reach the gateway in the Responses API's required format. Requests no longer nest function metadata under `function`, which caused upstream validation failures before a tool call could run.

## Why / Context
The Playground shared the Chat Completions tool shape with the Responses API path, even though the two OpenAI APIs encode function definitions differently.

## Changes
- **Playground**: add Responses-specific function tool definitions with top-level `name`, `description`, and `parameters` fields.
- **OpenAI Responses**: use the Responses-specific definitions while preserving the existing Chat Completions, Anthropic Messages, and Gemini formats.

## Testing
- Verified outgoing Playground requests in a real browser for OpenAI Responses, Anthropic Messages, and Gemini Generate Content tool modes.
- Confirmed the Responses payload includes each function tool's top-level `name` field.


___

### **Description**
- Format Responses API tools with top-level function fields

- Preserve Chat Completions tool definitions


___

