### PR TITLE
ci(workflows): refine OpenCode automation behavior

### DIFF
--- a/.github/prompts/release-notes.md
+++ b/.github/prompts/release-notes.md
@@ -4,11 +4,11 @@ You are the Plexus release notes writer. This is an automated pipeline step — 
 
 ## YOUR TASK
 
-Generate polished, user-friendly release notes for the release identified by `currentTag` in `.git/release-data.json` and write them to `.git/release-notes.md`.
+Generate polished, user-friendly release notes for the release identified by `currentTag` in `.git/opencode-release/release-data.json` and write them to `.git/opencode-release/release-notes.md`.
 
 ## STEP 1: Read the release data
 
-Read the file `.git/release-data.json`. It is a JSON object with:
+Read the file `.git/opencode-release/release-data.json`. It is a JSON object with:
 
 - `currentTag` — the version being released (e.g. `2026.05.06.1`)
 - `previousTag` — the previous release version, or `null` if this is the first release
@@ -59,4 +59,4 @@ Use the PR titles, bodies, and labels to determine the nature of each change. Us
 
 ## STEP 3: Write the output file
 
-Write the completed Markdown to `.git/release-notes.md`. Do **not** modify the working tree, create commits or branches, push changes, open PRs, post comments, or call any GitHub API. Do **not** create any other files. Just write `.git/release-notes.md` and finish.
+Write the completed Markdown to `.git/opencode-release/release-notes.md`. Do **not** modify the working tree, create commits or branches, push changes, open PRs, post comments, or call any GitHub API. Do **not** create any other files. Just write `.git/opencode-release/release-notes.md` and finish.

--- a/.github/prompts/release-notes.md
+++ b/.github/prompts/release-notes.md
@@ -4,11 +4,11 @@ You are the Plexus release notes writer. This is an automated pipeline step — 
 
 ## YOUR TASK
 
-Generate polished, user-friendly release notes for the release identified by `currentTag` in `release-data.json` and write them to the file `release-notes.md` in the repository root.
+Generate polished, user-friendly release notes for the release identified by `currentTag` in `.git/release-data.json` and write them to `.git/release-notes.md`.
 
 ## STEP 1: Read the release data
 
-Read the file `release-data.json` from the repository root. It is a JSON object with:
+Read the file `.git/release-data.json`. It is a JSON object with:
 
 - `currentTag` — the version being released (e.g. `2026.05.06.1`)
 - `previousTag` — the previous release version, or `null` if this is the first release
@@ -59,4 +59,4 @@ Use the PR titles, bodies, and labels to determine the nature of each change. Us
 
 ## STEP 3: Write the output file
 
-Write the completed Markdown to `release-notes.md` in the repository root. Do **not** create any other files, open any PRs, post any comments, or call any GitHub API. Just write the file and finish.
+Write the completed Markdown to `.git/release-notes.md`. Do **not** modify the working tree, create commits or branches, push changes, open PRs, post comments, or call any GitHub API. Do **not** create any other files. Just write `.git/release-notes.md` and finish.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -17,5 +17,7 @@
 - Keep OpenCode session sharing disabled so repository context is not published externally.
 - Preserve the collaborator and bot filters on the interactive workflow to prevent untrusted
   code-changing runs and comment loops.
-- `release.yml` uses OpenCode to generate release notes from `release-data.json`. Keep its tools
-  restricted to reading the release prompt/data and writing `release-notes.md`.
+- `release.yml` uses OpenCode to generate release notes from `.git/release-data.json`. Keep its tools
+  restricted to reading the release prompt/data and writing `.git/release-notes.md`. These scratch
+  files must remain under `.git/` so the OpenCode action does not treat them as worktree changes and
+  automatically commit and push them.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -17,7 +17,7 @@
 - Keep OpenCode session sharing disabled so repository context is not published externally.
 - Preserve the collaborator and bot filters on the interactive workflow to prevent untrusted
   code-changing runs and comment loops.
-- `release.yml` uses OpenCode to generate release notes from `.git/release-data.json`. Keep its tools
-  restricted to reading the release prompt/data and writing `.git/release-notes.md`. These scratch
-  files must remain under `.git/` so the OpenCode action does not treat them as worktree changes and
-  automatically commit and push them.
+- `release.yml` uses OpenCode to generate release notes under `.git/opencode-release/`. Keep its
+  tools restricted to reading the release prompt/data and writing the notes file. The workflow must
+  reset this scratch directory before generation to prevent stale output, and it must remain under
+  `.git/` so the OpenCode action does not automatically commit and push the files.

