### PR TITLE
chore(release): migrate notes to OpenCode

### DIFF
--- a/.github/prompts/release-notes.md
+++ b/.github/prompts/release-notes.md
@@ -4,7 +4,7 @@ You are the Plexus release notes writer. This is an automated pipeline step — 
 
 ## YOUR TASK
 
-Generate polished, user-friendly release notes for **{{env.RELEASE_TAG}}** and write them to the file `release-notes.md` in the repository root.
+Generate polished, user-friendly release notes for the release identified by `currentTag` in `release-data.json` and write them to the file `release-notes.md` in the repository root.
 
 ## STEP 1: Read the release data
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -17,8 +17,5 @@
 - Keep OpenCode session sharing disabled so repository context is not published externally.
 - Preserve the collaborator and bot filters on the interactive workflow to prevent untrusted
   code-changing runs and comment loops.
-
-## Remaining Pi action use
-
-`release.yml` still uses `mcowger/pi-action` to generate release notes. That is unrelated release
-pipeline automation and must not be removed as part of changes to the GitHub assistant.
+- `release.yml` uses OpenCode to generate release notes from `release-data.json`. Keep its tools
+  restricted to reading the release prompt/data and writing `release-notes.md`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,12 +121,15 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     env:
-      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}:${{ github.repository }}|${{ github.workflow }}|${{ github.job }}
+      LLM_API_HOST: ${{ secrets.LLM_API_HOST }}
+      OPENAI_API_KEY: ${{ secrets.LLM_API_KEY }}:${{ github.repository }}|${{ github.workflow }}|${{ github.job }}
+      OPENCODE_CONFIG_CONTENT: >-
+        {"permission":{"*":"deny","read":{"*":"deny",".github/prompts/release-notes.md":"allow","release-data.json":"allow"},"edit":{"*":"deny","release-notes.md":"allow"}},"provider":{"openai":{"options":{"baseURL":"{env:LLM_API_HOST}","apiKey":"{env:OPENAI_API_KEY}"},"models":{"${{ vars.LLM_MODEL_ID }}":{}}}}}
     outputs:
       notes: ${{ steps.read_notes.outputs.notes }}
     steps:
       - name: Mask API key
-        run: echo "::add-mask::$LLM_API_KEY"
+        run: echo "::add-mask::$OPENAI_API_KEY"
 
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -253,21 +256,31 @@ jobs:
             core.info('Wrote release-data.json');
 
       - name: Run release notes agent
-        id: release_notes_agent
-        uses: mcowger/pi-action@main
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          provider: openrouter
-          model: ${{ vars.LLM_MODEL_ID }}
-          token: ${{ env.LLM_API_KEY }}
-          base_url: ${{ secrets.LLM_API_HOST }}
-          trigger: generate-release-notes
-          load_builtin_extensions: true
-          suppress_final_comment: true
-          export_session_html: true
-          prompt_file: .github/prompts/release-notes.md
+        uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a # github-v1.2.19
         env:
-          RELEASE_TAG: ${{ needs.setup.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: openai/${{ vars.LLM_MODEL_ID }}
+          share: false
+          use_github_token: true
+          prompt: >-
+            Read `.github/prompts/release-notes.md` and follow its instructions exactly.
+
+      - name: Export OpenCode session
+        if: always()
+        run: |
+          if ! command -v opencode >/dev/null 2>&1; then
+            echo '::warning::OpenCode CLI is unavailable — no session will be uploaded'
+            exit 0
+          fi
+
+          session_id=$(opencode session list --format json --max-count 1 | jq -r '.[0].id // empty')
+          if [ -z "$session_id" ]; then
+            echo '::warning::OpenCode did not create a release notes session'
+            exit 0
+          fi
+
+          opencode export "$session_id" > opencode-session.json
 
       - name: Read agent-generated notes
         id: read_notes
@@ -286,12 +299,12 @@ jobs:
             echo 'notes=' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload agent session
+      - name: Upload OpenCode session
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: release-notes-session
-          path: ${{ steps.release_notes_agent.outputs.session_html_path }}
+          path: opencode-session.json
           retention-days: 7
           if-no-files-found: ignore
           archive: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,8 @@ Both workflows require these existing Actions settings:
 OpenCode uses the built-in `GITHUB_TOKEN`; no OpenCode GitHub App or additional GitHub token is
 required. Session sharing is disabled. After migration, the `PR_AGENT_MODEL_ID` repository
 variable can be retired manually. Do not remove `LLM_API_KEY`, `LLM_API_HOST`, or `LLM_MODEL_ID`:
-they remain in use, including by release-note automation. The `/pi` assistant no longer exists,
-but `mcowger/pi-action` remains in `.github/workflows/release.yml` solely to generate release notes.
+they remain in use, including by the OpenCode release-note automation in
+`.github/workflows/release.yml`.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

Migrate automated release-note generation from `mcowger/pi-action` to the repository's existing OpenCode integration. The release pipeline continues to use the existing OpenAI-compatible model configuration while keeping session sharing disabled and preserving a private run artifact.

## Changes

- **Release workflow**: run the pinned OpenCode GitHub Action with the existing `LLM_API_KEY`, `LLM_API_HOST`, and `LLM_MODEL_ID` settings.
- **Permissions**: restrict the release-note agent to reading the prompt and generated release data and writing only `release-notes.md`.
- **Session artifact**: export the OpenCode session as JSON and upload it with the existing retention policy.
- **Prompt and guidance**: derive the release version from `release-data.json` and update contributor and workflow documentation to remove stale pi-action references.
