### PR TITLE
feat(scripts): centralize dev port derivation and add paseo config

### DIFF
--- a/paseo.json
+++ b/paseo.json
@@ -1,7 +1,11 @@
 {
   "worktree": {
     "setup": ["bun run scripts/init_worktree.ts"],
-    "teardown": "bun run dev:stop"
+    "teardown": "bun run dev:stop",
+    "servicePorts": {
+      "portScript": "scripts/dev-port-allocator.ts",
+      "range": "10000-19999"
+    }
   },
   "scripts": {
     "dev": {

--- a/scripts/__tests__/dev-port-allocator.test.ts
+++ b/scripts/__tests__/dev-port-allocator.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+import { deriveDevPort } from '../dev-port-allocator';
+
+describe('deriveDevPort', () => {
+  const originalPort = process.env.PORT;
+
+  beforeEach(() => {
+    delete process.env.PORT;
+  });
+
+  afterEach(() => {
+    if (originalPort !== undefined) {
+      process.env.PORT = originalPort;
+    } else {
+      delete process.env.PORT;
+    }
+  });
+
+  it('derives a deterministic port within 10000-19999 range based on directory path', () => {
+    const cwd = '/workspace/plexus-worktree-a';
+    const port = deriveDevPort(cwd);
+    const num = Number(port);
+
+    expect(num).toBeGreaterThanOrEqual(10000);
+    expect(num).toBeLessThanOrEqual(19999);
+    expect(deriveDevPort(cwd)).toBe(port);
+  });
+
+  it('respects process.env.PORT when set', () => {
+    process.env.PORT = '4000';
+    expect(deriveDevPort('/some/path')).toBe('4000');
+  });
+});
+
+describe('dev-port-allocator executable', () => {
+  const scriptPath = join(__dirname, '../dev-port-allocator.ts');
+
+  it('outputs derived port when executed directly', () => {
+    const output = execFileSync(
+      'bun',
+      ['run', scriptPath, 'dev', 'wks_1', 'main', '/workspace/my-app'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, PORT: '' },
+      }
+    ).trim();
+
+    const expected = deriveDevPort('/workspace/my-app');
+    expect(output).toBe(expected);
+  });
+
+  it('uses PASEO_WORKTREE_PATH environment variable if present', () => {
+    const output = execFileSync('bun', ['run', scriptPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PORT: '',
+        PASEO_WORKTREE_PATH: '/workspace/my-app-env',
+      },
+    }).trim();
+
+    const expected = deriveDevPort('/workspace/my-app-env');
+    expect(output).toBe(expected);
+  });
+});

--- a/scripts/dev-agent.ts
+++ b/scripts/dev-agent.ts
@@ -20,16 +20,13 @@ import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import { openSync, existsSync, readFileSync } from 'fs';
 import { spawn } from 'child_process';
+import { deriveDevPort } from './dev-port-allocator';
 
 const dirName = basename(process.cwd());
 
 function derivePort(): string {
   if (process.env.PORT) return process.env.PORT;
-  let hash = 5381;
-  for (let i = 0; i < dirName.length; i++) {
-    hash = (hash * 33) ^ dirName.charCodeAt(i);
-  }
-  return String(10000 + (Math.abs(hash) % 10000));
+  return deriveDevPort();
 }
 
 const PORT = derivePort();

--- a/scripts/dev-config.ts
+++ b/scripts/dev-config.ts
@@ -9,17 +9,14 @@
 
 import { join, basename } from 'path';
 import { tmpdir } from 'os';
+import { deriveDevPort } from './dev-port-allocator';
 
 const dirName = basename(process.cwd());
 
 // --- Port (same logic as dev.ts) ---
 function getPort(): string {
   if (process.env.PORT) return process.env.PORT;
-  let hash = 5381;
-  for (let i = 0; i < dirName.length; i++) {
-    hash = (hash * 33) ^ dirName.charCodeAt(i);
-  }
-  return String(10000 + (Math.abs(hash) % 10000));
+  return deriveDevPort();
 }
 
 // --- DB path (same logic as dev.ts) ---

--- a/scripts/dev-port-allocator.ts
+++ b/scripts/dev-port-allocator.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+/**
+ * dev-port-allocator.ts
+ *
+ * Executable port allocator used by Paseo (via worktree.servicePorts.portScript)
+ * and internally by Plexus dev server scripts to ensure consistent, reliable
+ * port assignment whether started via Paseo or standalone.
+ *
+ * Usage:
+ *   # As Paseo portScript:
+ *   scripts/dev-port-allocator.ts [serviceName] [workspaceId] [branchName] [worktreePath]
+ *
+ *   # Standalone / CLI:
+ *   bun run scripts/dev-port-allocator.ts
+ */
+
+import { basename } from 'path';
+
+/**
+ * Derives a stable, deterministic TCP port number (10000-19999) based on the
+ * worktree directory name.
+ */
+export function deriveDevPort(cwd = process.cwd()): string {
+  if (process.env.PORT) return process.env.PORT;
+  const dirName = basename(cwd);
+  let hash = 5381;
+  for (let i = 0; i < dirName.length; i++) {
+    hash = (hash * 33) ^ dirName.charCodeAt(i);
+  }
+  return String(10000 + (Math.abs(hash) % 10000));
+}
+
+if (import.meta.main) {
+  // Paseo passes worktree path as 4th positional argument (argv[5]) or in PASEO_WORKTREE_PATH
+  const worktreePath =
+    process.env.PASEO_WORKTREE_PATH ||
+    (process.argv.length >= 6 ? process.argv[5] : undefined) ||
+    process.cwd();
+
+  const port = deriveDevPort(worktreePath);
+  console.log(port);
+}

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import { createServer } from 'net';
 import { existsSync, writeFileSync, unlinkSync } from 'fs';
 import { spawn as nodeSpawn, type ChildProcess } from 'child_process';
+import { deriveDevPort } from './dev-port-allocator';
 
 // --- Dev defaults (only applied when not already set in environment) ---
 
@@ -85,11 +86,7 @@ for (let i = 2; i < process.argv.length; i++) {
 // Two worktrees running simultaneously will land on different ports automatically.
 // Override with: PORT=4000 bun run dev
 if (!process.env.PORT) {
-  let hash = 5381;
-  for (let i = 0; i < dirName.length; i++) {
-    hash = (hash * 33) ^ dirName.charCodeAt(i);
-  }
-  process.env.PORT = String(10000 + (Math.abs(hash) % 10000));
+  process.env.PORT = deriveDevPort();
 }
 
 // Per-worktree database — persists across restarts, isolated per branch.

--- a/scripts/populate-dev.ts
+++ b/scripts/populate-dev.ts
@@ -20,23 +20,15 @@
 
 import { join, basename } from 'path';
 import type { components } from './openapi-types';
+import { deriveDevPort } from './dev-port-allocator';
+
+export { deriveDevPort };
 
 // ---------------------------------------------------------------------------
 // Config from environment
 // ---------------------------------------------------------------------------
 
 const ADMIN_KEY = process.env.PLEXUS_ADMIN_KEY ?? 'password';
-
-// Mirrors the stable port derivation in scripts/dev.ts so this script targets
-// the correct worktree instance without any configuration.
-export function deriveDevPort(cwd = process.cwd()): string {
-  const dirName = basename(cwd);
-  let hash = 5381;
-  for (let i = 0; i < dirName.length; i++) {
-    hash = (hash * 33) ^ dirName.charCodeAt(i);
-  }
-  return String(10000 + (Math.abs(hash) % 10000));
-}
 
 export function resolveApiRoot(
   env: Pick<NodeJS.ProcessEnv, 'PLEXUS_URL' | 'PLEXUS_PORT'> = process.env,

--- a/scripts/prep-dev.ts
+++ b/scripts/prep-dev.ts
@@ -33,21 +33,11 @@ import { basename, join } from 'path';
 import { pipeline } from 'stream/promises';
 import readline from 'readline';
 import { gzipSync, gunzipSync } from 'node:zlib';
+import { deriveDevPort } from './dev-port-allocator';
 
 // ---------------------------------------------------------------------------
 // Config from environment
 // ---------------------------------------------------------------------------
-
-// Mirrors the stable port derivation in scripts/dev.ts so this script targets
-// the correct worktree instance without any configuration.
-function deriveDevPort(): string {
-  const dirName = basename(process.cwd());
-  let hash = 5381;
-  for (let i = 0; i < dirName.length; i++) {
-    hash = (hash * 33) ^ dirName.charCodeAt(i);
-  }
-  return String(10000 + (Math.abs(hash) % 10000));
-}
 
 // Parse command line arguments
 const args = process.argv.slice(2);


### PR DESCRIPTION
Consolidate development port derivation logic into a shared `scripts/dev-port-allocator.ts` module, replacing duplicated implementations across dev, agent, config, populate, and prep scripts. Add Paseo worktree servicePorts configuration and corresponding unit tests for port allocation and environment resolution.