### PR TITLE
fix(providers): send hyphenated session-id header for codex cache routing

### DIFF
--- a/packages/backend/src/services/providers/provider-request-headers.ts
+++ b/packages/backend/src/services/providers/provider-request-headers.ts
@@ -44,7 +44,10 @@ export function setupProviderHeaders(
   // different backend server, causing cache misses.
   if (request.cacheRoutingHeaders) {
     if (request.cacheRoutingHeaders.session_id) {
-      headers['session_id'] = request.cacheRoutingHeaders.session_id;
+      // OpenAI's Codex backend deprecated the underscored header in favor of
+      // the hyphenated form (more proxy-compatible); the old name is now
+      // silently ignored upstream, so send the current one.
+      headers['session-id'] = request.cacheRoutingHeaders.session_id;
     }
     if (request.cacheRoutingHeaders['x-client-request-id']) {
       headers['x-client-request-id'] = request.cacheRoutingHeaders['x-client-request-id'];


### PR DESCRIPTION
### **User description**
## Summary
Fixes inconsistent prompt-cache hit rates on aliases routed through generic providers to the OpenAI Codex backend (e.g. `gpt-5.6-luna`). Plexus was sending a deprecated cache-routing header that the backend now silently ignores.

## Why / Context
Traced a live staging session (`gpt-5.6-luna`) with debug capture and confirmed the upstream is the ChatGPT Codex backend (`chatgpt.com` cookies/`x-codex-*` headers in the response). The client correctly sends a stable `prompt_cache_key` per conversation, and Plexus forwards it in the body correctly — but the separate header-based sticky-routing mechanism was broken: `provider-request-headers.ts` sent `session_id` (underscore), which OpenAI's Codex backend deprecated and later dropped (`openai/codex#21757`, `openai/codex#22193`) in favor of `session-id` (hyphen). The direct OAuth-native Codex path (`oauth-native-request.ts`) already used the correct hyphenated header; the generic provider dispatch path did not, so sessions going through non-OAuth providers lost sticky machine routing and fell back to weaker best-effort hash routing.

## Changes
- **Providers**: `setupProviderHeaders` now emits `session-id` instead of `session_id` when forwarding cache-routing headers to upstream providers.

## Testing
- `bun run test` (full backend suite via lefthook pre-commit): 197 passed.
- Typecheck and lint via lefthook pre-commit: passed.
- Verified against a live staging debug trace that the outgoing header change aligns with the backend's currently-supported header name.


___

### **Description**
- Use `session-id` for upstream cache routing

- Restore Codex sticky-session cache routing


___

