### PR TITLE
feat(models): add provider filtering and sorting

### DIFF
--- a/packages/frontend/src/components/models/AliasMobileCard.tsx
+++ b/packages/frontend/src/components/models/AliasMobileCard.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Trash2, Loader2, CheckCircle, AlertTriangle, Play } from 'lucide-react';
 import { CopyButton } from '../ui/CopyButton';
+import { Badge } from '../ui/Badge';
 import { Button } from '../ui/Button';
 import { Switch } from '../ui/Switch';
 import { ModelTypeBadge } from './ModelTypeBadge';
 import type { Alias, Provider, Cooldown } from '../../lib/api';
+import { getAliasProviderLabels, getAliasTargetCount } from '../../lib/modelList';
 
 interface Props {
   alias: Alias;
@@ -40,6 +42,10 @@ export const AliasMobileCard: React.FC<Props> = ({
   onTestTarget,
   onDismissTestMessage,
 }) => {
+  const providerLabels = getAliasProviderLabels(alias, providers);
+  const targetCount = getAliasTargetCount(alias);
+  const firstTargetGroup = alias.target_groups[0];
+
   return (
     <article key={alias.id} className="rounded-md border border-border-glass bg-bg-subtle p-3">
       <div className="flex items-start justify-between gap-3">
@@ -77,6 +83,23 @@ export const AliasMobileCard: React.FC<Props> = ({
           </div>
         </div>
         <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+          <div className="text-[10px] uppercase tracking-wider text-text-muted">Providers</div>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {providerLabels.length > 0 ? (
+              providerLabels.map((providerLabel) => (
+                <Badge key={providerLabel} status="neutral" noDot>
+                  {providerLabel}
+                </Badge>
+              ))
+            ) : (
+              <span className="text-text-muted">No providers</span>
+            )}
+          </div>
+          <div className="mt-1 text-[11px] text-text-muted">
+            {targetCount} target{targetCount === 1 ? '' : 's'}
+          </div>
+        </div>
+        <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
           <div className="text-[10px] uppercase tracking-wider text-text-muted">Aliases</div>
           <div className="flex flex-wrap gap-1 font-medium text-text-secondary">
             {alias.aliases?.length
@@ -89,131 +112,134 @@ export const AliasMobileCard: React.FC<Props> = ({
               : '-'}
           </div>
         </div>
-      </div>
-
-      <div className="mt-3">
-        <div className="mb-2 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
-          <span>Targets</span>
-          {alias.target_groups[0] && (
-            <>
-              <span className="opacity-40 normal-case">
-                direct/{alias.id}/{alias.target_groups[0].name}
-              </span>
-              <CopyButton value={`direct/${alias.id}/${alias.target_groups[0].name}`} size="sm" />
-            </>
-          )}
-        </div>
-        {alias.target_groups.length === 0 || alias.target_groups[0].targets.length === 0 ? (
-          <div className="rounded border border-border-glass bg-bg-glass px-2 py-2 text-xs italic text-text-muted">
-            No targets configured
+        <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+          <div className="mb-2 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+            <span>Targets</span>
+            {firstTargetGroup && (
+              <>
+                <span className="opacity-40 normal-case">
+                  direct/{alias.id}/{firstTargetGroup.name}
+                </span>
+                <CopyButton value={`direct/${alias.id}/${firstTargetGroup.name}`} size="sm" />
+              </>
+            )}
           </div>
-        ) : (
-          <div className="space-y-2">
-            {alias.target_groups[0].targets.map((t, i) => {
-              const provider = providers.find((p) => p.id === t.provider);
-              const isProviderDisabled = provider?.enabled === false;
-              const isTargetDisabled = t.enabled === false;
-              const isDisabled = isProviderDisabled || isTargetDisabled;
-              const testKey = `${alias.id}-${i}`;
-              const testState = testStates[testKey];
-              const cooldown = cooldowns.find(
-                (c) => c.provider === t.provider && c.model === t.model && !c.accountId
-              );
-              const cooldownMinutes = cooldown ? Math.ceil(cooldown.timeRemainingMs / 60000) : 0;
+          {alias.target_groups.length === 0 ||
+          !firstTargetGroup ||
+          firstTargetGroup.targets.length === 0 ? (
+            <div className="rounded border border-border-glass bg-bg-glass px-2 py-2 text-xs italic text-text-muted">
+              No targets configured
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {firstTargetGroup.targets.map((t, i) => {
+                const provider = providers.find((p) => p.id === t.provider);
+                const isProviderDisabled = provider?.enabled === false;
+                const isTargetDisabled = t.enabled === false;
+                const isDisabled = isProviderDisabled || isTargetDisabled;
+                const testKey = `${alias.id}-${i}`;
+                const testState = testStates[testKey];
+                const cooldown = cooldowns.find(
+                  (c) => c.provider === t.provider && c.model === t.model && !c.accountId
+                );
+                const cooldownMinutes = cooldown ? Math.ceil(cooldown.timeRemainingMs / 60000) : 0;
 
-              return (
-                <div
-                  key={`${t.provider}-${t.model}-${i}`}
-                  className={`rounded border border-border-glass bg-bg-glass px-2 py-2 ${
-                    isDisabled ? 'opacity-70' : ''
-                  }`}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div
-                        className={`truncate text-xs font-medium ${
-                          isDisabled ? 'text-danger line-through' : 'text-text-secondary'
-                        }`}
-                      >
-                        {t.provider || 'No provider'} <span className="text-text-muted">-&gt;</span>{' '}
-                        {t.model || 'No model'}
-                      </div>
-                      {isProviderDisabled && (
-                        <div className="mt-1 text-[11px] text-danger">Provider disabled</div>
-                      )}
-                      {cooldown && (
-                        <div className="mt-1 text-[11px] font-medium text-warning">
-                          Cooldown {cooldownMinutes}m
-                        </div>
-                      )}
-                      {testState?.showResult && testState.message && (
+                return (
+                  <div
+                    key={`${t.provider}-${t.model}-${i}`}
+                    className={`rounded border border-border-glass bg-bg-glass px-2 py-2 ${
+                      isDisabled ? 'opacity-70' : ''
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0 flex-1">
                         <div
-                          className={`mt-1 text-[11px] italic ${
-                            testState.result === 'success' ? 'text-success' : 'text-danger'
+                          className={`truncate text-xs font-medium ${
+                            isDisabled ? 'text-danger line-through' : 'text-text-secondary'
                           }`}
                         >
-                          {testState.message}
+                          {t.provider || 'No provider'}{' '}
+                          <span className="text-text-muted">-&gt;</span> {t.model || 'No model'}
+                        </div>
+                        {isProviderDisabled && (
+                          <div className="mt-1 text-[11px] text-danger">Provider disabled</div>
+                        )}
+                        {cooldown && (
+                          <div className="mt-1 text-[11px] font-medium text-warning">
+                            Cooldown {cooldownMinutes}m
+                          </div>
+                        )}
+                        {testState?.showResult && testState.message && (
+                          <div
+                            className={`mt-1 text-[11px] italic ${
+                              testState.result === 'success' ? 'text-success' : 'text-danger'
+                            }`}
+                          >
+                            {testState.message}
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (isDisabled) return;
+                            let testApiTypes: string[] = ['chat'];
+                            if (alias.type === 'embeddings') testApiTypes = ['embeddings'];
+                            else if (alias.type === 'image') testApiTypes = ['images'];
+
+                            onTestTarget(
+                              alias.id,
+                              `${alias.id}-mobile-${i}`,
+                              t.provider,
+                              t.model,
+                              testApiTypes
+                            );
+                          }}
+                          disabled={isDisabled}
+                          className="flex h-7 w-7 items-center justify-center rounded text-primary transition-colors hover:bg-bg-hover disabled:cursor-not-allowed disabled:opacity-40"
+                          aria-label={`Test ${alias.id} target ${i + 1}`}
+                        >
+                          {testState?.loading ? (
+                            <Loader2 size={14} className="animate-spin" />
+                          ) : testState?.showResult && testState.result === 'success' ? (
+                            <CheckCircle size={14} className="text-success" />
+                          ) : testState?.showResult && testState.result === 'error' ? (
+                            <AlertTriangle size={14} className="text-danger" />
+                          ) : (
+                            <Play size={14} />
+                          )}
+                        </button>
+                        <Switch
+                          checked={t.enabled !== false}
+                          onChange={(val) => onToggleTarget(alias, 0, i, val)}
+                          size="sm"
+                          disabled={isProviderDisabled}
+                        />
+                      </div>
+                    </div>
+                    {testState?.showMessage &&
+                      testState.result === 'error' &&
+                      testState.message && (
+                        <div
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDismissTestMessage(testKey);
+                          }}
+                          className="mt-2 cursor-pointer rounded border border-danger/30 bg-danger/10 px-2 py-1"
+                          title="Click to dismiss"
+                        >
+                          <span className="text-[11px] italic text-danger">
+                            {testState.message} [×]
+                          </span>
                         </div>
                       )}
-                    </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          if (isDisabled) return;
-                          let testApiTypes: string[] = ['chat'];
-                          if (alias.type === 'embeddings') testApiTypes = ['embeddings'];
-                          else if (alias.type === 'image') testApiTypes = ['images'];
-
-                          onTestTarget(
-                            alias.id,
-                            `${alias.id}-mobile-${i}`,
-                            t.provider,
-                            t.model,
-                            testApiTypes
-                          );
-                        }}
-                        disabled={isDisabled}
-                        className="flex h-7 w-7 items-center justify-center rounded text-primary transition-colors hover:bg-bg-hover disabled:cursor-not-allowed disabled:opacity-40"
-                        aria-label={`Test ${alias.id} target ${i + 1}`}
-                      >
-                        {testState?.loading ? (
-                          <Loader2 size={14} className="animate-spin" />
-                        ) : testState?.showResult && testState.result === 'success' ? (
-                          <CheckCircle size={14} className="text-success" />
-                        ) : testState?.showResult && testState.result === 'error' ? (
-                          <AlertTriangle size={14} className="text-danger" />
-                        ) : (
-                          <Play size={14} />
-                        )}
-                      </button>
-                      <Switch
-                        checked={t.enabled !== false}
-                        onChange={(val) => onToggleTarget(alias, 0, i, val)}
-                        size="sm"
-                        disabled={isProviderDisabled}
-                      />
-                    </div>
                   </div>
-                  {testState?.showMessage && testState.result === 'error' && testState.message && (
-                    <div
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDismissTestMessage(testKey);
-                      }}
-                      className="mt-2 cursor-pointer rounded border border-danger/30 bg-danger/10 px-2 py-1"
-                      title="Click to dismiss"
-                    >
-                      <span className="text-[11px] italic text-danger">
-                        {testState.message} [×]
-                      </span>
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        )}
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
     </article>
   );

--- a/packages/frontend/src/components/models/AliasTableRow.tsx
+++ b/packages/frontend/src/components/models/AliasTableRow.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Edit2, Trash2, Clock, Play, Loader2, CheckCircle, XCircle } from 'lucide-react';
 import { CopyButton } from '../ui/CopyButton';
+import { Badge } from '../ui/Badge';
 import { Switch } from '../ui/Switch';
 import { Alias, Provider, Cooldown } from '../../lib/api';
 import { formatMsToMinSec } from '@plexus/shared';
 import { SELECTOR_LABELS } from '../../lib/selectors';
+import { getAliasProviderLabels, getAliasTargetCount } from '../../lib/modelList';
 
 interface AliasTableRowProps {
   alias: Alias;
@@ -40,6 +42,9 @@ export const AliasTableRow: React.FC<AliasTableRowProps> = ({
   onTestTarget,
   onDismissTestMessage,
 }) => {
+  const providerLabels = getAliasProviderLabels(alias, providers);
+  const targetCount = getAliasTargetCount(alias);
+
   return (
     <tr className="hover:bg-bg-hover">
       <td
@@ -102,6 +107,25 @@ export const AliasTableRow: React.FC<AliasTableRowProps> = ({
             ))}
           </div>
         )}
+      </td>
+
+      <td className="px-4 py-1.5 text-left border-b border-border-glass text-text">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex flex-wrap gap-1.5">
+            {providerLabels.length > 0 ? (
+              providerLabels.map((providerLabel) => (
+                <Badge key={providerLabel} status="neutral" noDot>
+                  {providerLabel}
+                </Badge>
+              ))
+            ) : (
+              <span className="text-[11px] text-text-muted">No providers</span>
+            )}
+          </div>
+          <div className="text-[11px] text-text-muted">
+            {targetCount} target{targetCount === 1 ? '' : 's'}
+          </div>
+        </div>
       </td>
 
       <td className="px-4 py-1.5 text-left border-b border-border-glass text-text pr-6">

--- a/packages/frontend/src/lib/modelList.test.ts
+++ b/packages/frontend/src/lib/modelList.test.ts
@@ -89,7 +89,7 @@ describe('model list helpers', () => {
       filterAndSortAliasesForModelsPage(aliases, providers, '', [], 'provider', 'asc').map(
         (alias) => alias.id
       )
-    ).toEqual(['gamma', 'beta', 'alpha']);
+    ).toEqual(['gamma', 'alpha', 'beta']);
 
     expect(
       filterAndSortAliasesForModelsPage(aliases, providers, '', [], 'targets', 'desc').map(

--- a/packages/frontend/src/lib/modelList.test.ts
+++ b/packages/frontend/src/lib/modelList.test.ts
@@ -1,0 +1,116 @@
+// @ts-expect-error bun:test available at runtime but not in frontend tsconfig
+import { describe, expect, test } from 'bun:test';
+
+import type { Alias, Provider } from './api';
+import {
+  aliasMatchesProviderFilters,
+  filterAndSortAliasesForModelsPage,
+  getAliasProviderLabels,
+  getAliasTargetCount,
+  getDefaultModelListSortDirection,
+  getModelListProviderOptions,
+} from './modelList';
+
+const providers: Provider[] = [
+  { id: 'openai', name: 'OpenAI', type: 'openai', apiKey: '', enabled: true },
+  { id: 'anthropic', name: 'Anthropic', type: 'anthropic', apiKey: '', enabled: true },
+  { id: 'neuralwatt', name: 'Neuralwatt', type: 'openai', apiKey: '', enabled: true },
+];
+
+const aliases: Alias[] = [
+  {
+    id: 'alpha',
+    target_groups: [
+      {
+        name: 'default',
+        selector: 'random',
+        targets: [
+          { provider: 'openai', model: 'gpt-4o-mini' },
+          { provider: 'anthropic', model: 'claude-3-5-sonnet' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'beta',
+    target_groups: [
+      {
+        name: 'default',
+        selector: 'random',
+        targets: [{ provider: 'neuralwatt', model: 'nw-1' }],
+      },
+    ],
+  },
+  {
+    id: 'gamma',
+    target_groups: [
+      {
+        name: 'default',
+        selector: 'random',
+        targets: [
+          { provider: 'anthropic', model: 'claude-3-opus' },
+          { provider: 'anthropic', model: 'claude-3-haiku' },
+        ],
+      },
+    ],
+  },
+];
+
+describe('model list helpers', () => {
+  test('derives provider labels and target counts from aliases', () => {
+    expect(getAliasProviderLabels(aliases[0], providers)).toEqual([
+      'Anthropic (anthropic)',
+      'OpenAI (openai)',
+    ]);
+    expect(getAliasTargetCount(aliases[0])).toBe(2);
+    expect(getAliasTargetCount(aliases[2])).toBe(2);
+  });
+
+  test('builds provider filter options from the configured aliases', () => {
+    expect(getModelListProviderOptions(aliases, providers)).toEqual([
+      'Anthropic (anthropic)',
+      'Neuralwatt (neuralwatt)',
+      'OpenAI (openai)',
+    ]);
+  });
+
+  test('matches provider filters using any target provider', () => {
+    expect(aliasMatchesProviderFilters(aliases[0], ['OpenAI (openai)'], providers)).toBe(true);
+    expect(aliasMatchesProviderFilters(aliases[0], ['Neuralwatt (neuralwatt)'], providers)).toBe(
+      false
+    );
+    expect(aliasMatchesProviderFilters(aliases[1], ['Neuralwatt (neuralwatt)'], providers)).toBe(
+      true
+    );
+  });
+
+  test('sorts aliases by provider and target count', () => {
+    expect(
+      filterAndSortAliasesForModelsPage(aliases, providers, '', [], 'provider', 'asc').map(
+        (alias) => alias.id
+      )
+    ).toEqual(['gamma', 'beta', 'alpha']);
+
+    expect(
+      filterAndSortAliasesForModelsPage(aliases, providers, '', [], 'targets', 'desc').map(
+        (alias) => alias.id
+      )
+    ).toEqual(['alpha', 'gamma', 'beta']);
+  });
+
+  test('falls back to alias sorting and provider filtering together', () => {
+    expect(getDefaultModelListSortDirection('targets')).toBe('desc');
+    expect(getDefaultModelListSortDirection('alias')).toBe('asc');
+
+    expect(
+      filterAndSortAliasesForModelsPage(
+        aliases,
+        providers,
+        '',
+        ['Anthropic (anthropic)'],
+        'alias',
+        'asc'
+      ).map((alias) => alias.id)
+    ).toEqual(['alpha', 'gamma']);
+  });
+});

--- a/packages/frontend/src/lib/modelList.ts
+++ b/packages/frontend/src/lib/modelList.ts
@@ -1,0 +1,115 @@
+import type { Alias, Provider } from './api';
+
+export type ModelListSortField = 'alias' | 'provider' | 'targets';
+export type ModelListSortDirection = 'asc' | 'desc';
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+export const getProviderDisplayLabel = (provider: Provider | undefined, fallbackId = '') => {
+  if (!provider) return fallbackId;
+
+  const name = provider.name?.trim() || provider.id || fallbackId;
+  if (!name) return fallbackId;
+
+  return name === provider.id ? name : `${name} (${provider.id})`;
+};
+
+export const getAliasTargetCount = (alias: Alias) =>
+  alias.target_groups.reduce((count, group) => count + group.targets.length, 0);
+
+export const getAliasProviderLabels = (alias: Alias, providers: Provider[]) => {
+  const providerById = new Map(providers.map((provider) => [provider.id, provider] as const));
+  const labels = new Set<string>();
+
+  for (const group of alias.target_groups) {
+    for (const target of group.targets) {
+      labels.add(getProviderDisplayLabel(providerById.get(target.provider), target.provider));
+    }
+  }
+
+  return Array.from(labels).sort((left, right) => left.localeCompare(right));
+};
+
+export const getModelListProviderOptions = (aliases: Alias[], providers: Provider[]) => {
+  const providerIds = new Set<string>();
+  for (const alias of aliases) {
+    for (const group of alias.target_groups) {
+      for (const target of group.targets) {
+        providerIds.add(target.provider);
+      }
+    }
+  }
+
+  return providers
+    .filter((provider) => providerIds.has(provider.id))
+    .map((provider) => getProviderDisplayLabel(provider))
+    .sort((left, right) => left.localeCompare(right));
+};
+
+export const aliasMatchesProviderFilters = (
+  alias: Alias,
+  selectedProviders: string[],
+  providers: Provider[]
+) => {
+  if (selectedProviders.length === 0) return true;
+
+  const providerLabels = getAliasProviderLabels(alias, providers);
+  return providerLabels.some((label) => selectedProviders.includes(label));
+};
+
+export const aliasMatchesSearch = (alias: Alias, search: string) => {
+  const term = normalize(search);
+  if (!term) return true;
+
+  return normalize(alias.id).includes(term);
+};
+
+const getSortKey = (alias: Alias, providers: Provider[], field: ModelListSortField) => {
+  switch (field) {
+    case 'provider':
+      return getAliasProviderLabels(alias, providers).join(' / ');
+    case 'targets':
+      return String(getAliasTargetCount(alias)).padStart(6, '0');
+    case 'alias':
+    default:
+      return alias.id;
+  }
+};
+
+export const sortAliasesForModelsPage = (
+  aliases: Alias[],
+  providers: Provider[],
+  field: ModelListSortField,
+  direction: ModelListSortDirection
+) => {
+  const multiplier = direction === 'asc' ? 1 : -1;
+
+  return [...aliases].sort((left, right) => {
+    const leftKey = normalize(getSortKey(left, providers, field));
+    const rightKey = normalize(getSortKey(right, providers, field));
+    const primary = leftKey.localeCompare(rightKey);
+    if (primary !== 0) return primary * multiplier;
+
+    return left.id.localeCompare(right.id) * multiplier;
+  });
+};
+
+export const filterAndSortAliasesForModelsPage = (
+  aliases: Alias[],
+  providers: Provider[],
+  search: string,
+  selectedProviders: string[],
+  field: ModelListSortField,
+  direction: ModelListSortDirection
+) => {
+  const filtered = aliases.filter(
+    (alias) =>
+      aliasMatchesSearch(alias, search) &&
+      aliasMatchesProviderFilters(alias, selectedProviders, providers)
+  );
+
+  return sortAliasesForModelsPage(filtered, providers, field, direction);
+};
+
+export const getDefaultModelListSortDirection = (field: ModelListSortField) =>
+  field === 'targets' ? 'desc' : 'asc';

--- a/packages/frontend/src/lib/modelList.ts
+++ b/packages/frontend/src/lib/modelList.ts
@@ -90,7 +90,7 @@ export const sortAliasesForModelsPage = (
     const primary = leftKey.localeCompare(rightKey);
     if (primary !== 0) return primary * multiplier;
 
-    return left.id.localeCompare(right.id) * multiplier;
+    return left.id.localeCompare(right.id);
   });
 };
 

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -120,11 +120,11 @@ export const Models = () => {
       filterAndSortAliasesForModelsPage(
         aliases,
         providers,
-        search,
+        '',
         selectedProviderFilters,
         sortField,
         sortDirection
-      ),
+      )
     [aliases, providers, search, selectedProviderFilters, sortField, sortDirection]
   );
 

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -124,8 +124,8 @@ export const Models = () => {
         selectedProviderFilters,
         sortField,
         sortDirection
-      )
-    [aliases, providers, search, selectedProviderFilters, sortField, sortDirection]
+      ),
+    [aliases, providers, selectedProviderFilters, sortField, sortDirection]
   );
 
   const handleSort = (field: ModelListSortField) => {

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Alias } from '../lib/api';
 import { useModels } from '../hooks/useModels';
 import { AliasTableRow } from '../components/models/AliasTableRow';
@@ -14,11 +14,29 @@ import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
 import { SearchInput } from '../components/ui/SearchInput';
+import { TagSelect } from '../components/ui/TagSelect';
 import { Disclosure } from '../components/ui/Disclosure';
 import { PageHeader } from '../components/layout/PageHeader';
 import { PageContainer } from '../components/layout/PageContainer';
 import { useToast } from '../contexts/ToastContext';
-import { Plus, Trash2, Zap, Download, ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  filterAndSortAliasesForModelsPage,
+  getDefaultModelListSortDirection,
+  getModelListProviderOptions,
+  type ModelListSortDirection,
+  type ModelListSortField,
+} from '../lib/modelList';
+import {
+  Plus,
+  Trash2,
+  Zap,
+  Download,
+  ChevronDown,
+  ChevronRight,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+} from 'lucide-react';
 
 // Model alias types grouped into accordions on the Models page. Order
 // follows rough frequency of use.
@@ -40,6 +58,7 @@ export const Models = () => {
   const toast = useToast();
   const {
     aliases,
+    allAliases,
     providers,
     availableModels,
     cooldowns,
@@ -87,6 +106,42 @@ export const Models = () => {
   // Auto Add Modal State
   const [isAutoAddModalOpen, setIsAutoAddModalOpen] = useState(false);
   const [isAliasesOpen, setIsAliasesOpen] = useState(false);
+  const [selectedProviderFilters, setSelectedProviderFilters] = useState<string[]>([]);
+  const [sortField, setSortField] = useState<ModelListSortField>('alias');
+  const [sortDirection, setSortDirection] = useState<ModelListSortDirection>('asc');
+
+  const providerOptions = useMemo(
+    () => getModelListProviderOptions(allAliases, providers),
+    [allAliases, providers]
+  );
+
+  const visibleAliases = useMemo(
+    () =>
+      filterAndSortAliasesForModelsPage(
+        aliases,
+        providers,
+        search,
+        selectedProviderFilters,
+        sortField,
+        sortDirection
+      ),
+    [aliases, providers, search, selectedProviderFilters, sortField, sortDirection]
+  );
+
+  const handleSort = (field: ModelListSortField) => {
+    if (sortField === field) {
+      setSortDirection((currentDirection) => (currentDirection === 'asc' ? 'desc' : 'asc'));
+      return;
+    }
+
+    setSortField(field);
+    setSortDirection(getDefaultModelListSortDirection(field));
+  };
+
+  const getSortAriaLabel = (field: ModelListSortField) => {
+    if (sortField !== field) return 'none';
+    return sortDirection === 'asc' ? 'ascending' : 'descending';
+  };
 
   // Edit modal accordion toggles — architecture & metadata manage their own
   // in child components, but behaviors has no parent-provided toggle.
@@ -152,13 +207,18 @@ export const Models = () => {
     [setEditingAlias]
   );
 
-  const sortedAliases = [...aliases].sort((a, b) => a.id.localeCompare(b.id));
-
-  // Bucket the (already search-filtered) aliases into the ordered type groups.
   const aliasesByType = MODEL_TYPE_GROUPS.map((group) => ({
     group,
-    aliases: sortedAliases.filter((a) => (a.type ?? 'text') === group.type),
+    aliases: visibleAliases.filter((a) => (a.type ?? 'text') === group.type),
   }));
+
+  const hasActiveFilters = search.trim().length > 0 || selectedProviderFilters.length > 0;
+  const emptyStateMessage =
+    allAliases.length === 0
+      ? 'No aliases configured'
+      : hasActiveFilters
+        ? 'No aliases match your current search or provider filter'
+        : 'No aliases found';
 
   return (
     <div className="flex flex-col min-h-full">
@@ -172,7 +232,7 @@ export const Models = () => {
               size="sm"
               leftIcon={<Trash2 size={14} />}
               onClick={() => setIsDeleteAllModalOpen(true)}
-              disabled={aliases.length === 0}
+              disabled={allAliases.length === 0}
             >
               Delete All
             </Button>
@@ -190,7 +250,7 @@ export const Models = () => {
           </>
         }
       >
-        <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 items-stretch sm:items-center">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-start">
           <div className="w-full sm:w-72">
             <SearchInput
               placeholder="Search by alias, upstream id, tag…"
@@ -198,14 +258,35 @@ export const Models = () => {
               onChange={setSearch}
             />
           </div>
-          <VisionFallthroughSelector aliases={aliases} />
+          <div className="w-full sm:w-80">
+            <TagSelect
+              label="Filter by provider"
+              placeholder="All providers"
+              options={providerOptions}
+              selected={selectedProviderFilters}
+              onChange={setSelectedProviderFilters}
+            />
+          </div>
+          {selectedProviderFilters.length > 0 && (
+            <div className="flex items-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setSelectedProviderFilters([])}
+                className="whitespace-nowrap"
+              >
+                Clear providers
+              </Button>
+            </div>
+          )}
+          <VisionFallthroughSelector aliases={allAliases} />
         </div>
       </PageHeader>
 
       <PageContainer>
-        {sortedAliases.length === 0 ? (
+        {visibleAliases.length === 0 ? (
           <Card className="mb-6">
-            <div className="py-10 text-center text-sm text-text-muted">No aliases found</div>
+            <div className="py-10 text-center text-sm text-text-muted">{emptyStateMessage}</div>
           </Card>
         ) : (
           <div className="flex flex-col gap-3 mb-6">
@@ -246,16 +327,72 @@ export const Models = () => {
                     <thead>
                       <tr>
                         <th
+                          scope="col"
+                          aria-sort={getSortAriaLabel('alias')}
                           className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
                           style={{ paddingLeft: '24px' }}
                         >
-                          Alias
+                          <button
+                            type="button"
+                            onClick={() => handleSort('alias')}
+                            className="inline-flex items-center gap-1 hover:text-text transition-colors"
+                          >
+                            <span>Alias</span>
+                            {sortField === 'alias' ? (
+                              sortDirection === 'asc' ? (
+                                <ArrowUp size={12} aria-hidden="true" />
+                              ) : (
+                                <ArrowDown size={12} aria-hidden="true" />
+                              )
+                            ) : (
+                              <ArrowUpDown size={12} className="opacity-40" aria-hidden="true" />
+                            )}
+                          </button>
                         </th>
                         <th
+                          scope="col"
+                          aria-sort={getSortAriaLabel('provider')}
+                          className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                        >
+                          <button
+                            type="button"
+                            onClick={() => handleSort('provider')}
+                            className="inline-flex items-center gap-1 hover:text-text transition-colors"
+                          >
+                            <span>Provider</span>
+                            {sortField === 'provider' ? (
+                              sortDirection === 'asc' ? (
+                                <ArrowUp size={12} aria-hidden="true" />
+                              ) : (
+                                <ArrowDown size={12} aria-hidden="true" />
+                              )
+                            ) : (
+                              <ArrowUpDown size={12} className="opacity-40" aria-hidden="true" />
+                            )}
+                          </button>
+                        </th>
+                        <th
+                          scope="col"
+                          aria-sort={getSortAriaLabel('targets')}
                           className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
                           style={{ paddingRight: '24px' }}
                         >
-                          Targets
+                          <button
+                            type="button"
+                            onClick={() => handleSort('targets')}
+                            className="inline-flex items-center gap-1 hover:text-text transition-colors"
+                          >
+                            <span>Targets</span>
+                            {sortField === 'targets' ? (
+                              sortDirection === 'asc' ? (
+                                <ArrowUp size={12} aria-hidden="true" />
+                              ) : (
+                                <ArrowDown size={12} aria-hidden="true" />
+                              )
+                            ) : (
+                              <ArrowUpDown size={12} className="opacity-40" aria-hidden="true" />
+                            )}
+                          </button>
                         </th>
                       </tr>
                     </thead>
@@ -509,8 +646,8 @@ export const Models = () => {
           title="Delete All Models"
           message={
             <>
-              This will permanently remove <strong>{aliases.length}</strong> model alias
-              {aliases.length !== 1 ? 'es' : ''} from the configuration.
+              This will permanently remove <strong>{allAliases.length}</strong> model alias
+              {allAliases.length !== 1 ? 'es' : ''} from the configuration.
             </>
           }
           confirmLabel="Delete All"


### PR DESCRIPTION
### **User description**
## Summary
Add provider-aware controls to the Models page so admins can narrow large model lists quickly and sort them by useful columns. The page now supports multi-select provider filtering, sortable Alias/Provider/Targets headers, and clearer provider/target summaries in each row/card.

## Changes
- **Models page**: added a provider filter chip list next to the search field and wired it into the existing Models view state.
- **Sorting**: made Alias, Provider, and Targets headers clickable with accessible sort state and default ordering per column.
- **Row/card presentation**: show provider badges and target counts so the new sort/filter controls reflect visible data.
- **Shared helpers**: extracted model-list filter/sort helpers into `packages/frontend/src/lib/modelList.ts` for reuse and easier testing.
- **Tests**: added focused helper tests covering provider label extraction, provider filtering, and sorting behavior.

## Testing
- `bun run test`
- `bun run typecheck`
- Manual browser verification in the worktree-safe dev stack (`bun run dev:agent`): opened the Models page, applied a provider filter, and confirmed the visible rows narrowed; clicked the Provider and Targets headers and confirmed the list re-ordered.
- Screenshot captured: `/home/matt.cowger/.agent-browser/tmp/screenshots/screenshot-1783729004684.png`

## Notes
- `agent-browser install --with-deps` could not install Linux packages in this environment because `sudo` requires an interactive terminal, but the existing browser binary was sufficient for validation.


___

### **Description**
- Add provider filtering to the Models page

- Add sortable alias, provider, and target columns

- Display provider badges and target counts

- Test model-list filtering and sorting helpers


___

