### PR TITLE
feat(adapters): control GPT-5 option suppression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ This file is a **guardrail**, not general documentation.
 - **NEVER** manually create SQL migrations.
 - **NEVER** run `drizzle-kit generate` directly.
 - **NEVER** produce implementation or summary documents unless specifically requested.
+- **NEVER** assume Plexus supports file-based configuration. Providers, models, keys, quotas, and settings are database-backed; manage them through the Admin UI or Management API. Environment variables are only for server-level settings.
 - **AVOID** searching library type definitions for documentation. Use context/search skills first when available.
 - **ASK** when requirements are ambiguous.
 - **NEVER** use --delete-branch on gh commands

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,8 +1,10 @@
 # Configuration
 
+> **Plexus does not support file-based application configuration.** It does not load providers, models, keys, quotas, or settings from YAML, JSON, TOML, or other configuration files. Code examples in this document show request payload shapes only; apply them through the Admin UI or Management API.
+
 Plexus stores all configuration in the database and manages it via the **Admin UI** (recommended) or **Management API**.
 
-**Environment variables** control server-level settings. Everything else (providers, models, keys, quotas) is stored in the database.
+**Environment variables** control server-level settings. Everything else (providers, models, keys, quotas, and settings) is stored in the database.
 
 ---
 
@@ -243,7 +245,7 @@ OAuth providers are not supported by the raw endpoint.
 
 Adapters rewrite request payloads outbound to a provider and raw response payloads inbound, fixing provider-specific field-name incompatibilities without modifying the core transformer pipeline.
 
-Adapters can be set at **provider level** (applied to every model under the provider) or at **model level** (appended after provider-level adapters for a specific model). Both accept a single name or a list.
+Adapters can be set at **provider level** (applied to every model under the provider) or at **model level** (appended after provider-level adapters for a specific model). Both accept a single name or a list. Use `{ "name": "...", "enabled": false }` at model level to disable an inherited or automatic adapter; a later enabled entry restores it.
 
 | Adapter | Description |
 |---------|-------------|
