### PR TITLE
fix(oauth): emit tool name once in chat streams

### DIFF
--- a/packages/backend/src/transformers/__tests__/oauth-anthropic-stream-regression.test.ts
+++ b/packages/backend/src/transformers/__tests__/oauth-anthropic-stream-regression.test.ts
@@ -121,6 +121,61 @@ describe('OAuth -> Anthropic stream regression', () => {
     expect(chunk).toBeNull();
   });
 
+  test('piAiEventToChunk emits tool identity once before argument deltas', () => {
+    const partial = {
+      content: [
+        { type: 'thinking', thinking: 'I should run a command' },
+        {
+          type: 'toolCall',
+          id: 'call_1|fc_1',
+          name: 'execute',
+          arguments: {},
+        },
+      ],
+    };
+
+    const startChunk = piAiEventToChunk(
+      { type: 'toolcall_start', contentIndex: 1, partial } as any,
+      'gpt-5.6-sol',
+      'openai-codex'
+    );
+    const firstDelta = piAiEventToChunk(
+      {
+        type: 'toolcall_delta',
+        contentIndex: 1,
+        delta: '{\"command\":',
+        partial,
+      } as any,
+      'gpt-5.6-sol',
+      'openai-codex'
+    );
+    const secondDelta = piAiEventToChunk(
+      {
+        type: 'toolcall_delta',
+        contentIndex: 1,
+        delta: '\"printf hello\"}',
+        partial,
+      } as any,
+      'gpt-5.6-sol',
+      'openai-codex'
+    );
+
+    expect(startChunk?.delta.tool_calls?.[0]).toEqual({
+      index: 0,
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'execute', arguments: '' },
+    });
+    expect(firstDelta?.delta.tool_calls?.[0]).toEqual({
+      index: 0,
+      function: { arguments: '{\"command\":' },
+    });
+    expect(secondDelta?.delta.tool_calls?.[0]).toEqual({
+      index: 0,
+      function: { arguments: '\"printf hello\"}' },
+    });
+  });
+
   test('piAiEventToChunk uses 0-based sequential indices for tool calls when thinking is present', () => {
     // Simulate a partial message state from pi-ai where:
     // Index 0: thinking block
@@ -148,6 +203,7 @@ describe('OAuth -> Anthropic stream regression', () => {
     }
 
     expect(toolCalls[0]!.index).toBe(0); // MUST be 0 for OpenAI compatibility, even if it's block 1 in Anthropic
-    expect(toolCalls[0]!.id).toBe('toolu_123');
+    expect(toolCalls[0]!.id).toBeUndefined();
+    expect(toolCalls[0]!.function?.name).toBeUndefined();
   });
 });

--- a/packages/backend/src/transformers/__tests__/oauth-anthropic-stream-regression.test.ts
+++ b/packages/backend/src/transformers/__tests__/oauth-anthropic-stream-regression.test.ts
@@ -121,6 +121,13 @@ describe('OAuth -> Anthropic stream regression', () => {
     expect(chunk).toBeNull();
   });
 
