### PR TITLE
fix(dispatch): auto-strip unsupported tool_search_tool_* on openrouter

### DIFF
--- a/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
+++ b/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
@@ -26,6 +26,46 @@ describe('resolveAdapters', () => {
     expect(resolveAdapters(route)).toHaveLength(0);
   });
 
+  it('auto-injects the tool-search strip adapter when pi_ai_provider is openrouter', () => {
+    const route: RouteResult = {
+      ...makeRoute(undefined, undefined),
+      config: {
+        ...makeRoute().config,
+        pi_ai_provider: 'openrouter',
+      },
+    };
+    const resolved = resolveAdapters(route);
+    expect(resolved.map((r) => r.adapter.name)).toEqual(['strip_unsupported_tool_search']);
+  });
+
+  it('does not auto-inject anything for non-openrouter pi_ai_provider', () => {
+    const route: RouteResult = {
+      ...makeRoute(undefined, undefined),
+      config: {
+        ...makeRoute().config,
+        pi_ai_provider: 'anthropic',
+      },
+    };
+    expect(resolveAdapters(route)).toHaveLength(0);
+  });
+
+  it('does not auto-inject anything when pi_ai_provider is unset', () => {
+    expect(resolveAdapters(makeRoute(undefined, undefined))).toHaveLength(0);
+  });
+
+  it('runs the implicit adapter before user-configured adapters', () => {
+    const base = makeRoute([{ name: 'reasoning_content', options: {} }]);
+    const route: RouteResult = {
+      ...base,
+      config: { ...base.config, pi_ai_provider: 'openrouter' },
+    };
+    const resolved = resolveAdapters(route);
+    expect(resolved.map((r) => r.adapter.name)).toEqual([
+      'strip_unsupported_tool_search',
+      'reasoning_content',
+    ]);
+  });
+
   it('resolves a provider-level adapter entry', () => {
     const route = makeRoute([{ name: 'reasoning_content', options: {} }]);
     const resolved = resolveAdapters(route);

--- a/packages/backend/src/services/dispatch/adapter-resolver.ts
+++ b/packages/backend/src/services/dispatch/adapter-resolver.ts
@@ -2,14 +2,19 @@ import type { ProviderAdapter, ResolvedAdapter } from '../../types/provider-adap
 import type { RouteResult } from '../routing/router';
 import type { AdapterEntry } from '../../config';
 import { ADAPTER_REGISTRY } from '../../transformers/adapters/index';
+import { stripUnsupportedToolSearchAdapter } from '../../transformers/adapters/strip-unsupported-tool-search.adapter';
 import { logger } from '../../utils/logger';
 
 /**
  * Resolves the ordered list of ProviderAdapters for a given route.
  *
  * Resolution order:
- *   1. Provider-level `adapter` (applies to all models under the provider)
- *   2. Model-level `adapter`   (appended after provider-level adapters)
+ *   1. Implicit adapters automatically injected for the route's target
+ *      provider (currently: tool-search stripping for `pi_ai_provider ===
+ *      'openrouter'`). These run first so user-configured adapters see the
+ *      cleaned-up payload if they inspect it.
+ *   2. Provider-level `adapter` (applies to all models under the provider)
+ *   3. Model-level `adapter`   (appended after provider-level adapters)
  *
  * Each entry is an { name, options } object. Unknown adapter names are logged
  * as warnings and skipped (rather than throwing) so that a misconfigured
@@ -19,6 +24,7 @@ import { logger } from '../../utils/logger';
  */
 export function resolveAdapters(route: RouteResult): ResolvedAdapter[] {
   const entries: AdapterEntry[] = [
+    ...resolveImplicitAdapters(route),
     ...(route.config.adapter ?? []),
     ...(route.modelConfig?.adapter ?? []),
   ];
@@ -39,4 +45,26 @@ export function resolveAdapters(route: RouteResult): ResolvedAdapter[] {
   }
 
   return resolved;
+}
+
+/**
+ * Adapters automatically injected for a route based on its target pi-ai
+ * provider, independent of user-configured adapters.
+ *
+ * Today this fires for `pi_ai_provider === 'openrouter'`, because OpenRouter's
+ * Anthropic-compat /v1/messages endpoint only accepts a small subset of
+ * Anthropic server-tool shorthands and rejects the rest with HTTP 400
+ * "Unknown server-tool shorthand". We strip the unsupported ones (currently
+ * `tool_search_tool_*`) so that messages<>messages pass-through and the
+ * transformer-driven dispatch both end up with a body OpenRouter will accept.
+ *
+ * Implicit adapters go through the same registry path as user-configured
+ * adapters, so an unresolved name here would fail loudly rather than
+ * silently no-op.
+ */
+function resolveImplicitAdapters(route: RouteResult): AdapterEntry[] {
+  if (route.config.pi_ai_provider === 'openrouter') {
+    return [{ name: stripUnsupportedToolSearchAdapter.name, options: {} }];
+  }
+  return [];
 }

--- a/packages/backend/src/transformers/adapters/__tests__/strip-unsupported-tool-search.adapter.test.ts
+++ b/packages/backend/src/transformers/adapters/__tests__/strip-unsupported-tool-search.adapter.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+  stripUnsupportedToolSearchAdapter,
+  isToolSearchShorthand,
+} from '../strip-unsupported-tool-search.adapter';
+
+// ── isToolSearchShorthand ──────────────────────────────────────────────────
+
+describe('isToolSearchShorthand', () => {
+  it('recognises tool_search_tool_bm25_20251119', () => {
+    expect(
+      isToolSearchShorthand({
+        type: 'tool_search_tool_bm25_20251119',
+        name: 'tool_search_tool_bm25',
+      })
+    ).toBe(true);
+  });
+
+  it('recognises tool_search_tool_regex_20251119', () => {
+    expect(
+      isToolSearchShorthand({
+        type: 'tool_search_tool_regex_20251119',
+        name: 'tool_search_tool_regex',
+      })
+    ).toBe(true);
+  });
+
+  it('is case-insensitive on the type prefix', () => {
+    expect(
+      isToolSearchShorthand({
+        type: 'Tool_Search_Tool_BM25_20251119',
+        name: 'tool_search_tool_bm25',
+      })
+    ).toBe(true);
+  });
+
+  it('returns false for the Anthropic web_search shorthand', () => {
+    expect(isToolSearchShorthand({ type: 'web_search_20250305' })).toBe(false);
+  });
+
+  it('returns false for ordinary function tools', () => {
+    expect(
+      isToolSearchShorthand({
+        type: 'function',
+        function: { name: 'get_weather' },
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isToolSearchShorthand(null)).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(isToolSearchShorthand('tool_search_tool_bm25_20251119')).toBe(false);
+    expect(isToolSearchShorthand(42)).toBe(false);
+  });
+
+  it('returns false when type is missing', () => {
+    expect(isToolSearchShorthand({ name: 'tool_search_tool_bm25' })).toBe(false);
+  });
+
+  it('returns false when type is not a string', () => {
+    expect(isToolSearchShorthand({ type: 123 })).toBe(false);
+  });
+
+  it('does not match substrings inside other tool types', () => {
+    expect(isToolSearchShorthand({ type: 'tool_search' })).toBe(false);
+    expect(isToolSearchShorthand({ type: 'something_tool_search_tool_' })).toBe(false);
+  });
+});
+
+// ── stripUnsupportedToolSearchAdapter.preDispatch ──────────────────────────
+
+describe('stripUnsupportedToolSearchAdapter.preDispatch', () => {
+  it('returns payload unchanged when tools is missing', () => {
+    const payload = { model: 'anthropic/claude-sonnet-5' };
+    expect(stripUnsupportedToolSearchAdapter.preDispatch(payload)).toBe(payload);
+  });
+
+  it('returns payload unchanged when tools is empty', () => {
+    const payload = { model: 'anthropic/claude-sonnet-5', tools: [] };
+    expect(stripUnsupportedToolSearchAdapter.preDispatch(payload)).toBe(payload);
+  });
+
+  it('returns payload unchanged when no tool_search_tool_* entries are present', () => {
+    const calculator = {
+      type: 'function',
+      function: { name: 'calculator', parameters: {} },
+    };
+    const payload = {
+      model: 'anthropic/claude-sonnet-5',
+      tools: [calculator, { type: 'web_search_20250305', name: 'web_search' }],
+    };
+    expect(stripUnsupportedToolSearchAdapter.preDispatch(payload)).toBe(payload);
+  });
+
+  it('strips a single tool_search_tool_bm25_20251119 entry', () => {
+    const searchTool = {
+      type: 'tool_search_tool_bm25_20251119',
+      name: 'tool_search_tool_bm25',
+    };
+    const listFiles = {
+      name: 'list_files',
+      description: 'list files',
+      input_schema: { type: 'object', properties: {} },
+    };
+    const payload = {
+      model: 'anthropic/claude-sonnet-5',
+      tools: [searchTool, listFiles],
+    };
+    const result = stripUnsupportedToolSearchAdapter.preDispatch(payload);
+    expect(result.tools).toEqual([listFiles]);
+    expect(result.model).toBe(payload.model);
+  });
+
+  it('strips a single tool_search_tool_regex_20251119 entry', () => {
+    const searchTool = {
+      type: 'tool_search_tool_regex_20251119',
+      name: 'tool_search_tool_regex',
+    };
+    const payload = {
+      model: 'anthropic/claude-sonnet-5',
+      tools: [searchTool, { name: 'read_file' }],
+    };
+    const result = stripUnsupportedToolSearchAdapter.preDispatch(payload);
+    expect(result.tools).toEqual([{ name: 'read_file' }]);
+  });
+
+  it('strips both bm25 and regex variants in one pass', () => {
+    const payload = {
+      model: 'anthropic/claude-sonnet-5',
+      tools: [
+        { type: 'tool_search_tool_bm25_20251119', name: 'tool_search_tool_bm25' },
+        { name: 'list_files' },
+        { type: 'tool_search_tool_regex_20251119', name: 'tool_search_tool_regex' },
+      ],
+    };
+    const result = stripUnsupportedToolSearchAdapter.preDispatch(payload);
+    expect(result.tools).toEqual([{ name: 'list_files' }]);
+  });
+
+  it('returns an empty tools array when every entry is a tool_search_tool_*', () => {
+    const payload = {
+      model: 'anthropic/claude-sonnet-5',
+      tools: [
+        { type: 'tool_search_tool_bm25_20251119', name: 'tool_search_tool_bm25' },
+        { type: 'tool_search_tool_regex_20251119', name: 'tool_search_tool_regex' },
+      ],
+    };
+    const result = stripUnsupportedToolSearchAdapter.preDispatch(payload);
+    expect(result.tools).toEqual([]);
+  });
+
+  it('preserves web_search_20250305 and other server-tool shorthands', () => {
+    const payload = {
+      model: 'anthropic/claude-sonnet-5',
+      tools: [
+        { type: 'web_search_20250305', name: 'web_search' },
+        { type: 'tool_search_tool_bm25_20251119', name: 'tool_search_tool_bm25' },
+      ],
+    };
+    const result = stripUnsupportedToolSearchAdapter.preDispatch(payload);
+    expect(result.tools).toEqual([{ type: 'web_search_20250305', name: 'web_search' }]);
+  });
+
+  it('does not mutate the original payload', () => {
+    const searchTool = {
+      type: 'tool_search_tool_bm25_20251119',
+      name: 'tool_search_tool_bm25',
+    };
+    const original = {
+      model: 'anthropic/claude-sonnet-5',
+      tools: [searchTool, { name: 'list_files' }],
+    };
+    const copy = JSON.parse(JSON.stringify(original));
+    stripUnsupportedToolSearchAdapter.preDispatch(original);
+    expect(original).toEqual(copy);
+  });
+});
+
+// ── postDispatch ───────────────────────────────────────────────────────────
+
+describe('stripUnsupportedToolSearchAdapter.postDispatch', () => {
+  it('returns the response unchanged', () => {
+    const response = { id: 'msg_1', content: [] };
+    expect(stripUnsupportedToolSearchAdapter.postDispatch(response)).toBe(response);
+  });
+});

--- a/packages/backend/src/transformers/adapters/index.ts
+++ b/packages/backend/src/transformers/adapters/index.ts
@@ -4,6 +4,7 @@ import { suppressDeveloperRoleAdapter } from './suppress-developer-role.adapter'
 import { modelOverrideAdapter } from './model-override.adapter';
 import { reasoningRewriteAdapter } from './reasoning-rewrite.adapter';
 import { webSearchCoercionAdapter } from './web-search-coercion.adapter';
+import { stripUnsupportedToolSearchAdapter } from './strip-unsupported-tool-search.adapter';
 
 /**
  * Registry of all built-in provider adapters.
@@ -15,4 +16,5 @@ export const ADAPTER_REGISTRY: Record<string, ProviderAdapter> = {
   [modelOverrideAdapter.name]: modelOverrideAdapter,
   [reasoningRewriteAdapter.name]: reasoningRewriteAdapter,
   [webSearchCoercionAdapter.name]: webSearchCoercionAdapter,
+  [stripUnsupportedToolSearchAdapter.name]: stripUnsupportedToolSearchAdapter,
 };

--- a/packages/backend/src/transformers/adapters/strip-unsupported-tool-search.adapter.ts
+++ b/packages/backend/src/transformers/adapters/strip-unsupported-tool-search.adapter.ts
@@ -1,0 +1,76 @@
+import type { ProviderAdapter } from '../../types/provider-adapter';
+
+/**
+ * strip_unsupported_tool_search adapter
+ *
+ * Strips Anthropic advanced-tool-use `tool_search_tool_*` shorthand entries
+ * from `payload.tools` so that wire protocols that don't understand them
+ * don't reject the request.
+ *
+ * Why this exists:
+ *
+ * When the incoming API type and the target API type match (e.g. a client
+ * sends an Anthropic /v1/messages body and the chosen target's wire API is
+ * also Anthropic /v1/messages), the dispatcher takes a pass-through shortcut
+ * that forwards the original request body untouched (`shouldUsePassThrough`).
+ * This is the correct behaviour for upstream providers that speak real
+ * Anthropic (Anthropic direct, Vertex, Bedrock-native), but OpenRouter's
+ * /v1/messages compatibility layer only recognises a small subset of
+ * Anthropic server-tool shorthands — `web_search_20250305` and a couple of
+ * others — and rejects the newer advanced-tool-use shorthands
+ * (`tool_search_tool_bm25_20251119`, `tool_search_tool_regex_20251119`)
+ * with HTTP 400 "Unknown server-tool shorthand".
+ *
+ * This adapter is auto-injected by `adapter-resolver.ts` for any route whose
+ * `pi_ai_provider === 'openrouter'`, so it fires on both pass-through and
+ * transformer-driven dispatch paths without any user-visible config.
+ *
+ * Outbound (preDispatch):
+ *   - Drops any tool entry whose `type` starts with `tool_search_tool_`
+ *     (case-insensitive). All other tools — including ordinary function
+ *     tools and other server-side tools — are left untouched.
+ *   - If nothing is dropped, the payload reference is returned unchanged so
+ *     callers can cheaply detect "no work done".
+ *   - If everything in `tools` is dropped, the empty array is still emitted
+ *     so the request body shape is preserved (the upstream provider simply
+ *     sees no tools).
+ *
+ * Inbound (postDispatch) and stream hooks: no-op — the response shape is
+ * not affected by which tools were declared.
+ */
+export const stripUnsupportedToolSearchAdapter: ProviderAdapter = {
+  name: 'strip_unsupported_tool_search',
+
+  preDispatch(payload: Record<string, any>): Record<string, any> {
+    if (!Array.isArray(payload.tools) || payload.tools.length === 0) return payload;
+
+    const filtered = payload.tools.filter((tool: any) => !isToolSearchShorthand(tool));
+    if (filtered.length === payload.tools.length) return payload;
+
+    return { ...payload, tools: filtered };
+  },
+
+  postDispatch(response: Record<string, any>): Record<string, any> {
+    return response;
+  },
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when a tool entry is an Anthropic tool-search shorthand that
+ * only the real Anthropic / Vertex / Bedrock wire protocols understand.
+ *
+ * Anthropic advanced-tool-use server tools are declared with a `type` field
+ * like `tool_search_tool_bm25_20251119` or `tool_search_tool_regex_20251119`
+ * and carry a `name` matching the user-facing tool name. The `tool_search_tool_`
+ * prefix is the discriminator; matching it covers the current bm25/regex
+ * variants and any future `tool_search_tool_*` shorthand Anthropic ships
+ * under the same advanced-tool-use umbrella.
+ */
+export function isToolSearchShorthand(tool: any): boolean {
+  if (!tool || typeof tool !== 'object') return false;
+  const type = tool.type;
+  if (typeof type !== 'string') return false;
+  return type.toLowerCase().startsWith('tool_search_tool_');
+}


### PR DESCRIPTION
## Summary
Add a new `strip_unsupported_tool_search` ProviderAdapter that drops Anthropic advanced-tool-use `tool_search_tool_*` entries from outbound request bodies, and auto-inject it for any route whose `pi_ai_provider` is `openrouter`. This stops the messages<>messages pass-through (and transformer-driven dispatch) from sending tool shorthands OpenRouter's `/v1/messages` Anthropic-compat endpoint rejects with HTTP 400 `Unknown server-tool shorthand`.

## Why / Context
OpenRouter only accepts a small subset of Anthropic server-tool shorthands (`web_search_20250305` plus a couple of others) on `/v1/messages`. The newer `tool_search_tool_bm25_20251119` and `tool_search_tool_regex_20251119` shorthands from Anthropic's advanced-tool-use beta are rejected with a 400 even though they're valid on the real Anthropic / Vertex / Bedrock wire protocols. Because Plexus takes a pass-through shortcut when the incoming and outgoing API types match, the unsupported tool entries were forwarded to OpenRouter verbatim and the request failed before reaching Claude.

Investigation of debug trace `3851fd36-9f22-4a98-a923-75f79a8d0b55` (matched error `d7e1a758-0829-4b7c-b42e-d61ca1caf604`) confirmed OpenRouter rejects the unmodified body even when sent directly with the OpenRouter API key — so the fix has to happen on the Plexus side, and it must run after the pass-through decision so both code paths (messages→messages passthrough and the transformer fallback) get the cleaned body.

## Changes
- **`packages/backend/src/transformers/adapters/strip-unsupported-tool-search.adapter.ts`** — new `strip_unsupported_tool_search` adapter. `preDispatch` filters `payload.tools` to remove entries whose `type` (case-insensitive) starts with `tool_search_tool_`; returns the payload reference unchanged when nothing is dropped, and an empty `tools` array when every entry is a tool-search shorthand. `postDispatch` and the stream hooks are no-ops.
- **`packages/backend/src/transformers/adapters/index.ts`** — register the new adapter in `ADAPTER_REGISTRY` so it's discoverable by name.
- **`packages/backend/src/services/dispatch/adapter-resolver.ts`** — auto-inject the strip adapter via a new `resolveImplicitAdapters(route)` helper when `route.config.pi_ai_provider === 'openrouter'`. Implicit adapters run before user-configured provider/model adapters so any downstream adapter that inspects `payload.tools` sees the cleaned body.
- **`packages/backend/src/__tests__/adapters/adapter-resolver.test.ts`** — add four new resolver cases covering auto-injection on `openrouter`, no-op for other `pi_ai_provider` values, no-op when unset, and ordering of implicit-then-user-configured adapters.
- **`packages/backend/src/transformers/adapters/__tests__/strip-unsupported-tool-search.adapter.test.ts`** — new adapter unit tests covering both variants of `tool_search_tool_*`, preservation of `web_search_20250305` and other server-tool shorthands, empty-tools-after-strip, payload immutability, and the helpers `isToolSearchShorthand`.

## Testing
- `bun run test` — 33 files / 232 tests passing, including the 4 new resolver cases and 19 new adapter cases.
- `bun run typecheck` — passes across all workspaces.
- `bun run format:check` — clean for the touched files (the pre-existing `raw-passthrough.test.ts` formatting nit is unrelated to this branch and is on `main`).
- Pre-commit gates (biome format/lint, typecheck, backend-tests) all green via lefthook.

## Notes / Follow-ups
- The strip is intentionally conservative: it only fires when `pi_ai_provider === 'openrouter'`. Anthropic / Vertex / Bedrock-native routes continue to forward tool-search shorthands unchanged, so users who happen to send those tools to native Anthropic keep the full feature.
- If OpenRouter later adds tool-search support, the auto-injection becomes a no-op (the strip adapter short-circuits when no `tool_search_tool_*` entry is present).
- The adapter name `strip_unsupported_tool_search` is exposed via `ADAPTER_REGISTRY` so it can also be referenced explicitly in a provider or model `adapter:` config if a user needs to opt in for another pi_ai provider in the future.
