### PR TITLE
feat(models): dynamic pi.dev model catalog on pi-ai 0.80.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
       "name": "plexus-backend",
       "version": "1.0.0",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.80.7",
+        "@earendil-works/pi-ai": "0.80.9",
         "@fastify/bearer-auth": "^10.1.2",
         "@fastify/cors": "^11.3.0",
         "@fastify/multipart": "^10.1.0",
@@ -63,7 +63,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@earendil-works/pi-ai": "0.80.7",
+        "@earendil-works/pi-ai": "0.80.9",
         "@monaco-editor/react": "4.7.0",
         "@plexus/shared": "workspace:*",
         "@types/human-format": "^1.0.3",
@@ -190,7 +190,7 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.7", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.9", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-kHsH5nO4FU7mbKnskK0BVPVuWzNb2DrZtiN1fb6LamP+6BMI8xEZiAOw2fqs4VudvlMQgOLjtbgErv+kNJRPIg=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.5.4", "", {}, "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g=="],
 

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -22,6 +22,11 @@
 # Provider performance rolling window size per provider:model combo (default: 100)
 # PLEXUS_PROVIDER_PERFORMANCE_RETENTION_LIMIT=100
 
+# Model catalog refresh: set to false to disable the background pi.dev catalog
+# refresh at startup (the persisted overlay in <db dir>/models-store.json still
+# loads). New models then require a pi-ai dependency bump to resolve.
+# PLEXUS_MODEL_CATALOG_REFRESH=true
+
 # Encryption at Rest
 # Optional: Set to encrypt sensitive data (API keys, OAuth tokens, provider credentials) in the database.
 # Generate with: openssl rand -hex 32

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,7 @@
     "lint:migrations": "cd ../.. && bun run scripts/lint-migrations.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.80.7",
+    "@earendil-works/pi-ai": "0.80.9",
     "@fastify/bearer-auth": "^10.1.2",
     "@fastify/cors": "^11.3.0",
     "@fastify/multipart": "^10.1.0",

--- a/packages/backend/src/__tests__/config-pi-ai-hints.test.ts
+++ b/packages/backend/src/__tests__/config-pi-ai-hints.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { validateConfig } from '../config';
 import { logger } from '../utils/logger';
+import { resetModelCatalogForTesting } from '../services/pi-ai/catalog';
+import { registerSpy } from '../../test/test-utils';
 
 // pi-ai and logger are globally mocked in test/vitest.setup.ts
 
