### PR TITLE
fix(usage): centralize SSE event broadcasting

### DIFF
--- a/packages/backend/src/routes/management/__tests__/usage-events.test.ts
+++ b/packages/backend/src/routes/management/__tests__/usage-events.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { UsageStorageService } from '../../../services/usage-storage';
+import { UsageEventsBroadcaster } from '../usage';
+
+describe('UsageEventsBroadcaster', () => {
+  let broadcaster: UsageEventsBroadcaster | null = null;
+
+  afterEach(() => {
+    broadcaster?.dispose();
+    broadcaster = null;
+  });
+
+  it('keeps a single UsageStorageService listener regardless of connected SSE clients', () => {
+    const usageStorage = new UsageStorageService();
+    broadcaster = new UsageEventsBroadcaster(usageStorage);
+
+    const received: Array<{ eventType: string; requestId: string }> = [];
+    const cleanups: Array<() => void> = [];
+
+    for (let index = 0; index < 12; index += 1) {
+      cleanups.push(
+        broadcaster.subscribe({
+          scopeKey: index % 2 === 0 ? null : 'team-a',
+          send: (eventType, record) => {
+            received.push({
+              eventType,
+              requestId: record.requestId,
+            });
+          },
+        })
+      );
+    }
+
+    expect(usageStorage.listenerCount('started')).toBe(1);
+    expect(usageStorage.listenerCount('updated')).toBe(1);
+    expect(usageStorage.listenerCount('completed')).toBe(1);
+    expect(usageStorage.listenerCount('created')).toBe(1);
+
+    usageStorage.emit('started', { requestId: 'req-1', apiKey: 'team-a' });
+    expect(received).toHaveLength(12);
+    expect(received.every((entry) => entry.requestId === 'req-1')).toBe(true);
+
+    usageStorage.emit('started', { requestId: 'req-2', apiKey: 'team-b' });
+    expect(received).toHaveLength(18);
+    expect(received.slice(12).every((entry) => entry.requestId === 'req-2')).toBe(true);
+
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+
+    expect(usageStorage.listenerCount('started')).toBe(1);
+
+    broadcaster.dispose();
+    expect(usageStorage.listenerCount('started')).toBe(0);
+    expect(usageStorage.listenerCount('updated')).toBe(0);
+    expect(usageStorage.listenerCount('completed')).toBe(0);
+    expect(usageStorage.listenerCount('created')).toBe(0);
+  });
+});

--- a/packages/backend/src/routes/management/usage.ts
+++ b/packages/backend/src/routes/management/usage.ts
@@ -54,10 +54,74 @@ const USAGE_FIELDS = new Set([
   'hasError',
 ]);
 
