### PR TITLE
fix(oauth): translate cross-format Codex responses

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-codex-native.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-codex-native.test.ts
@@ -11,7 +11,7 @@ import type { UnifiedChatRequest } from '../../types/unified';
 // Responses body. Two paths:
 //   1. CLI-shaped body  → sent VERBATIM (auth only), extensions preserved.
 //   2. Not CLI-shaped   → normalized via ResponsesTransformer + adorned.
-// Both stream RAW backend Responses SSE to the client (no IR re-serialization).
+// Responses clients stream RAW backend SSE; cross-format clients get translated.
 
 const { Dispatcher } = await import('../dispatch/dispatcher');
 
@@ -143,6 +143,38 @@ function plainResponsesRequest(): UnifiedChatRequest {
   } as any;
 }
 
+function chatRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'codex-alias',
+    stream: true,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'codex-alias',
+    messages: body.messages,
+    stream: true,
+    incomingApiType: 'chat',
+    originalBody: body,
+  } as any;
+}
+
+function messagesRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'codex-alias',
+    max_tokens: 256,
+    stream: true,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'codex-alias',
+    messages: body.messages,
+    max_tokens: 256,
+    stream: true,
+    incomingApiType: 'messages',
+    originalBody: body,
+  } as any;
+}
+
 async function drain(stream: ReadableStream): Promise<string> {
   const reader = stream.getReader();
   const dec = new TextDecoder();
@@ -185,7 +217,7 @@ describe('Native Codex OAuth pass-through', () => {
   beforeEach(() => {
     OAuthAuthManager.resetForTesting();
     registerSpy(OAuthAuthManager.getInstance(), 'getApiKey').mockResolvedValue(CODEX_TOKEN);
-    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+    fetchSpy = registerSpy(global, 'fetch').mockResolvedValue(
       new Response(UPSTREAM_SSE, {
         status: 200,
         headers: { 'content-type': 'text/event-stream' },
@@ -225,9 +257,10 @@ describe('Native Codex OAuth pass-through', () => {
 
   test('PATH 2 (non-CLI): normalizes + adorns the body for the backend', async () => {
     setConfigForTesting(codexOAuthConfig());
-    await new Dispatcher().dispatch(plainResponsesRequest());
+    const response = await new Dispatcher().dispatch(plainResponsesRequest());
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(response.bypassTransformation).toBe(true);
     const [url, init] = fetchSpy.mock.calls[0] as any[];
     expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
 
@@ -266,5 +299,25 @@ describe('Native Codex OAuth pass-through', () => {
     expect((fetchSpy.mock.calls[0] as any[])[0]).toBe(
       'https://chatgpt.com/backend-api/codex/responses'
     );
+  });
+
+  test('marks backend Responses SSE for translation to a Chat Completions client', async () => {
+    setConfigForTesting(codexOAuthConfig());
+    const response = await new Dispatcher().dispatch(chatRequest());
+
+    expect(response.bypassTransformation).toBe(false);
+    const sent = JSON.parse((fetchSpy.mock.calls[0] as any[])[1].body);
+    expect(sent.input).toBeDefined();
+    expect(sent.messages).toBeUndefined();
+  });
+
+  test('marks backend Responses SSE for translation to a Messages client', async () => {
+    setConfigForTesting(codexOAuthConfig());
+    const response = await new Dispatcher().dispatch(messagesRequest());
+
+    expect(response.bypassTransformation).toBe(false);
+    const sent = JSON.parse((fetchSpy.mock.calls[0] as any[])[1].body);
+    expect(sent.input).toBeDefined();
+    expect(sent.messages).toBeUndefined();
   });
 });

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -199,11 +199,17 @@ export async function buildRequestPayload(
     logger.debug(
       `Native OAuth payload prepared for ${provider}/${route.model} (url=${prepared.url})`
     );
-    // Anthropic/Codex always raw-passthrough their response (their clients are
-    // same-format by construction). Copilot is multi-API: honor the computed
-    // same-format decision so cross-format requests get their response
-    // translated by the standard pipeline.
-    const nativeBypass = copilotNative ? bypassTransformation : true;
+    // Codex CLI and Responses clients receive the native Responses stream.
+    // Cross-format Codex requests must translate the response back to the
+    // incoming client format. Anthropic remains raw pass-through, while
+    // Copilot honors its computed same-format decision.
+    const incomingIsResponses =
+      getApiBaseType(request.incomingApiType?.toLowerCase() ?? '') === 'responses';
+    const nativeBypass = codexNative
+      ? codexCliPassthrough || incomingIsResponses
+      : copilotNative
+        ? bypassTransformation
+        : true;
     return { payload: prepared.body, bypassTransformation: nativeBypass };
   }
 

--- a/packages/backend/src/services/oauth/__tests__/dropped-oauth-providers.test.ts
+++ b/packages/backend/src/services/oauth/__tests__/dropped-oauth-providers.test.ts
@@ -46,7 +46,9 @@ describe('dropRetiredOAuthProviders — startup purge of persisted rows', () => 
     const schema = getSchema();
     const db = getDatabase();
     await db.delete(schema.providers);
+    await db.delete(schema.apiKeys);
     await db.delete(schema.oauthCredentials);
+    await db.delete(schema.mcpServers);
     repo = new ConfigRepository();
     service = new ConfigService(repo);
   });

--- a/packages/backend/vitest.db-tests.ts
+++ b/packages/backend/vitest.db-tests.ts
@@ -7,6 +7,7 @@ export const DB_TEST_FILES = [
   'src/db/**/*.test.ts',
   'src/routes/management/__tests__/usage-summary.test.ts',
   'src/services/__tests__/usage-storage-performance.test.ts',
+  'src/services/oauth/__tests__/dropped-oauth-providers.test.ts',
   'src/services/quota/__tests__/quota-enforcer.test.ts',
   'src/services/quota/__tests__/quota-scheduler.test.ts',
 ] as const;


### PR DESCRIPTION
### **User description**
## Summary
Restore response translation when Chat Completions or Anthropic Messages clients route through native `openai-codex` OAuth targets. Codex CLI and plain Responses API clients continue receiving byte-preserved native Responses streams.

## Why / Context
The native Codex path forced response pass-through for every incoming API format. Cross-format clients therefore received raw Responses API SSE that they could not parse, despite their requests being translated correctly on the upstream leg.

## Changes
- **OAuth dispatch**: bypass response transformation only for Codex CLI-shaped requests and Responses API clients.
- **Cross-format responses**: route Chat Completions and Anthropic Messages clients through the standard provider-to-client stream translation pipeline.
- **Regression coverage**: verify Chat and Messages requests are transformed upstream and marked for response translation while plain Responses clients retain pass-through.
- **Test isolation**: use the shared tracked spy helper for the native Codex fetch mock.

## Testing
- Added native Codex dispatcher regression cases for Chat Completions and Anthropic Messages clients.
- Extended the non-CLI Responses case to assert raw response pass-through remains enabled.

Fixes #726


___

### **Description**
- Translate Codex Responses streams for cross-format clients

- Preserve raw streams for CLI and Responses clients

- Add Chat and Messages dispatch regression coverage


___

