### PR TITLE
fix(raw): suppress expected unknown API warnings

### DIFF
--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -1,15 +1,41 @@
+import { once } from 'node:events';
 import { describe, expect, test, beforeEach } from 'vitest';
+import { registerSpy } from '../../../test/test-utils';
 import { DebugLoggingInspector } from '../inspectors/debug-logging';
 import { DebugManager } from '../debug-manager';
+import { logger } from '../../utils/logger';
 
 describe('DebugLoggingInspector Reconstruction', () => {
   const requestId = 'test-reconstruction-id';
 
   beforeEach(() => {
     const dm = DebugManager.getInstance();
+    dm.resetForTesting();
     dm.setEnabled(true);
-    // @ts-ignore - access private for testing
-    dm.pendingLogs.clear();
+  });
+
+  test('does not warn for non-inference responses', async () => {
+    const warnSpy = registerSpy(logger, 'warn');
+    warnSpy.mockClear();
+    const stream = new DebugLoggingInspector(requestId, 'raw').createInspector('unknown');
+    const ended = once(stream, 'end');
+
+    stream.end(Buffer.from('{}'));
+    await ended;
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('warns for unsupported provider API types', async () => {
+    const warnSpy = registerSpy(logger, 'warn');
+    warnSpy.mockClear();
+    const stream = new DebugLoggingInspector(requestId, 'raw').createInspector('unsupported');
+    const ended = once(stream, 'end');
+
+    stream.end(Buffer.from('{}'));
+    await ended;
+
+    expect(warnSpy).toHaveBeenCalledWith('Unknown providerApiType: unsupported');
   });
 
   test('reconstructChatCompletions handles non-streaming JSON', async () => {

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -83,6 +83,8 @@ export class DebugLoggingInspector extends BaseInspector {
           case 'oauth':
             reconstructed = this.reconstructOAuth(rawBody);
             break;
+          case 'unknown':
+            break;
           default:
             logger.warn(`Unknown providerApiType: ${providerApiType}`);
         }


### PR DESCRIPTION
## Summary
Suppress warning noise when raw passthrough handles expected non-inference endpoints such as `/v1/models`. Unexpected provider API type values continue to produce warnings for diagnostics.

## Why / Context
Raw passthrough classifies endpoints without an inference response format as `unknown`. The response inspectors previously treated that intentional sentinel as an error, producing duplicate warnings for otherwise successful requests.

## Changes
- **Debug inspector**: recognize `unknown` as an expected response type without attempting reconstruction or logging a warning.
- **Tests**: cover silent handling of the sentinel and preserve warnings for genuinely unsupported API types.
- **Test setup**: reset the debug manager through its supported testing API.

## Testing
- Added focused coverage for both non-inference raw responses and unsupported provider API types.
