### PR TITLE
docs(openapi): synchronize management API docs with live routes

### DIFF
--- a/docs/openapi/components/schemas/CompactionSettings.yaml
+++ b/docs/openapi/components/schemas/CompactionSettings.yaml
@@ -1,0 +1,52 @@
+type: object
+description: Context compaction settings. All fields are optional overrides.
+properties:
+  enabled:
+    type: boolean
+  strategy:
+    type: string
+    enum:
+      - native
+      - headroom
+  triggerRatio:
+    type: number
+    minimum: 0
+    maximum: 1
+  absoluteTriggerTokens:
+    type:
+      - integer
+      - 'null'
+    minimum: 1
+  minTokens:
+    type: integer
+    minimum: 0
+  protectRecent:
+    type: integer
+    minimum: 0
+  native:
+    type: object
+    properties:
+      maxArrayItems:
+        type: integer
+        minimum: 1
+      maxStringChars:
+        type: integer
+        minimum: 1
+  headroom:
+    type: object
+    properties:
+      baseUrl:
+        type: string
+        format: uri
+      apiKey:
+        type: string
+      targetRatio:
+        type:
+          - number
+          - 'null'
+        minimum: 0
+        maximum: 1
+      timeoutMs:
+        type: integer
+        minimum: 100
+        maximum: 60000

--- a/docs/openapi/components/schemas/LocalMcpRuntimeStatus.yaml
+++ b/docs/openapi/components/schemas/LocalMcpRuntimeStatus.yaml
@@ -1,0 +1,42 @@
+type: object
+required:
+  - serverName
+  - status
+  - pid
+  - url
+  - lastError
+  - startedAt
+  - exitedAt
+properties:
+  serverName:
+    type: string
+  status:
+    type: string
+    enum:
+      - stopped
+      - starting
+      - running
+      - failed
+  pid:
+    type:
+      - integer
+      - 'null'
+  url:
+    type:
+      - string
+      - 'null'
+    format: uri
+  lastError:
+    type:
+      - string
+      - 'null'
+  startedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+  exitedAt:
+    type:
+      - string
+      - 'null'
+    format: date-time

--- a/docs/openapi/components/schemas/Meter.yaml
+++ b/docs/openapi/components/schemas/Meter.yaml
@@ -1,0 +1,129 @@
+type: object
+description: >
+  A single quota meter reading for one provider checker, as returned in the
+  `meters` array of a quota snapshot. Mirrors the `Meter` type in
+  `packages/backend/src/types/meter.ts`.
+
+
+  A checker reports one meter per quota dimension it tracks (e.g. a balance
+  meter and/or one or more time-windowed allowance meters). Meters are
+  identified by `key`, not by a fixed window-type enum.
+required:
+  - key
+  - label
+  - kind
+  - unit
+  - utilizationPercent
+  - status
+properties:
+  key:
+    type: string
+    description: >
+      Stable identifier for this meter within the checker. Examples:
+      `balance`, `five_hour`, `daily`. Provider-specific; there is no fixed
+      global enum. Used as the `meterKey` filter on the history endpoint.
+  label:
+    type: string
+    description: Human-readable label for the meter (e.g. `Five-hour window`).
+  group:
+    type: string
+    description: Optional grouping label for multi-tenant or sub-account setups.
+  scope:
+    type: string
+    description: Optional scope qualifier for the meter.
+  kind:
+    type: string
+    enum:
+      - balance
+      - allowance
+    description: >
+      What the meter tracks.
+
+      - **balance** — A prepaid account balance (unit typically `usd`).
+        Renders as a wallet in the UI.
+      - **allowance** — A time-windowed rate limit (unit `requests`, `tokens`,
+        or `percentage`). Renders as a progress bar in the UI.
+  unit:
+    type: string
+    description: >
+      Unit of measurement. Common values: `usd`, `requests`, `tokens`,
+      `percentage`; providers may define additional units.
+  limit:
+    type:
+      - number
+      - 'null'
+    description: Maximum allowed value for this meter. Null when unbounded/unknown.
+  used:
+    type:
+      - number
+      - 'null'
+    description: Amount consumed so far. Null when unbounded/unknown.
+  remaining:
+    type:
+      - number
+      - 'null'
+    description: Calculated as `limit - used`. May be negative. Null when unbounded/unknown.
+  utilizationPercent:
+    oneOf:
+      - type: number
+      - type: string
+        enum:
+          - unknown
+          - not_applicable
+    description: >
+      Utilisation of the meter. Either a numeric percentage, or a sentinel:
+
+      - **unknown** — The provider did not report enough information to compute utilisation.
+      - **not_applicable** — Utilisation is not meaningful for this meter (e.g. a balance with no limit).
+  status:
+    $ref: ./MeterStatus.yaml
+  periodValue:
+    type:
+      - integer
+      - 'null'
+    description: >
+      Length of the allowance window (only for `kind: allowance`). e.g. `1`
+      for a 1-hour window. Null for `kind: balance`.
+  periodUnit:
+    type:
+      - string
+      - 'null'
+    enum:
+      - minute
+      - hour
+      - day
+      - week
+      - month
+      - null
+    description: >
+      Unit for `periodValue` (only for `kind: allowance`). Null for
+      `kind: balance`.
+  periodCycle:
+    type:
+      - string
+      - 'null'
+    enum:
+      - fixed
+      - rolling
+      - null
+    description: >
+      How the allowance window resets (only for `kind: allowance`).
+
+      - **fixed** — Resets at a calendar boundary (e.g. midnight).
+      - **rolling** — Sliding window from first use.
+      Null for `kind: balance`.
+  resetsAt:
+    type:
+      - string
+      - 'null'
+    format: date-time
+    description: >
+      ISO-8601 timestamp when the meter window resets. Null for rolling windows
+      or balances without a defined reset time.
+  exhaustionThreshold:
+    type:
+      - number
+      - 'null'
+    description: >
+      Optional utilisation percentage at which the checker gates the provider
+      onto cooldown.

