### PR TITLE
fix(logs): reconnect stale SSE streams

### DIFF
--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -387,6 +387,7 @@ export const Logs = () => {
       controller.signal.addEventListener('abort', abortConnection, { once: true });
       let heartbeatTimer: ReturnType<typeof setTimeout> | undefined;
       let heartbeatTimedOut = false;
+      let streamConnected = false;
 
       const resetHeartbeatTimer = () => {
         clearTimeout(heartbeatTimer);
@@ -395,6 +396,8 @@ export const Logs = () => {
           connectionController.abort();
         }, SSE_HEARTBEAT_TIMEOUT_MS);
       };
+
+      resetHeartbeatTimer();
 
       try {
         const response = await fetch('/v0/management/events', {
@@ -415,6 +418,7 @@ export const Logs = () => {
         const reader = response.body?.getReader();
         if (!reader) return false;
 
+        streamConnected = true;
         sseConnected.current = true;
         setSseStatus('connected');
         resetHeartbeatTimer();
@@ -538,7 +542,7 @@ export const Logs = () => {
           }
           if (heartbeatTimedOut) {
             console.warn('SSE heartbeat timed out — reconnecting');
-            return true;
+            return streamConnected;
           }
         }
         console.error('Log stream error:', err);

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -87,6 +87,8 @@ import geminiLogo from '../assets/gemini.svg';
 // @ts-ignore
 import responsesLogo from '../assets/responses.svg';
 
+const SSE_HEARTBEAT_TIMEOUT_MS = 30_000;
+
 interface RetryAttemptDetail {
   index: number;
   provider: string;
@@ -380,10 +382,24 @@ export const Logs = () => {
     //   false — connection-level error (transient; safe to retry)
     //   null  — permanent server error (4xx); stop retrying
     const connectOnce = async (): Promise<boolean | null> => {
+      const connectionController = new AbortController();
+      const abortConnection = () => connectionController.abort();
+      controller.signal.addEventListener('abort', abortConnection, { once: true });
+      let heartbeatTimer: ReturnType<typeof setTimeout> | undefined;
+      let heartbeatTimedOut = false;
+
+      const resetHeartbeatTimer = () => {
+        clearTimeout(heartbeatTimer);
+        heartbeatTimer = setTimeout(() => {
+          heartbeatTimedOut = true;
+          connectionController.abort();
+        }, SSE_HEARTBEAT_TIMEOUT_MS);
+      };
+
       try {
         const response = await fetch('/v0/management/events', {
           headers: { 'x-admin-key': adminKey },
-          signal: controller.signal,
+          signal: connectionController.signal,
         });
 
         if (!response.ok) {
@@ -401,6 +417,7 @@ export const Logs = () => {
 
         sseConnected.current = true;
         setSseStatus('connected');
+        resetHeartbeatTimer();
 
         const decoder = new TextDecoder();
         let buffer = '';
@@ -412,6 +429,8 @@ export const Logs = () => {
             break;
           }
 
+          // Any bytes prove the stream is alive; the server sends a ping every 10 seconds.
+          resetHeartbeatTimer();
           buffer += decoder.decode(value, { stream: true });
           const lines = buffer.split('\n\n'); // SSE messages are separated by double newline
           buffer = lines.pop() || '';
@@ -513,11 +532,20 @@ export const Logs = () => {
       } catch (err: any) {
         handleDisconnect();
         if (err.name === 'AbortError') {
-          // Intentional teardown — do not retry.
-          throw err;
+          if (controller.signal.aborted) {
+            // Intentional teardown — do not retry.
+            throw err;
+          }
+          if (heartbeatTimedOut) {
+            console.warn('SSE heartbeat timed out — reconnecting');
+            return true;
+          }
         }
         console.error('Log stream error:', err);
         return false;
+      } finally {
+        clearTimeout(heartbeatTimer);
+        controller.signal.removeEventListener('abort', abortConnection);
       }
     };
 

--- a/packages/frontend/src/pages/SystemLogs.tsx
+++ b/packages/frontend/src/pages/SystemLogs.tsx
@@ -25,6 +25,9 @@ const LEVEL_CLASS: Record<string, string> = {
   silly: 'text-text-muted',
 };
 
+const INITIAL_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
 export const SystemLogs: React.FC = () => {
   const toast = useToast();
   const [logs, setLogs] = useState<LogEntry[]>([]);
@@ -85,61 +88,85 @@ export const SystemLogs: React.FC = () => {
 
     const controller = new AbortController();
     abortControllerRef.current = controller;
+    let reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
 
-    try {
-      const response = await fetch('/v0/system/logs/stream', {
-        headers: { 'x-admin-key': adminKey },
-        signal: controller.signal,
-      });
-      if (!response.ok) throw new Error(`Failed to connect: ${response.statusText}`);
-
-      const reader = response.body?.getReader();
-      if (!reader) return;
-
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n\n');
-        buffer = lines.pop() || '';
-
-        for (const block of lines) {
-          const blockLines = block.split('\n');
-          let eventData = '';
-          let isSyslogEvent = false;
-
-          for (const line of blockLines) {
-            if (line.startsWith('event: syslog')) {
-              isSyslogEvent = true;
-            } else if (line.startsWith('event: ping')) {
-              isSyslogEvent = false;
-            } else if (line.startsWith('data: ')) {
-              eventData = line.slice(6);
-            } else if (line.startsWith('data:')) {
-              eventData = line.slice(5);
-            }
+    while (!controller.signal.aborted) {
+      try {
+        const response = await fetch('/v0/system/logs/stream', {
+          headers: { 'x-admin-key': adminKey },
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          if (response.status >= 400 && response.status < 500) {
+            console.error(`Log stream permanent error ${response.status} — stopping reconnect`);
+            return;
           }
+          throw new Error(`Failed to connect: ${response.statusText}`);
+        }
 
-          if (isSyslogEvent && eventData) {
-            try {
-              const data = JSON.parse(eventData);
-              if (!isPausedRef.current) {
-                setLogs((prev) => [...prev.slice(-999), data]);
+        const reader = response.body?.getReader();
+        if (!reader) throw new Error('Log stream response has no body');
+
+        reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (!controller.signal.aborted) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n\n');
+          buffer = lines.pop() || '';
+
+          for (const block of lines) {
+            const blockLines = block.split('\n');
+            let eventData = '';
+            let isSyslogEvent = false;
+
+            for (const line of blockLines) {
+              if (line.startsWith('event: syslog')) {
+                isSyslogEvent = true;
+              } else if (line.startsWith('event: ping')) {
+                isSyslogEvent = false;
+              } else if (line.startsWith('data: ')) {
+                eventData = line.slice(6);
+              } else if (line.startsWith('data:')) {
+                eventData = line.slice(5);
               }
-            } catch {
-              // ignore
+            }
+
+            if (isSyslogEvent && eventData) {
+              try {
+                const data = JSON.parse(eventData);
+                if (!isPausedRef.current) {
+                  setLogs((prev) => [...prev.slice(-999), data]);
+                }
+              } catch {
+                // ignore
+              }
             }
           }
         }
-      }
-    } catch (err: any) {
-      if (err.name !== 'AbortError') {
+      } catch (err: any) {
+        if (controller.signal.aborted || err.name === 'AbortError') return;
         console.error('Log stream error:', err);
       }
+
+      if (controller.signal.aborted) return;
+
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, reconnectDelay);
+        controller.signal.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timer);
+            resolve();
+          },
+          { once: true }
+        );
+      });
+      reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
     }
   };
 

--- a/packages/frontend/src/pages/SystemLogs.tsx
+++ b/packages/frontend/src/pages/SystemLogs.tsx
@@ -107,7 +107,6 @@ export const SystemLogs: React.FC = () => {
         const reader = response.body?.getReader();
         if (!reader) throw new Error('Log stream response has no body');
 
-        reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
         const decoder = new TextDecoder();
         let buffer = '';
 
@@ -118,6 +117,7 @@ export const SystemLogs: React.FC = () => {
           buffer += decoder.decode(value, { stream: true });
           const lines = buffer.split('\n\n');
           buffer = lines.pop() || '';
+          if (lines.length > 0) reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
 
           for (const block of lines) {
             const blockLines = block.split('\n');


### PR DESCRIPTION
## Summary

Keep both frontend log views live when their SSE connections become stale or terminate. Request Logs now detects a silent stream using the existing server heartbeat, while System Logs automatically reconnects after transient disconnects.

## Why / Context

A half-open Request Logs stream could remain marked connected indefinitely because heartbeat events were consumed but not monitored. System Logs also stopped receiving updates after any stream failure until the page was reloaded.

## Changes

- **Request Logs**: add a 30-second activity watchdog around the 10-second server heartbeat and abort stale per-connection readers.
- **Request Logs**: route watchdog aborts through the existing exponential reconnect loop while preserving intentional teardown behavior.
- **System Logs**: reconnect transient stream failures with exponential backoff from 1 to 30 seconds.
- **System Logs**: stop retrying permanent 4xx responses and retain abort-on-unmount cleanup.

## Testing

- Used a browser fetch shim to hold the first Request Logs SSE response open without data; confirmed the watchdog aborted it, retried, and returned the UI status to `Live`.
- Forced the System Logs SSE endpoint to fail repeatedly, restored it, and confirmed the page reconnected without reloading.
