### PR TITLE
fix(gemini): accumulate streamed tool calls

### DIFF
--- a/packages/backend/src/transformers/__tests__/oauth-gemini-stream-error-regression.test.ts
+++ b/packages/backend/src/transformers/__tests__/oauth-gemini-stream-error-regression.test.ts
@@ -54,7 +54,7 @@ describe('OAuth -> Gemini stream error regression', () => {
     expect(chunk?.delta?.content).toBe('upstream quota exceeded');
   });
 
-  test('formatGeminiStream does not throw when tool call args are partial JSON', async () => {
+  test('formatGeminiStream suppresses partial tool call args until completion', async () => {
     const stream = createUnifiedChunkStream([
       {
         id: 'oauth-1',
@@ -89,8 +89,7 @@ describe('OAuth -> Gemini stream error regression', () => {
     const formatted = formatGeminiStream(stream);
     const output = await readUtf8(formatted as ReadableStream<Uint8Array>);
 
-    expect(output).toContain('functionCall');
-    expect(output).toContain('"args":{}');
+    expect(output).not.toContain('functionCall');
     expect(output).toContain('"finishReason":"STOP"');
   });
 });

--- a/packages/backend/src/transformers/gemini/__tests__/stream-formatter.test.ts
+++ b/packages/backend/src/transformers/gemini/__tests__/stream-formatter.test.ts
@@ -242,6 +242,77 @@ describe('formatGeminiStream', () => {
     ).toBe('STOP');
   });
 
+  test('should emit functionCall id and thoughtSignature from real Google OpenAI-compat chunks', async () => {
+    // Modeled on a captured gemini-3.5-flash stream via the OpenAI-compat
+    // endpoint: tool calls have no `index`, carry an `id`, complete args per
+    // chunk, and thought signature under extra_content.google.
+    const inputStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          id: 'resp_real',
+          model: 'gemini-3.5-flash',
+          created: Date.now(),
+          delta: {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'xjcm5z4x',
+                type: 'function',
+                function: { name: 'get_weather', arguments: '{"city":"Paris"}' },
+                extra_content: { google: { thought_signature: 'sig-abc' } },
+              },
+            ],
+          },
+          finish_reason: null,
+        });
+        controller.enqueue({
+          id: 'resp_real',
+          model: 'gemini-3.5-flash',
+          created: Date.now(),
+          delta: {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'pc5lscvl',
+                type: 'function',
+                function: { name: 'get_weather', arguments: '{"city":"Tokyo"}' },
+              },
+            ],
+          },
+          finish_reason: null,
+        });
+        controller.enqueue({
+          id: 'resp_real',
+          model: 'gemini-3.5-flash',
+          created: Date.now(),
+          delta: { role: 'assistant' },
+          finish_reason: 'stop',
+        });
+        controller.close();
+      },
+    });
+
+    const sseChunks = await readAllChunks(formatGeminiStream(inputStream));
+    const functionCallParts = sseChunks.flatMap(
+      (chunk) =>
+        chunk.data.candidates?.[0]?.content?.parts?.filter((part: any) => part.functionCall) ?? []
+    );
+
+    expect(functionCallParts).toHaveLength(2);
+    expect(functionCallParts[0].functionCall).toEqual({
+      name: 'get_weather',
+      args: { city: 'Paris' },
+      id: 'xjcm5z4x',
+    });
+    expect(functionCallParts[0].thoughtSignature).toBe('sig-abc');
+    expect(functionCallParts[1].functionCall).toEqual({
+      name: 'get_weather',
+      args: { city: 'Tokyo' },
+      id: 'pc5lscvl',
+    });
+    expect(functionCallParts[1].thoughtSignature).toBeUndefined();
+  });
+
   test('should emit done event when stream ends with done chunk', async () => {
     const inputStream = new ReadableStream({
       start(controller) {

--- a/packages/backend/src/transformers/gemini/__tests__/stream-formatter.test.ts
+++ b/packages/backend/src/transformers/gemini/__tests__/stream-formatter.test.ts
@@ -1,12 +1,8 @@
 import { test, expect, describe } from 'vitest';
-import { formatGeminiStream } from '../stream-formatter';
-import { UnifiedChatStreamChunk } from '../../../types/unified';
 import { createParser, EventSourceMessage } from 'eventsource-parser';
+import { formatGeminiStream } from '../stream-formatter';
 
-/**
- * Helper to read SSE chunks from a ReadableStream
- */
-async function readSSEChunks(stream: ReadableStream): Promise<any[]> {
+async function readAllChunks(stream: ReadableStream): Promise<any[]> {
   const reader = stream.getReader();
   const chunks: any[] = [];
   const decoder = new TextDecoder();
@@ -18,8 +14,8 @@ async function readSSEChunks(stream: ReadableStream): Promise<any[]> {
         if (event.data === '[DONE]') return;
         try {
           chunks.push({ event: event.event, data: JSON.parse(event.data) });
-        } catch (e) {
-          // ignore
+        } catch {
+          // ignore malformed events
         }
       },
     });
@@ -34,95 +30,283 @@ async function readSSEChunks(stream: ReadableStream): Promise<any[]> {
         parser.feed(decoder.decode(value, { stream: true }));
       }
     };
+
     read();
   });
 }
 
 describe('formatGeminiStream', () => {
   test('should format usage event correctly', async () => {
-    const unifiedChunks: UnifiedChatStreamChunk[] = [
-      {
-        id: 'resp_123',
-        model: 'gemini-3-flash-preview',
-        created: Date.now(),
-        event: 'usage',
-        delta: {},
-        usage: {
-          input_tokens: 100,
-          output_tokens: 50,
-          total_tokens: 150,
-          reasoning_tokens: 10,
-          cached_tokens: 20,
-          cache_creation_tokens: 0,
-          upstream_inference_cost: 0.001,
-          upstream_inference_prompt_cost: 0.0004,
-          upstream_inference_completions_cost: 0.0006,
-        } as any,
-      },
-    ];
-
     const inputStream = new ReadableStream({
       start(controller) {
-        for (const chunk of unifiedChunks) {
-          controller.enqueue(chunk);
-        }
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-3-flash-preview',
+          created: Date.now(),
+          event: 'usage',
+          delta: {},
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+            reasoning_tokens: 10,
+            cached_tokens: 20,
+            cache_creation_tokens: 0,
+            upstream_inference_cost: 0.001,
+            upstream_inference_prompt_cost: 0.0004,
+            upstream_inference_completions_cost: 0.0006,
+          },
+        });
         controller.close();
       },
     });
 
-    const formattedStream = formatGeminiStream(inputStream);
-    const sseChunks = await readSSEChunks(formattedStream);
+    const sseChunks = await readAllChunks(formatGeminiStream(inputStream));
 
-    expect(sseChunks.length).toBe(1);
-    const usageEvent = sseChunks[0];
-    expect(usageEvent.event).toBe('usage');
-    expect(usageEvent.data.type).toBe('usage');
-    expect(usageEvent.data.usage).toBeDefined();
-    expect(usageEvent.data.usage.prompt_tokens).toBe(120);
-    expect(usageEvent.data.usage.completion_tokens).toBe(50);
-    expect(usageEvent.data.usage.total_tokens).toBe(150);
-    expect(usageEvent.data.usage.prompt_tokens_details.cached_tokens).toBe(20);
-    expect(usageEvent.data.usage.cost_details.upstream_inference_cost).toBe(0.001);
-    expect(usageEvent.data.usage.completion_tokens_details.reasoning_tokens).toBe(10);
+    expect(sseChunks).toHaveLength(1);
+    expect(sseChunks[0].event).toBe('usage');
+    expect(sseChunks[0].data.type).toBe('usage');
+    expect(sseChunks[0].data.usage.prompt_tokens).toBe(120);
+    expect(sseChunks[0].data.usage.completion_tokens).toBe(50);
+    expect(sseChunks[0].data.usage.total_tokens).toBe(150);
+    expect(sseChunks[0].data.usage.prompt_tokens_details.cached_tokens).toBe(20);
+    expect(sseChunks[0].data.usage.cost_details.upstream_inference_cost).toBe(0.001);
+    expect(sseChunks[0].data.usage.completion_tokens_details.reasoning_tokens).toBe(10);
   });
 