--- a/docs/openapi/components/schemas/MeterStatus.yaml
+++ b/docs/openapi/components/schemas/MeterStatus.yaml
@@ -1,0 +1,13 @@
+type: string
+enum:
+  - ok
+  - warning
+  - critical
+  - exhausted
+description: >
+  Utilisation severity level for a quota meter.
+
+  - **ok** — 0–75% utilisation. Healthy, plenty of quota remaining.
+  - **warning** — 75–90% utilisation. Approaching exhaustion.
+  - **critical** — 90–100% utilisation. Near exhaustion, take action soon.
+  - **exhausted** — 100% utilisation. Quota fully consumed, requests will fail.

--- a/docs/openapi/components/schemas/QuotaCheckerSnapshot.yaml
+++ b/docs/openapi/components/schemas/QuotaCheckerSnapshot.yaml
@@ -1,4 +1,12 @@
 type: object
+description: >
+  Latest quota snapshot for a single provider checker, returned by
+  `GET /v0/management/quotas` and `GET /v0/management/quotas/{checkerId}`.
+
+
+  A checker reports its current readings as an array of `Meter` objects (one
+  per quota dimension). When the last check failed, `success` is false,
+  `meters` is empty, and `error` carries the failure message.
 properties:
   checkerId:
     type: string
@@ -8,21 +16,11 @@ properties:
   checkerType:
     type: string
     description: >
-      Provider identifier (e.g. `naga`, `moonshot`, `openai-codex`). Maps to
-      provider config slug.
-  checkerCategory:
+      Checker type identifier (e.g. `naga`, `moonshot`, `openai-codex`). Maps
+      to the provider quota-checker definition.
+  provider:
     type: string
-    enum:
-      - balance
-      - rate-limit
-    description: >
-      Whether the checker tracks a prepaid account balance or a time-windowed
-      rate limit.
-
-      - **balance** — Tracks a prepaid subscription balance (unit: `dollars`).
-        Renders as a wallet icon in the UI.
-      - **rate-limit** — Tracks a time-windowed rate limit (unit: `requests`,
-        `tokens`, or `percentage`). Renders as a progress bar in the UI.
+    description: Provider identifier at capture time.
   oauthAccountId:
     type: string
     description: >
@@ -34,11 +32,16 @@ properties:
     description: >
       OAuth provider identifier (e.g. `openai-codex`, `anthropic-claude-code`).
       Present when credentials are stored via OAuth flow.
-  latest:
+  success:
+    type: boolean
+    description: Whether the most recent quota check succeeded.
+  error:
+    type: string
+    description: Error message when the most recent check failed. Omitted on success.
+  meters:
     type: array
     items:
-      $ref: ./QuotaSample.yaml
+      $ref: ./Meter.yaml
     description: >
-      Most recent quota samples for each window type. The array contains
-      samples for the primary windows (subscription, daily, etc.) that the
-      provider reports.
+      Current meter readings for this checker (one `Meter` per quota
+      dimension). Empty when the last check failed.

--- a/docs/openapi/components/schemas/QuotaSample.yaml
+++ b/docs/openapi/components/schemas/QuotaSample.yaml
@@ -1,114 +1,149 @@
 type: object
-description: Individual quota measurement at a point in time.
+description: >
+  A single persisted quota-snapshot row, as returned in the `history` array of
+  `GET /v0/management/quotas/{checkerId}/history`.
+
+
+  These are raw rows from the `meter_snapshots` table (one row per meter per
+  check), so field names follow the stored column shape (camelCased by the
+  ORM). For the current/latest reading of a meter, see the `Meter` schema —
+  `getLatestQuota` maps these rows into the friendlier `Meter` shape. There is
+  no `windowType` field; a meter is identified by `meterKey`.
 properties:
   id:
     type: integer
-    description: Database record ID for this sample.
-  provider:
-    type: string
-    description: Provider identifier (e.g. `naga`, `moonshot`).
+    description: Database record ID for this snapshot row.
   checkerId:
     type: string
     description: >
-      Foreign key to the checker this sample belongs to. Matches
+      Foreign key to the checker this snapshot belongs to. Matches
       `QuotaCheckerSnapshot.checkerId`.
-  groupId:
-    type:
-      - string
-      - 'null'
+  checkerType:
+    type: string
+    description: Checker type identifier at capture time.
+  provider:
+    type: string
+    description: Provider identifier at capture time (e.g. `naga`, `moonshot`).
+  meterKey:
+    type: string
     description: >
-      Optional grouping identifier. For multi-tenant or sub-account setups.
-      Null when not applicable.
-  windowType:
+      Stable identifier for the meter this row captures (e.g. `balance`,
+      `five_hour`, `daily`). Provider-specific; used as the `meterKey` query
+      filter on the history endpoint.
+  kind:
     type: string
     enum:
