### PR TITLE
fix(dispatch): aggregate Codex SSE for non-stream clients

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-codex-native.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-codex-native.test.ts
@@ -30,6 +30,21 @@ const UPSTREAM_SSE = [
   '',
 ].join('\n');
 
+// The real Codex backend can leave response.completed.response.output empty;
+// the completed output item is carried by response.output_item.done instead.
+const UPSTREAM_SSE_EMPTY_COMPLETION_OUTPUT = [
+  'event: response.created',
+  'data: {"type":"response.created","response":{"id":"resp_abc","object":"response","status":"in_progress","model":"gpt-5-codex","output":[]}}',
+  '',
+  'event: response.output_item.done',
+  'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_abc","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"NATIVE"}]}}',
+  '',
+  'event: response.completed',
+  'data: {"type":"response.completed","response":{"id":"resp_abc","object":"response","status":"completed","model":"gpt-5-codex","output":[],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}',
+  '',
+  '',
+].join('\n');
+
 // A fake Codex OAuth token: JWT whose payload carries the chatgpt_account_id
 // claim the wire header is derived from.
 const ACCOUNT_ID = 'acc_test_12345';
@@ -153,6 +168,21 @@ function chatRequest(): UnifiedChatRequest {
     model: 'codex-alias',
     messages: body.messages,
     stream: true,
+    incomingApiType: 'chat',
+    originalBody: body,
+  } as any;
+}
+
+function nonStreamingChatRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'codex-alias',
+    stream: false,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'codex-alias',
+    messages: body.messages,
+    stream: false,
     incomingApiType: 'chat',
     originalBody: body,
   } as any;
@@ -309,6 +339,25 @@ describe('Native Codex OAuth pass-through', () => {
     const sent = JSON.parse((fetchSpy.mock.calls[0] as any[])[1].body);
     expect(sent.input).toBeDefined();
     expect(sent.messages).toBeUndefined();
+  });
+
+  test('aggregates backend Responses SSE for a non-streaming Chat Completions client', async () => {
+    setConfigForTesting(codexOAuthConfig());
+    // The ChatGPT backend can return its forced SSE body with a JSON content
+    // type when the original client requested a non-streaming response.
+    fetchSpy.mockResolvedValueOnce(
+      new Response(UPSTREAM_SSE_EMPTY_COMPLETION_OUTPUT, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    const response = await new Dispatcher().dispatch(nonStreamingChatRequest());
+
+    expect(response.stream).toBeUndefined();
+    expect(response.content).toBe('NATIVE');
+    const sent = JSON.parse((fetchSpy.mock.calls[0] as any[])[1].body);
+    expect(sent.stream).toBe(true);
   });
 
   test('marks backend Responses SSE for translation to a Messages client', async () => {

--- a/packages/backend/src/services/dispatch/dispatcher.ts
+++ b/packages/backend/src/services/dispatch/dispatcher.ts
@@ -1,3 +1,4 @@
+import { createParser } from 'eventsource-parser';
 import {
   UnifiedChatRequest,
   UnifiedChatResponse,
@@ -477,6 +478,47 @@ export class Dispatcher {
     try {
       return JSON.parse(responseText);
     } catch (cause) {
+      const isEventStream =
+        response.headers.get('content-type')?.includes('text/event-stream') ||
+        /^\s*(?:event|data):/m.test(responseText);
+      if (isEventStream) {
+        let completedResponse: any;
+        const completedOutputItems = new Map<number, any>();
+        const parser = createParser({
+          onEvent: (event) => {
+            try {
+              const payload = JSON.parse(event.data);
+              if (payload.type === 'response.output_item.done' && payload.item) {
+                const index =
+                  typeof payload.output_index === 'number'
+                    ? payload.output_index
+                    : completedOutputItems.size;
+                completedOutputItems.set(index, payload.item);
+              }
+              if (payload.type === 'response.completed' && payload.response) {
+                const streamedOutput = [...completedOutputItems.entries()]
+                  .sort(([left], [right]) => left - right)
+                  .map(([, item]) => item);
+                completedResponse = {
+                  ...payload.response,
+                  output:
+                    Array.isArray(payload.response.output) && payload.response.output.length > 0
+                      ? payload.response.output
+                      : streamedOutput,
+                };
+              }
+            } catch {
+              // Ignore malformed intermediate events. If there is no valid
+              // completion event, preserve the normal parse failure below.
+            }
+          },
+        });
+        parser.feed(responseText);
+        if (completedResponse) {
+          return completedResponse;
+        }
+      }
+
       if (requestId) {
         DebugManager.getInstance().addRawResponse(requestId, responseText);
         DebugManager.getInstance().addReconstructedRawResponse(requestId, {


### PR DESCRIPTION
## Summary

- recover Responses SSE returned to non-streaming clients, including when the upstream response is mislabeled as `application/json`
- rebuild an empty `response.completed.response.output` from ordered `response.output_item.done` events
- keep a non-empty completion payload authoritative and preserve the existing JSON/error paths

## Problem

The native Codex OAuth backend is stream-only. Plexus forces `stream: true` upstream, but the non-streaming dispatch path still attempts to parse the buffered response as JSON. In practice the backend can return SSE with `Content-Type: application/json`; additionally, the final `response.completed` event can have an empty `output` array while completed output items were emitted earlier. This produced HTTP 200 responses with null/empty assistant content for both `/v1/chat/completions` and `/v1/responses` clients using `stream: false`.

## Verification

- `bun run --cwd packages/backend test:force-all` — 215 files, 2209 tests passed
- `bun run typecheck` — passed for shared, frontend, and backend workspaces
- targeted native Codex dispatcher suite — 9 tests passed
- Biome formatting check for both changed files — passed
- live local Codex OAuth smoke tests:
  - non-streaming `/v1/chat/completions` returned the expected assistant text
  - non-streaming `/v1/responses` returned the expected output text
