### PR TITLE
fix(providers): forward prompt cache headers

### DIFF
--- a/packages/backend/src/routes/inference/messages.ts
+++ b/packages/backend/src/routes/inference/messages.ts
@@ -15,6 +15,7 @@ import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/t
 import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
 import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
+import { getCacheRoutingHeaders, getHeaderValue } from '../../utils/cache-routing-headers';
 
 export async function registerMessagesRoute(
   fastify: FastifyInstance,
@@ -69,6 +70,8 @@ export async function registerMessagesRoute(
       unifiedRequest.incomingApiType = 'messages';
       unifiedRequest.originalBody = body;
       unifiedRequest.requestId = requestId;
+      unifiedRequest.cacheRoutingHeaders = getCacheRoutingHeaders(request.headers);
+      unifiedRequest.anthropicBeta = getHeaderValue(request.headers, 'anthropic-beta');
       unifiedRequest = attachKeyAccessPolicy(request, unifiedRequest);
       const xAppHeader = Array.isArray(request.headers['x-app'])
         ? request.headers['x-app'][0]

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -20,6 +20,7 @@ import { wireUpstreamTimeout, wireEarlyDisconnectDetection } from '../../utils/t
 import { wireStallDetection, getGlobalStallConfig } from '../../utils/stall';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
 import { CLIENT_REQUEST_ID_HEADER, getClientRequestId } from '../../utils/client-request-id';
+import { getCacheRoutingHeaders } from '../../utils/cache-routing-headers';
 
 export function detectResponsesApiType(
   headers: Record<string, unknown>,
@@ -184,16 +185,10 @@ export async function registerResponsesRoute(
         unifiedRequest.previousResponseId = body.previous_response_id;
       }
 
-      // Forward cache routing headers for prompt caching support.
-      // These headers enable server-side cache routing at the upstream provider.
-      const sessionId = request.headers['session_id'] as string | undefined;
-      const clientRequestId = request.headers['x-client-request-id'] as string | undefined;
-      if (sessionId || clientRequestId || body.prompt_cache_key) {
-        unifiedRequest.cacheRoutingHeaders = {
-          session_id: sessionId || body.prompt_cache_key,
-          'x-client-request-id': clientRequestId || body.prompt_cache_key,
-        };
-      }
+      unifiedRequest.cacheRoutingHeaders = getCacheRoutingHeaders(
+        request.headers,
+        body.prompt_cache_key
+      );
       unifiedRequest = attachKeyAccessPolicy(request, unifiedRequest);
       const xAppHeader = Array.isArray(request.headers['x-app'])
         ? request.headers['x-app'][0]

--- a/packages/backend/src/services/providers/__tests__/provider-request-headers.test.ts
+++ b/packages/backend/src/services/providers/__tests__/provider-request-headers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { setupProviderHeaders } from '../provider-request-headers';
+
+describe('setupProviderHeaders', () => {
+  test('forwards session affinity headers to a Messages provider', () => {
+    const headers = setupProviderHeaders(
+      {
+        provider: 'wisgate',
+        config: { api_key: 'provider-key' },
+      } as any,
+      'messages',
+      {
+        stream: true,
+        cacheRoutingHeaders: {
+          session_id: 'conversation-1',
+          'x-session-affinity': 'conversation-1',
+          'x-session-id': 'conversation-1',
+          'x-prompt-cache-isolation-key': 'tenant-1',
+          'x-multi-turn-session-id': 'rollout-1',
+        },
+        anthropicBeta: 'prompt-caching-2024-07-31',
+      } as any
+    );
+
+    expect(headers['session-id']).toBe('conversation-1');
+    expect(headers['x-session-affinity']).toBe('conversation-1');
+    expect(headers['x-session-id']).toBe('conversation-1');
+    expect(headers['x-prompt-cache-isolation-key']).toBe('tenant-1');
+    expect(headers['x-multi-turn-session-id']).toBe('rollout-1');
+    expect(headers['anthropic-beta']).toBe('prompt-caching-2024-07-31');
+  });
+
+  test('does not forward Anthropic beta features to non-Messages providers', () => {
+    const headers = setupProviderHeaders(
+      {
+        provider: 'openai',
+        config: { api_key: 'provider-key' },
+      } as any,
+      'chat',
+      {
+        stream: false,
+        anthropicBeta: 'prompt-caching-2024-07-31',
+      } as any
+    );
+
+    expect(headers).not.toHaveProperty('anthropic-beta');
+  });
+});

--- a/packages/backend/src/services/providers/provider-request-headers.ts
+++ b/packages/backend/src/services/providers/provider-request-headers.ts
@@ -52,6 +52,23 @@ export function setupProviderHeaders(
     if (request.cacheRoutingHeaders['x-client-request-id']) {
       headers['x-client-request-id'] = request.cacheRoutingHeaders['x-client-request-id'];
     }
+    if (request.cacheRoutingHeaders['x-session-affinity']) {
+      headers['x-session-affinity'] = request.cacheRoutingHeaders['x-session-affinity'];
+    }
+    if (request.cacheRoutingHeaders['x-session-id']) {
+      headers['x-session-id'] = request.cacheRoutingHeaders['x-session-id'];
+    }
+    if (request.cacheRoutingHeaders['x-prompt-cache-isolation-key']) {
+      headers['x-prompt-cache-isolation-key'] =
+        request.cacheRoutingHeaders['x-prompt-cache-isolation-key'];
+    }
+    if (request.cacheRoutingHeaders['x-multi-turn-session-id']) {
+      headers['x-multi-turn-session-id'] = request.cacheRoutingHeaders['x-multi-turn-session-id'];
+    }
+  }
+
+  if (getApiBaseType(apiType) === 'messages' && request.anthropicBeta) {
+    headers['anthropic-beta'] = request.anthropicBeta;
   }
 
   if (apiType.toLowerCase() === 'responses:lite') {

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -143,13 +143,20 @@ export interface UnifiedChatRequest {
     type: 'text' | 'json_object' | 'json_schema';
     json_schema?: any;
   };
-  cacheRoutingHeaders?: {
-    session_id?: string;
-    'x-client-request-id'?: string;
-  };
+  cacheRoutingHeaders?: CacheRoutingHeaders;
+  anthropicBeta?: string;
   incomingApiType?: string;
   originalBody?: any;
   metadata?: Record<string, any> & { plexus_metadata?: PlexusMetadata };
+}
+
+export interface CacheRoutingHeaders {
+  session_id?: string;
+  'x-client-request-id'?: string;
+  'x-session-affinity'?: string;
+  'x-session-id'?: string;
+  'x-prompt-cache-isolation-key'?: string;
+  'x-multi-turn-session-id'?: string;
 }
 
 // Unified Response

--- a/packages/backend/src/utils/__tests__/cache-routing-headers.test.ts
+++ b/packages/backend/src/utils/__tests__/cache-routing-headers.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import { getCacheRoutingHeaders } from '../cache-routing-headers';
+
+describe('getCacheRoutingHeaders', () => {
+  test('extracts session affinity headers from an incoming request', () => {
+    expect(
+      getCacheRoutingHeaders({
+        'session-id': 'conversation-1',
+        'x-session-affinity': 'conversation-1',
+        'x-session-id': 'conversation-1',
+        'x-prompt-cache-isolation-key': 'tenant-1',
+        'x-multi-turn-session-id': 'rollout-1',
+      })
+    ).toEqual({
+      session_id: 'conversation-1',
+      'x-client-request-id': undefined,
+      'x-session-affinity': 'conversation-1',
+      'x-session-id': 'conversation-1',
+      'x-prompt-cache-isolation-key': 'tenant-1',
+      'x-multi-turn-session-id': 'rollout-1',
+    });
+  });
+
+  test('preserves prompt cache key fallbacks for Responses requests', () => {
+    expect(getCacheRoutingHeaders({}, 'prompt-1')).toEqual({
+      session_id: 'prompt-1',
+      'x-client-request-id': 'prompt-1',
+      'x-session-affinity': undefined,
+      'x-session-id': undefined,
+      'x-prompt-cache-isolation-key': undefined,
+      'x-multi-turn-session-id': undefined,
+    });
+  });
+
+  test('returns undefined when no cache routing values are present', () => {
+    expect(getCacheRoutingHeaders({})).toBeUndefined();
+  });
+});

--- a/packages/backend/src/utils/cache-routing-headers.ts
+++ b/packages/backend/src/utils/cache-routing-headers.ts
@@ -1,0 +1,27 @@
+import type { CacheRoutingHeaders } from '../types/unified';
+
+type Headers = Record<string, string | string[] | undefined>;
+
+export function getHeaderValue(headers: Headers, name: string): string | undefined {
+  const value = headers[name];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function getCacheRoutingHeaders(
+  headers: Headers,
+  promptCacheKey?: string
+): CacheRoutingHeaders | undefined {
+  const cacheRoutingHeaders: CacheRoutingHeaders = {
+    session_id:
+      getHeaderValue(headers, 'session_id') ||
+      getHeaderValue(headers, 'session-id') ||
+      promptCacheKey,
+    'x-client-request-id': getHeaderValue(headers, 'x-client-request-id') || promptCacheKey,
+    'x-session-affinity': getHeaderValue(headers, 'x-session-affinity'),
+    'x-session-id': getHeaderValue(headers, 'x-session-id'),
+    'x-prompt-cache-isolation-key': getHeaderValue(headers, 'x-prompt-cache-isolation-key'),
+    'x-multi-turn-session-id': getHeaderValue(headers, 'x-multi-turn-session-id'),
+  };
+
+  return Object.values(cacheRoutingHeaders).some(Boolean) ? cacheRoutingHeaders : undefined;
+}


### PR DESCRIPTION
## Summary
Forward cache-routing and Anthropic beta headers through Plexus so upstream providers can keep multi-turn conversations on cache-owning replicas and honor requested Anthropic features. This prevents Plexus from silently dropping stable session identifiers supplied by clients.

## Why / Context
Staging traffic through Wisgate showed prompt-cache usage bouncing between near-complete hits and full rewrites within one conversation. Debug traces confirmed the client sent stable session-affinity headers and an unchanged prompt prefix, but Plexus rebuilt upstream headers without forwarding those values.

## Changes
- **Messages API**: capture incoming cache-routing headers and `anthropic-beta` before dispatch.
- **Responses API**: centralize existing `session_id`, `x-client-request-id`, and `prompt_cache_key` fallback extraction.
- **Provider dispatch**: forward `session-id`, `x-session-affinity`, `x-session-id`, `x-prompt-cache-isolation-key`, and `x-multi-turn-session-id` through an explicit allowlist.
- **Anthropic compatibility**: forward `anthropic-beta` only to Messages-compatible upstreams.
- **Tests**: cover incoming extraction, Responses fallbacks, Messages forwarding, and non-Messages beta isolation.

## Notes / Follow-ups
Targeted Wisgate debug capture remains enabled on staging. After deployment, consecutive requests should be checked to confirm whether Wisgate honors the forwarded affinity headers and produces stable cache hits.
