### PR TITLE
fix(oauth): bundle flows in standalone binary

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -27,6 +27,7 @@ if (subcommand === 'backup') {
 import Fastify, { FastifyReply, FastifyRequest } from 'fastify';
 import cors from '@fastify/cors';
 import multipart from '@fastify/multipart';
+import { registerBunOAuthFlows } from '@earendil-works/pi-ai/bun-oauth';
 import path from 'path';
 import indexHtmlPath from '../../frontend/dist/index.html' with { type: 'file' };
 import mainJsPath from '../../frontend/dist/main.js' with { type: 'file' };
@@ -61,6 +62,8 @@ import { runMigrations } from './db/migrate';
 import { runEncryptionMigration } from './db/encrypt-migration';
 import { isEncryptionEnabled } from './utils/encryption';
 import { mcpProcessManager } from './services/mcp-local/mcp-process-manager';
+
+registerBunOAuthFlows();
 
 /**
  * Plexus Backend Server

--- a/packages/backend/src/services/__tests__/raw-passthrough.test.ts
+++ b/packages/backend/src/services/__tests__/raw-passthrough.test.ts
@@ -64,16 +64,14 @@ describe('raw passthrough transport helpers', () => {
     });
   });
 
-  test.each([
-    '/../admin',
-    '/%2e%2e/admin',
-    '/.%2e/admin',
-    '/%252e%252e/admin',
-  ])('rejects base-path traversal through %s', (suffix) => {
-    expect(() => buildRawUpstreamUrl('https://provider.example/api', suffix)).toThrow(
-      'cannot contain dot segments'
-    );
-  });
+  test.each(['/../admin', '/%2e%2e/admin', '/.%2e/admin', '/%252e%252e/admin'])(
+    'rejects base-path traversal through %s',
+    (suffix) => {
+      expect(() => buildRawUpstreamUrl('https://provider.example/api', suffix)).toThrow(
+        'cannot contain dot segments'
+      );
+    }
+  );
 
   test('keeps normal raw paths under the configured base path', () => {
     expect(


### PR DESCRIPTION
## Summary
Register pi-ai's statically bundled OAuth flow loaders during backend startup. This prevents compiled Plexus binaries from trying to resolve opaque runtime imports such as `./anthropic.js`, restoring Anthropic OAuth-backed requests in standalone releases.

## Why / Context
pi-ai intentionally hides OAuth implementation imports from normal bundlers, but exposes `registerBunOAuthFlows()` for standalone Bun binaries. Without that registration, the Linux binary reaches the lazy Anthropic OAuth loader on the first request and fails with `Cannot find module './anthropic.js' from '/$bunfs/root/plexus-linux-amd64'`.

## Changes
- **Backend startup**: register pi-ai's bundled Anthropic, Codex, Copilot, xAI, and Radius OAuth loaders before provider credentials are resolved.
- **Formatting**: apply Biome's expected wrapping to the raw passthrough traversal parameterized test.

## Testing
- Compiled the `plexus-linux-amd64` release target successfully, confirming Bun can bundle the statically registered OAuth flow modules.