-      - subscription
-      - hourly
-      - five_hour
-      - daily
-      - weekly
-      - monthly
-      - custom
-    description: >
-      Time window that the quota measurement covers.
-
-      - **subscription** — Monthly/billing-cycle quota or prepaid balance.
-      - **hourly** — Hourly rolling window.
-      - **five_hour** — 5-hour rolling window (common across multiple providers).
-      - **daily** — Daily reset quota.
-      - **weekly** — 7-day rolling window (common across multiple providers).
-      - **monthly** — Calendar month quota.
-      - **custom** — Provider-specific window.
-  checkedAt:
-    type: string
-    format: date-time
-    description: Timestamp when this sample was captured.
-  limit:
-    type: number
-    description: >
-      Maximum allowed value for this window. For `balance` category checkers,
-      this is the prepaid balance in dollars. For `rate-limit` category, this
-      is the request/token limit for the window.
-  used:
-    type: number
-    description: >
-      Amount consumed so far in this window. For `balance` category, this is
-      dollars spent. For `rate-limit` category, this is requests or tokens used.
-  remaining:
-    type: number
-    description: >
-      Calculated as `limit - used`. The remaining quota available in this
-      window. May be negative if over-consumption occurred.
-  utilizationPercent:
-    type: number
-    description: >
-      Percentage of quota consumed, calculated as `(used / limit) * 100`.
-      Use this to drive UI progress bars and status warnings.
+      - balance
+      - allowance
+    description: Whether this meter tracks a prepaid balance or a time-windowed allowance.
   unit:
     type: string
     description: >
-      Unit of measurement. Common values: `dollars` (prepaid balances),
-      `requests` (request count limits), `tokens` (token count limits),
-      `percentage` (percentage-based limits).
+      Unit of measurement. Common values: `usd`, `requests`, `tokens`,
+      `percentage`; providers may define additional units.
+  label:
+    type: string
+    description: Human-readable label for the meter.
+  group:
+    type:
+      - string
+      - 'null'
+    description: Optional grouping label for multi-tenant or sub-account setups.
+  scope:
+    type:
+      - string
+      - 'null'
+    description: Optional scope qualifier.
+  limit:
+    type:
+      - number
+      - 'null'
+    description: >
+      Maximum allowed value for this meter. For `balance` kind, the prepaid
+      balance in dollars. For `allowance` kind, the request/token limit.
+  used:
+    type:
+      - number
+      - 'null'
+    description: Amount consumed so far. Null when unbounded/unknown.
+  remaining:
+    type:
+      - number
+      - 'null'
+    description: Calculated as `limit - used`. May be negative.
+  utilizationState:
+    type: string
+    enum:
+      - reported
+      - unknown
+      - not_applicable
+    description: >
+      Whether a meaningful utilisation was reported for this row.
+
+      - **reported** — `utilizationPercent` holds a numeric percentage.
+      - **unknown** — The provider did not report enough to compute utilisation.
+      - **not_applicable** — Utilisation is not meaningful for this meter.
+  utilizationPercent:
+    type:
+      - number
+      - 'null'
+    description: >
+      Percentage of quota consumed (`(used / limit) * 100`). Only meaningful
+      when `utilizationState` is `reported`; null otherwise.
+  status:
+    $ref: ./MeterStatus.yaml
+  periodValue:
+    type:
+      - integer
+      - 'null'
+    description: Length of the allowance window. Null for `balance` kind.
+  periodUnit:
+    type:
+      - string
+      - 'null'
+    enum:
+      - minute
+      - hour
+      - day
+      - week
+      - month
+      - null
+    description: Unit for `periodValue`. Null for `balance` kind.
+  periodCycle:
+    type:
+      - string
+      - 'null'
+    enum:
+      - fixed
+      - rolling
+      - null
+    description: How the allowance window resets. Null for `balance` kind.
   resetsAt:
     type:
       - string
       - 'null'
     format: date-time
     description: >
-      Timestamp when this quota window resets. Null for rolling windows or
-      subscription balances without a defined reset time.
-  status:
-    type: string
-    enum:
-      - ok
-      - warning
-      - critical
-      - exhausted
-    description: >
-      Utilisation severity level.
-
-      - **ok** — 0–75% utilisation. Healthy, plenty of quota remaining.
-      - **warning** — 75–90% utilisation. Approaching exhaustion.
-      - **critical** — 90–100% utilisation. Near exhaustion, take action soon.
-      - **exhausted** — 100% utilisation. Quota fully consumed, requests will fail.
+      ISO-8601 timestamp when the meter window resets. Null for rolling windows
+      or balances without a defined reset time.
   success:
     type: boolean
     description: >
       Whether the quota query to the provider succeeded. False if the provider
-      API is unreachable or returned an error.
+      API was unreachable or returned an error.
   errorMessage:
     type:
       - string
       - 'null'
-    description: >
-      Error message when `success` is false. Contains the provider's error
-      response or a network error description.
+    description: Error message when `success` is false.
+  checkedAt:
+    type: string
+    format: date-time
+    description: Timestamp when this snapshot was captured.
   createdAt:
     type:
       - string
       - 'null'
     format: date-time
     description: >
-      Timestamp when this record was created. Usually matches `checkedAt`
-      but may differ due to batch processing.
+      Timestamp when this record was persisted. Usually matches `checkedAt`.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -425,6 +425,14 @@ paths:
     $ref: paths/v0_management_config_exploration-rate.yaml
   /v0/management/config/failover:
     $ref: paths/v0_management_config_failover.yaml
+  /v0/management/config/capture-trace-on-error:
+    $ref: paths/v0_management_config_capture-trace-on-error.yaml
+  /v0/management/config/trusted-proxies:
+    $ref: paths/v0_management_config_trusted-proxies.yaml
+  /v0/management/config/compaction:
+    $ref: paths/v0_management_config_compaction.yaml
+  /v0/management/config/mcp-enabled:
+    $ref: paths/v0_management_config_mcp-enabled.yaml
   /v0/management/system-settings:
     $ref: paths/v0_management_system-settings.yaml
   /v0/management/providers:
@@ -461,6 +469,16 @@ paths:
     $ref: paths/v0_management_mcp-servers.yaml
   /v0/management/mcp-servers/{serverName}:
     $ref: paths/v0_management_mcp-servers_{serverName}.yaml