@@ -89,15 +91,21 @@ describe('config schema: pi_ai_provider and pi_ai_model_id', () => {
 });
 
 describe('hydrateConfig: startup registry validation', () => {
+  afterEach(() => {
+    // Drop any catalog singleton built from a test-specific builtinModels
+    // spy so the rest of the worker gets the standard mock back.
+    resetModelCatalogForTesting();
+  });
+
   it('warns (non-fatally) when pi_ai_model_id is not in the pi-ai registry', async () => {
-    // Import the pi-ai module — in tests it's globally mocked as a factory.
-    // We can spy on the mocked object's getModel using vi.spyOn on the module
-    // to temporarily make it throw.
+    // Config validation reads the model catalog, which caches the (globally
+    // mocked) builtinModels() collection in a singleton. Point it at a fake
+    // collection that rejects the bogus pair, then reset the singleton so it
+    // is rebuilt from the fake.
     const piAiProvidersModule = await import('@earendil-works/pi-ai/providers/all');
 
-    const getModelSpy = vi
-      .spyOn(piAiProvidersModule, 'getBuiltinModel')
-      .mockImplementationOnce((provider: string, modelId: string) => {
+    registerSpy(piAiProvidersModule, 'builtinModels').mockReturnValue({
+      getModel: (provider: string, modelId: string) => {
         if (provider === 'anthropic' && modelId === 'bogus-model-xyz') {
           throw new Error('Unknown model');
         }
@@ -109,9 +117,13 @@ describe('hydrateConfig: startup registry validation', () => {
           api: 'anthropic-messages',
           baseUrl: '',
         } as any;
-      });
+      },
+      getModels: () => [],
+      getProviders: () => [],
+    } as any);
+    resetModelCatalogForTesting();
 
-    const warnSpy = vi.spyOn(logger, 'warn');
+    const warnSpy = registerSpy(logger, 'warn');
 
     // Should not throw
     expect(() =>
@@ -143,13 +155,10 @@ describe('hydrateConfig: startup registry validation', () => {
     const firstWarning = piAiWarnings[0];
     expect(firstWarning).toBeDefined();
     expect(String(firstWarning![0])).toContain('bogus-model-xyz');
-
-    warnSpy.mockRestore();
-    getModelSpy.mockRestore();
   });
 
   it('does not warn when pi_ai_model_id is not configured', () => {
-    const warnSpy = vi.spyOn(logger, 'warn');
+    const warnSpy = registerSpy(logger, 'warn');
 
     validateConfig(
       JSON.stringify({
@@ -169,7 +178,5 @@ describe('hydrateConfig: startup registry validation', () => {
       return typeof msg === 'string' && msg.includes('pi-ai registry');
     });
     expect(piAiWarnings).toHaveLength(0);
-
-    warnSpy.mockRestore();
   });
 });

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -4,7 +4,7 @@ import { DEFAULT_VISION_DESCRIPTION_PROMPT } from './utils/constants';
 import { isValidIpRule } from './utils/ip-match';
 import { resolveGpuParams, VALID_GPU_PROFILES } from '@plexus/shared';
 import type { ModelArchitecture } from '@plexus/shared';
-import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
+import { getCatalogModel } from './services/pi-ai/catalog';
 
 // --- Zod Schemas ---
 
@@ -1232,18 +1232,11 @@ function hydrateConfig(config: z.infer<typeof RawPlexusConfigSchema>): PlexusCon
 
   // Startup registry validation: warn (non-fatally) for any configured
   // (pi_ai_provider, pi_ai_model_id) pair that does not resolve via the
-  // built-in pi-ai registry. getModel() returns undefined for unknown pairs;
-  // this is a warning (not fatal) so renamed registry entries do not prevent
-  // Plexus from starting.
-  // getModel may return undefined (pi-ai 0.79.x) or throw (older versions /
-  // mocked) for unknown pairs — treat both as "not found".
-  const registryHas = (provider: string, modelId: string): boolean => {
-    try {
-      return getBuiltinModel(provider as any, modelId as any) != null;
-    } catch {
-      return false;
-    }
-  };
+  // pi-ai model catalog (built-in baseline + pi.dev overlay). The catalog
+  // returns null for unknown pairs; this is a warning (not fatal) so renamed
+  // registry entries do not prevent Plexus from starting.
+  const registryHas = (provider: string, modelId: string): boolean =>
+    getCatalogModel(provider, modelId) != null;
   const piPairResolves = (provider: string, modelId: string): boolean =>
     registryHas(provider, modelId);
   for (const [providerId, providerConfig] of Object.entries(resolvedProviders)) {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -56,6 +56,7 @@ import { registerRawPassthroughRoutes } from './routes/raw-passthrough';
 import { registerMcpRoutes } from './routes/mcp';
 import { McpUsageStorageService } from './services/mcp-proxy/mcp-usage-storage';
 import { QuotaEnforcer } from './services/quota/quota-enforcer';
+import { initModelCatalog } from './services/pi-ai/catalog';
 import { initializeDatabase } from './db/client';
 import { runMigrations } from './db/migrate';
 import { runEncryptionMigration } from './db/encrypt-migration';
@@ -168,6 +169,17 @@ if (!isEncryptionEnabled()) {
   logger.warn(
     'ENCRYPTION_KEY not set — sensitive data will be stored in plaintext. Set ENCRYPTION_KEY for encryption at rest.'
   );
+}
+
+// --- Model Catalog Initialization ---
+// Restore the persisted pi.dev catalog overlay (offline, fast) so config
+// validation and dispatch see models released between pi-ai versions, then
+// refresh from pi.dev in the background. Non-fatal: the static built-in
+// catalog is the fallback.
+try {
+  await initModelCatalog();
+} catch (e) {
+  logger.error('Failed to initialize model catalog', e);
 }
 
 // --- Configuration Initialization ---

--- a/packages/backend/src/routes/inference/models.ts
+++ b/packages/backend/src/routes/inference/models.ts
@@ -7,7 +7,7 @@ import {
   resolveModelMetadata,
   resolvePreferredApi,
 } from '../../services/models/model-metadata-manager';
-import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
+import { getCatalogModel } from '../../services/pi-ai/catalog';
 
 export async function registerModelsRoute(fastify: FastifyInstance) {
   /**
@@ -40,32 +40,18 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
       // Look up pi compat options if a pi model reference is configured.
       let piOptions: Record<string, unknown> | undefined;
       if (!piModelConfig && automaticIdentity.provider) {
-        try {
-          const inferred = getBuiltinModel(
-            automaticIdentity.provider as any,
-            automaticIdentity.model as any
-          );
-          if (inferred) {
-            piModelConfig = {
-              provider: automaticIdentity.provider,
-              model_id: automaticIdentity.model,
-            };
-          }
-        } catch {
-          // No Pi registry match — metadata and preferred API inference still apply.
+        const inferred = getCatalogModel(automaticIdentity.provider, automaticIdentity.model);
+        if (inferred) {
+          piModelConfig = {
+            provider: automaticIdentity.provider,
+            model_id: automaticIdentity.model,
+          };
         }
       }
       if (piModelConfig) {
-        try {
-          const piModel = getBuiltinModel(
-            piModelConfig.provider as any,
-            piModelConfig.model_id as any
-          );
-          if (piModel?.compat && Object.keys(piModel.compat).length > 0) {
-            piOptions = piModel.compat as Record<string, unknown>;
-          }
-        } catch {
-          // Unknown provider or model — skip silently.
+        const piModel = getCatalogModel(piModelConfig.provider, piModelConfig.model_id);
+        if (piModel?.compat && Object.keys(piModel.compat).length > 0) {
+          piOptions = piModel.compat as Record<string, unknown>;
         }
       }
 

--- a/packages/backend/src/routes/management/__tests__/oauth.test.ts
+++ b/packages/backend/src/routes/management/__tests__/oauth.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Fastify from 'fastify';
-import type { OAuthProviderInterface } from '@earendil-works/pi-ai/oauth';
+import type { OAuthProviderDescriptor } from '../../../services/oauth/oauth-providers';
 import { registerOAuthRoutes } from '../oauth';
 import { OAuthLoginSessionManager } from '../../../services/oauth/oauth-login-session';
 import { OAuthAuthManager } from '../../../services/oauth/oauth-auth-manager';
@@ -35,26 +35,35 @@ describe('OAuth management routes', () => {
   beforeEach(async () => {
     OAuthAuthManager.resetForTesting();
 
-    const provider: OAuthProviderInterface = {
+    const provider: OAuthProviderDescriptor = {
       id: 'test-provider',
       name: 'Test Provider',
-      async login(callbacks) {
-        callbacks.onAuth({ url: 'https://example.com/auth', instructions: 'Test instructions' });
-        const code = await callbacks.onPrompt({ message: 'Enter code' });
-        if (code !== 'test-code') {
-          throw new Error('Invalid code');
-        }
-        return {
-          access: 'access-token',
-          refresh: 'refresh-token',
-          expires: Date.now() + 60_000,
-        };
-      },
-      async refreshToken(credentials) {
-        return credentials;
-      },
-      getApiKey(credentials) {
-        return credentials.access;
+      usesCallbackServer: false,
+      oauth: {
+        name: 'Test Provider',
+        async login(interaction) {
+          interaction.notify({
+            type: 'auth_url',
+            url: 'https://example.com/auth',
+            instructions: 'Test instructions',
+          });
+          const code = await interaction.prompt({ type: 'text', message: 'Enter code' });
+          if (code !== 'test-code') {
+            throw new Error('Invalid code');
+          }
+          return {
+            type: 'oauth',
+            access: 'access-token',
+            refresh: 'refresh-token',
+            expires: Date.now() + 60_000,
+          };
+        },
+        async refresh(credential) {
+          return credential;
+        },
+        async toAuth(credential) {
+          return { apiKey: credential.access };
+        },
       },
     };
 
@@ -77,7 +86,14 @@ describe('OAuth management routes', () => {
     });
     const session = response.json() as { data: { id: string } };
 
-    await waitForStatus(fastify, session.data.id, 'awaiting_prompt');
+    const awaiting = await waitForStatus(fastify, session.data.id, 'awaiting_prompt');
+    // Text prompts surface through the generic prompt input, and blank
+    // submission stays enabled (providers validate blank semantics, e.g.
+    // Copilot's blank-for-github.com domain).
+    const prompt = (awaiting.data as { prompt?: { message?: string; allowEmpty?: boolean } })
+      ?.prompt;
+    expect(prompt?.message).toBe('Enter code');
+    expect(prompt?.allowEmpty).toBe(true);
 
     await fastify.inject({
       method: 'POST',
@@ -106,27 +122,34 @@ describe('OAuth management routes', () => {
 
   it('accepts manual code input for callback flows', async () => {
     const accountId = 'personal';
-    const manualProvider: OAuthProviderInterface = {
+    const manualProvider: OAuthProviderDescriptor = {
       id: 'manual-provider',
       name: 'Manual Provider',
       usesCallbackServer: true,
-      async login(callbacks) {
-        callbacks.onAuth({ url: 'https://example.com/callback' });
-        const manual = await callbacks.onManualCodeInput?.();
-        if (manual !== 'manual-code') {
-          throw new Error('Invalid manual code');
-        }
-        return {
-          access: 'manual-access',
-          refresh: 'manual-refresh',
-          expires: Date.now() + 60_000,
-        };
-      },
-      async refreshToken(credentials) {
-        return credentials;
-      },
-      getApiKey(credentials) {
-        return credentials.access;
+      oauth: {
+        name: 'Manual Provider',
+        async login(interaction) {
+          interaction.notify({ type: 'auth_url', url: 'https://example.com/callback' });
+          const manual = await interaction.prompt({
+            type: 'manual_code',
+            message: 'Enter the code from the browser',
+          });
+          if (manual !== 'manual-code') {
+            throw new Error('Invalid manual code');
+          }
+          return {
+            type: 'oauth',
+            access: 'manual-access',
+            refresh: 'manual-refresh',
+            expires: Date.now() + 60_000,
+          };
+        },
+        async refresh(credential) {
+          return credential;
+        },
+        async toAuth(credential) {
+          return { apiKey: credential.access };
+        },
       },
     };
 
@@ -144,7 +167,10 @@ describe('OAuth management routes', () => {
     });
     const session = response.json() as { data: { id: string } };
 
-    await waitForStatus(fastify, session.data.id, 'awaiting_manual_code');
+    const awaiting = await waitForStatus(fastify, session.data.id, 'awaiting_manual_code');
+    // Manual-code entry uses the dedicated redirect-URL input only — the
+    // generic prompt object must stay unset so the UI renders one input.
+    expect((awaiting.data as { prompt?: unknown })?.prompt).toBeUndefined();
 
     await fastify.inject({
       method: 'POST',

--- a/packages/backend/src/routes/management/models.ts
+++ b/packages/backend/src/routes/management/models.ts
@@ -8,11 +8,8 @@ import {
   resolvePreferredApi,
 } from '../../services/models/model-metadata-manager';
 import { getConfig, ModelConfigSchema } from '../../config';
-import {
-  getBuiltinModel,
-  getBuiltinModels,
-  getBuiltinProviders,
-} from '@earendil-works/pi-ai/providers/all';
+import { getBuiltinProviders } from '@earendil-works/pi-ai/providers/all';
+import { getCatalogModel, getCatalogModels } from '../../services/pi-ai/catalog';
 
 interface FetchModelRequest {
   Params: {
@@ -47,13 +44,9 @@ export async function registerModelRoutes(fastify: FastifyInstance) {
     );
     let piModel: { provider: string; model_id: string; name: string } | null = null;
     if (identity.provider) {
-      try {
-        const match = getBuiltinModel(identity.provider as any, identity.model as any);
-        if (match) {
-          piModel = { provider: identity.provider, model_id: identity.model, name: match.name };
-        }
-      } catch {
-        // A catalog match can exist without a corresponding Pi registry entry.
+      const match = getCatalogModel(identity.provider, identity.model);
+      if (match) {
+        piModel = { provider: identity.provider, model_id: identity.model, name: match.name };
       }
     }
 
@@ -152,15 +145,8 @@ export async function registerModelRoutes(fastify: FastifyInstance) {
       return reply.status(400).send({ error: `Missing 'provider' parameter` });
     }
 
-    // Built-in registry models for this provider.
-    let builtin: ReturnType<typeof getBuiltinModels> = [];
-    try {
-      builtin = getBuiltinModels(query.provider as any) ?? [];
-    } catch {
-      builtin = [];
-    }
-
-    const merged = builtin.map((m) => ({
+    // Catalog models for this provider (built-in baseline + pi.dev overlay).
+    const merged = getCatalogModels(query.provider).map((m) => ({
       id: m.id,
       name: m.name,
       api: m.api as string,

--- a/packages/backend/src/routes/management/oauth.ts
+++ b/packages/backend/src/routes/management/oauth.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { OAuthLoginSessionManager } from '../../services/oauth/oauth-login-session';
 import { OAuthAuthManager } from '../../services/oauth/oauth-auth-manager';
-import type { OAuthProvider, OAuthProviderId } from '@earendil-works/pi-ai/oauth';
+import type { OAuthProvider, OAuthProviderId } from '../../services/oauth/oauth-providers';
 import { getOAuthProviderModels } from '../../services/providers/provider-model-discovery';
 
 const startSessionSchema = z.object({

--- a/packages/backend/src/services/oauth/oauth-auth-manager.ts
+++ b/packages/backend/src/services/oauth/oauth-auth-manager.ts
@@ -1,10 +1,7 @@
 import { logger } from '../../utils/logger';
-import {
-  getOAuthApiKey,
-  type OAuthProvider,
-  type OAuthCredentials,
-} from '@earendil-works/pi-ai/oauth';
+import type { OAuthCredential, OAuthCredentials } from '@earendil-works/pi-ai';
 import { ConfigService } from '../configuration/config-service';
+import { getOAuthProviderAuth, type OAuthProvider } from './oauth-providers';
 
 const LEGACY_ACCOUNT_ID = 'legacy';
 
@@ -173,35 +170,36 @@ export class OAuthAuthManager {
       );
     }
 
-    const result = await getOAuthApiKey(provider, {
-      [provider]: credentials,
-    });
-
-    if (!result) {
-      throw new Error(
-        `OAuth: Not authenticated for provider '${provider}' and account '${resolvedAccountId}'. ` +
-          `Please run OAuth login for this account.`
-      );
+    const descriptor = getOAuthProviderAuth(provider);
+    if (!descriptor) {
+      throw new Error(`OAuth: provider '${provider}' does not support OAuth login.`);
     }
 
-    if (result.newCredentials) {
-      const wasRefreshed =
-        result.newCredentials.access !== credentials.access ||
-        result.newCredentials.expires !== credentials.expires;
+    // Refresh expired tokens and persist the rotated credentials.
+    let current = credentials;
+    if (current.expires <= Date.now()) {
+      const refreshed = await descriptor.oauth.refresh({ ...current, type: 'oauth' });
       logger.debug(
-        `OAuth: getApiKey for ${provider}/${resolvedAccountId} — ` +
-          `token ${wasRefreshed ? 'WAS refreshed' : 'was NOT refreshed (not expired)'}. ` +
-          `new_refresh=${result.newCredentials.refresh ? `present(${result.newCredentials.refresh.length} chars)` : 'MISSING'}`
+        `OAuth: getApiKey for ${provider}/${resolvedAccountId} — token WAS refreshed. ` +
+          `new_refresh=${refreshed.refresh ? `present(${refreshed.refresh.length} chars)` : 'MISSING'}`
       );
-      providerRecord.accounts[resolvedAccountId] = {
-        type: 'oauth',
-        ...result.newCredentials,
-      } as OAuthCredentials;
-      // Save refreshed credentials to database
-      await this.saveToDatabase(provider, resolvedAccountId, result.newCredentials);
+      current = { ...refreshed };
+      providerRecord.accounts[resolvedAccountId] = current;
+      await this.saveToDatabase(provider, resolvedAccountId, current);
+    } else {
+      logger.debug(
+        `OAuth: getApiKey for ${provider}/${resolvedAccountId} — token was NOT refreshed (not expired).`
+      );
     }
 
-    return result.apiKey;
+    const auth = await descriptor.oauth.toAuth({ ...current, type: 'oauth' } as OAuthCredential);
+    if (!auth.apiKey) {
+      throw new Error(
+        `OAuth: could not derive an API key for provider '${provider}' and account '${resolvedAccountId}'.`
+      );
+    }
+
+    return auth.apiKey;
   }
 
   getCredentials(provider: OAuthProvider, accountId?: string | null): OAuthCredentials | null {

--- a/packages/backend/src/services/oauth/oauth-login-session.ts
+++ b/packages/backend/src/services/oauth/oauth-login-session.ts
@@ -1,13 +1,11 @@
-import { getOAuthProvider, getOAuthProviders } from '@earendil-works/pi-ai/oauth';
-import type {
-  OAuthAuthInfo,
-  OAuthCredentials,
-  OAuthLoginCallbacks,
-  OAuthPrompt,
-  OAuthProviderId,
-  OAuthProviderInterface,
-} from '@earendil-works/pi-ai/oauth';
+import type { AuthInteraction, OAuthCredentials } from '@earendil-works/pi-ai';
 import { OAuthAuthManager } from './oauth-auth-manager';
+import {
+  getOAuthProviderAuth,
+  listOAuthProviders,
+  type OAuthProviderDescriptor,
+  type OAuthProviderId,
+} from './oauth-providers';
 
 export type OAuthSessionStatus =
   | 'in_progress'
@@ -17,6 +15,17 @@ export type OAuthSessionStatus =
   | 'success'
   | 'error'
   | 'cancelled';
+
+export type OAuthAuthInfo = {
+  url: string;
+  instructions?: string;
+};
+
+export type OAuthPrompt = {
+  message: string;
+  placeholder?: string;
+  allowEmpty?: boolean;
+};
 
 export type OAuthSession = {
   id: string;
@@ -41,7 +50,7 @@ type SessionInternal = OAuthSession & {
   expiresAt: number;
 };
 
-type ProviderResolver = (id: OAuthProviderId) => OAuthProviderInterface | undefined;
+type ProviderResolver = (id: OAuthProviderId) => OAuthProviderDescriptor | undefined;
 
 const DEFAULT_SESSION_TTL_MS = 20 * 60 * 1000;
 
@@ -67,7 +76,7 @@ export class OAuthLoginSessionManager {
   private providerResolver: ProviderResolver;
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(providerResolver: ProviderResolver = getOAuthProvider) {
+  constructor(providerResolver: ProviderResolver = getOAuthProviderAuth) {
     this.providerResolver = providerResolver;
     this.startCleanup();
   }
@@ -89,8 +98,8 @@ export class OAuthLoginSessionManager {
     this.sessions.clear();
   }
 
-  listProviders(): OAuthProviderInterface[] {
-    return getOAuthProviders();
+  listProviders(): OAuthProviderDescriptor[] {
+    return listOAuthProviders();
   }
 
   getSession(sessionId: string): OAuthSession | undefined {
@@ -210,56 +219,76 @@ export class OAuthLoginSessionManager {
   }
 
   private async runLogin(
-    provider: OAuthProviderInterface,
+    provider: OAuthProviderDescriptor,
     session: SessionInternal
   ): Promise<void> {
     const authManager = OAuthAuthManager.getInstance();
 
-    const callbacks: OAuthLoginCallbacks = {
-      onAuth: (info) => {
-        session.authInfo = info;
-        session.status = 'awaiting_auth';
-        this.touch(session);
-      },
-      onDeviceCode: (info) => {
-        session.authInfo = {
-          url: info.verificationUri,
-          instructions: `Enter code: ${info.userCode}`,
-        };
-        session.status = 'awaiting_auth';
-        this.touch(session);
-      },
-      onPrompt: async (prompt) => {
-        session.prompt = prompt;
-        session.status = 'awaiting_prompt';
-        this.touch(session);
-        const deferred = createDeferred();
+    const awaitUserInput = (manual: boolean, message: string, placeholder?: string) => {
+      // Manual-code entry renders as the UI's dedicated redirect-URL input
+      // (driven by the awaiting_manual_code status), not the generic prompt
+      // input — keep session.prompt unset so only one input is shown.
+      //
+      // allowEmpty: pi-ai 0.80.9's AuthPrompt dropped the old allowEmpty
+      // flag; blank input is passed through and each provider validates it
+      // (e.g. Copilot treats a blank GHE domain as github.com), so the UI
+      // must not block empty submission.
+      session.prompt = manual ? undefined : { message, placeholder, allowEmpty: true };
+      session.status = manual ? 'awaiting_manual_code' : 'awaiting_prompt';
+      this.touch(session);
+      const deferred = createDeferred();
+      if (manual) {
+        session.resolveManualCode = deferred.resolve;
+        session.rejectManualCode = deferred.reject;
+      } else {
         session.resolvePrompt = deferred.resolve;
         session.rejectPrompt = deferred.reject;
-        return deferred.promise;
-      },
-      onProgress: (message) => {
-        session.progress.push(message);
-        if (session.progress.length > 100) {
-          session.progress.shift();
+      }
+      return deferred.promise;
+    };
+
+    const interaction: AuthInteraction = {
+      signal: session.abortController.signal,
+      notify: (event) => {
+        switch (event.type) {
+          case 'auth_url':
+            session.authInfo = { url: event.url, instructions: event.instructions };
+            session.status = 'awaiting_auth';
+            break;
+          case 'device_code':
+            session.authInfo = {
+              url: event.verificationUri,
+              instructions: `Enter code: ${event.userCode}`,
+            };
+            session.status = 'awaiting_auth';
+            break;
+          case 'progress':
+          case 'info':
+            session.progress.push(event.message);
+            if (session.progress.length > 100) {
+              session.progress.shift();
+            }
+            break;
         }
         this.touch(session);
       },
-      onManualCodeInput: async () => {
-        session.status = 'awaiting_manual_code';
-        this.touch(session);
-        const deferred = createDeferred();
-        session.resolveManualCode = deferred.resolve;
-        session.rejectManualCode = deferred.reject;
-        return deferred.promise;
+      prompt: (prompt) => {
+        // Select prompts (e.g. Codex login-method chooser) keep the previous
+        // behaviour: auto-pick the first option.
+        if (prompt.type === 'select') {
+          const selected = prompt.options[0]?.id;
+          if (selected === undefined) {
+            return Promise.reject(new Error('Login cancelled: no options to select'));
+          }
+          return Promise.resolve(selected);
+        }
+        return awaitUserInput(prompt.type === 'manual_code', prompt.message, prompt.placeholder);
       },
-      onSelect: async (prompt) => prompt.options[0]?.id,
-      signal: session.abortController.signal,
     };
 
     try {
-      const credentials: OAuthCredentials = await provider.login(callbacks);
-      authManager.setCredentials(provider.id, session.accountId, credentials);
+      const credentials: OAuthCredentials = await provider.oauth.login(interaction);
+      authManager.setCredentials(session.providerId, session.accountId, credentials);
       session.status = 'success';
       session.error = undefined;
       session.prompt = undefined;

--- a/packages/backend/src/services/oauth/oauth-native-request.ts
+++ b/packages/backend/src/services/oauth/oauth-native-request.ts
@@ -24,8 +24,8 @@
  * translation.
  */
 
-import { getBuiltinModel } from '@earendil-works/pi-ai/providers/all';
-import type { OAuthProvider } from '@earendil-works/pi-ai/oauth';
+import { getCatalogModel } from '../pi-ai/catalog';
+import type { OAuthProvider } from './oauth-providers';
 import { logger } from '../../utils/logger';
 import { OAuthAuthManager } from './oauth-auth-manager';
 import {
@@ -81,7 +81,7 @@ const OAUTH_PROVIDER_BASE_URLS: Record<string, string> = {
  * or not-yet-registered model ids still resolve. Trailing slash stripped.
  */
 function resolveOAuthBaseUrl(provider: OAuthProvider, modelId: string): string {
-  const model = getBuiltinModel(provider as any, modelId);
+  const model = getCatalogModel(provider, modelId);
   const baseUrl = (model as any)?.baseUrl || OAUTH_PROVIDER_BASE_URLS[provider];
   if (!baseUrl) {
     throw new Error(
@@ -617,7 +617,7 @@ export function nativeOAuthApiType(
  */
 export function copilotWireApiType(modelId: string | undefined): string {
   if (modelId) {
-    const model = getBuiltinModel('github-copilot' as any, modelId);
+    const model = getCatalogModel('github-copilot', modelId);
     const api = (model as any)?.api as string | undefined;
     if (api && PIAI_API_TO_PLEXUS[api]) return PIAI_API_TO_PLEXUS[api];
   }

--- a/packages/backend/src/services/oauth/oauth-providers.ts
+++ b/packages/backend/src/services/oauth/oauth-providers.ts
@@ -1,0 +1,55 @@
+/**
+ * Plexus's OAuth provider facade over pi-ai's built-in providers.
+ *
+ * pi-ai 0.80.8 removed the pi-ai/oauth provider registry — OAuth is now owned
+ * by each built-in Provider as `provider.auth.oauth` (login/refresh/toAuth).
+ * This module is the single place Plexus resolves OAuth providers, plus the
+ * provider metadata the management UI needs.
+ */
+
+import { builtinModels } from '@earendil-works/pi-ai/providers/all';
+import type { OAuthAuth } from '@earendil-works/pi-ai';
+
+/** Provider id of an OAuth provider (e.g. 'anthropic', 'openai-codex'). */
+export type OAuthProvider = string;
+export type OAuthProviderId = string;
+
+export interface OAuthProviderDescriptor {
+  id: string;
+  /** Display name from pi-ai (e.g. "Anthropic (Claude Pro/Max)"). */
+  name: string;
+  /** Whether login runs a local callback server with manual code fallback. */
+  usesCallbackServer: boolean;
+  /** pi-ai's OAuth flow implementation (login/refresh/toAuth). */
+  oauth: OAuthAuth;
+}
+
+/** Providers whose login flow runs a local callback server. */
+const CALLBACK_SERVER_PROVIDERS = new Set(['anthropic', 'openai-codex']);
+
+const models = builtinModels();
+
+function toDescriptor(providerId: string): OAuthProviderDescriptor | undefined {
+  const provider = models.getProvider(providerId);
+  const oauth = provider?.auth?.oauth;
+  if (!provider || !oauth) return undefined;
+  return {
+    id: provider.id,
+    name: oauth.name,
+    usesCallbackServer: CALLBACK_SERVER_PROVIDERS.has(provider.id),
+    oauth,
+  };
+}
+
+/** Resolve an OAuth provider by id; undefined when unknown or OAuth-less. */
+export function getOAuthProviderAuth(providerId: string): OAuthProviderDescriptor | undefined {
+  return toDescriptor(providerId);
+}
+
+/** List all built-in providers that support OAuth login. */
+export function listOAuthProviders(): OAuthProviderDescriptor[] {
+  return models
+    .getProviders()
+    .map((provider) => toDescriptor(provider.id))
+    .filter((descriptor): descriptor is OAuthProviderDescriptor => descriptor !== undefined);
+}

--- a/packages/backend/src/services/pi-ai/__tests__/catalog.test.ts
+++ b/packages/backend/src/services/pi-ai/__tests__/catalog.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { ModelsStore, ModelsStoreEntry, MutableModels, Provider } from '@earendil-works/pi-ai';
+import {
+  createModelCatalog,
+  defaultModelsStorePath,
+  FileModelsStore,
+  REMOTE_CATALOG_REFRESH_INTERVAL_MS,
+} from '../catalog';
+
+// pi-ai and logger are globally mocked in test/vitest.setup.ts, with the
+// real createProvider re-exported — these tests exercise genuine pi-ai
+// overlay semantics against hand-rolled provider/store/fetch fakes.
+
+const BASELINE_MODEL = {
+  id: 'claude-base',
+  name: 'Baseline',
+  provider: 'anthropic',
+  api: 'anthropic-messages',
+  contextWindow: 200000,
+};
+
+function makeProvider(id: string, models: any[]): Provider {
+  return {
+    id,
+    name: id,
+    auth: {},
+    getModels: () => models,
+    stream: () => {
+      throw new Error('not used in catalog tests');
+    },
+    streamSimple: () => {
+      throw new Error('not used in catalog tests');
+    },
+  } as unknown as Provider;
+}
+
+function makeModels(...providers: Provider[]): MutableModels {
+  const map = new Map(providers.map((p) => [p.id, p]));
+  return {
+    getProviders: () => [...map.values()],
+    getProvider: (id: string) => map.get(id),
+    setProvider: (p: Provider) => void map.set(p.id, p),
+    deleteProvider: (id: string) => void map.delete(id),
+    clearProviders: () => map.clear(),
+    getModel: (provider: string, id: string) =>
+      map
+        .get(provider)
+        ?.getModels()
+        .find((m: any) => m.id === id),
+    getModels: (provider?: string) =>
+      provider === undefined
+        ? [...map.values()].flatMap((p) => p.getModels())
+        : (map.get(provider)?.getModels() ?? []),
+  } as unknown as MutableModels;
+}
+
+class MapStore implements ModelsStore {
+  readonly entries = new Map<string, ModelsStoreEntry>();
+  async read(id: string) {
+    return this.entries.get(id);
+  }
+  async write(id: string, entry: ModelsStoreEntry) {
+    this.entries.set(id, entry);
+  }
+  async delete(id: string) {
+    this.entries.delete(id);
+  }
+}
+
+const jsonResponse = (body: unknown, status = 200) =>
+  ({ status, ok: status >= 200 && status < 300, json: async () => body }) as Response;
+
+function makeCatalog(overrides: {
+  providers?: Provider[];
+  store?: MapStore;
+  fetchImpl?: any;
+  now?: () => number;
+}) {
+  return createModelCatalog({
+    models: makeModels(...(overrides.providers ?? [makeProvider('anthropic', [BASELINE_MODEL])])),
+    store: overrides.store ?? new MapStore(),
+    fetchImpl: (overrides.fetchImpl ?? vi.fn()) as any,
+    now: overrides.now,
+  });
+}
+
+describe('createModelCatalog', () => {
+  it('serves baseline models before any refresh, without network', async () => {
+    const fetchImpl = vi.fn();
+    const catalog = makeCatalog({ fetchImpl });
+    await catalog.init({ allowNetwork: false });
+
+    expect(catalog.getModel('anthropic', 'claude-base')?.id).toBe('claude-base');
+    expect(catalog.getModel('anthropic', 'nope')).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('merges the remote overlay over the baseline', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        'claude-new': { id: 'claude-new', name: 'New', contextWindow: 500000 },
+        'claude-base': { id: 'claude-base', name: 'Baseline v2', contextWindow: 400000 },
+      })
+    );
+    const catalog = makeCatalog({ fetchImpl });
+    await catalog.init({ allowNetwork: false });
+    const result = await catalog.refresh();
+
+    expect(result.errors).toEqual({});
+    expect(catalog.getModel('anthropic', 'claude-new')?.contextWindow).toBe(500000);
+    expect(catalog.getModel('anthropic', 'claude-new')?.provider).toBe('anthropic');
+    expect(catalog.getModel('anthropic', 'claude-base')?.name).toBe('Baseline v2');
+  });
+
+  it('persists the overlay and restores it without network', async () => {
+    const store = new MapStore();
+    const fetchImpl = vi.fn(async () => jsonResponse({ 'claude-new': { id: 'claude-new' } }));
+    await makeCatalog({ store, fetchImpl }).refresh();
+
+    const fetchImpl2 = vi.fn();
+    const second = makeCatalog({ store, fetchImpl: fetchImpl2 });
+    await second.init({ allowNetwork: false });
+
+    expect(second.getModel('anthropic', 'claude-new')?.id).toBe('claude-new');
+    expect(fetchImpl2).not.toHaveBeenCalled();
+  });
+
+  it('throttles remote checks to the refresh interval unless forced', async () => {
+    // createProvider stamps checkedAt with the real clock, so the fake clock
+    // anchors to real time and only advances relative to it.
+    let now = Date.now();
+    const fetchImpl = vi.fn(async () => jsonResponse({ 'claude-new': { id: 'claude-new' } }));
+    const catalog = makeCatalog({ fetchImpl, now: () => now });
+
+    await catalog.refresh();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await catalog.refresh();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    now += REMOTE_CATALOG_REFRESH_INTERVAL_MS + 1;
+    await catalog.refresh();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    await catalog.refresh({ force: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('treats 404 as "no overlay" without failing and records the check', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, 404));
+    const catalog = makeCatalog({ fetchImpl });
+
+    const result = await catalog.refresh();
+    expect(result.errors).toEqual({});
+    expect(catalog.getModel('anthropic', 'claude-base')?.id).toBe('claude-base');
+
+    await catalog.refresh();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains the stored overlay when the remote fetch fails', async () => {
+    const store = new MapStore();
+    store.entries.set('anthropic', {
+      models: [{ id: 'claude-stored', provider: 'anthropic' } as any],
+      checkedAt: 1,
+    });
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    const catalog = makeCatalog({ store, fetchImpl, now: () => 2_000_000_000 });
+
+    const result = await catalog.refresh();
+    expect(result.errors['anthropic']).toContain('network down');
+    expect(catalog.getModel('anthropic', 'claude-stored')?.id).toBe('claude-stored');
+  });
+
+  it('accepts model-ID keyed, array, and {models:[]} catalog shapes', async () => {
+    const bodies: unknown[] = [{ m1: { id: 'm1' } }, [{ id: 'm1' }], { models: [{ id: 'm1' }] }];
+    for (const body of bodies) {
+      const fetchImpl = vi.fn(async () => jsonResponse(body));
+      const catalog = makeCatalog({ providers: [makeProvider('p', [])], fetchImpl });
+      await catalog.refresh();
+      expect(catalog.getModel('p', 'm1')?.provider).toBe('p');
+    }
+  });
+
+  it('returns an empty list for unknown providers', () => {
+    const catalog = makeCatalog({});
+    expect(catalog.getModels('unknown')).toEqual([]);
+  });
+
+  it('refreshes in the background when init allows network', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ 'claude-new': { id: 'claude-new' } }));
+    const catalog = makeCatalog({ fetchImpl });
+
+    await catalog.init({ allowNetwork: true });
+    await vi.waitFor(() =>
+      expect(catalog.getModel('anthropic', 'claude-new')?.id).toBe('claude-new')
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FileModelsStore', () => {
+  it('round-trips entries through the JSON file', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'plexus-catalog-'));
+    try {
+      const file = path.join(dir, 'models-store.json');
+      const store = new FileModelsStore(file);
+      await store.write('anthropic', { models: [{ id: 'm' } as any], checkedAt: 123 });
+
+      const fresh = new FileModelsStore(file);
+      expect(await fresh.read('anthropic')).toEqual({ models: [{ id: 'm' }], checkedAt: 123 });
+      expect(await fresh.read('openai')).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('starts empty when the file is corrupt', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'plexus-catalog-'));
+    try {
+      const file = path.join(dir, 'models-store.json');
+      await writeFile(file, 'not json{');
+      const store = new FileModelsStore(file);
+      expect(await store.read('anthropic')).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('defaultModelsStorePath', () => {
+  it('resolves next to the sqlite database file', () => {
+    expect(defaultModelsStorePath('sqlite:///data/plexus.db')).toBe(
+      path.join('/data', 'models-store.json')
+    );
+  });
+
+  it('returns undefined for in-memory and non-sqlite databases', () => {
+    expect(defaultModelsStorePath('sqlite://:memory:')).toBeUndefined();
+    expect(defaultModelsStorePath('postgres://user:pass@host/db')).toBeUndefined();
+  });
+});

--- a/packages/backend/src/services/pi-ai/__tests__/catalog.test.ts
+++ b/packages/backend/src/services/pi-ai/__tests__/catalog.test.ts
@@ -201,6 +201,28 @@ describe('createModelCatalog', () => {
       expect(catalog.getModel('anthropic', 'claude-new')?.id).toBe('claude-new')
     );
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+    catalog.dispose();
+  });
+
+  it('periodically re-refreshes after init and stops on dispose', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ 'claude-new': { id: 'claude-new' } }));
+    const catalog = createModelCatalog({
+      models: makeModels(makeProvider('anthropic', [BASELINE_MODEL])),
+      store: new MapStore(),
+      fetchImpl: fetchImpl as any,
+      // Always stale, so every interval tick performs a real fetch.
+      now: () => Date.now() + REMOTE_CATALOG_REFRESH_INTERVAL_MS,
+      refreshIntervalMs: 25,
+    });
+
+    await catalog.init({ allowNetwork: true });
+    await vi.waitFor(() => expect(fetchImpl.mock.calls.length).toBeGreaterThanOrEqual(2));
+
+    catalog.dispose();
+    const callsAtDispose = fetchImpl.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    // A refresh already in flight may complete; no new ones may start.
+    expect(fetchImpl.mock.calls.length).toBeLessThanOrEqual(callsAtDispose + 1);
   });
 });
 
@@ -227,6 +249,31 @@ describe('FileModelsStore', () => {
       await writeFile(file, 'not json{');
       const store = new FileModelsStore(file);
       expect(await store.read('anthropic')).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers the write chain after a failed persist', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'plexus-catalog-'));
+    try {
+      // Block persistence: the store's parent path is a file, not a directory.
+      const blocker = path.join(dir, 'blocked');
+      await writeFile(blocker, 'occupied');
+      const file = path.join(blocker, 'models-store.json');
+      const store = new FileModelsStore(file);
+
+      await expect(
+        store.write('anthropic', { models: [{ id: 'm' } as any], checkedAt: 1 })
+      ).rejects.toThrow();
+
+      // Unblock: the next write must actually persist, not vanish into a
+      // permanently rejected serialization chain.
+      await rm(blocker);
+      await store.write('anthropic', { models: [{ id: 'm' } as any], checkedAt: 2 });
+
+      const fresh = new FileModelsStore(file);
+      expect(await fresh.read('anthropic')).toEqual({ models: [{ id: 'm' }], checkedAt: 2 });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/backend/src/services/pi-ai/__tests__/catalog.test.ts
+++ b/packages/backend/src/services/pi-ai/__tests__/catalog.test.ts
@@ -192,6 +192,24 @@ describe('createModelCatalog', () => {
     expect(catalog.getModels('unknown')).toEqual([]);
   });
 
+  it('does not drive refresh for self-refreshing providers', async () => {
+    const radiusRefresh = vi.fn(async () => {});
+    const radius = {
+      ...makeProvider('radius', []),
+      refreshModels: radiusRefresh,
+    } as unknown as Provider;
+    const fetchImpl = vi.fn(async () => jsonResponse({ m1: { id: 'm1' } }));
+    const catalog = createModelCatalog({
+      models: makeModels(radius, makeProvider('anthropic', [BASELINE_MODEL])),
+      store: new MapStore(),
+      fetchImpl: fetchImpl as any,
+    });
+
+    await catalog.refresh();
+    expect(radiusRefresh).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it('refreshes in the background when init allows network', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({ 'claude-new': { id: 'claude-new' } }));
     const catalog = makeCatalog({ fetchImpl });

--- a/packages/backend/src/services/pi-ai/catalog.ts
+++ b/packages/backend/src/services/pi-ai/catalog.ts
@@ -188,12 +188,18 @@ export class FileModelsStore implements ModelsStore {
   }
 
   private persist(): Promise<void> {
-    this.writing = this.writing.then(async () => {
-      await mkdir(path.dirname(this.filePath), { recursive: true });
-      const tmp = `${this.filePath}.tmp`;
-      await Bun.write(tmp, JSON.stringify(this.entries));
-      await rename(tmp, this.filePath);
-    });
+    // Recover the chain from a previous rejection: without the catch, one
+    // transient failure would leave this.writing rejected and every later
+    // write/delete would silently skip its persistence callback. Each caller
+    // still receives their own rejection via the returned promise.
+    this.writing = this.writing
+      .catch(() => undefined)
+      .then(async () => {
+        await mkdir(path.dirname(this.filePath), { recursive: true });
+        const tmp = `${this.filePath}.tmp`;
+        await Bun.write(tmp, JSON.stringify(this.entries));
+        await rename(tmp, this.filePath);
+      });
     return this.writing;
   }
 }
@@ -232,6 +238,8 @@ export interface ModelCatalogDeps {
   fetchImpl?: typeof fetch;
   catalogBaseUrl?: string;
   now?: () => number;
+  /** Periodic re-refresh cadence. Defaults to the 4h throttle interval. */
+  refreshIntervalMs?: number;
 }
 
 export interface CatalogRefreshResult {
@@ -245,9 +253,12 @@ export interface ModelCatalog {
   /**
    * Wrap static providers with the remote overlay and restore the persisted
    * catalog from the store. When allowNetwork is not false, also kicks off a
-   * background pi.dev refresh (errors are logged, never thrown).
+   * background pi.dev refresh and schedules periodic re-refreshes (errors
+   * are logged, never thrown).
    */
   init(options?: { allowNetwork?: boolean }): Promise<void>;
+  /** Stop the periodic re-refresh scheduled by init. */
+  dispose(): void;
   /**
    * Restore every provider's persisted overlay, then fetch stale providers
    * from pi.dev (throttled to REMOTE_CATALOG_REFRESH_INTERVAL_MS unless
@@ -268,6 +279,7 @@ export function createModelCatalog(deps: ModelCatalogDeps): ModelCatalog {
   const { models, store } = deps;
   const now = deps.now ?? Date.now;
   let wrapped = false;
+  let refreshTimer: ReturnType<typeof setInterval> | undefined;
 
   function wrapProviders(): void {
     if (wrapped) return;
@@ -326,27 +338,44 @@ export function createModelCatalog(deps: ModelCatalogDeps): ModelCatalog {
     return { refreshed, errors };
   }
 
+  function logRefreshOutcome(promise: Promise<CatalogRefreshResult>): void {
+    void promise
+      .then((result) => {
+        const errorCount = Object.keys(result.errors).length;
+        if (errorCount > 0) {
+          logger.warn(
+            `Model catalog refresh completed with ${errorCount} provider error(s): ` +
+              Object.entries(result.errors)
+                .map(([id, message]) => `${id}: ${message}`)
+                .join('; ')
+          );
+        } else {
+          logger.debug(`Model catalog refresh completed (${result.refreshed} providers)`);
+        }
+      })
+      .catch((error) => logger.warn(`Model catalog refresh failed: ${error}`));
+  }
+
   return {
     async init(options: { allowNetwork?: boolean } = {}) {
       wrapProviders();
       // Restore the persisted overlay before serving reads (no network).
       await refresh({ allowNetwork: false });
       if (options.allowNetwork ?? true) {
-        void refresh()
-          .then((result) => {
-            const errorCount = Object.keys(result.errors).length;
-            if (errorCount > 0) {
-              logger.warn(
-                `Model catalog refresh completed with ${errorCount} provider error(s): ` +
-                  Object.entries(result.errors)
-                    .map(([id, message]) => `${id}: ${message}`)
-                    .join('; ')
-              );
-            } else {
-              logger.debug(`Model catalog refresh completed (${result.refreshed} providers)`);
-            }
-          })
-          .catch((error) => logger.warn(`Model catalog refresh failed: ${error}`));
+        logRefreshOutcome(refresh());
+        // Long-running instances re-check pi.dev on the throttle cadence;
+        // models published after startup would otherwise need a restart.
+        refreshTimer ??= setInterval(
+          () => logRefreshOutcome(refresh()),
+          deps.refreshIntervalMs ?? REMOTE_CATALOG_REFRESH_INTERVAL_MS
+        );
+        refreshTimer.unref?.();
+      }
+    },
+    dispose(): void {
+      if (refreshTimer) {
+        clearInterval(refreshTimer);
+        refreshTimer = undefined;
       }
     },
     refresh,
@@ -380,6 +409,7 @@ export function getModelCatalog(): ModelCatalog {
 }
 
 export function resetModelCatalogForTesting(): void {
+  singleton?.dispose();
   singleton = undefined;
 }
 

--- a/packages/backend/src/services/pi-ai/catalog.ts
+++ b/packages/backend/src/services/pi-ai/catalog.ts
@@ -1,0 +1,409 @@
+/**
+ * Dynamic pi-ai model catalog.
+ *
+ * pi-ai ships a static, compile-time catalog, so historically every newly
+ * released model required a pi-ai version bump. pi.dev serves per-provider
+ * catalog overlays built from the same source, and pi-ai's createProvider()
+ * owns the overlay machinery (baseline+overlay merge, store restore/persist,
+ * inflight dedup). This module supplies the two things pi-ai does not:
+ *
+ *  - fetchPiDevCatalog: the pi.dev protocol client (URL, user agent,
+ *    response parsing, 404/501 handling).
+ *  - scheduling: refresh always restores the persisted overlay first, then
+ *    only hits the network when the stored check is older than 4h (or
+ *    forced). Overlays persist to <db dir>/models-store.json so restarts
+ *    and offline boots keep the last-known catalog.
+ *
+ * After initModelCatalog() runs at startup, getCatalogModel/getCatalogModels
+ * resolve models released between pi-ai versions at runtime. The pi.dev
+ * endpoint is unauthenticated, so refresh calls provider.refreshModels()
+ * directly rather than pi-ai's credential-gated Models.refresh().
+ */
+
+import { mkdir, rename } from 'node:fs/promises';
+import path from 'node:path';
+import { createProvider } from '@earendil-works/pi-ai';
+import { builtinModels } from '@earendil-works/pi-ai/providers/all';
+import type {
+  Api,
+  Model,
+  ModelsStore,
+  ModelsStoreEntry,
+  MutableModels,
+  Provider,
+  ProviderModelsStore,
+  ProviderStreams,
+} from '@earendil-works/pi-ai';
+import { logger } from '../../utils/logger';
+
+const DEFAULT_CATALOG_BASE_URL = 'https://pi.dev';
+const CATALOG_USER_AGENT = 'plexus-gateway';
+
+/** Matches pi's own throttle for configured-provider catalog checks. */
+export const REMOTE_CATALOG_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+/** Providers that manage their own catalog lifecycle (e.g. Radius gateways). */
+const SELF_REFRESHING_PROVIDERS = new Set(['radius']);
+
+// ─── pi.dev protocol client ─────────────────────────────────────────────────
+
+/** pi.dev answers model-ID keyed objects; tolerate array/{models:[]} shapes too. */
+function parseCatalog(providerId: string, value: unknown): Model<Api>[] {
+  const entries = Array.isArray(value)
+    ? value
+    : typeof value === 'object' &&
+        value !== null &&
+        'models' in value &&
+        Array.isArray(value.models)
+      ? value.models
+      : typeof value === 'object' && value !== null
+        ? Object.values(value)
+        : undefined;
+  if (!entries) throw new Error(`Invalid model catalog for provider "${providerId}"`);
+  return entries
+    .filter(
+      (entry): entry is Model<Api> => typeof entry === 'object' && entry !== null && 'id' in entry
+    )
+    .map((model) => ({ ...model, provider: providerId }));
+}
+
+/**
+ * Fetch a provider's catalog overlay from pi.dev. 404/501 means no overlay is
+ * published for the provider — keep whatever the store already holds.
+ */
+async function fetchPiDevCatalog(
+  providerId: string,
+  options: {
+    store: ProviderModelsStore;
+    signal?: AbortSignal;
+    catalogBaseUrl?: string;
+    fetchImpl?: typeof fetch;
+  }
+): Promise<readonly Model<Api>[]> {
+  const catalogBaseUrl = options.catalogBaseUrl ?? DEFAULT_CATALOG_BASE_URL;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const url = new URL(`/api/models/providers/${encodeURIComponent(providerId)}`, catalogBaseUrl);
+  const response = await fetchImpl(url, {
+    headers: { accept: 'application/json', 'User-Agent': CATALOG_USER_AGENT },
+    signal: options.signal,
+  });
+  if (response.status === 404 || response.status === 501) {
+    const stored = await options.store.read();
+    return stored?.models ?? [];
+  }
+  if (!response.ok) {
+    throw new Error(`Model catalog request failed for ${providerId}: ${response.status}`);
+  }
+  return parseCatalog(providerId, await response.json());
+}
+
+/**
+ * Rebuild a static built-in provider through pi-ai's createProvider() with a
+ * pi.dev fetchModels overlay. Streams delegate to the original provider, so
+ * dispatch behaviour is identical to the built-in catalog.
+ */
+export function withRemoteCatalog(
+  provider: Provider,
+  options: { catalogBaseUrl?: string; fetchImpl?: typeof fetch } = {}
+): Provider {
+  const streams: ProviderStreams = {
+    stream: provider.stream as unknown as ProviderStreams['stream'],
+    streamSimple: provider.streamSimple as unknown as ProviderStreams['streamSimple'],
+  };
+  return createProvider({
+    id: provider.id,
+    name: provider.name,
+    baseUrl: provider.baseUrl,
+    headers: provider.headers,
+    auth: provider.auth,
+    models: provider.getModels(),
+    filterModels: provider.filterModels,
+    fetchModels: (context) =>
+      fetchPiDevCatalog(provider.id, { ...options, store: context.store, signal: context.signal }),
+    api: streams,
+  }) as Provider;
+}
+
+// ─── Stores ─────────────────────────────────────────────────────────────────
+
+/** In-memory ModelsStore (fallback when no persistent path is resolvable). */
+export class MemoryModelsStore implements ModelsStore {
+  private readonly entries = new Map<string, ModelsStoreEntry>();
+
+  async read(providerId: string): Promise<ModelsStoreEntry | undefined> {
+    const entry = this.entries.get(providerId);
+    return entry ? structuredClone(entry) : undefined;
+  }
+
+  async write(providerId: string, entry: ModelsStoreEntry): Promise<void> {
+    this.entries.set(providerId, structuredClone(entry));
+  }
+
+  async delete(providerId: string): Promise<void> {
+    this.entries.delete(providerId);
+  }
+}
+
+/**
+ * File-backed ModelsStore: one JSON object keyed by provider ID. Writes are
+ * atomic (tmp + rename) and serialized so concurrent provider refreshes
+ * cannot interleave.
+ */
+export class FileModelsStore implements ModelsStore {
+  private entries: Record<string, ModelsStoreEntry> | undefined;
+  private loading: Promise<Record<string, ModelsStoreEntry>> | undefined;
+  private writing: Promise<void> = Promise.resolve();
+
+  constructor(private readonly filePath: string) {}
+
+  async read(providerId: string): Promise<ModelsStoreEntry | undefined> {
+    const entry = (await this.load())[providerId];
+    return entry ? structuredClone(entry) : undefined;
+  }
+
+  async write(providerId: string, entry: ModelsStoreEntry): Promise<void> {
+    (await this.load())[providerId] = entry;
+    await this.persist();
+  }
+
+  async delete(providerId: string): Promise<void> {
+    delete (await this.load())[providerId];
+    await this.persist();
+  }
+
+  private load(): Promise<Record<string, ModelsStoreEntry>> {
+    this.loading ??= (async () => {
+      try {
+        const file = Bun.file(this.filePath);
+        this.entries = (await file.exists())
+          ? ((await file.json()) as Record<string, ModelsStoreEntry>)
+          : {};
+      } catch (error) {
+        logger.warn(`Model catalog store unreadable, starting empty: ${error}`);
+        this.entries = {};
+      }
+      return this.entries!;
+    })();
+    return this.loading;
+  }
+
+  private persist(): Promise<void> {
+    this.writing = this.writing.then(async () => {
+      await mkdir(path.dirname(this.filePath), { recursive: true });
+      const tmp = `${this.filePath}.tmp`;
+      await Bun.write(tmp, JSON.stringify(this.entries));
+      await rename(tmp, this.filePath);
+    });
+    return this.writing;
+  }
+}
+
+/**
+ * Default store location: models-store.json next to the SQLite database.
+ * Returns undefined for postgres / in-memory databases (caller falls back to
+ * the in-memory store). Path resolution mirrors db/client.ts resolvePath.
+ */
+export function defaultModelsStorePath(
+  databaseUrl: string | undefined = process.env.DATABASE_URL
+): string | undefined {
+  if (!databaseUrl?.startsWith('sqlite://')) return undefined;
+  const connStr = databaseUrl.replace('sqlite://', '');
+  if (
+    connStr === ':memory:' ||
+    connStr === 'memory:' ||
+    connStr === ':memory:/' ||
+    connStr === 'memory:/'
+  ) {
+    return undefined;
+  }
+  const dbPath = path.isAbsolute(connStr)
+    ? connStr
+    : connStr.startsWith('./')
+      ? path.resolve(process.cwd(), connStr)
+      : path.join(path.resolve(process.cwd(), '../../'), connStr);
+  return path.join(path.dirname(dbPath), 'models-store.json');
+}
+
+// ─── Catalog ────────────────────────────────────────────────────────────────
+
+export interface ModelCatalogDeps {
+  models: MutableModels;
+  store: ModelsStore;
+  fetchImpl?: typeof fetch;
+  catalogBaseUrl?: string;
+  now?: () => number;
+}
+
+export interface CatalogRefreshResult {
+  /** Providers whose refreshModels completed (cache restore counts). */
+  refreshed: number;
+  /** Per-provider error messages for failed refreshes. */
+  errors: Record<string, string>;
+}
+
+export interface ModelCatalog {
+  /**
+   * Wrap static providers with the remote overlay and restore the persisted
+   * catalog from the store. When allowNetwork is not false, also kicks off a
+   * background pi.dev refresh (errors are logged, never thrown).
+   */
+  init(options?: { allowNetwork?: boolean }): Promise<void>;
+  /**
+   * Restore every provider's persisted overlay, then fetch stale providers
+   * from pi.dev (throttled to REMOTE_CATALOG_REFRESH_INTERVAL_MS unless
+   * forced).
+   */
+  refresh(options?: {
+    force?: boolean;
+    allowNetwork?: boolean;
+    signal?: AbortSignal;
+  }): Promise<CatalogRefreshResult>;
+  /** Sync read of the merged catalog. Returns null for unknown pairs. */
+  getModel(provider: string, id: string): Model<Api> | null;
+  /** Sync read of the merged catalog, one provider or all. */
+  getModels(provider?: string): readonly Model<Api>[];
+}
+
+export function createModelCatalog(deps: ModelCatalogDeps): ModelCatalog {
+  const { models, store } = deps;
+  const now = deps.now ?? Date.now;
+  let wrapped = false;
+
+  function wrapProviders(): void {
+    if (wrapped) return;
+    wrapped = true;
+    for (const provider of models.getProviders()) {
+      if (SELF_REFRESHING_PROVIDERS.has(provider.id)) continue;
+      if (typeof provider.refreshModels === 'function') continue;
+      if (typeof provider.getModels !== 'function') continue;
+      models.setProvider(withRemoteCatalog(provider, deps));
+    }
+  }
+
+  async function refresh(
+    options: { force?: boolean; allowNetwork?: boolean; signal?: AbortSignal } = {}
+  ): Promise<CatalogRefreshResult> {
+    wrapProviders();
+    const allowNetwork = options.allowNetwork ?? true;
+    const errors: Record<string, string> = {};
+    let refreshed = 0;
+    await Promise.all(
+      models.getProviders().map(async (provider) => {
+        if (typeof provider.refreshModels !== 'function') return;
+        const scoped: ProviderModelsStore = {
+          read: () => store.read(provider.id),
+          write: (entry) => store.write(provider.id, entry),
+          delete: () => store.delete(provider.id),
+        };
+        try {
+          // Always restore the persisted overlay first.
+          await provider.refreshModels({
+            store: scoped,
+            allowNetwork: false,
+            signal: options.signal,
+          });
+          if (allowNetwork && !options.signal?.aborted) {
+            const stored = await store.read(provider.id);
+            const stale =
+              options.force === true ||
+              stored?.checkedAt === undefined ||
+              now() - stored.checkedAt >= REMOTE_CATALOG_REFRESH_INTERVAL_MS;
+            if (stale) {
+              await provider.refreshModels({
+                store: scoped,
+                allowNetwork: true,
+                force: options.force,
+                signal: options.signal,
+              });
+            }
+          }
+          refreshed++;
+        } catch (error) {
+          errors[provider.id] = error instanceof Error ? error.message : String(error);
+        }
+      })
+    );
+    return { refreshed, errors };
+  }
+
+  return {
+    async init(options: { allowNetwork?: boolean } = {}) {
+      wrapProviders();
+      // Restore the persisted overlay before serving reads (no network).
+      await refresh({ allowNetwork: false });
+      if (options.allowNetwork ?? true) {
+        void refresh()
+          .then((result) => {
+            const errorCount = Object.keys(result.errors).length;
+            if (errorCount > 0) {
+              logger.warn(
+                `Model catalog refresh completed with ${errorCount} provider error(s): ` +
+                  Object.entries(result.errors)
+                    .map(([id, message]) => `${id}: ${message}`)
+                    .join('; ')
+              );
+            } else {
+              logger.debug(`Model catalog refresh completed (${result.refreshed} providers)`);
+            }
+          })
+          .catch((error) => logger.warn(`Model catalog refresh failed: ${error}`));
+      }
+    },
+    refresh,
+    getModel(provider: string, id: string): Model<Api> | null {
+      try {
+        return models.getModel(provider, id) ?? null;
+      } catch {
+        return null;
+      }
+    },
+    getModels(provider?: string): readonly Model<Api>[] {
+      try {
+        return models.getModels(provider);
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+// ─── Singleton + module-level API ───────────────────────────────────────────
+
+let singleton: ModelCatalog | undefined;
+
+export function getModelCatalog(): ModelCatalog {
+  singleton ??= createModelCatalog({
+    models: builtinModels(),
+    store: createDefaultStore(),
+  });
+  return singleton;
+}
+
+export function resetModelCatalogForTesting(): void {
+  singleton = undefined;
+}
+
+function createDefaultStore(): ModelsStore {
+  const storePath = defaultModelsStorePath();
+  return storePath ? new FileModelsStore(storePath) : new MemoryModelsStore();
+}
+
+/** Catalog-aware replacement for pi-ai's static getBuiltinModel. */
+export function getCatalogModel(provider: string, modelId: string): Model<Api> | null {
+  return getModelCatalog().getModel(provider, modelId);
+}
+
+/** Catalog-aware replacement for pi-ai's static getBuiltinModels. */
+export function getCatalogModels(provider?: string): readonly Model<Api>[] {
+  return getModelCatalog().getModels(provider);
+}
+
+/**
+ * Startup hook: restore the persisted overlay, then refresh from pi.dev in
+ * the background. Set PLEXUS_MODEL_CATALOG_REFRESH=false to disable the
+ * network refresh (the persisted overlay still loads).
+ */
+export async function initModelCatalog(options: { allowNetwork?: boolean } = {}): Promise<void> {
+  const allowNetwork = options.allowNetwork ?? process.env.PLEXUS_MODEL_CATALOG_REFRESH !== 'false';
+  await getModelCatalog().init({ allowNetwork });
+}

--- a/packages/backend/src/services/pi-ai/catalog.ts
+++ b/packages/backend/src/services/pi-ai/catalog.ts
@@ -286,6 +286,10 @@ export function createModelCatalog(deps: ModelCatalogDeps): ModelCatalog {
     wrapped = true;
     for (const provider of models.getProviders()) {
       if (SELF_REFRESHING_PROVIDERS.has(provider.id)) continue;
+      // createProvider() only exposes refreshModels when the provider was
+      // built with its own fetchModels — i.e. it already has a dynamic
+      // catalog source. Wrapping it would silently replace its native
+      // refresh with ours, so leave already-dynamic providers alone.
       if (typeof provider.refreshModels === 'function') continue;
       if (typeof provider.getModels !== 'function') continue;
       models.setProvider(withRemoteCatalog(provider, deps));

--- a/packages/backend/src/services/pi-ai/catalog.ts
+++ b/packages/backend/src/services/pi-ai/catalog.ts
@@ -305,6 +305,9 @@ export function createModelCatalog(deps: ModelCatalogDeps): ModelCatalog {
     let refreshed = 0;
     await Promise.all(
       models.getProviders().map(async (provider) => {
+        // Self-refreshing providers manage their own catalog lifecycle
+        // (own store, own cadence) — don't drive their refresh here.
+        if (SELF_REFRESHING_PROVIDERS.has(provider.id)) return;
         if (typeof provider.refreshModels !== 'function') return;
         const scoped: ProviderModelsStore = {
           read: () => store.read(provider.id),

--- a/packages/backend/src/services/pi-ai/registry.ts
+++ b/packages/backend/src/services/pi-ai/registry.ts
@@ -7,16 +7,15 @@
  *    base-URL stripping rules, keyed off the upstream pi-ai API.
  *  - buildReasoningOptionsForModel / buildGenerationOptions: capability-aware
  *    egress reasoning + generation options from the pi-ai Model record.
- *  - resolvePiAiModel: resolve a builtin pi-ai Model for a (provider, model) pair.
+ *  - resolvePiAiModel: resolve a pi-ai Model for a (provider, model) pair.
  *  - isPlaceholderThinkingSignature: guard against pi-ai's field-name placeholder
  *    thinking signatures.
  */
 
 import { clampThinkingLevel, getSupportedThinkingLevels } from '@earendil-works/pi-ai';
-import { getBuiltinModel, builtinModels } from '@earendil-works/pi-ai/providers/all';
 import type { Model as PiAiModel, ModelThinkingLevel } from '@earendil-works/pi-ai';
 
-export const piAiModels = builtinModels();
+import { getCatalogModel } from './catalog';
 
 import type { RouteResult } from '../routing/router';
 import type { ReasoningEffort, ReasoningIntent } from './reasoning';
@@ -329,23 +328,11 @@ function isOpenAiFamily(api: string | undefined): boolean {
 }
 
 /**
- * getModel may return undefined (pi-ai 0.79.x) or throw (older versions /
- * mocked) for unknown pairs — normalise both to null.
- */
-function safeGetModel(provider: string, modelId: string): PiAiModel<any> | null {
-  try {
-    return getBuiltinModel(provider as any, modelId as any) ?? null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Resolve a builtin pi-ai Model for a (provider, modelId) pair.
- * Returns null when unresolved.
+ * Resolve a pi-ai Model for a (provider, modelId) pair from the dynamic
+ * catalog (built-in baseline + pi.dev overlay). Returns null when unresolved.
  */
 export function resolvePiAiModel(piAiProvider: string, piAiModelId: string): PiAiModel<any> | null {
-  return safeGetModel(piAiProvider, piAiModelId);
+  return getCatalogModel(piAiProvider, piAiModelId);
 }
 
 // ─── Thinking signature validation ───────────────────────────────────────────

--- a/packages/backend/src/services/providers/provider-model-discovery.ts
+++ b/packages/backend/src/services/providers/provider-model-discovery.ts
@@ -1,4 +1,4 @@
-import { getBuiltinModels } from '@earendil-works/pi-ai/providers/all';
+import { getCatalogModels } from '../pi-ai/catalog';
 import { getProviderTypes, type ProviderConfig } from '../../config';
 import { logger } from '../../utils/logger';
 
@@ -119,7 +119,7 @@ export async function fetchModelsFromUrl(
 }
 
 export function getOAuthProviderModels(providerId: string): DiscoveredModel[] {
-  return getBuiltinModels(providerId as any).map((model) => ({
+  return getCatalogModels(providerId).map((model) => ({
     id: model.id,
     name: model.name,
     context_length: model.contextWindow,

--- a/packages/backend/src/services/quota/checkers/claude-code-checker.ts
+++ b/packages/backend/src/services/quota/checkers/claude-code-checker.ts
@@ -1,7 +1,7 @@
 import { defineChecker } from '../checker-registry';
 import { z } from 'zod';
 import { OAuthAuthManager } from '../../oauth/oauth-auth-manager';
-import type { OAuthProvider } from '@earendil-works/pi-ai/oauth';
+import type { OAuthProvider } from '../../oauth/oauth-providers';
 import { logger } from '../../../utils/logger';
 
 interface UsageWindow {

--- a/packages/backend/src/services/quota/checkers/copilot-checker.ts
+++ b/packages/backend/src/services/quota/checkers/copilot-checker.ts
@@ -1,7 +1,7 @@
 import { defineChecker } from '../checker-registry';
 import { z } from 'zod';
 import { OAuthAuthManager } from '../../oauth/oauth-auth-manager';
-import type { OAuthProvider } from '@earendil-works/pi-ai/oauth';
+import type { OAuthProvider } from '../../oauth/oauth-providers';
 import { logger } from '../../../utils/logger';
 
 interface CopilotUsageResponse {

--- a/packages/backend/src/services/quota/checkers/openai-codex-checker.ts
+++ b/packages/backend/src/services/quota/checkers/openai-codex-checker.ts
@@ -2,7 +2,7 @@ import { defineChecker } from '../checker-registry';
 import { z } from 'zod';
 import { OAuthAuthManager } from '../../oauth/oauth-auth-manager';
 import { CodexVersionService } from '../../oauth/codex-version-service';
-import type { OAuthProvider } from '@earendil-works/pi-ai/oauth';
+import type { OAuthProvider } from '../../oauth/oauth-providers';
 import { logger } from '../../../utils/logger';
 import type { Meter } from '../../../types/meter';
 import type { MeterContext } from '../checker-registry';

--- a/packages/backend/test/vitest.setup.ts
+++ b/packages/backend/test/vitest.setup.ts
@@ -209,13 +209,20 @@ const mockGetProviders = () => ['anthropic', 'openai-codex', 'openai', 'google']
 //     dispatches on model.api and crashes with \"No API provider registered\"
 //     if it is missing.
 // ---------------------------------------------------------------------------
-vi.mock('@earendil-works/pi-ai', () => ({
-  complete: mockModels.complete,
-  stream: mockModels.stream,
-  calculateCost: vi.fn(() => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 })),
-  clampThinkingLevel: (_m: any, l: string) => l,
-  getSupportedThinkingLevels: () => ['off', 'low', 'medium', 'high'],
-}));
+vi.mock('@earendil-works/pi-ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@earendil-works/pi-ai')>();
+  return {
+    complete: mockModels.complete,
+    stream: mockModels.stream,
+    calculateCost: vi.fn(() => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 })),
+    clampThinkingLevel: (_m: any, l: string) => l,
+    getSupportedThinkingLevels: () => ['off', 'low', 'medium', 'high'],
+    // The model catalog overlay delegates merge/restore/persist to pi-ai's
+    // real createProvider — keep it real so catalog tests exercise genuine
+    // library semantics.
+    createProvider: actual.createProvider,
+  };
+});
 
 vi.mock('@earendil-works/pi-ai/providers/all', () => ({
   builtinModels: () => mockModels,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -23,7 +23,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@earendil-works/pi-ai": "0.80.7",
+    "@earendil-works/pi-ai": "0.80.9",
     "@monaco-editor/react": "4.7.0",
     "@plexus/shared": "workspace:*",
     "@types/human-format": "^1.0.3",


### PR DESCRIPTION
## Summary

Plexus now refreshes its pi-ai model catalog from pi.dev at runtime, so models released between pi-ai versions (new Claude/GPT/Gemini drops on existing APIs) resolve without a dependency bump — including their reasoning levels, compat flags, costs, and context windows. Adopting the overlay machinery required migrating to pi-ai 0.80.9, which removed the `pi-ai/oauth` registry this project's login flow was built on; that migration is included here.

## Why / Context

pi-ai ships a static, compile-time model catalog, so every newly released model previously required a pi-ai version bump for Plexus to recognize it. pi v0.80.8 added dynamic-catalog infrastructure (`createProvider({ fetchModels })`, `ModelsStore`) and pi.dev began serving per-provider catalog overlays built from the same source. The actual pi.dev fetcher lives in pi's coding-agent package (not exported), so Plexus supplies its own thin protocol client while delegating all merge/persist/dedup semantics to the library.

## Changes

- **Model catalog** (`services/pi-ai/catalog.ts`): built-in providers are rebuilt through pi-ai's real `createProvider()` with a pi.dev `fetchModels` overlay — the library owns baseline+overlay merge, store restore/persist, and inflight dedup. Ours is only the pi.dev protocol client (URL, UA, parsing, 404/501 handling) plus scheduling: startup restores the persisted overlay offline, then refreshes in the background, throttled to 4h. Overlays persist to `<db dir>/models-store.json`; `PLEXUS_MODEL_CATALOG_REFRESH=false` disables the network call.
- **Catalog read-paths**: all static `getBuiltinModel(s)` call sites (dispatch registry, config startup validation, `/v1/models`, management model routes, OAuth provider discovery, native OAuth dispatch) now read the merged catalog.
- **OAuth migration to pi-ai 0.80.9**: new `services/oauth/oauth-providers.ts` facade over `provider.auth.oauth`; login sessions speak `AuthInteraction` natively (notify → authInfo/progress, prompt → session prompt/manual-code deferreds) with the session wire format unchanged; token refresh uses `oauth.refresh()`/`toAuth()` instead of the removed `getOAuthApiKey` helper; `OAuthProvider` types are now owned by Plexus.
- **Two login UI fixes**: manual-code prompts no longer render a duplicate dead input (the UI draws both a prompt input and a dedicated redirect-URL input when both are set), and blank prompt submission stays enabled (`allowEmpty`) so Copilot's blank-for-github.com GHE domain works.
- **Tests**: new catalog suite exercises genuine pi-ai `createProvider` semantics (the global mock re-exports the real implementation) with hand-rolled provider/store/fetch fakes; OAuth route-test doubles updated to the new `OAuthAuth` shape; assertions added for prompt vs manual-code session shapes.

## Testing

- Live smoke test against real pi.dev: 36 providers refreshed with 0 errors; overlay models resolve with full `thinkingLevelMap`/`compat`/`cost`; offline restore from the persisted store verified; wrapped providers report correct stream APIs.
- Live UI verification on the dev stack: Anthropic "Restart OAuth" renders exactly one redirect-URL input; GitHub Copilot starts with Submit enabled on an empty GHE domain and a blank submit advances to the github.com device-code step. Codex login verified manually by the reporter.
- 2172 backend tests / 214 files pass; typecheck clean across all packages.

## Notes / Follow-ups

- pi.dev's catalog currently mirrors the 0.80.9 static catalog — the payoff is models released between pi versions going forward, and it depends on pi.dev being maintained.
- Catalog refresh covers "new model on an existing API". New API types or stream-parsing quirks still require a pi-ai bump, but the OAuth registry removal (the blocker for any bump) is now resolved.
- `listOAuthProviders()` now also surfaces pi-ai's newer `xai`/`radius` OAuth entries; the config schema still restricts actual OAuth provider configs to the three supported providers (anthropic, openai-codex, github-copilot).