-  test('should format usage correctly even if event is missing but usage is present', async () => {
-    const unifiedChunks: UnifiedChatStreamChunk[] = [
-      {
-        id: 'resp_123',
-        model: 'gemini-3-flash-preview',
-        created: Date.now(),
-        delta: {},
-        usage: {
-          input_tokens: 100,
-          output_tokens: 50,
-          total_tokens: 150,
-          reasoning_tokens: 10,
-          cached_tokens: 20,
-          cache_creation_tokens: 0,
-          upstream_inference_cost: 0.001,
-          upstream_inference_prompt_cost: 0.0004,
-          upstream_inference_completions_cost: 0.0006,
-        } as any,
-      },
-    ];
-
+  test('should buffer partial tool call arguments until they are complete', async () => {
     const inputStream = new ReadableStream({
       start(controller) {
-        for (const chunk of unifiedChunks) {
-          controller.enqueue(chunk);
-        }
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_1',
+                type: 'function',
+                function: {
+                  name: 'manage_todo_list',
+                  arguments: '{"items":[',
+                },
+              },
+            ],
+          },
+          finish_reason: null,
+        });
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                function: {
+                  arguments: '"buy milk"]}',
+                },
+              },
+            ],
+          },
+          finish_reason: null,
+        });
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: {},
+          finish_reason: 'stop',
+        });
         controller.close();
       },
     });
 