+  /v0/management/mcp-servers/{serverName}/status:
+    $ref: paths/v0_management_mcp-servers_{serverName}_status.yaml
+  /v0/management/mcp-servers/{serverName}/start:
+    $ref: paths/v0_management_mcp-servers_{serverName}_start.yaml
+  /v0/management/mcp-servers/{serverName}/stop:
+    $ref: paths/v0_management_mcp-servers_{serverName}_stop.yaml
+  /v0/management/mcp-servers/{serverName}/restart:
+    $ref: paths/v0_management_mcp-servers_{serverName}_restart.yaml
+  /v0/management/mcp-servers/{serverName}/process-logs:
+    $ref: paths/v0_management_mcp-servers_{serverName}_process-logs.yaml
   /v0/management/quota-checker-types:
     $ref: paths/v0_management_quota-checker-types.yaml
   /v0/management/quota-checkers:
@@ -531,6 +549,8 @@ paths:
     $ref: paths/v0_management_user-quotas_{name}.yaml
   /v0/management/quota/clear:
     $ref: paths/v0_management_quota_clear.yaml
+  /v0/management/quota/recompute:
+    $ref: paths/v0_management_quota_recompute.yaml
   /v0/management/quota/status/{key}:
     $ref: paths/v0_management_quota_status_{key}.yaml
   /v0/management/test:
@@ -551,6 +571,8 @@ paths:
     $ref: paths/v0_system_logs_recent.yaml
   /mcp/{name}:
     $ref: paths/mcp_{name}.yaml
+  /mcp/plexus:
+    $ref: paths/mcp_plexus.yaml
   /.well-known/oauth-authorization-server:
     $ref: paths/.well-known_oauth-authorization-server.yaml
   /.well-known/oauth-protected-resource:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -256,19 +256,11 @@ tags:
       Upstream provider quota checkers (`checkerId`-based).
 
       Each checker periodically polls an upstream provider for its current
-      quota utilisation and stores a `QuotaSample` snapshot.
-
-      ### Window types
-
-      | Window Type | Description |
-      |---|---|
-      | `subscription` | Monthly/billing-cycle quota or prepaid balance. |
-      | `hourly` | Hourly rolling window. |
-      | `five_hour` | 5-hour rolling window (common across multiple providers). |
-      | `daily` | Daily reset quota. |
-      | `weekly` | 7-day rolling window (common across multiple providers). |
-      | `monthly` | Calendar month quota. |
-      | `custom` | Provider-specific window. |
+      quota utilisation and persists a `Meter` snapshot (one row per meter).
+      Each meter is identified by a provider-specific `meterKey` (e.g.
+      `balance`, `five_hour`, `daily`) rather than a fixed window-type enum.
+      Use `GET /quotas/{checkerId}/history?meterKey=...` for historical rows,
+      and `GET /quotas/{checkerId}` for the latest meter readings.
 
       ### Status thresholds
 

--- a/docs/openapi/paths/mcp_plexus.yaml
+++ b/docs/openapi/paths/mcp_plexus.yaml
@@ -1,0 +1,134 @@
+post:
+  tags:
+    - MCP Proxy
+  summary: Plexus Management MCP (JSON-RPC, admin only)
+  description: |
+    The Plexus Management MCP server is an in-process Model Context Protocol
+    server exposing compact domain tools for managing Plexus.
+
+    ## Authentication
+
+    Requires the `x-admin-key` header. Bearer inference keys are rejected.
+
+    ## MCP disabled
+
+    When `mcpEnabled` is `false`, requests return HTTP 418
+    (`mcp_disabled`) before authentication. Enable it via
+    `PATCH /v0/management/config/mcp-enabled` or the MCP Servers UI.
+
+    ## Transport
+
+    Uses the Streamable HTTP transport with JSON responses. Each request
+    creates a stateless per-request MCP server instance.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          description: JSON-RPC 2.0 request envelope.
+          properties:
+            jsonrpc:
+              type: string
+              const: '2.0'
+            id:
+              oneOf:
+                - type: string
+                - type: number
+            method:
+              type: string
+              description: JSON-RPC method, for example `tools/list` or `tools/call`.
+            params:
+              type: object
+              description: Method-specific parameters.
+        examples:
+          listTools:
+            summary: List available tools
+            value:
+              jsonrpc: '2.0'
+              id: '1'
+              method: tools/list
+          callTool:
+            summary: Call a tool
+            value:
+              jsonrpc: '2.0'
+              id: '2'
+              method: tools/call
+              params:
+                name: plexus_provider
+                arguments:
+                  operation: list
+  responses:
+    '200':
+      description: JSON-RPC response. Content is JSON or a stream depending on the request.
+      content:
+        application/json:
+          schema:
+            type: object
+            description: JSON-RPC 2.0 response envelope.
+        text/event-stream:
+          schema:
+            type: string
+    '400':
+      description: Malformed JSON-RPC request.
+    '401':
+      description: Authentication required or invalid credentials.
+    '403':
+      description: Limited principals are rejected; this endpoint is admin-only.
+    '418':
+      description: 'Plexus Management MCP is disabled (`mcpEnabled: false`).'
+  operationId: postMcpPlexus
+get:
+  tags:
+    - MCP Proxy
+  summary: Plexus Management MCP (SSE stream, admin only)
+  description: |
+    GET endpoint for the Plexus Management MCP server, supporting
+    server-sent-event MCP transport. It has the same authentication,
+    disabled-check, and tool surface as `POST /mcp/plexus`.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: SSE stream or JSON-RPC response.
+      content:
+        text/event-stream:
+          schema:
+            type: string
+        application/json:
+          schema:
+            type: object
+    '401':
+      description: Authentication required or invalid credentials.
+    '403':
+      description: Limited principals are rejected; this endpoint is admin-only.
+    '418':
+      description: 'Plexus Management MCP is disabled (`mcpEnabled: false`).'
+  operationId: getMcpPlexus
+delete:
+  tags:
+    - MCP Proxy
+  summary: Plexus Management MCP (session close, admin only)
+  description: |
+    DELETE closes an MCP session. The current stateless per-request transport
+    returns immediately.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Session closed or no-op for stateless transport.
+    '401':
+      description: Authentication required or invalid credentials.
+    '403':
+      description: Limited principals are rejected; this endpoint is admin-only.
+    '418':
+      description: 'Plexus Management MCP is disabled (`mcpEnabled: false`).'
+  operationId: deleteMcpPlexus