--- a/.github/workflows/opencode-review-run.yml
+++ b/.github/workflows/opencode-review-run.yml
@@ -117,17 +117,29 @@ jobs:
             tools and file access are intentionally disabled. If the patch says it was truncated,
             review the available portion and clearly note that limitation.
 
+            Act as a practical merge gate, not a brainstorming partner. Report a finding only when
+            the patch introduces a concrete issue that is likely to affect users, production,
+            security, or future changes. You must be able to describe a realistic failure scenario
+            caused by the changed lines; do not report a concern merely because an alternative
+            implementation might be cleaner or more defensive.
+
             Focus on substantive findings only:
             - correctness and likely bugs
             - security and trust-boundary issues
             - error handling and failure modes
-            - missing or inadequate test coverage
+            - missing test coverage when the changed behavior has a meaningful regression risk
             - maintainability problems that create concrete risk
 
-            Avoid stylistic nitpicks and speculative suggestions. Return a concise, actionable
-            summary. For each finding, explain the impact and recommended fix, and include file
-            paths and line references when possible. If there are no substantive findings, say so
-            briefly.
+            Do not report stylistic preferences, minor cleanup opportunities, speculative edge
+            cases, pre-existing problems, or requests for tests that would only increase coverage
+            without protecting meaningful behavior. Do not manufacture findings to make the review
+            appear thorough. It is valid—and preferred—to conclude that the PR is fine when no issue
+            meets this bar.
+
+            Return a concise, actionable summary. For each finding, explain the realistic impact and
+            recommended fix, and include file paths and line references when possible. If there are
+            no substantive findings, respond briefly with: "No substantive findings — this PR looks
+            fine."
 
       - name: Export review response
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       LLM_API_HOST: ${{ secrets.LLM_API_HOST }}
       OPENAI_API_KEY: ${{ secrets.LLM_API_KEY }}:${{ github.repository }}|${{ github.workflow }}|${{ github.job }}
       OPENCODE_CONFIG_CONTENT: >-
-        {"permission":{"*":"deny","read":{"*":"deny",".github/prompts/release-notes.md":"allow",".git/release-data.json":"allow"},"edit":{"*":"deny",".git/release-notes.md":"allow"}},"provider":{"openai":{"options":{"baseURL":"{env:LLM_API_HOST}","apiKey":"{env:OPENAI_API_KEY}"},"models":{"${{ vars.LLM_MODEL_ID }}":{}}}}}
+        {"permission":{"*":"deny","read":{"*":"deny",".github/prompts/release-notes.md":"allow",".git/opencode-release/release-data.json":"allow"},"edit":{"*":"deny",".git/opencode-release/release-notes.md":"allow"}},"provider":{"openai":{"options":{"baseURL":"{env:LLM_API_HOST}","apiKey":"{env:OPENAI_API_KEY}"},"models":{"${{ vars.LLM_MODEL_ID }}":{}}}}}
     outputs:
       notes: ${{ steps.read_notes.outputs.notes }}
     steps:
@@ -144,6 +144,10 @@ jobs:
             const currentTag = '${{ needs.setup.outputs.tag }}';
             const calVerRegex = /^\d{4}\.\d{2}\.\d{2}\.\d+$/;
             const fs = require('fs');
