### PR TITLE
fix(dispatch): strip truncation from Codex requests

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-codex-native.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-codex-native.test.ts
@@ -98,6 +98,7 @@ function codexCliRequest(): UnifiedChatRequest {
     // Unsupported sampling params must be stripped even on the verbatim path.
     temperature: 0.7,
     top_p: 0.9,
+    truncation: 'auto',
     client_metadata: {
       'x-codex-installation-id': 'inst-1',
       session_id: 'sess-cli-1',
@@ -126,6 +127,7 @@ function plainResponsesRequest(): UnifiedChatRequest {
     model: 'codex-alias',
     stream: true,
     top_p: 0.5,
+    truncation: 'auto',
     frequency_penalty: 1,
     max_output_tokens: 256,
     input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
@@ -276,6 +278,7 @@ describe('Native Codex OAuth pass-through', () => {
     // Unsupported sampling params are stripped even on the verbatim path.
     expect(sent).not.toHaveProperty('temperature');
     expect(sent).not.toHaveProperty('top_p');
+    expect(sent).not.toHaveProperty('truncation');
 
     // Codex fingerprint headers + auth derived from the token JWT.
     expect(init.headers['Authorization']).toBe(`Bearer ${CODEX_TOKEN}`);
@@ -310,6 +313,7 @@ describe('Native Codex OAuth pass-through', () => {
     expect(sent).not.toHaveProperty('temperature');
     expect(sent).not.toHaveProperty('top_p');
     expect(sent).not.toHaveProperty('frequency_penalty');
+    expect(sent).not.toHaveProperty('truncation');
     // The Codex backend accepts NO max-tokens field (rejects both names).
     expect(sent).not.toHaveProperty('max_output_tokens');
     expect(sent).not.toHaveProperty('max_completion_tokens');

--- a/packages/backend/src/services/oauth/oauth-native-request.ts
+++ b/packages/backend/src/services/oauth/oauth-native-request.ts
@@ -287,6 +287,7 @@ const CODEX_UNSUPPORTED_PARAMS = [
   'frequency_penalty',
   'presence_penalty',
   'logit_bias',
+  'truncation',
   'max_output_tokens',
   'max_completion_tokens',
 ] as const;


### PR DESCRIPTION
## Summary
Strip the unsupported `truncation` field before sending requests to the ChatGPT Codex backend. This prevents otherwise valid Codex requests from failing when clients include that Responses API option.

## Why / Context
The Codex backend does not accept `truncation`, so it must be removed alongside the other parameters rejected by every Codex model.

## Changes
- **Codex dispatch**: add `truncation` to the shared unsupported-parameter list used by native Codex OAuth requests.
- **Coverage**: verify stripping for both CLI-shaped pass-through requests and normalized non-CLI Responses requests.

## Testing
- Extended the native Codex dispatcher scenarios to exercise `truncation: "auto"` on both request paths and assert it is not forwarded.