--- a/docs/openapi/paths/v0_management_config_capture-trace-on-error.yaml
+++ b/docs/openapi/paths/v0_management_config_capture-trace-on-error.yaml
@@ -1,0 +1,73 @@
+get:
+  tags:
+    - Management — Config
+  summary: Get capture-trace-on-error setting (admin only)
+  description: |
+    Returns whether Plexus captures and persists debug traces for inference
+    errors even when regular debug capture is disabled.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Current setting.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - enabled
+            properties:
+              enabled:
+                type: boolean
+    '401':
+      description: Authentication required or invalid credentials.
+    '500':
+      description: Internal server error.
+  operationId: getV0ManagementConfigCaptureTraceOnError
+patch:
+  tags:
+    - Management — Config
+  summary: Update capture-trace-on-error setting (admin only)
+  description: |
+    Enables or disables capture of debug traces for inference errors when
+    regular debug capture is disabled.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - enabled
+          properties:
+            enabled:
+              type: boolean
+        examples:
+          enabled:
+            value:
+              enabled: true
+  responses:
+    '200':
+      description: Updated setting.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - enabled
+            properties:
+              enabled:
+                type: boolean
+    '400':
+      description: Object body is required and `enabled` must be a boolean.
+    '401':
+      description: Authentication required or invalid credentials.
+    '500':
+      description: Internal server error.
+  operationId: patchV0ManagementConfigCaptureTraceOnError

--- a/docs/openapi/paths/v0_management_config_compaction.yaml
+++ b/docs/openapi/paths/v0_management_config_compaction.yaml
@@ -1,0 +1,70 @@
+get:
+  tags:
+    - Management — Config
+  summary: Get context compaction settings (admin only)
+  description: |
+    Returns the global context compaction settings. The response may be an
+    empty object when no global overrides have been configured.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Current compaction settings.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/CompactionSettings.yaml
+    '401':
+      description: Authentication required or invalid credentials.
+    '500':
+      description: Internal server error.
+  operationId: getV0ManagementConfigCompaction
+patch:
+  tags:
+    - Management — Config
+  summary: Update context compaction settings (admin only)
+  description: |
+    Merges the supplied fields into the global context compaction settings,
+    then validates the resulting configuration. Omitted fields retain their
+    current values; nested `native` and `headroom` objects are also merged.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/CompactionSettings.yaml
+        examples:
+          native:
+            value:
+              enabled: true
+              strategy: native
+              triggerRatio: 0.8
+              minTokens: 2000
+              protectRecent: 4
+          headroom:
+            value:
+              strategy: headroom
+              headroom:
+                baseUrl: https://headroom.example.com
+                targetRatio: 0.7
+                timeoutMs: 5000
+  responses:
+    '200':
+      description: Updated compaction settings.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/CompactionSettings.yaml
+    '400':
+      description: Invalid request body or compaction configuration.
+    '401':
+      description: Authentication required or invalid credentials.
+    '500':
+      description: Internal server error.
+  operationId: patchV0ManagementConfigCompaction

--- a/docs/openapi/paths/v0_management_config_mcp-enabled.yaml
+++ b/docs/openapi/paths/v0_management_config_mcp-enabled.yaml
@@ -1,0 +1,71 @@
+get:
+  tags:
+    - Management — Config
+  summary: Get MCP enabled state (admin only)
+  description: |
+    Returns whether the MCP gateway is enabled.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Current MCP enabled state.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - enabled
+            properties:
+              enabled:
+                type: boolean
+    '401':
+      description: Authentication required or invalid credentials.
+    '500':
+      description: Internal server error.
+  operationId: getV0ManagementConfigMcpEnabled
+patch:
+  tags:
+    - Management — Config
+  summary: Update MCP enabled state (admin only)
+  description: |
+    Enables or disables the MCP gateway.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - enabled
+          properties:
+            enabled:
+              type: boolean
+        examples:
+          enabled:
+            value:
+              enabled: true
+  responses:
+    '200':
+      description: Updated MCP enabled state.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - enabled
+            properties:
+              enabled:
+                type: boolean
+    '400':
+      description: Object body is required and `enabled` must be a boolean.
+    '401':
+      description: Authentication required or invalid credentials.
+    '500':
+      description: Internal server error.
+  operationId: patchV0ManagementConfigMcpEnabled