@@ -252,6 +254,7 @@ Adapters can be set at **provider level** (applied to every model under the prov
 | `model_override` | Conditionally rewrites the provider model name based on request payload fields. Used for providers that expose reasoning variants as separate model names rather than respecting reasoning-related fields in the request body. See [Model Override Adapter](#model-override-adapter) below. |
 | `reasoning_rewrite` | Manually rewrites reasoning/thinking request fields for providers with bespoke compatibility requirements. Prefer `auto_compat` for models linked to the pi-ai builtin registry; this adapter is now best treated as an escape hatch. |
 | `web_search_coercion` | Translates server-side web search tool entries to the format expected by the target provider. Clients can use any web search format; Plexus rewrites it transparently. See [Web Search Coercion Adapter](#web-search-coercion-adapter) below. |
+| `suppress_unsupported_gpt5_options` | Removes generation options unsupported by GPT-5 models. Enabled automatically for the GPT-5 family; set `enabled: false` for a model to opt out. |
 
 **Example — provider-level:**
 ```json

--- a/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
+++ b/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
@@ -38,6 +38,37 @@ describe('resolveAdapters', () => {
     expect(resolved.map((r) => r.adapter.name)).toEqual(['strip_unsupported_tool_search']);
   });
 
+  it('auto-injects unsupported-option suppression for GPT-5 family models', () => {
+    const route: RouteResult = { ...makeRoute(), model: 'gpt-5.2' };
+    expect(resolveAdapters(route).map((r) => r.adapter.name)).toEqual([
+      'suppress_unsupported_gpt5_options',
+    ]);
+  });
+
+  it('does not auto-inject GPT-5 suppression for other model families', () => {
+    const route: RouteResult = { ...makeRoute(), model: 'gpt-4.1' };
+    expect(resolveAdapters(route)).toHaveLength(0);
+  });
+
+  it('allows a model adapter entry to disable GPT-5 suppression', () => {
+    const route = makeRoute(undefined, [
+      { name: 'suppress_unsupported_gpt5_options', enabled: false },
+    ]);
+    route.model = 'gpt-5.2';
+    expect(resolveAdapters(route)).toHaveLength(0);
+  });
+
+  it('allows a model adapter entry to restore an adapter disabled by its provider', () => {
+    const route = makeRoute(
+      [{ name: 'suppress_unsupported_gpt5_options', enabled: false }],
+      [{ name: 'suppress_unsupported_gpt5_options', enabled: true }]
+    );
+    route.model = 'gpt-5.2';
+    expect(resolveAdapters(route).map((r) => r.adapter.name)).toEqual([
+      'suppress_unsupported_gpt5_options',
+    ]);
+  });
+
   it('does not auto-inject anything for non-openrouter pi_ai_provider', () => {
     const route: RouteResult = {
       ...makeRoute(undefined, undefined),
@@ -61,6 +92,20 @@ describe('resolveAdapters', () => {
     };
     const resolved = resolveAdapters(route);
     expect(resolved.map((r) => r.adapter.name)).toEqual([
+      'strip_unsupported_tool_search',
+      'reasoning_content',
+    ]);
+  });
+
+  it('runs GPT-5 suppression before other implicit and configured adapters', () => {
+    const base = makeRoute([{ name: 'reasoning_content', options: {} }]);
+    const route: RouteResult = {
+      ...base,
+      model: 'gpt-5-codex',
+      config: { ...base.config, pi_ai_provider: 'openrouter' },
+    };
+    expect(resolveAdapters(route).map((r) => r.adapter.name)).toEqual([
+      'suppress_unsupported_gpt5_options',
       'strip_unsupported_tool_search',
       'reasoning_content',
     ]);

--- a/packages/backend/src/__tests__/config-adapter.test.ts
+++ b/packages/backend/src/__tests__/config-adapter.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { validateConfig } from '../config';
+
+describe('adapter configuration', () => {
+  it('accepts a disabled model adapter entry', () => {
+    const config = validateConfig(
+      JSON.stringify({
+        providers: {
+          upstream: {
+            api_base_url: 'https://api.example.com/v1',
+            api_key: 'test-key',
+            models: {
+              'gpt-5.2': {
+                pricing: { source: 'simple', input: 0, output: 0 },
+                adapter: [{ name: 'suppress_unsupported_gpt5_options', enabled: false }],
+              },
+            },
+          },
+        },
+        models: {},
+        keys: {},
+      })
+    );
+
+    const models = config.providers.upstream!.models as Record<string, any>;
+    expect(models['gpt-5.2']!.adapter).toEqual([
+      { name: 'suppress_unsupported_gpt5_options', options: {}, enabled: false },
+    ]);
+  });
+});

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -94,6 +94,7 @@ const ModelOverrideOptionsSchema = z.object({
 const AdapterEntrySchema = z.object({
   name: z.string().min(1),
   options: z.record(z.string(), z.any()).default({}),
+  enabled: z.boolean().default(true),
 });
 
 /**
@@ -109,10 +110,10 @@ const AdapterConfigSchema = z.preprocess((val) => {
   const arr = Array.isArray(val) ? val : [val];
   return arr.map((entry: any) => {
     if (typeof entry === 'string') {
-      return { name: entry, options: {} };
+      return { name: entry, options: {}, enabled: true };
     }
     if (entry && typeof entry === 'object' && 'name' in entry) {
-      return { name: entry.name, options: entry.options ?? {} };
+      return { name: entry.name, options: entry.options ?? {}, enabled: entry.enabled ?? true };
     }
     return entry; // Let Zod produce a clear validation error
   });

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -51,18 +51,18 @@ function toJson(value: unknown): string | unknown {
 }
 
 /**
- * Normalize adapter entries from DB storage to the canonical { name, options } form.
+ * Normalize adapter entries from DB storage to the canonical { name, options, enabled } form.
  *
  * Legacy rows stored adapter entries as bare strings (e.g. ["reasoning_content"]).
  * This function converts them to the uniform object form:
- * [{ name: "reasoning_content", options: {} }]
+ * [{ name: "reasoning_content", options: {}, enabled: true }]
  *
  * Rows are self-healing: on next save through the API, the normalized form
  * is persisted back to the DB.
  */
 function normalizeAdapterEntries(
   raw: unknown
-): Array<{ name: string; options: Record<string, any> }> | null {
+): Array<{ name: string; options: Record<string, any>; enabled: boolean }> | null {
   if (raw === null || raw === undefined) return null;
   const arr = Array.isArray(raw) ? raw : [raw];
   if (arr.length === 0) return null;
@@ -71,20 +71,23 @@ function normalizeAdapterEntries(
     .map((entry) => {
       if (typeof entry === 'string') {
         // Legacy bare-string form
-        return { name: entry, options: {} };
+        return { name: entry, options: {}, enabled: true };
       }
       if (entry && typeof entry === 'object' && 'name' in entry) {
         // Already in object form
         return {
           name: (entry as any).name,
           options: (entry as any).options ?? {},
+          enabled: (entry as any).enabled ?? true,
         };
       }
       // Malformed entry — skip with a warning (don't crash)
       logger.warn(`Skipping malformed adapter entry: ${JSON.stringify(entry)}`);
       return null;
     })
-    .filter((e): e is { name: string; options: Record<string, any> } => e !== null);
+    .filter(
+      (e): e is { name: string; options: Record<string, any>; enabled: boolean } => e !== null
+    );
 }
 
 /**

--- a/packages/backend/src/services/dispatch/adapter-resolver.ts
+++ b/packages/backend/src/services/dispatch/adapter-resolver.ts
@@ -3,6 +3,7 @@ import type { RouteResult } from '../routing/router';
 import type { AdapterEntry } from '../../config';
 import { ADAPTER_REGISTRY } from '../../transformers/adapters/index';
 import { stripUnsupportedToolSearchAdapter } from '../../transformers/adapters/strip-unsupported-tool-search.adapter';
+import { suppressUnsupportedGpt5OptionsAdapter } from '../../transformers/adapters/suppress-unsupported-gpt5-options.adapter';
 import { logger } from '../../utils/logger';
 
 /**
@@ -15,6 +16,9 @@ import { logger } from '../../utils/logger';
  *      cleaned-up payload if they inspect it.
  *   2. Provider-level `adapter` (applies to all models under the provider)
  *   3. Model-level `adapter`   (appended after provider-level adapters)
+ *
+ * An `{ name, enabled: false }` entry removes earlier instances of that adapter,
+ * including implicit defaults. A later enabled entry restores it.
  *
  * Each entry is an { name, options } object. Unknown adapter names are logged
  * as warnings and skipped (rather than throwing) so that a misconfigured
@@ -31,8 +35,12 @@ export function resolveAdapters(route: RouteResult): ResolvedAdapter[] {
 
   if (entries.length === 0) return [];
 
-  const resolved: ResolvedAdapter[] = [];
+  let resolved: ResolvedAdapter[] = [];
   for (const entry of entries) {
+    if (entry.enabled === false) {
+      resolved = resolved.filter((resolvedEntry) => resolvedEntry.adapter.name !== entry.name);
+      continue;
+    }
     const adapter = ADAPTER_REGISTRY[entry.name];
     if (!adapter) {
       logger.warn(
@@ -63,8 +71,16 @@ export function resolveAdapters(route: RouteResult): ResolvedAdapter[] {
  * silently no-op.
  */
 function resolveImplicitAdapters(route: RouteResult): AdapterEntry[] {
-  if (route.config.pi_ai_provider === 'openrouter') {
-    return [{ name: stripUnsupportedToolSearchAdapter.name, options: {} }];
+  const adapters: AdapterEntry[] = [];
+  if (isGpt5Model(route.model)) {
+    adapters.push({ name: suppressUnsupportedGpt5OptionsAdapter.name, options: {}, enabled: true });
   }
-  return [];
+  if (route.config.pi_ai_provider === 'openrouter') {
+    adapters.push({ name: stripUnsupportedToolSearchAdapter.name, options: {}, enabled: true });
+  }
+  return adapters;
+}
+
+function isGpt5Model(model: string): boolean {
+  return /^gpt-5(?:[.-]|$)/i.test(model);
 }

--- a/packages/backend/src/services/oauth/oauth-native-request.ts
+++ b/packages/backend/src/services/oauth/oauth-native-request.ts
@@ -40,6 +40,7 @@ import {
 } from '../../transformers/oauth/masking';
 import type { RenamePair } from '../../transformers/oauth/masking/types';
 import { CodexVersionService } from './codex-version-service';
+import { stripUnsupportedGpt5Options } from '../../transformers/adapters/suppress-unsupported-gpt5-options.adapter';
 
 /**
  * Auth for a native Anthropic request. Two modes, mirroring the old executor:
@@ -270,42 +271,12 @@ function extractChatgptAccountId(token: string): string | undefined {
 }
 
 /**
- * Parameters that NO Codex model supports — the ChatGPT Codex backend rejects
- * them (e.g. `400 Unsupported parameter: temperature` /
- * `Unsupported parameter: max_completion_tokens`). Stripped on BOTH paths
- * (verbatim CLI and adorned): even a passed-through body must not carry them,
- * and `ResponsesTransformer` in particular defaults `temperature` to `1.0` and
- * emits `max_output_tokens`. The backend accepts NO max-tokens field, so both
- * the Responses (`max_output_tokens`) and Chat (`max_completion_tokens`) names
- * are stripped (pi-ai likewise never forwards a token cap).
- */
-const CODEX_UNSUPPORTED_PARAMS = [
-  'temperature',
-  'top_p',
-  'logprobs',
-  'top_logprobs',
-  'frequency_penalty',
-  'presence_penalty',
-  'logit_bias',
-  'truncation',
-  'max_output_tokens',
-  'max_completion_tokens',
-] as const;
-
-function stripUnsupportedCodexParams(body: any): any {
-  if (!body || typeof body !== 'object') return body;
-  const next: any = { ...body };
-  for (const key of CODEX_UNSUPPORTED_PARAMS) delete next[key];
-  return next;
-}
-
-/**
  * Adorn a normalized (non-CLI) Responses body with the fields the ChatGPT Codex
  * backend requires, reproducing pi-ai's `buildRequestBody` forcings: `store:false`,
  * `stream:true`, encrypted-content `include`, an `instructions` fallback, a
  * `text.verbosity` fallback, and `tool_choice`/`parallel_tool_calls` defaults.
  * Client-provided values are preserved where present; the always-unsupported
- * sampling params are removed separately by `stripUnsupportedCodexParams`.
+ * unsupported options are removed separately by `stripUnsupportedGpt5Options`.
  */
 function adornCodexResponsesBody(body: any): any {
   const next: any = { ...(body ?? {}) };
@@ -319,7 +290,7 @@ function adornCodexResponsesBody(body: any): any {
   next.text = { ...(next.text ?? {}), verbosity: next.text?.verbosity ?? 'low' };
   if (next.tool_choice == null) next.tool_choice = 'auto';
   if (next.parallel_tool_calls == null) next.parallel_tool_calls = true;
-  // Token-cap fields are removed by stripUnsupportedCodexParams (the backend
+  // Token-cap fields are removed by stripUnsupportedGpt5Options (the backend
   // accepts none).
   return next;
 }
@@ -335,9 +306,10 @@ function prepareCodexOAuthRequest(
   streaming: boolean,
   passthrough: boolean
 ): PreparedOAuthRequest {
-  // Strip the always-unsupported sampling params on BOTH paths (even verbatim
-  // CLI), then adorn only the non-CLI path.
-  const body = stripUnsupportedCodexParams(
+  // Preserve final-path suppression for native CLI pass-through, whose body may
+  // be mutated after adapter resolution. All GPT-5 routes receive the same
+  // suppression through the implicit model adapter.
+  const body = stripUnsupportedGpt5Options(
     passthrough ? nativeBody : adornCodexResponsesBody(nativeBody)
   );
 

--- a/packages/backend/src/transformers/adapters/__tests__/suppress-unsupported-gpt5-options.adapter.test.ts
+++ b/packages/backend/src/transformers/adapters/__tests__/suppress-unsupported-gpt5-options.adapter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { suppressUnsupportedGpt5OptionsAdapter } from '../suppress-unsupported-gpt5-options.adapter';
+
+describe('suppressUnsupportedGpt5OptionsAdapter', () => {
+  it('removes unsupported GPT-5 generation options and preserves other fields', () => {
+    const payload = suppressUnsupportedGpt5OptionsAdapter.preDispatch({
+      model: 'gpt-5.2',
+      input: 'hello',
+      temperature: 1,
+      top_p: 0.9,
+      logprobs: true,
+      top_logprobs: 3,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      logit_bias: { '1': 1 },
+      truncation: 'auto',
+      max_output_tokens: 10,
+      max_completion_tokens: 10,
+    });
+
+    expect(payload).toEqual({ model: 'gpt-5.2', input: 'hello' });
+  });
+});

--- a/packages/backend/src/transformers/adapters/index.ts
+++ b/packages/backend/src/transformers/adapters/index.ts
@@ -5,6 +5,7 @@ import { modelOverrideAdapter } from './model-override.adapter';
 import { reasoningRewriteAdapter } from './reasoning-rewrite.adapter';
 import { webSearchCoercionAdapter } from './web-search-coercion.adapter';
 import { stripUnsupportedToolSearchAdapter } from './strip-unsupported-tool-search.adapter';
+import { suppressUnsupportedGpt5OptionsAdapter } from './suppress-unsupported-gpt5-options.adapter';
 
 /**
  * Registry of all built-in provider adapters.
@@ -17,4 +18,5 @@ export const ADAPTER_REGISTRY: Record<string, ProviderAdapter> = {
   [reasoningRewriteAdapter.name]: reasoningRewriteAdapter,
   [webSearchCoercionAdapter.name]: webSearchCoercionAdapter,
   [stripUnsupportedToolSearchAdapter.name]: stripUnsupportedToolSearchAdapter,
+  [suppressUnsupportedGpt5OptionsAdapter.name]: suppressUnsupportedGpt5OptionsAdapter,
 };

--- a/packages/backend/src/transformers/adapters/suppress-unsupported-gpt5-options.adapter.ts
+++ b/packages/backend/src/transformers/adapters/suppress-unsupported-gpt5-options.adapter.ts
@@ -1,0 +1,32 @@
+import type { ProviderAdapter } from '../../types/provider-adapter';
+
+const GPT5_UNSUPPORTED_OPTIONS = [
+  'temperature',
+  'top_p',
+  'logprobs',
+  'top_logprobs',
+  'frequency_penalty',
+  'presence_penalty',
+  'logit_bias',
+  'truncation',
+  'max_output_tokens',
+  'max_completion_tokens',
+] as const;
+
+export function stripUnsupportedGpt5Options(payload: Record<string, any>): Record<string, any> {
+  const next = { ...payload };
+  for (const option of GPT5_UNSUPPORTED_OPTIONS) delete next[option];
+  return next;
+}
+
+export const suppressUnsupportedGpt5OptionsAdapter: ProviderAdapter = {
+  name: 'suppress_unsupported_gpt5_options',
+
+  preDispatch(payload: Record<string, any>): Record<string, any> {
+    return stripUnsupportedGpt5Options(payload);
+  },
+
+  postDispatch(response: Record<string, any>): Record<string, any> {
+    return response;
+  },
+};

--- a/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderModelsEditor.tsx
@@ -32,6 +32,12 @@ const API_ACCESS_OPTIONS = [
   { type: 'ollama', label: 'ollama' },
 ] as const;
 
+const GPT5_SUPPRESSION_ADAPTER = 'suppress_unsupported_gpt5_options';
+
+function isGpt5Model(modelId: string): boolean {
+  return /^gpt-5(?:[.-]|$)/i.test(modelId);
+}
+
 const getApiBadgeStyle = (apiType: string): React.CSSProperties => {
   switch (apiType.toLowerCase()) {
     case 'messages':
@@ -940,6 +946,75 @@ export function ProviderModelsEditor({
                               background: 'var(--color-bg-subtle)',
                             }}
                           >
+                            {isGpt5Model(mId) &&
+                              (() => {
+                                const modelAdapters: any[] = mCfg.adapter
+                                  ? Array.isArray(mCfg.adapter)
+                                    ? mCfg.adapter
+                                    : [mCfg.adapter]
+                                  : [];
+                                const suppressionDisabled = modelAdapters.some(
+                                  (entry: any) =>
+                                    typeof entry !== 'string' &&
+                                    entry.name === GPT5_SUPPRESSION_ADAPTER &&
+                                    entry.enabled === false
+                                );
+                                return (
+                                  <label
+                                    style={{
+                                      gridColumn: '1 / -1',
+                                      display: 'flex',
+                                      alignItems: 'flex-start',
+                                      gap: '8px',
+                                      cursor: 'pointer',
+                                      padding: '4px 8px',
+                                      borderRadius: 'var(--radius-sm)',
+                                      border: '1px solid var(--color-border-glass)',
+                                      background: suppressionDisabled
+                                        ? 'var(--color-bg-glass)'
+                                        : 'var(--color-bg-hover)',
+                                    }}
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={!suppressionDisabled}
+                                      style={{ marginTop: '2px', flexShrink: 0 }}
+                                      onChange={() => {
+                                        const withoutSuppression = modelAdapters.filter(
+                                          (entry: any) =>
+                                            (typeof entry === 'string' ? entry : entry.name) !==
+                                            GPT5_SUPPRESSION_ADAPTER
+                                        );
+                                        const next = suppressionDisabled
+                                          ? withoutSuppression
+                                          : [
+                                              ...withoutSuppression,
+                                              {
+                                                name: GPT5_SUPPRESSION_ADAPTER,
+                                                options: {},
+                                                enabled: false,
+                                              },
+                                            ];
+                                        updateModelConfig(mId, {
+                                          adapter: next.length > 0 ? next : undefined,
+                                        });
+                                      }}
+                                    />
+                                    <div>
+                                      <div className="font-body text-[12px] font-medium text-text">
+                                        Suppress Unsupported GPT-5 Options
+                                      </div>
+                                      <div
+                                        className="font-body text-[11px] text-text-secondary"
+                                        style={{ lineHeight: 1.35 }}
+                                      >
+                                        Enabled by default. Removes generation options GPT-5 does
+                                        not accept.
+                                      </div>
+                                    </div>
+                                  </label>
+                                );
+                              })()}
                             {KNOWN_ADAPTERS.map((a) => {
                               const modelAdapters: any[] = mCfg.adapter
                                 ? Array.isArray(mCfg.adapter)


### PR DESCRIPTION
## Summary
GPT-5 option suppression is now a default model adapter rather than Codex-only behavior, and administrators can manage it from the provider model editor. The branch also clarifies that Plexus configuration is database-backed and managed through the Admin UI or Management API.

## Why / Context
GPT-5 models reject several generation options regardless of provider. The previous suppression was tied to the Codex OAuth path and could not be controlled through the Admin UI.

## Changes
- **Dispatch**: add an implicit `suppress_unsupported_gpt5_options` adapter for GPT-5 family model IDs and reuse it for native Codex final-path protection.
- **Adapter resolution**: support ordered `{ name, enabled: false }` entries so model configuration can disable inherited or automatic adapters and later entries can restore them.
- **Management UI**: add a checked-by-default GPT-5 option-suppression control in each GPT-5 model's Model Adapters panel; saving disabled state persists a model-level override.
- **Configuration persistence**: preserve adapter enabled state when loading legacy and stored adapter entries.
- **Documentation**: state that application configuration belongs in the Admin UI or Management API, not files, and document the adapter opt-out payload.

## Testing
- Browser-tested disabling and re-enabling the GPT-5 suppression control in the provider editor, including management API read-back.
- Added adapter resolution, configuration validation, and suppression transformation tests.
