### PR TITLE
feat(frontend): add estimated tokens-per-second metric for live logs

### DIFF
--- a/packages/frontend/src/lib/format.test.ts
+++ b/packages/frontend/src/lib/format.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getEstimatedBytesPerToken } from './format';
+
+describe('getEstimatedBytesPerToken', () => {
+  it('returns ~115 B/token for Anthropic messages streaming', () => {
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'messages', isStreamed: true })).toBe(115);
+    expect(
+      getEstimatedBytesPerToken({ outgoingApiType: 'anthropic-messages', isStreamed: true })
+    ).toBe(115);
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'oauth', isStreamed: true })).toBe(115);
+  });
+
+  it('returns ~160 B/token for OpenAI chat & responses streaming', () => {
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'chat', isStreamed: true })).toBe(160);
+    expect(
+      getEstimatedBytesPerToken({ outgoingApiType: 'openai-completions', isStreamed: true })
+    ).toBe(160);
+    expect(
+      getEstimatedBytesPerToken({ incomingApiType: 'openai-responses', isStreamed: true })
+    ).toBe(160);
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'antigravity', isStreamed: true })).toBe(
+      160
+    );
+  });
+
+  it('returns ~140 B/token for Gemini streaming', () => {
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'gemini', isStreamed: true })).toBe(140);
+    expect(
+      getEstimatedBytesPerToken({ outgoingApiType: 'google-generative-ai', isStreamed: true })
+    ).toBe(140);
+  });
+
+  it('returns ~140 B/token default for generic streaming', () => {
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'raw', isStreamed: true })).toBe(140);
+  });
+
+  it('returns ~4.5 B/token for non-streamed responses', () => {
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'chat', isStreamed: false })).toBe(4.5);
+  });
+});

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -228,3 +228,45 @@ export function toTitleCase(str: string): string {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ');
 }
+
+/**
+ * Estimate average wire bytes per token for an API response stream.
+ * In live SSE streams, each token chunk is wrapped in SSE event headers and JSON schema
+ * structures (`data: {"id":...,"choices":[{"delta":...}]}`). This protocol framing
+ * dominates wire payload size compared to plain text (~4 bytes/token).
+ */
+export function getEstimatedBytesPerToken(options: {
+  incomingApiType?: string | null;
+  outgoingApiType?: string | null;
+  isStreamed?: boolean | null;
+}): number {
+  if (options.isStreamed === false) {
+    // Non-streamed response: single bulk JSON payload (~4.5 bytes per token)
+    return 4.5;
+  }
+
+  const apiType = (options.incomingApiType || options.outgoingApiType || '').toLowerCase();
+
+  if (apiType.includes('anthropic') || apiType.includes('messages') || apiType === 'oauth') {
+    // Anthropic SSE: `event: content_block_delta\ndata: {"type":...}\n\n` (~115 B/token)
+    return 115;
+  }
+
+  if (
+    apiType.includes('openai') ||
+    apiType.includes('chat') ||
+    apiType.includes('responses') ||
+    apiType.includes('antigravity')
+  ) {
+    // OpenAI SSE: `data: {"id":...,"object":"chat.completion.chunk",...}\n\n` (~160 B/token)
+    return 160;
+  }
+
+  if (apiType.includes('gemini') || apiType.includes('google')) {
+    // Gemini SSE streaming: (~140 B/token)
+    return 140;
+  }
+
+  // Default SSE stream overhead fallback
+  return 140;
+}

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -23,6 +23,7 @@ import {
   formatMs,
   formatSlices,
   formatTPS,
+  getEstimatedBytesPerToken,
 } from '../lib/format';
 import { isClipboardAvailable, copyToClipboard } from '../lib/clipboard';
 import { formatApiTypeLabel, getApiBaseType } from '../lib/apiFormats';
@@ -1552,6 +1553,20 @@ export const Logs = () => {
                               ? e2eOutputTokens / (log.durationMs / 1000)
                               : null;
                           if (progress) {
+                            const bytesPerToken = getEstimatedBytesPerToken(log);
+                            const effectiveBytesPerSec =
+                              progress.bytesPerSec != null && progress.bytesPerSec > 0
+                                ? progress.bytesPerSec
+                                : progress.elapsedMs > 0 && progress.bytesReceived > 0
+                                  ? (progress.bytesReceived / progress.elapsedMs) * 1000
+                                  : null;
+                            const estTokensPerSec =
+                              effectiveBytesPerSec != null &&
+                              Number.isFinite(effectiveBytesPerSec) &&
+                              effectiveBytesPerSec > 0
+                                ? effectiveBytesPerSec / bytesPerToken
+                                : null;
+
                             return (
                               <div style={{ display: 'flex', flexDirection: 'column' }}>
                                 <span>Duration: {liveDuration}</span>
@@ -1579,6 +1594,21 @@ export const Logs = () => {
                                   >
                                     <Gauge size={12} className="text-text-secondary" />
                                     {formatBytes(progress.bytesPerSec)}/s
+                                  </span>
+                                )}
+                                {estTokensPerSec != null && (
+                                  <span
+                                    style={{
+                                      color: 'var(--color-text-secondary)',
+                                      fontSize: '0.85em',
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      gap: '4px',
+                                    }}
+                                    title={`Estimated tokens/sec (~${Math.round(bytesPerToken)} bytes/token accounting for SSE + JSON framing)`}
+                                  >
+                                    <Zap size={12} className="text-amber-400" />
+                                    <span>~{formatTPS(estTokensPerSec)} tok/s</span>
                                   </span>
                                 )}
                               </div>


### PR DESCRIPTION
Add `getEstimatedBytesPerToken` utility to estimate wire bytes per token based on API type and streaming state, accounting for SSE and JSON protocol framing overhead. Integrate this estimation into the `Logs` live request view to display an estimated tokens-per-second rate alongside existing throughput metrics during active streams.