--- a/docs/openapi/paths/v0_management_config_trusted-proxies.yaml
+++ b/docs/openapi/paths/v0_management_config_trusted-proxies.yaml
@@ -1,0 +1,83 @@
+get:
+  tags:
+    - Management — Config
+  summary: Get trusted proxy rules (admin only)
+  description: |
+    Returns the IP addresses, CIDR ranges, and address ranges whose forwarding
+    headers are trusted when determining the original client address.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Trusted proxy rules.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - trustedProxies
+            properties:
+              trustedProxies:
+                type: array
+                items:
+                  type: string
+                description: IPv4/IPv6 addresses, CIDR ranges, or address ranges.
+    '401':
+      description: Authentication required or invalid credentials.
+    '500':
+      description: Internal server error.
+  operationId: getV0ManagementConfigTrustedProxies
+patch:
+  tags:
+    - Management — Config
+  summary: Replace trusted proxy rules (admin only)
+  description: |
+    Replaces the trusted proxy allowlist. Entries may be IPv4/IPv6 addresses,
+    CIDR ranges, or supported address ranges. Empty strings are discarded.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - trustedProxies
+          properties:
+            trustedProxies:
+              type: array
+              items:
+                type: string
+              description: IPv4/IPv6 addresses, CIDR ranges, or address ranges.
+        examples:
+          local_networks:
+            value:
+              trustedProxies:
+                - 127.0.0.1
+                - 10.0.0.0/8
+  responses:
+    '200':
+      description: Updated trusted proxy rules.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - trustedProxies
+            properties:
+              trustedProxies:
+                type: array
+                items:
+                  type: string
+    '400':
+      description: Invalid body or IP rule.
+    '401':
+      description: Authentication required or invalid credentials.
+    '500':
+      description: Internal server error.
+  operationId: patchV0ManagementConfigTrustedProxies

--- a/docs/openapi/paths/v0_management_mcp-servers_{serverName}_process-logs.yaml
+++ b/docs/openapi/paths/v0_management_mcp-servers_{serverName}_process-logs.yaml
@@ -1,0 +1,37 @@
+parameters:
+  - in: path
+    name: serverName
+    required: true
+    schema:
+      type: string
+    description: Registered MCP server name.
+get:
+  tags:
+    - Management — Config
+  summary: Get local MCP process logs (admin only)
+  description: |
+    Returns the captured stdout/stderr log lines for a local MCP server
+    process. Logs are accumulated from process spawn through exit and are
+    capped at a maximum number of lines, with the oldest lines trimmed.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Captured process log lines.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                type: array
+                items:
+                  type: string
+                description: Timestamped log lines, oldest first.
+    '401':
+      description: Authentication required or invalid credentials.
+  operationId: getV0ManagementMcpServersByServerNameProcessLogs

--- a/docs/openapi/paths/v0_management_mcp-servers_{serverName}_restart.yaml
+++ b/docs/openapi/paths/v0_management_mcp-servers_{serverName}_restart.yaml
@@ -1,0 +1,48 @@
+parameters:
+  - in: path
+    name: serverName
+    required: true
+    schema:
+      type: string
+    description: Registered MCP server name.
+post:
+  tags:
+    - Management — Config
+  summary: Restart a local MCP server process (admin only)
+  description: |
+    Stops then starts the child process for a local (`local_http`) MCP
+    server. Returns the updated runtime status after the new process is ready.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Process restarted.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/LocalMcpRuntimeStatus.yaml
+    '400':
+      description: Server is not `local_http` mode.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+    '401':
+      description: Authentication required or invalid credentials.
+    '404':
+      description: MCP server not found.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+    '500':
+      description: Process failed to start or become ready.
+  operationId: postV0ManagementMcpServersByServerNameRestart

--- a/docs/openapi/paths/v0_management_mcp-servers_{serverName}_start.yaml
+++ b/docs/openapi/paths/v0_management_mcp-servers_{serverName}_start.yaml
@@ -1,0 +1,53 @@
+parameters:
+  - in: path
+    name: serverName
+    required: true
+    schema:
+      type: string
+    description: Registered MCP server name.
+post:
+  tags:
+    - Management — Config
+  summary: Start a local MCP server process (admin only)
+  description: |
+    Spawns (or reuses) the child process for a local (`local_http`) MCP
+    server. Plexus waits for the process to become ready before returning.
+
+    If the server configuration fingerprint has changed since the last start,
+    the existing process is restarted with the new configuration.
+
+    Returns the updated runtime status.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Process started (or already running).
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/LocalMcpRuntimeStatus.yaml
+    '400':
+      description: Server is not `local_http` mode.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+    '401':
+      description: Authentication required or invalid credentials.
+    '404':
+      description: MCP server not found.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+    '500':
+      description: Process failed to start or become ready.
+  operationId: postV0ManagementMcpServersByServerNameStart

--- a/docs/openapi/paths/v0_management_mcp-servers_{serverName}_status.yaml
+++ b/docs/openapi/paths/v0_management_mcp-servers_{serverName}_status.yaml
@@ -1,0 +1,41 @@
+parameters:
+  - in: path
+    name: serverName
+    required: true
+    schema:
+      type: string
+    description: Registered MCP server name.
+get:
+  tags:
+    - Management — Config
+  summary: Get local MCP process runtime status (admin only)
+  description: |
+    Returns the runtime status of a local (`local_http`) MCP server process
+    managed by Plexus. This reflects the child process lifecycle, not the
+    MCP server's configuration.
+
+    The `status` field is one of `stopped`, `starting`, `running`, or
+    `failed`. When the process is running, `pid` and `url` are populated.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Process runtime status.
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/LocalMcpRuntimeStatus.yaml
+    '401':
+      description: Authentication required or invalid credentials.
+    '404':
+      description: MCP server not found.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+  operationId: getV0ManagementMcpServersByServerNameStatus

--- a/docs/openapi/paths/v0_management_mcp-servers_{serverName}_stop.yaml
+++ b/docs/openapi/paths/v0_management_mcp-servers_{serverName}_stop.yaml
@@ -1,0 +1,31 @@
+parameters:
+  - in: path
+    name: serverName
+    required: true
+    schema:
+      type: string
+    description: Registered MCP server name.
+post:
+  tags:
+    - Management — Config
+  summary: Stop a local MCP server process (admin only)
+  description: |
+    Stops the child process for a local MCP server by sending `SIGTERM`,
+    then waits up to 3 seconds for graceful exit.
+
+    Returns the updated runtime status. It is safe to call when no process is
+    running; the route does not require a stored server configuration.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  responses:
+    '200':
+      description: Process stopped (or was not running).
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/LocalMcpRuntimeStatus.yaml
+    '401':
+      description: Authentication required or invalid credentials.
+  operationId: postV0ManagementMcpServersByServerNameStop