+            const releaseScratchDir = '.git/opencode-release';
+
+            fs.rmSync(releaseScratchDir, { recursive: true, force: true });
+            fs.mkdirSync(releaseScratchDir, { recursive: true });
 
             async function getTagDate(tag) {
               const ref = await github.rest.git.getRef({
@@ -252,8 +256,8 @@ jobs:
               commits: relevantCommits,
             };
 
-            fs.writeFileSync('.git/release-data.json', JSON.stringify(releaseData, null, 2));
-            core.info('Wrote .git/release-data.json');
+            fs.writeFileSync(`${releaseScratchDir}/release-data.json`, JSON.stringify(releaseData, null, 2));
+            core.info(`Wrote ${releaseScratchDir}/release-data.json`);
 
       - name: Run release notes agent
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a # github-v1.2.19
@@ -286,16 +290,16 @@ jobs:
         id: read_notes
         if: always()
         run: |
-          if [ -f .git/release-notes.md ]; then
+          if [ -f .git/opencode-release/release-notes.md ]; then
             # Ensure the file ends with a newline to prevent delimiter parser issues
-            [[ -n "$(tail -c1 .git/release-notes.md)" ]] && echo "" >> .git/release-notes.md
+            [[ -n "$(tail -c1 .git/opencode-release/release-notes.md)" ]] && echo "" >> .git/opencode-release/release-notes.md
             {
               echo 'notes<<RELEASE_NOTES_EOF'
-              cat .git/release-notes.md
+              cat .git/opencode-release/release-notes.md
               echo 'RELEASE_NOTES_EOF'
             } >> "$GITHUB_OUTPUT"
           else
-            echo '::warning::Agent did not write .git/release-notes.md — release will have no body'
+            echo '::warning::Agent did not write .git/opencode-release/release-notes.md — release will have no body'
             echo 'notes=' >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       LLM_API_HOST: ${{ secrets.LLM_API_HOST }}
       OPENAI_API_KEY: ${{ secrets.LLM_API_KEY }}:${{ github.repository }}|${{ github.workflow }}|${{ github.job }}
       OPENCODE_CONFIG_CONTENT: >-
-        {"permission":{"*":"deny","read":{"*":"deny",".github/prompts/release-notes.md":"allow","release-data.json":"allow"},"edit":{"*":"deny","release-notes.md":"allow"}},"provider":{"openai":{"options":{"baseURL":"{env:LLM_API_HOST}","apiKey":"{env:OPENAI_API_KEY}"},"models":{"${{ vars.LLM_MODEL_ID }}":{}}}}}
+        {"permission":{"*":"deny","read":{"*":"deny",".github/prompts/release-notes.md":"allow",".git/release-data.json":"allow"},"edit":{"*":"deny",".git/release-notes.md":"allow"}},"provider":{"openai":{"options":{"baseURL":"{env:LLM_API_HOST}","apiKey":"{env:OPENAI_API_KEY}"},"models":{"${{ vars.LLM_MODEL_ID }}":{}}}}}
     outputs:
       notes: ${{ steps.read_notes.outputs.notes }}
     steps:
@@ -252,8 +252,8 @@ jobs:
               commits: relevantCommits,
             };
 
-            fs.writeFileSync('release-data.json', JSON.stringify(releaseData, null, 2));
-            core.info('Wrote release-data.json');
+            fs.writeFileSync('.git/release-data.json', JSON.stringify(releaseData, null, 2));
+            core.info('Wrote .git/release-data.json');
 
       - name: Run release notes agent
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a # github-v1.2.19
@@ -286,16 +286,16 @@ jobs:
         id: read_notes
         if: always()
         run: |
-          if [ -f release-notes.md ]; then
+          if [ -f .git/release-notes.md ]; then
             # Ensure the file ends with a newline to prevent delimiter parser issues
-            [[ -n "$(tail -c1 release-notes.md)" ]] && echo "" >> release-notes.md
+            [[ -n "$(tail -c1 .git/release-notes.md)" ]] && echo "" >> .git/release-notes.md
             {
               echo 'notes<<RELEASE_NOTES_EOF'
-              cat release-notes.md
+              cat .git/release-notes.md
               echo 'RELEASE_NOTES_EOF'
             } >> "$GITHUB_OUTPUT"
           else
-            echo '::warning::Agent did not write release-notes.md — release will have no body'
+            echo '::warning::Agent did not write .git/release-notes.md — release will have no body'
             echo 'notes=' >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary

Make automated PR reviews prioritize concrete merge-blocking risks while allowing a clean “this PR looks fine” result. Also prevent release-note generation from triggering OpenCode’s automatic commit-and-push path.

## Why / Context

PR reviews were incentivized to produce findings even when only low-value nitpicks remained. Separately, release run 29208548725 failed because the OpenCode GitHub wrapper detected generated release files as worktree changes and attempted to commit them without a configured Git identity.

## Changes

- **PR review prompt**: require realistic failure scenarios, exclude speculative or stylistic findings, and explicitly permit a clean review.
- **Release workflow**: keep generated release input and output under `.git/` so they do not dirty the worktree and trigger the wrapper’s automatic commit behavior.
- **Release prompt**: explicitly prohibit working-tree changes, commits, branches, pushes, PRs, comments, and GitHub API calls.
- **Workflow guardrails**: preserve the `.git/` scratch-file invariant for future changes.

## Notes

The release workflow was not manually dispatched because doing so would initiate a real release. The fix follows the pinned OpenCode action’s dirty-tree handling: clean repository state bypasses its commit, push, and PR path.
