### PR TITLE
fix(oauth): release callback ports on session termination

### DIFF
--- a/packages/backend/src/services/oauth/__tests__/oauth-login-session.test.ts
+++ b/packages/backend/src/services/oauth/__tests__/oauth-login-session.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OAuthLoginSessionManager } from '../oauth-login-session';
+import type { OAuthProviderDescriptor } from '../oauth-providers';
+
+// A provider whose login mimics pi-ai's Anthropic flow: it waits on a
+// manual-code prompt and only releases its (fake) callback resource when that
+// prompt settles. Rejecting the prompt is therefore what frees the port.
+function makeProviderResolver() {
+  let promptRejected: ((reason: unknown) => void) | null = null;
+  const portReleased = vi.fn();
+
+  const descriptor = {
+    id: 'anthropic',
+    name: 'Anthropic',
+    usesCallbackServer: true,
+    oauth: {
+      name: 'Anthropic',
+      async login(interaction: any) {
+        try {
+          await interaction.prompt({ type: 'manual_code', message: 'paste' });
+          return { type: 'oauth', access: 'a', refresh: 'r', expires: Date.now() };
+        } catch (error) {
+          promptRejected?.(error);
+          throw error;
+        } finally {
+          portReleased();
+        }
+      },
+      refresh: async () => ({ type: 'oauth', access: 'a', refresh: 'r', expires: 0 }),
+      toAuth: async () => ({ apiKey: 'a' }),
+    },
+  } as unknown as OAuthProviderDescriptor;
+
+  return {
+    resolver: () => descriptor,
+    portReleased,
+    onPromptRejected: (fn: (reason: unknown) => void) => {
+      promptRejected = fn;
+    },
+  };
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('OAuthLoginSessionManager — callback port release', () => {
+  it('rejects the pending prompt (releasing the port) on cancel', async () => {
+    const provider = makeProviderResolver();
+    const manager = new OAuthLoginSessionManager(provider.resolver);
+
+    const session = await manager.createSession('anthropic', 'acct');
+    await flush();
+    expect(manager.getSession(session.id)?.status).toBe('awaiting_manual_code');
+
+    await manager.cancel(session.id);
+    await flush();
+
+    expect(provider.portReleased).toHaveBeenCalledTimes(1);
+    manager.dispose();
+  });
+
+  it('rejects the pending prompt (releasing the port) when a session expires', async () => {
+    const provider = makeProviderResolver();
+    const manager = new OAuthLoginSessionManager(provider.resolver);
+
+    const session = await manager.createSession('anthropic', 'acct');
+    await flush();
+
+    // Force expiry, then trigger cleanup via any read.
+    (manager as any).sessions.get(session.id).expiresAt = Date.now() - 1;
+    manager.getSession(session.id);
+    await flush();
+
+    expect(provider.portReleased).toHaveBeenCalledTimes(1);
+    manager.dispose();
+  });
+
+  it('rejects the pending prompt (releasing the port) on dispose', async () => {
+    const provider = makeProviderResolver();
+    const manager = new OAuthLoginSessionManager(provider.resolver);
+
+    await manager.createSession('anthropic', 'acct');
+    await flush();
+
+    manager.dispose();
+    await flush();
+
+    expect(provider.portReleased).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('OAuthLoginSessionManager — concurrent login guard', () => {
+  it('supersedes an active callback-server login, releasing its port', async () => {
+    const provider = makeProviderResolver();
+    const manager = new OAuthLoginSessionManager(provider.resolver);
+
+    const first = await manager.createSession('anthropic', 'acct-1');
+    await flush();
+
+    const second = await manager.createSession('anthropic', 'acct-2');
+    await flush();
+
+    // The stale login was cancelled and its port released before the new one.
+    expect(provider.portReleased).toHaveBeenCalledTimes(1);
+    expect(manager.getSession(first.id)?.status).toBe('cancelled');
+    expect(manager.getSession(first.id)?.error).toBe('Superseded by a new login');
+    expect(second.accountId).toBe('acct-2');
+    expect(manager.getSession(second.id)?.status).toBe('awaiting_manual_code');
+
+    manager.dispose();
+  });
+
+  it('allows a new login once the previous one is cancelled', async () => {
+    const provider = makeProviderResolver();
+    const manager = new OAuthLoginSessionManager(provider.resolver);
+
+    const first = await manager.createSession('anthropic', 'acct-1');
+    await flush();
+    await manager.cancel(first.id);
+    await flush();
+
+    const second = await manager.createSession('anthropic', 'acct-2');
+    expect(second.accountId).toBe('acct-2');
+
+    manager.dispose();
+  });
+});

--- a/packages/backend/src/services/oauth/oauth-login-session.ts
+++ b/packages/backend/src/services/oauth/oauth-login-session.ts
@@ -54,6 +54,13 @@ type ProviderResolver = (id: OAuthProviderId) => OAuthProviderDescriptor | undef
 
 const DEFAULT_SESSION_TTL_MS = 20 * 60 * 1000;
 
+const ACTIVE_STATUSES: ReadonlySet<OAuthSessionStatus> = new Set([
+  'in_progress',
+  'awaiting_auth',
+  'awaiting_prompt',
+  'awaiting_manual_code',
+]);
+
 const createSessionId = (): string => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -95,6 +102,9 @@ export class OAuthLoginSessionManager {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
     }
+    for (const session of this.sessions.values()) {
+      this.releaseSession(session, 'Login manager disposed');
+    }
     this.sessions.clear();
   }
 
@@ -117,6 +127,22 @@ export class OAuthLoginSessionManager {
     const provider = this.providerResolver(providerId);
     if (!provider) {
       throw new Error(`Unknown OAuth provider: ${providerId}`);
+    }
+
+    // Callback-server providers bind a fixed local port during login, so only
+    // one login per provider can be in flight at a time. A prior session may be
+    // orphaned (its id lost to a reload, or the browser is on another machine),
+    // leaving no way to cancel it — so supersede it here: cancel the stale login
+    // and wait for its callback server to release the port before continuing.
+    if (provider.usesCallbackServer) {
+      const active = this.findActiveSession(providerId);
+      if (active) {
+        active.status = 'cancelled';
+        active.error = 'Superseded by a new login';
+        this.releaseSession(active, 'Superseded by a new login');
+        this.touch(active);
+        await active.completion;
+      }
     }
 
     const now = Date.now();
@@ -179,15 +205,35 @@ export class OAuthLoginSessionManager {
     }
     session.status = 'cancelled';
     session.error = 'Login cancelled';
+    this.releaseSession(session, 'Login cancelled');
+    this.touch(session);
+    return this.stripInternal(session);
+  }
+
+  /**
+   * Abort the underlying login and reject any pending prompt. Rejecting the
+   * prompt is what makes pi-ai's login promise settle and close its callback
+   * server (which binds a fixed local port, e.g. Anthropic's 53692). Aborting
+   * the signal alone does not, so callers that drop a session (cancel, expiry,
+   * dispose) must go through here to avoid leaking the port.
+   */
+  private releaseSession(session: SessionInternal, reason: string): void {
     session.abortController.abort();
-    session.rejectPrompt?.(new Error('Login cancelled'));
-    session.rejectManualCode?.(new Error('Login cancelled'));
+    session.rejectPrompt?.(new Error(reason));
+    session.rejectManualCode?.(new Error(reason));
     session.resolvePrompt = undefined;
     session.rejectPrompt = undefined;
     session.resolveManualCode = undefined;
     session.rejectManualCode = undefined;
-    this.touch(session);
-    return this.stripInternal(session);
+  }
+
+  private findActiveSession(providerId: OAuthProviderId): SessionInternal | undefined {
+    for (const session of this.sessions.values()) {
+      if (session.providerId === providerId && ACTIVE_STATUSES.has(session.status)) {
+        return session;
+      }
+    }
+    return undefined;
   }
 
   private getInternal(sessionId: string): SessionInternal {
@@ -315,7 +361,7 @@ export class OAuthLoginSessionManager {
     const now = Date.now();
     for (const [id, session] of this.sessions.entries()) {
       if (session.expiresAt <= now) {
-        session.abortController.abort();
+        this.releaseSession(session, 'OAuth login session expired');
         this.sessions.delete(id);
       }
     }


### PR DESCRIPTION
Fixes local port leaks in OAuth login sessions using callback servers by explicitly rejecting pending prompts when sessions are cancelled, expired, disposed, or superseded by concurrent logins.