--- a/docs/openapi/paths/v0_management_quota-checkers.yaml
+++ b/docs/openapi/paths/v0_management_quota-checkers.yaml
@@ -65,7 +65,7 @@ get:
                     meters:
                       type: array
                       items:
-                        type: object
+                        $ref: ../components/schemas/Meter.yaml
                     success:
                       type: boolean
                     error:

--- a/docs/openapi/paths/v0_management_quota_recompute.yaml
+++ b/docs/openapi/paths/v0_management_quota_recompute.yaml
@@ -1,0 +1,73 @@
+post:
+  tags:
+    - Management — Quotas (Provider)
+  summary: Recompute a quota bucket from request usage (admin only)
+  description: |
+    Repairs a quota bucket by recomputing its usage from successful request
+    usage records instead of trusting the stored counter. The quota must be
+    attached to the key, directly or through the configured default quotas.
+
+    Rolling requests and rolling tokens quotas are rejected because their
+    decay history cannot be reconstructed exactly from request usage records.
+
+    **Admin only** — limited principals receive 403.
+  security:
+    - AdminKey: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - key
+            - quota
+          properties:
+            key:
+              type: string
+              description: API key name whose quota bucket should be repaired.
+            quota:
+              type: string
+              description: Attached quota definition name to recompute.
+        examples:
+          recompute:
+            value:
+              key: production-key
+              quota: monthly-tokens
+  responses:
+    '200':
+      description: Quota usage was recomputed.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - success
+              - key
+              - quota
+              - usage
+              - windowStartMs
+              - message
+            properties:
+              success:
+                type: boolean
+                const: true
+              key:
+                type: string
+              quota:
+                type: string
+              usage:
+                type: number
+              windowStartMs:
+                type: integer
+              message:
+                type: string
+    '400':
+      description: Missing fields, unattached quota, or unsupported quota type.
+    '401':
+      description: Authentication required or invalid credentials.
+    '404':
+      description: API key not found.
+    '500':
+      description: Internal server error.
+  operationId: postV0ManagementQuotaRecompute

--- a/docs/openapi/paths/v0_management_quotas.yaml
+++ b/docs/openapi/paths/v0_management_quotas.yaml
@@ -13,9 +13,9 @@ get:
     ## What this returns
 
     A snapshot per provider, containing:
-    - Checker metadata (ID, type, category)
+    - Checker metadata (ID, type)
     - OAuth account info (if using OAuth)
-    - Array of `QuotaSample` for each window the provider reports
+    - Array of `Meter` readings, one per quota dimension the provider reports
 
     ## Which providers contribute data
 
@@ -25,7 +25,7 @@ get:
     ## Polling cadence
 
     Quota checkers run on a scheduler (typically every 1–5 minutes). The
-    `latest` array shows the most recent sample for each window type. To
+    `meters` array shows the most recent reading for each meter. To
     see historical data, use `/quotas/{checkerId}/history`.
 
     **Admin only** — limited principals receive 403.

--- a/docs/openapi/paths/v0_management_quotas_{checkerId}_history.yaml
+++ b/docs/openapi/paths/v0_management_quotas_{checkerId}_history.yaml
@@ -12,13 +12,15 @@ get:
     - Management — Quotas (Provider)
   summary: Historical quota samples (admin only)
   description: |
-    Returns historical quota measurements for a specific checker.
+    Returns historical quota-snapshot rows for a specific checker, one row per
+    meter per check, sorted by `checkedAt` descending (most recent first).
 
     ## Query parameters
 
-    - **windowType** — Filter by time window. Options: `subscription`,
-      `hourly`, `five_hour`, `daily`, `weekly`, `monthly`, `custom`.
-      When omitted, returns all window types.
+    - **meterKey** — Filter to a single meter (e.g. `balance`, `five_hour`,
+      `daily`). When omitted, returns rows for all meters the checker reports.
+      Meter keys are provider-specific; discover them from the `meters[].key`
+      field of a snapshot.
 
     - **since** — Start of the time range. Supports two formats:
       - **Absolute**: ISO 8601 timestamp, e.g. `2026-01-01T00:00:00Z`
@@ -27,9 +29,9 @@ get:
     ## Response structure
 
     - `checkerId` — The checker this history is for
-    - `windowType` — The window type filter used (null if no filter)
-    - `since` — The timestamp of the earliest sample
-    - `history` — Array of `QuotaSample` objects sorted by `checkedAt` ascending
+    - `meterKey` — The meter filter used (null if no filter)
+    - `since` — The timestamp of the earliest sample (null if no `since` filter)
+    - `history` — Array of `QuotaSample` snapshot rows
 
     ## Retention
 
@@ -42,19 +44,12 @@ get:
     - AdminKey: []
   parameters:
     - in: query
-      name: windowType
+      name: meterKey
       schema:
         type: string
-        enum:
-          - subscription
-          - hourly
-          - five_hour
-          - daily
-          - weekly
-          - monthly
-          - custom
       description: >
-        Filter by time window type. Returns all window types when omitted.
+        Filter to a single meter (e.g. `balance`, `five_hour`, `daily`).
+        Returns rows for all meters when omitted.
     - in: query
       name: since
       schema:
@@ -72,7 +67,7 @@ get:
             properties:
               checkerId:
                 type: string
-              windowType:
+              meterKey:
                 type:
                   - string
                   - 'null'