-    const formattedStream = formatGeminiStream(inputStream);
-    const sseChunks = await readSSEChunks(formattedStream);
+    const sseChunks = await readAllChunks(formatGeminiStream(inputStream));
+    const functionCallChunks = sseChunks.filter((chunk) =>
+      chunk.data.candidates?.[0]?.content?.parts?.some((part: any) => part.functionCall)
+    );
 
-    expect(sseChunks.length).toBe(1);
-    const usageChunk = sseChunks[0];
-    expect(usageChunk.data.usageMetadata).toBeDefined();
-    expect(usageChunk.data.usageMetadata.promptTokenCount).toBe(120);
-    expect(usageChunk.data.usageMetadata.candidatesTokenCount).toBe(50);
+    expect(functionCallChunks).toHaveLength(1);
+    expect(functionCallChunks[0].data.candidates[0].content.parts[0].functionCall.name).toBe(
+      'manage_todo_list'
+    );
+    expect(functionCallChunks[0].data.candidates[0].content.parts[0].functionCall.args).toEqual({
+      items: ['buy milk'],
+    });
+    expect(
+      sseChunks.find((chunk) => chunk.data.candidates?.[0]?.finishReason)?.data.candidates[0]
+        .finishReason
+    ).toBe('STOP');
+  });
+
+  test('should preserve parallel tool calls when partial arguments arrive interleaved', async () => {
+    const inputStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_1',
+                type: 'function',
+                function: {
+                  name: 'get_date',
+                  arguments: '{"timezone":"',
+                },
+              },
+            ],
+          },
+          finish_reason: null,
+        });
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: {
+            tool_calls: [
+              {
+                index: 1,
+                id: 'call_2',
+                type: 'function',
+                function: {
+                  name: 'add_tasks',
+                  arguments: '{"tasks":["buy milk"',
+                },
+              },
+            ],
+          },
+          finish_reason: null,
+        });
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: {
+            tool_calls: [
+              {
+                index: 1,
+                function: {
+                  arguments: ',"clean kitchen"]}',
+                },
+              },
+            ],
+          },
+          finish_reason: null,
+        });
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                function: {
+                  arguments: 'UTC"}',
+                },
+              },
+            ],
+          },
+          finish_reason: 'stop',
+        });
+        controller.close();
+      },
+    });
+
+    const sseChunks = await readAllChunks(formatGeminiStream(inputStream));
+    const functionCallChunks = sseChunks.filter((chunk) =>
+      chunk.data.candidates?.[0]?.content?.parts?.some((part: any) => part.functionCall)
+    );
+
+    expect(functionCallChunks).toHaveLength(2);
+    expect(functionCallChunks[0].data.candidates[0].content.parts[0].functionCall.name).toBe(
+      'add_tasks'
+    );
+    expect(functionCallChunks[0].data.candidates[0].content.parts[0].functionCall.args).toEqual({
+      tasks: ['buy milk', 'clean kitchen'],
+    });
+    expect(functionCallChunks[1].data.candidates[0].content.parts[0].functionCall.name).toBe(
+      'get_date'
+    );
+    expect(functionCallChunks[1].data.candidates[0].content.parts[0].functionCall.args).toEqual({
+      timezone: 'UTC',
+    });
+    expect(
+      sseChunks.find((chunk) => chunk.data.candidates?.[0]?.finishReason)?.data.candidates[0]
+        .finishReason
+    ).toBe('STOP');
+  });
+
+  test('should emit done event when stream ends with done chunk', async () => {
+    const inputStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          event: 'done',
+          delta: {},
+        });
+        controller.close();
+      },
+    });
+
+    const sseChunks = await readAllChunks(formatGeminiStream(inputStream));
+    expect(sseChunks.some((chunk) => chunk.event === 'done')).toBe(true);
+  });
+
+  test('should emit usage in finish chunk', async () => {
+    const inputStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: { content: 'Response' },
+          finish_reason: 'stop',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+            reasoning_tokens: 25,
+            cached_tokens: 20,
+          },
+        });
+        controller.close();
+      },
+    });
+
+    const sseChunks = await readAllChunks(formatGeminiStream(inputStream));
+    const usageEvent = sseChunks.find((chunk) => chunk.data.usageMetadata !== undefined);
+
+    expect(usageEvent).toBeDefined();
+    expect(usageEvent?.data.usageMetadata.promptTokenCount).toBe(120);
+    expect(usageEvent?.data.usageMetadata.candidatesTokenCount).toBe(50);
+    expect(usageEvent?.data.usageMetadata.totalTokenCount).toBe(150);
+    expect(usageEvent?.data.usageMetadata.thoughtsTokenCount).toBe(25);
+  });
+
+  test('should keep stop finish reason when no function calls', async () => {
+    const inputStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          id: 'resp_123',
+          model: 'gemini-2.0-flash',
+          created: Date.now(),
+          delta: { content: 'Hello world' },
+          finish_reason: 'stop',
+        });
+        controller.close();
+      },
+    });
+
+    const sseChunks = await readAllChunks(formatGeminiStream(inputStream));
+    const finishChunk = sseChunks.find((chunk) => chunk.data.candidates?.[0]?.finishReason);
+    expect(finishChunk?.data.candidates[0].finishReason).toBe('STOP');
   });
 });