+type UsageStreamEventName = 'started' | 'updated' | 'completed' | 'created';
+
+type UsageStreamClient = {
+  scopeKey: string | null;
+  send: (eventType: UsageStreamEventName, record: any) => void;
+};
+
+export class UsageEventsBroadcaster {
+  private readonly clients = new Set<UsageStreamClient>();
+  private readonly startedListener = (record: any) => this.broadcast('started', record);
+  private readonly updatedListener = (record: any) => this.broadcast('updated', record);
+  private readonly completedListener = (record: any) => this.broadcast('completed', record);
+  private readonly createdListener = (record: any) => this.broadcast('completed', record);
+
+  constructor(readonly usageStorage: UsageStorageService) {
+    this.usageStorage.on('started', this.startedListener);
+    this.usageStorage.on('updated', this.updatedListener);
+    this.usageStorage.on('completed', this.completedListener);
+    // Also listen for 'created' for backward compatibility
+    this.usageStorage.on('created', this.createdListener);
+  }
+
+  subscribe(client: UsageStreamClient): () => void {
+    this.clients.add(client);
+
+    return () => {
+      this.clients.delete(client);
+    };
+  }
+
+  dispose(): void {
+    this.usageStorage.off('started', this.startedListener);
+    this.usageStorage.off('updated', this.updatedListener);
+    this.usageStorage.off('completed', this.completedListener);
+    this.usageStorage.off('created', this.createdListener);
+    this.clients.clear();
+  }
+
+  private broadcast(eventType: UsageStreamEventName, record: any): void {
+    for (const client of this.clients) {
+      if (client.scopeKey && record?.apiKey !== client.scopeKey) continue;
+      client.send(eventType, record);
+    }
+  }
+}
+
+let usageEventsBroadcaster: UsageEventsBroadcaster | null = null;
+
+function getUsageEventsBroadcaster(usageStorage: UsageStorageService): UsageEventsBroadcaster {
+  if (!usageEventsBroadcaster || usageEventsBroadcaster.usageStorage !== usageStorage) {
+    usageEventsBroadcaster?.dispose();
+    usageEventsBroadcaster = new UsageEventsBroadcaster(usageStorage);
+  }
+
+  return usageEventsBroadcaster;
+}
+
 export async function registerUsageRoutes(
   fastify: FastifyInstance,
   usageStorage: UsageStorageService
 ) {
+  fastify.addHook('onClose', async () => {
+    if (usageEventsBroadcaster?.usageStorage === usageStorage) {
+      usageEventsBroadcaster.dispose();
+      usageEventsBroadcaster = null;
+    }
+  });
+
   const sortableFields = new Set<UsageSortField>([
     'date',
     'apiKey',
@@ -424,33 +488,28 @@ export async function registerUsageRoutes(
       'Access-Control-Allow-Origin': '*',
     });
 
+    const broadcaster = getUsageEventsBroadcaster(usageStorage);
+
     // Limited users must only observe activity for their own key. Admins
     // (scopeKey === null) continue to receive every event.
     const scopeKey = scopedKeyName(request);
 
     // Helper to send events to the client
-    const sendEvent = (eventType: string, record: any) => {
+    const sendEvent = (eventType: UsageStreamEventName, record: any) => {
       if (reply.raw.destroyed) return;
       if (scopeKey && record?.apiKey !== scopeKey) return;
-      reply.raw.write(
-        encode({
-          data: JSON.stringify(record),
-          event: eventType,
-          id: String(Date.now()),
-        })
-      );
+      try {
+        reply.raw.write(
+          encode({
+            data: JSON.stringify(record),
+            event: eventType,
+            id: String(Date.now()),
+          })
+        );
+      } catch {
+        // Fire-and-forget: ignore write errors
+      }
     };
-
-    // Listen for all event types: started, updated, and completed
-    const startedListener = (record: any) => sendEvent('started', record);
-    const updatedListener = (record: any) => sendEvent('updated', record);
-    const completedListener = (record: any) => sendEvent('completed', record);
-
-    usageStorage.on('started', startedListener);
-    usageStorage.on('updated', updatedListener);
-    usageStorage.on('completed', completedListener);
-    // Also listen for 'created' for backward compatibility
-    usageStorage.on('created', completedListener);
 
     // Periodic progress updates for in-flight requests (every 1s, fire-and-forget)
     const progressInterval = setInterval(() => {
@@ -476,33 +535,37 @@ export async function registerUsageRoutes(
     // Cleanup on server shutdown (closeAllConnections destroys sockets → 'close' fires)
     // and as a fallback for other disconnect scenarios.
     let cleanedUp = false;
+    const unsubscribe = broadcaster.subscribe({
+      scopeKey,
+      send: sendEvent,
+    });
     const cleanup = () => {
       if (cleanedUp) return;
       cleanedUp = true;
       clearInterval(progressInterval);
-      usageStorage.off('started', startedListener);
-      usageStorage.off('updated', updatedListener);
-      usageStorage.off('completed', completedListener);
-      usageStorage.off('created', completedListener);
+      unsubscribe();
     };
 
-    reply.raw.on('close', cleanup);
+    reply.raw.once('close', cleanup);
+    reply.raw.once('error', cleanup);
 
-    // Keep connection alive with periodic pings
-    while (!reply.raw.destroyed) {
-      await new Promise((resolve) => setTimeout(resolve, 10000));
-      if (!reply.raw.destroyed) {
-        reply.raw.write(
-          encode({
-            event: 'ping',
-            data: 'pong',
-            id: String(Date.now()),
-          })
-        );
+    try {
+      // Keep connection alive with periodic pings
+      while (!reply.raw.destroyed) {
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+        if (!reply.raw.destroyed) {
+          reply.raw.write(
+            encode({
+              event: 'ping',
+              data: 'pong',
+              id: String(Date.now()),
+            })
+          );
+        }
       }
+    } finally {
+      // Cleanup: socket destroyed (client disconnect or server shutdown)
+      cleanup();
     }
-
-    // Cleanup: socket destroyed (client disconnect or server shutdown)
-    cleanup();
   });
 }

--- a/packages/backend/src/routes/management/usage.ts
+++ b/packages/backend/src/routes/management/usage.ts
@@ -63,20 +63,26 @@ type UsageStreamClient = {
 
 export class UsageEventsBroadcaster {
   private readonly clients = new Set<UsageStreamClient>();
+  private listening = false;
   private readonly startedListener = (record: any) => this.broadcast('started', record);
   private readonly updatedListener = (record: any) => this.broadcast('updated', record);
   private readonly completedListener = (record: any) => this.broadcast('completed', record);
   private readonly createdListener = (record: any) => this.broadcast('completed', record);
 
-  constructor(readonly usageStorage: UsageStorageService) {
-    this.usageStorage.on('started', this.startedListener);
-    this.usageStorage.on('updated', this.updatedListener);
-    this.usageStorage.on('completed', this.completedListener);
-    // Also listen for 'created' for backward compatibility
-    this.usageStorage.on('created', this.createdListener);
-  }
+  constructor(readonly usageStorage: UsageStorageService) {}
 
   subscribe(client: UsageStreamClient): () => void {
+    // Attach storage listeners lazily so constructing the broadcaster has no
+    // side effects until the first SSE client connects.
+    if (!this.listening) {
+      this.listening = true;
+      this.usageStorage.on('started', this.startedListener);
+      this.usageStorage.on('updated', this.updatedListener);
+      this.usageStorage.on('completed', this.completedListener);
+      // Also listen for 'created' for backward compatibility
+      this.usageStorage.on('created', this.createdListener);
+    }
+
     this.clients.add(client);
 
     return () => {
@@ -85,10 +91,13 @@ export class UsageEventsBroadcaster {
   }
 
   dispose(): void {
-    this.usageStorage.off('started', this.startedListener);
-    this.usageStorage.off('updated', this.updatedListener);
-    this.usageStorage.off('completed', this.completedListener);
-    this.usageStorage.off('created', this.createdListener);
+    if (this.listening) {
+      this.listening = false;
+      this.usageStorage.off('started', this.startedListener);
+      this.usageStorage.off('updated', this.updatedListener);
+      this.usageStorage.off('completed', this.completedListener);
+      this.usageStorage.off('created', this.createdListener);
+    }
     this.clients.clear();
   }
 
@@ -100,26 +109,14 @@ export class UsageEventsBroadcaster {
   }
 }
 
-let usageEventsBroadcaster: UsageEventsBroadcaster | null = null;
-
-function getUsageEventsBroadcaster(usageStorage: UsageStorageService): UsageEventsBroadcaster {
-  if (!usageEventsBroadcaster || usageEventsBroadcaster.usageStorage !== usageStorage) {
-    usageEventsBroadcaster?.dispose();
-    usageEventsBroadcaster = new UsageEventsBroadcaster(usageStorage);
-  }
-
-  return usageEventsBroadcaster;
-}
-
 export async function registerUsageRoutes(
   fastify: FastifyInstance,
   usageStorage: UsageStorageService
 ) {
+  const usageEventsBroadcaster = new UsageEventsBroadcaster(usageStorage);
+
   fastify.addHook('onClose', async () => {
-    if (usageEventsBroadcaster?.usageStorage === usageStorage) {
-      usageEventsBroadcaster.dispose();
-      usageEventsBroadcaster = null;
-    }
+    usageEventsBroadcaster.dispose();
   });
 
   const sortableFields = new Set<UsageSortField>([
@@ -488,8 +485,6 @@ export async function registerUsageRoutes(
       'Access-Control-Allow-Origin': '*',
     });
 
-    const broadcaster = getUsageEventsBroadcaster(usageStorage);
-
     // Limited users must only observe activity for their own key. Admins
     // (scopeKey === null) continue to receive every event.
     const scopeKey = scopedKeyName(request);
@@ -535,7 +530,7 @@ export async function registerUsageRoutes(
     // Cleanup on server shutdown (closeAllConnections destroys sockets → 'close' fires)
     // and as a fallback for other disconnect scenarios.
     let cleanedUp = false;
-    const unsubscribe = broadcaster.subscribe({
+    const unsubscribe = usageEventsBroadcaster.subscribe({
       scopeKey,
       send: sendEvent,
     });


### PR DESCRIPTION
### **User description**
## Summary
Fix the `UsageStorageService` listener leak behind the management usage SSE endpoint by moving `started`/`updated`/`completed`/`created` event subscription to a single shared broadcaster. Per-request SSE clients now subscribe to that broadcaster instead of registering their own listeners on every request, so the `started` listener count no longer grows with traffic.

## Changes
- **Backend route**: introduced `UsageEventsBroadcaster` in `packages/backend/src/routes/management/usage.ts` to own the `UsageStorageService` event subscriptions.
- **SSE lifecycle**: each `/v0/management/events` request now subscribes/unsubscribes a lightweight client callback instead of binding new storage listeners per request.
- **Cleanup**: added `onClose`, `close`, `error`, and `finally` cleanup paths so subscriptions are released reliably.
- **Regression coverage**: added a Vitest regression test that asserts the storage service keeps one listener per event type even with many connected SSE clients.

## Testing
- `bun run test`
- `bun run typecheck`


___

### **Description**
- Centralize usage SSE storage event listeners

- Reuse a shared broadcaster across SSE clients

- Reliably clean up client and server subscriptions

- Add listener-leak regression coverage


___