--- a/scripts/sync-openapi.ts
+++ b/scripts/sync-openapi.ts
@@ -76,6 +76,23 @@ interface SyncReport {
 
 // ─── Route Parser ────────────────────────────────────────────────────
 
+function extractRouteMethods(expression: string, content: string): HttpMethod[] {
+  const directMethods = [
+    ...expression.matchAll(/['"\x60](get|post|put|patch|delete|options|head)['"\x60]/gi),
+  ].map((match) => match[1].toLowerCase() as HttpMethod);
+  if (directMethods.length > 0) return [...new Set(directMethods)];
+
+  const spread = expression.match(/\.\.\.([a-zA-Z_][a-zA-Z0-9_]*)/);
+  if (!spread) return [];
+  const definition = content.match(
+    new RegExp('(?:const|let)\\s+' + spread[1] + '\\s*=\\s*\\[([^\\]]*)\\]', 's')
+  );
+  if (!definition) return [];
+  return [
+    ...definition[1].matchAll(/['"\x60](get|post|put|patch|delete|options|head)['"\x60]/gi),
+  ].map((match) => match[1].toLowerCase() as HttpMethod);
+}
+
 /**
  * Parse a TypeScript file to extract Fastify route registrations.
  * Uses regex-based parsing (simpler than AST for this use case).
@@ -115,6 +132,27 @@ async function parseRoutesFromFile(filePath: string): Promise<RouteInfo[]> {
           file: filePath,
           line: i + 1,
           handler: line.trim().substring(0, 100),
+        });
+      }
+    }
+
+    // Handle object-style registrations such as:
+    // rawRoutes.route({ method: [...RAW_METHODS], url: '/raw/:provider/*', ... })
+    const routeObjectRegex =
+      /[a-zA-Z_][a-zA-Z0-9_]*\.route\s*\(\s*\{[\s\S]*?method:\s*(\[[\s\S]*?\])[\s\S]*?url:\s*['\x60]([^'\x60]+)['\x60]/g;
+    let routeObjectMatch;
+    while ((routeObjectMatch = routeObjectRegex.exec(content)) !== null) {
+      const methods = extractRouteMethods(routeObjectMatch[1], content);
+      const path = routeObjectMatch[2];
+      if (methods.length === 0 || path.startsWith('/__') || path.includes('__')) continue;
+      const lineNumber = content.substring(0, routeObjectMatch.index).split('\n').length;
+      for (const method of methods) {
+        routes.push({
+          path,
+          method,
+          file: filePath,
+          line: lineNumber,
+          handler: 'Route object ' + method.toUpperCase() + ' ' + path,
         });
       }
     }
@@ -362,10 +400,10 @@ async function generateSyncReport(): Promise<SyncReport> {
       // Check if this is a wildcard route that exists in OpenAPI with named parameters
       // e.g., code has /providers/{wildcard} but OpenAPI has /providers/{slug}
       if (normalizedPath.includes('{wildcard}')) {
-        // Look for similar paths in OpenAPI
-        const basePattern = normalizedPath.replace(/{wildcard}/g, '');
+        // Compare full templates so a nested path cannot hide a different route.
+        const wildcardTemplate = normalizedPath.replace(/\{[^}]+\}/g, '{}');
         const hasSimilarPath = Array.from(openApiByPath.keys()).some(
-          (key) => key.includes(basePattern) && key.match(/{[a-zA-Z_][a-zA-Z0-9_]*}/)
+          (key) => key.replace(/\{[^}]+\}/g, '{}') === wildcardTemplate
         );
         if (hasSimilarPath) {
           // Skip - this wildcard route is documented with named parameters
@@ -392,10 +430,11 @@ async function generateSyncReport(): Promise<SyncReport> {
   const missingFromRoutes: OpenApiPathInfo[] = [];
   for (const [path, openApiInfo] of openApiByPath) {
     if (!routesByPath.has(path)) {
-      // Skip if this is a wildcard route that exists with different param naming
-      // e.g., OpenAPI has {slug} but code uses * (wildcard)
-      const hasWildcardVersion = routesByPath.has(
-        path.replace(/{[a-zA-Z_][a-zA-Z0-9_]*}/g, '{wildcard}')
+      // Match OpenAPI named parameters against code wildcards using the same
+      // full-template comparison as the forward reconciliation above.
+      const wildcardTemplate = path.replace(/\{[^}]+\}/g, '{}');
+      const hasWildcardVersion = Array.from(routesByPath.keys()).some(
+        (key) => key.replace(/\{[^}]+\}/g, '{}') === wildcardTemplate
       );
       if (hasWildcardVersion) {
         continue;


### PR DESCRIPTION
## Summary

Bring the split OpenAPI specification in line with Plexus's live management API surface.

## Why

The management API has grown faster than its OpenAPI coverage, leaving several live endpoints difficult to discover and making the specification an incomplete contract for API consumers and generated clients.

The provider-quota documentation had also drifted from the implementation. It described the retired per-window `QuotaSample`/`windowType` model, while the backend now exposes current `Meter` readings and persists meter history keyed by `meterKey`. Keeping those shapes aligned avoids sending clients toward fields and filters that the API no longer supports.

The route-sync tooling is updated alongside the documentation so this coverage can be checked against the current Fastify route-registration patterns going forward.

## Changes

- Adds documentation for previously uncovered management endpoints, including:
  - local MCP runtime controls and process logs
  - compaction, trusted-proxy, trace-capture, and MCP settings
  - quota recomputation
  - the Plexus MCP endpoint
- Updates provider quota documentation to reflect the live `Meter` model:
  - adds shared `Meter` and `MeterStatus` schemas
  - replaces obsolete `latest` and `windowType` fields
  - documents `meters`, `meterKey`, and persisted meter history rows
- Improves the OpenAPI route-sync script to detect the current Fastify route patterns.
- Ensures the documented paths remain synchronized with the backend routes.

No backend runtime behavior is changed.