+  // Regression for issue #719 (Codex). pi-ai emits a `toolcall_start` (identity)
+  // then N `toolcall_delta`s (arg fragments). The OpenAI/Codex streaming contract
+  // requires the id + function name to appear EXACTLY ONCE, on the first chunk;
+  // repeating them on every delta made clients re-accumulate the name into an
+  // over-length string that Codex rejected. This asserts identity lands on the
+  // start chunk and every delta is args-only. See toolCallIdentityChannel() in
+  // ../oauth/type-mappers.ts for the full cross-provider rationale.
   test('piAiEventToChunk emits tool identity once before argument deltas', () => {
     const partial = {
       content: [
@@ -176,6 +183,46 @@ describe('OAuth -> Anthropic stream regression', () => {
     });
   });
 
+  // Anthropic uses the SAME 'start' channel as Codex — this is the row that a
+  // naive #719 fix broke. anthropic/stream-formatter.ts opens a tool_use block
+  // only on a chunk carrying a truthy `tc.id` (`if (!toolCallId) continue;`); if
+  // identity never arrives on any chunk, the whole tool call is silently dropped.
+  // So Anthropic must get identity on the start chunk (NOT stripped from deltas
+  // with nothing to replace it). This guards against regressing back to that.
+  test('piAiEventToChunk emits Anthropic tool identity on the start event, args-only on deltas', () => {
+    const partial = {
+      content: [
+        { type: 'thinking', thinking: 'I should list files' },
+        { type: 'toolCall', id: 'toolu_123', name: 'bash', arguments: {} },
+      ],
+    };
+
+    const startChunk = piAiEventToChunk(
+      { type: 'toolcall_start', contentIndex: 1, partial } as any,
+      'claude-sonnet-4-6',
+      'anthropic'
+    );
+    const delta = piAiEventToChunk(
+      { type: 'toolcall_delta', contentIndex: 1, delta: '{"cmd": "ls"}', partial } as any,
+      'claude-sonnet-4-6',
+      'anthropic'
+    );
+
+    // Identity travels on the start chunk so the Anthropic formatter can open the
+    // tool_use block (it drops tool calls whose id is missing).
+    expect(startChunk?.delta.tool_calls?.[0]).toEqual({
+      index: 0,
+      id: 'toolu_123',
+      type: 'function',
+      function: { name: 'bash', arguments: '' },
+    });
+    // Deltas are args-only so the name is not re-accumulated per chunk.
+    expect(delta?.delta.tool_calls?.[0]).toEqual({
+      index: 0,
+      function: { arguments: '{"cmd": "ls"}' },
+    });
+  });
+
   test('piAiEventToChunk uses 0-based sequential indices for tool calls when thinking is present', () => {
     // Simulate a partial message state from pi-ai where:
     // Index 0: thinking block
@@ -203,6 +250,11 @@ describe('OAuth -> Anthropic stream regression', () => {
     }
 
     expect(toolCalls[0]!.index).toBe(0); // MUST be 0 for OpenAI compatibility, even if it's block 1 in Anthropic
+    // id and name are intentionally absent on Anthropic DELTAS — they were emitted
+    // once on the toolcall_start chunk (see the "start event" test above). This is
+    // the 'start' channel contract, NOT a bug: repeating them here would re-trigger
+    // the #719 name-accumulation problem. For Gemini the opposite holds (identity
+    // lives on the delta); that is covered in oauth-gemini-stream-error-regression.
     expect(toolCalls[0]!.id).toBeUndefined();
     expect(toolCalls[0]!.function?.name).toBeUndefined();
   });

--- a/packages/backend/src/transformers/__tests__/oauth-gemini-stream-error-regression.test.ts
+++ b/packages/backend/src/transformers/__tests__/oauth-gemini-stream-error-regression.test.ts
@@ -28,7 +28,15 @@ async function readUtf8(stream: ReadableStream<Uint8Array>): Promise<string> {
 }
 
 describe('OAuth -> Gemini stream error regression', () => {
-  test('piAiEventToChunk ignores tool call starts for non-Codex OAuth providers', () => {
+  // Gemini uses the 'delta' identity channel — the mirror image of Codex/Anthropic.
+  // Background: commit 082d33f8 ("Gemini compatibility") suppressed the start chunk
+  // because the old Gemini formatter emitted a functionCall part per chunk, so an
+  // empty-args start chunk produced a premature/malformed `args:{}` call. That
+  // suppression is still correct. But the current formatter reads the function name
+  // ONLY from the delta stream and drops any call whose name never arrives, so the
+  // identity must ride on the deltas. The three tests below lock down both halves
+  // of that contract. See toolCallIdentityChannel() in ../oauth/type-mappers.ts.
+  test('piAiEventToChunk suppresses tool call start chunks for Gemini', () => {
     const chunk = piAiEventToChunk(
       {
         type: 'toolcall_start',
@@ -48,7 +56,77 @@ describe('OAuth -> Gemini stream error regression', () => {
       'google-gemini-cli'
     );
 
+    // Half 1: no start chunk. An empty-args start chunk historically produced a
+    // malformed functionCall in the Gemini formatter (see commit 082d33f8).
     expect(chunk).toBeNull();
+  });
+
+  test('piAiEventToChunk keeps tool identity on Gemini argument deltas', () => {
+    const partial = {
+      content: [
+        {
+          type: 'toolCall',
+          id: 'call_1',
+          name: 'manage_todo_list',
+          arguments: {},
+        },
+      ],
+    };
+
+    const delta = piAiEventToChunk(
+      {
+        type: 'toolcall_delta',
+        contentIndex: 0,
+        delta: '{"status":"done"}',
+        partial,
+      } as any,
+      'gemini-3-flash-preview',
+      'google-gemini-cli'
+    );
+
+    // Half 2: because there is no start chunk, the delta MUST carry id + name.
+    // gemini/stream-formatter.ts sets `state.name = tc.function.name` from deltas
+    // and drops the call via `if (!state.name) return null;` if it never arrives.
+    // The first cut of #719 stripped identity from all deltas, which made every
+    // Gemini tool call vanish — this asserts we don't regress to that.
+    expect(delta?.delta.tool_calls?.[0]).toEqual({
+      index: 0,
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'manage_todo_list', arguments: '{"status":"done"}' },
+    });
+  });
+
+  // End-to-end guard: drive real mapper output through the real Gemini formatter.
+  // A unit test on the mapper alone would not have caught the dropped-tool-call
+  // regression, because the harm only shows up once the formatter tries (and fails)
+  // to build a functionCall with no name. This is the test that actually exercises
+  // that path — start event suppressed, identity + args accumulated from deltas,
+  // a well-formed functionCall emitted on completion.
+  test('formatGeminiStream emits a functionCall for a Gemini tool call with no start chunk', async () => {
+    const partial = {
+      content: [{ type: 'toolCall', id: 'call_1', name: 'get_weather', arguments: {} }],
+    };
+
+    const events = [
+      { type: 'toolcall_start', contentIndex: 0, partial },
+      { type: 'toolcall_delta', contentIndex: 0, delta: '{"city":', partial },
+      { type: 'toolcall_delta', contentIndex: 0, delta: '"sf"}', partial },
+      { type: 'done', reason: 'tool_use', message: {} },
+    ];
+
+    const unifiedChunks = events
+      .map((event) => piAiEventToChunk(event as any, 'gemini-3-flash-preview', 'google-gemini-cli'))
+      .filter((chunk): chunk is NonNullable<typeof chunk> => chunk !== null);
+
+    const output = await readUtf8(
+      formatGeminiStream(createUnifiedChunkStream(unifiedChunks)) as ReadableStream<Uint8Array>
+    );
+
+    expect(output).toContain('"functionCall"');
+    expect(output).toContain('"get_weather"');
+    expect(output).toContain('"city"');
+    expect(output).toContain('"sf"');
   });
 
   test('piAiEventToChunk maps oauth error message into chunk content', () => {

--- a/packages/backend/src/transformers/__tests__/oauth-gemini-stream-error-regression.test.ts
+++ b/packages/backend/src/transformers/__tests__/oauth-gemini-stream-error-regression.test.ts
@@ -28,6 +28,29 @@ async function readUtf8(stream: ReadableStream<Uint8Array>): Promise<string> {
 }
 
 describe('OAuth -> Gemini stream error regression', () => {
+  test('piAiEventToChunk ignores tool call starts for non-Codex OAuth providers', () => {
+    const chunk = piAiEventToChunk(
+      {
+        type: 'toolcall_start',
+        contentIndex: 0,
+        partial: {
+          content: [
+            {
+              type: 'toolCall',
+              id: 'call_1',
+              name: 'manage_todo_list',
+              arguments: {},
+            },
+          ],
+        },
+      } as any,
+      'gemini-3-flash-preview',
+      'google-gemini-cli'
+    );
+
+    expect(chunk).toBeNull();
+  });
+
   test('piAiEventToChunk maps oauth error message into chunk content', () => {
     const chunk = piAiEventToChunk(
       {

--- a/packages/backend/src/transformers/oauth/type-mappers.ts
+++ b/packages/backend/src/transformers/oauth/type-mappers.ts
@@ -463,6 +463,11 @@ export function piAiEventToChunk(
         },
       };
     case 'toolcall_start': {
+      // Codex Chat streams need the tool identity as a separate delta. Other OAuth
+      // formatters historically consume identity from the argument event, and Gemini
+      // rejects the empty arguments emitted by a start chunk.
+      if (provider !== 'openai-codex') return null;
+
       const toolCall = event.partial?.content?.[event.contentIndex];
       if (!toolCall || toolCall.type !== 'toolCall') return null;
 

--- a/packages/backend/src/transformers/oauth/type-mappers.ts
+++ b/packages/backend/src/transformers/oauth/type-mappers.ts
@@ -462,13 +462,35 @@ export function piAiEventToChunk(
           thinking: { content: event.delta },
         },
       };
-    case 'toolcall_start':
-      // Gemini doesn't need start events with empty args which cause parsing errors in formatter
-      return null;
+    case 'toolcall_start': {
+      const toolCall = event.partial?.content?.[event.contentIndex];
+      if (!toolCall || toolCall.type !== 'toolCall') return null;
+
+      const { callId } = parseToolCallIds(toolCall.id);
+      const toolCallIndex = event.partial.content
+        .slice(0, event.contentIndex)
+        .filter((content) => content.type === 'toolCall').length;
+
+      return {
+        ...baseChunk,
+        delta: {
+          tool_calls: [
+            {
+              index: toolCallIndex,
+              id: callId || toolCall.id,
+              type: 'function',
+              function: {
+                name: normalizeToolName(toolCall.name),
+                arguments: '',
+              },
+            },
+          ],
+        },
+      };
+    }
     case 'toolcall_delta': {
       const toolCall = event.partial?.content?.[event.contentIndex];
       if (toolCall && toolCall.type === 'toolCall') {
-        const { callId } = parseToolCallIds((toolCall as any).id);
         const thoughtSignature = (toolCall as any).thoughtSignature;
 
         // Calculate the correct tool_call index for OpenAI format.
@@ -484,10 +506,7 @@ export function piAiEventToChunk(
             tool_calls: [
               {
                 index: toolCallIndex,
-                id: callId || (toolCall as any).id,
-                type: 'function',
                 function: {
-                  name: normalizeToolName((toolCall as any).name),
                   arguments: event.delta,
                 },
               },

--- a/packages/backend/src/transformers/oauth/type-mappers.ts
+++ b/packages/backend/src/transformers/oauth/type-mappers.ts
@@ -463,10 +463,13 @@ export function piAiEventToChunk(
         },
       };
     case 'toolcall_start': {
-      // Codex Chat streams need the tool identity as a separate delta. Other OAuth
-      // formatters historically consume identity from the argument event, and Gemini
-      // rejects the empty arguments emitted by a start chunk.
-      if (provider !== 'openai-codex') return null;
+      // Emit the one-and-only identity chunk (id + name, empty args) for 'start'
+      // providers (Codex, Anthropic); suppress it for 'delta' providers (Gemini),
+      // whose formatter reads identity from the argument deltas and would choke on
+      // an empty-args start chunk. See toolCallIdentityChannel() below for the full
+      // rationale and the failure mode per formatter — do not change this gate
+      // without reading it.
+      if (toolCallIdentityChannel(provider) !== 'start') return null;
 
       const toolCall = event.partial?.content?.[event.contentIndex];
       if (!toolCall || toolCall.type !== 'toolCall') return null;
@@ -505,15 +508,37 @@ export function piAiEventToChunk(
           .slice(0, event.contentIndex)
           .filter((c: any) => c.type === 'toolCall').length;
 
+        // Include identity (id + name) on the delta only for 'delta' providers
+        // (Gemini), which never received a start chunk and would otherwise drop the
+        // tool call for lack of a name. 'start' providers (Codex, Anthropic) get
+        // args-only deltas here — repeating the name per chunk is the exact bug
+        // (#719) that made Codex reject over-length accumulated names. See
+        // toolCallIdentityChannel() below.
+        const includeIdentity = toolCallIdentityChannel(provider) === 'delta';
+        const { callId } = includeIdentity
+          ? parseToolCallIds((toolCall as any).id)
+          : { callId: undefined };
+
         return {
           ...baseChunk,
           delta: {
             tool_calls: [
               {
                 index: toolCallIndex,
-                function: {
-                  arguments: event.delta,
-                },
+                ...(includeIdentity
+                  ? {
+                      id: callId || (toolCall as any).id,
+                      type: 'function' as const,
+                      function: {
+                        name: normalizeToolName((toolCall as any).name),
+                        arguments: event.delta,
+                      },
+                    }
+                  : {
+                      function: {
+                        arguments: event.delta,
+                      },
+                    }),
               },
             ],
             ...(thoughtSignature
@@ -614,6 +639,61 @@ function mapStopReason(reason: string): string {
     default:
       return 'stop';
   }
+}
+
+// ---------------------------------------------------------------------------
+// Streamed tool-call identity routing (LOAD-BEARING — read before editing)
+// ---------------------------------------------------------------------------
+// When pi-ai streams a tool call it emits `toolcall_start` (identity: id + name,
+// no args yet) followed by N `toolcall_delta` events (argument fragments). This
+// mapper turns those into OpenAI-shaped `tool_calls` chunks. The *identity*
+// (id + function name) must appear exactly once, but WHERE it must appear
+// differs per downstream OAuth formatter, so this decision is centralized here.
+//
+// Two channels:
+//   'start' — emit identity once on the toolcall_start chunk; deltas are
+//             args-only. Used by Codex and Anthropic.
+//   'delta' — suppress the start chunk (return null); carry identity on every
+//             argument delta. Used by Gemini.
+//
+// Why each formatter needs what it needs (with the failure mode if you get it
+// wrong — all three have bitten us before):
+//
+//   * openai-codex — The OpenAI Chat streaming contract puts identity in the
+//     first chunk and args-only after. Repeating id+name on every delta made
+//     clients re-accumulate the function name into an ever-growing string that
+//     Codex rejected for exceeding its name-length limit. That is the bug this
+//     whole mechanism fixes (issue #719, "emit tool name once").
+//
+//   * anthropic — anthropic/stream-formatter.ts opens a tool_use block only when
+//     a chunk carries a truthy `tc.id` (`if (!toolCallId) continue;`). If NO
+//     chunk ever carries the id (e.g. start suppressed AND deltas stripped of
+//     identity), the block never opens and the entire tool call is silently
+//     dropped. So Anthropic must get identity on the start chunk. It tolerates
+//     args-only deltas because it de-dupes the block by id.
+//
+//   * google-gemini-cli — Gemini gets NO start chunk. Historically (commit
+//     082d33f8, "Gemini compatibility") the Gemini formatter emitted a
+//     functionCall part per chunk immediately, so an empty-args start chunk
+//     produced a premature/malformed functionCall with `args:{}` before the real
+//     args arrived. The fix then was to suppress the start event entirely. The
+//     formatter was later rewritten to accumulate state and defer emission
+//     (gemini/stream-formatter.ts), but it now reads the function *name* only
+//     from the delta stream (`state.name = tc.function.name`) and drops any call
+//     whose name never arrives (`if (!state.name) return null;`). So for Gemini
+//     the identity MUST ride on the deltas — suppressing the start chunk is
+//     still correct, but stripping id+name from the deltas (as the first cut of
+//     #719 did for all providers) makes every Gemini tool call vanish.
+//
+// Net: 'start' for everyone except Gemini. A new OAuth backend that needs
+// delta-carried identity is a one-line addition here — do NOT re-fork the
+// switch cases in piAiEventToChunk. Regression coverage lives in
+// __tests__/oauth-anthropic-stream-regression.test.ts and
+// __tests__/oauth-gemini-stream-error-regression.test.ts.
+type ToolCallIdentityChannel = 'start' | 'delta';
+
+function toolCallIdentityChannel(provider?: string): ToolCallIdentityChannel {
+  return provider === 'google-gemini-cli' ? 'delta' : 'start';
 }
 
 function parseToolCallIds(rawId?: string): { callId?: string; functionCallId?: string } {


### PR DESCRIPTION
## Summary

Emit OAuth tool-call identity once when an OpenAI Chat Completions stream starts a tool call, then emit only new argument fragments in subsequent deltas. This prevents clients from accumulating the function name repeatedly and producing malformed historical calls that Codex rejects for exceeding its name length limit.

## Changes

- Map pi-ai `toolcall_start` events to Chat tool-call chunks containing the zero-based index, parsed call ID, function type, normalized name, and empty arguments.
- Restrict `toolcall_delta` chunks to the tool-call index and newly streamed argument fragment.
- Preserve zero-based tool indexing when thinking content precedes a tool call.
- Add regression coverage for compound Codex IDs and multiple argument deltas without repeated identity fields.

Closes #719