--- a/packages/backend/src/transformers/gemini/stream-formatter.ts
+++ b/packages/backend/src/transformers/gemini/stream-formatter.ts
@@ -65,6 +65,10 @@ function buildGeminiFunctionCallPart(
     },
   };
 
+  if (state.id) {
+    functionCallPart.functionCall.id = state.id;
+  }
+
   if (state.thoughtSignature) {
     functionCallPart.thoughtSignature = state.thoughtSignature;
   }
@@ -242,6 +246,7 @@ export function formatGeminiStream(stream: ReadableStream): ReadableStream {
           const sig =
             tc.thinking?.signature ||
             tc.thought_signature ||
+            tc.extra_content?.google?.thought_signature ||
             chunk.delta?.thinking?.signature ||
             chunk.delta?.thought_signature;
           if (sig) {

--- a/packages/backend/src/transformers/gemini/stream-formatter.ts
+++ b/packages/backend/src/transformers/gemini/stream-formatter.ts
@@ -1,6 +1,77 @@
 import { Part } from '@google/genai';
 import { encode } from 'eventsource-encoder';
 
+type PendingGeminiToolCall = {
+  index?: number;
+  id?: string;
+  name?: string;
+  argumentsText: string;
+  structuredArguments?: unknown;
+  thoughtSignature?: string;
+  emitted: boolean;
+};
+
+function getToolCallKeys(toolCall: any, fallbackKey: string): string[] {
+  const keys: string[] = [];
+
+  if (typeof toolCall.index === 'number') {
+    keys.push(`index:${toolCall.index}`);
+  }
+
+  if (typeof toolCall.id === 'string' && toolCall.id.trim().length > 0) {
+    keys.push(`id:${toolCall.id}`);
+  }
+
+  if (keys.length === 0) {
+    keys.push(fallbackKey);
+  }
+
+  return keys;
+}
+
+function resolveToolCallArguments(
+  state: PendingGeminiToolCall,
+  allowEmptyObject = false
+): unknown | undefined {
+  if (state.structuredArguments !== undefined) {
+    return state.structuredArguments;
+  }
+
+  const rawArguments = state.argumentsText.trim();
+  if (rawArguments.length === 0) {
+    return allowEmptyObject ? {} : undefined;
+  }
+
+  try {
+    return JSON.parse(rawArguments);
+  } catch {
+    return undefined;
+  }
+}
+
+function buildGeminiFunctionCallPart(
+  state: PendingGeminiToolCall,
+  allowEmptyObject = false
+): Part | null {
+  if (!state.name) return null;
+
+  const args = resolveToolCallArguments(state, allowEmptyObject);
+  if (args === undefined) return null;
+
+  const functionCallPart: any = {
+    functionCall: {
+      name: state.name,
+      args,
+    },
+  };
+
+  if (state.thoughtSignature) {
+    functionCallPart.thoughtSignature = state.thoughtSignature;
+  }
+
+  return functionCallPart;
+}
+
 /**
  * Formats unified chunks back into Gemini's SSE format.
  *
@@ -13,6 +84,8 @@ import { encode } from 'eventsource-encoder';
  */
 export function formatGeminiStream(stream: ReadableStream): ReadableStream {
   const encoder = new TextEncoder();
+  const toolCallStates = new Map<string, PendingGeminiToolCall>();
+  let anonymousToolCallCounter = 0;
 
   const transformer = new TransformStream({
     transform(chunk: any, controller) {
@@ -116,6 +189,7 @@ export function formatGeminiStream(stream: ReadableStream): ReadableStream {
 
       // Handle regular content chunks (non-event)
       const parts: Part[] = [];
+      const completedToolCallParts: Part[] = [];
 
       if (chunk.delta?.content) parts.push({ text: chunk.delta.content });
       if (chunk.delta?.reasoning_content)
@@ -123,41 +197,82 @@ export function formatGeminiStream(stream: ReadableStream): ReadableStream {
           text: chunk.delta.reasoning_content,
           thought: true,
         } as any);
-      if (chunk.delta?.tool_calls) {
-        chunk.delta.tool_calls.forEach((tc: any) => {
-          let parsedArgs: Record<string, unknown> = {};
-          const rawArgs = tc.function?.arguments;
 
-          if (typeof rawArgs === 'string' && rawArgs.trim().length > 0) {
-            try {
-              parsedArgs = JSON.parse(rawArgs);
-            } catch {
-              // Tool arguments can arrive as partial JSON during streaming.
-              parsedArgs = {};
+      if (chunk.delta?.tool_calls) {
+        chunk.delta.tool_calls.forEach((tc: any, callPosition: number) => {
+          const fallbackKey = `anon:${anonymousToolCallCounter + callPosition}`;
+          const keys = getToolCallKeys(tc, fallbackKey);
+
+          let state: PendingGeminiToolCall | undefined;
+          for (const key of keys) {
+            const existing = toolCallStates.get(key);
+            if (existing) {
+              state = existing;
+              break;
             }
-          } else if (rawArgs && typeof rawArgs === 'object') {
-            parsedArgs = rawArgs;
           }
 
-          const functionCallPart: any = {
-            functionCall: {
-              name: tc.function.name,
-              args: parsedArgs,
-            },
-          };
+          if (!state) {
+            state = {
+              argumentsText: '',
+              emitted: false,
+            };
+          }
 
-          // Check for signature in the tool call itself (preferred) or fall back to global thinking signature in the chunk
+          for (const key of keys) {
+            toolCallStates.set(key, state);
+          }
+
+          if (typeof tc.index === 'number') {
+            state.index = tc.index;
+          }
+          if (typeof tc.id === 'string' && tc.id.trim().length > 0) {
+            state.id = tc.id;
+          }
+          if (typeof tc.function?.name === 'string' && tc.function.name.trim().length > 0) {
+            state.name = tc.function.name;
+          }
+
+          const rawArgs = tc.function?.arguments;
+          if (typeof rawArgs === 'string') {
+            state.argumentsText += rawArgs;
+          } else if (rawArgs !== undefined) {
+            state.structuredArguments = rawArgs;
+          }
+
           const sig =
             tc.thinking?.signature ||
             tc.thought_signature ||
             chunk.delta?.thinking?.signature ||
             chunk.delta?.thought_signature;
           if (sig) {
-            functionCallPart.thoughtSignature = sig;
+            state.thoughtSignature = sig;
           }
 
-          parts.push(functionCallPart);
+          const functionCallPart = buildGeminiFunctionCallPart(state);
+          if (functionCallPart && !state.emitted) {
+            state.emitted = true;
+            completedToolCallParts.push(functionCallPart);
+          }
         });
+
+        anonymousToolCallCounter += chunk.delta.tool_calls.length;
+      }
+
+      if (chunk.finish_reason) {
+        for (const state of new Set(toolCallStates.values())) {
+          if (state.emitted) continue;
+
+          const functionCallPart = buildGeminiFunctionCallPart(state, true);
+          if (functionCallPart) {
+            state.emitted = true;
+            completedToolCallParts.push(functionCallPart);
+          }
+        }
+      }
+
+      if (completedToolCallParts.length > 0) {
+        parts.push(...completedToolCallParts);
       }
 
       // Map OpenAI-style finish_reason to valid Gemini values
@@ -166,6 +281,11 @@ export function formatGeminiStream(stream: ReadableStream): ReadableStream {
       if (geminiFinishReason === 'TOOL_CALLS') {
         geminiFinishReason = 'STOP';
       }
+
+      if (parts.length === 0 && !geminiFinishReason) {
+        return;
+      }
+
       const geminiChunk: any = {
         candidates: [
           {

--- a/packages/backend/src/transformers/gemini/stream-formatter.ts
+++ b/packages/backend/src/transformers/gemini/stream-formatter.ts
@@ -85,7 +85,6 @@ function buildGeminiFunctionCallPart(
 export function formatGeminiStream(stream: ReadableStream): ReadableStream {
   const encoder = new TextEncoder();
   const toolCallStates = new Map<string, PendingGeminiToolCall>();
-  let anonymousToolCallCounter = 0;
 
   const transformer = new TransformStream({
     transform(chunk: any, controller) {
@@ -200,7 +199,7 @@ export function formatGeminiStream(stream: ReadableStream): ReadableStream {
 
       if (chunk.delta?.tool_calls) {
         chunk.delta.tool_calls.forEach((tc: any, callPosition: number) => {
-          const fallbackKey = `anon:${anonymousToolCallCounter + callPosition}`;
+          const fallbackKey = `anon:${callPosition}`;
           const keys = getToolCallKeys(tc, fallbackKey);
 
           let state: PendingGeminiToolCall | undefined;
@@ -255,8 +254,6 @@ export function formatGeminiStream(stream: ReadableStream): ReadableStream {
             completedToolCallParts.push(functionCallPart);
           }
         });
-
-        anonymousToolCallCounter += chunk.delta.tool_calls.length;
       }
 
       if (chunk.finish_reason) {


### PR DESCRIPTION
### **User description**
## Summary
Fix Gemini streaming translation so streamed tool-call deltas are accumulated before being emitted as completed `functionCall` parts. This prevents Gemini clients from executing partial or empty calls while preserving parallel tool calls as separate completed entries.

## Why / Context
Upstream Gemini-compatible streaming responses can deliver function-call names and argument JSON in fragments. The previous formatter emitted each fragment immediately, which turned partial deltas into malformed standalone calls.

## Changes
- **Gemini stream formatter**: track in-flight tool calls by `index` and/or `id`, merge partial name/argument fragments, and emit each call once it is complete.
- **Parallel tool calls**: preserve independent accumulation state for multiple concurrent calls so interleaved deltas still resolve correctly.
- **Finish handling**: flush any completed pending tool calls on the final chunk while still avoiding premature emission of incomplete partials.
- **Regression coverage**: add focused tests for partial-args buffering and interleaved parallel calls.
- **Compatibility regression**: update the OAuth→Gemini stream regression test so partial tool-call JSON is no longer surfaced as `{}`.

## Testing
- `bun run test`
- `bun run typecheck`

## Notes
The change is intentionally scoped to the Gemini streaming formatter and its regression tests; no schema or API surface changes were made.


___

### **Description**
- Buffer fragmented Gemini tool-call arguments

- Emit calls only after valid JSON completion

- Preserve interleaved parallel tool calls

- Add streaming regression coverage


___

