### PR TITLE
fix(debug): avoid wrapping oversized trace lines

### DIFF
--- a/packages/frontend/src/pages/Debug.tsx
+++ b/packages/frontend/src/pages/Debug.tsx
@@ -764,6 +764,11 @@ const AccordionPanel: React.FC<{
   defaultOpen?: boolean;
 }> = ({ title, content, color, defaultOpen = false }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  // Monaco's wrapped-line layout becomes prohibitively expensive for captured
+  // request bodies containing a very large escaped string (for example, a
+  // prompt with many embedded newlines). Preserve wrapping for normal JSON,
+  // but let exceptionally long lines scroll horizontally instead.
+  const hasVeryLongLine = content.split('\n').some((line) => line.length > 10_000);
   const [copied, setCopied] = useState(false);
   const [folded, setFolded] = useState(false);
   const editorRef = useRef<any>(null);
@@ -847,7 +852,7 @@ const AccordionPanel: React.FC<{
               fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
               lineNumbers: 'on',
               folding: true,
-              wordWrap: 'on',
+              wordWrap: hasVeryLongLine ? 'off' : 'on',
               padding: { top: 10, bottom: 10 },
             }}
           />


### PR DESCRIPTION
### **User description**
## Summary
Prevents the Traces page from leaving all Monaco panels in a loading state when a captured request contains an exceptionally long JSON line. Normal traces retain wrapped JSON; oversized lines remain fully available through Monaco’s horizontal scrolling, copy, download, and folding controls.

## Why / Context
The production trace that triggered the issue loaded successfully and Monaco’s complete CDN module tree returned 200 responses. Its request and transformed-request payloads each contained a 103,272-character escaped string line, which made Monaco’s wrapped-line layout prohibitively expensive before the editors could report ready.

## Changes
- **Debug trace panels**: detect formatted content with a line longer than 10,000 characters.
- **Monaco configuration**: disable word wrapping only for those exceptional panels, avoiding pathological layout work while preserving wrapping for normal JSON.

## Testing
- Inspected the production HAR to verify the trace response, all Monaco CDN requests, and the oversized-line shape.
- Manually opened a local trace and confirmed all Monaco panels initialize; screenshot: `/home/matt.cowger/.agent-browser/tmp/screenshots/screenshot-1783796694112.png`.


___

### **Description**
- Prevent Monaco stalls on oversized trace JSON lines

- Disable wrapping above 10,000-character lines

- Preserve wrapping for normal trace content


___

