### PR TITLE
fix(gemini): signal malformed function calls

### DIFF
--- a/packages/backend/src/services/__tests__/usage-logging.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging.test.ts
@@ -396,6 +396,37 @@ describe('UsageInspector', () => {
       expect(capturedRecord!.tokensInput).toBeGreaterThan(0);
       expect(capturedRecord!.tokensEstimated).toBe(1);
     });
+
+    it('does not update performance metrics for errored streams', async () => {
+      const requestId = 'test-error-performance-metrics';
+      const inspector = new UsageInspector(
+        requestId,
+        mockStorage,
+        {
+          requestId,
+          provider: 'google',
+          selectedModelName: 'gemini-3.6-flash',
+          responseStatus: 'error',
+        } as Partial<UsageRecord>,
+        mockPricing,
+        undefined,
+        Date.now() - 100,
+        false,
+        'gemini',
+        undefined,
+        undefined,
+        DEFAULT_GPU_PARAMS,
+        DEFAULT_MODEL
+      );
+
+      const source = new PassThrough();
+      source.pipe(inspector);
+      source.end();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(mockStorage.saveRequest).toHaveBeenCalled();
+      expect(mockStorage.updatePerformanceMetrics).not.toHaveBeenCalled();
+    });
   });
 
   describe('_destroy() — client disconnect handling', () => {

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -287,7 +287,11 @@ export class UsageInspector extends PassThrough {
         });
       }
 
-      if (this.usageRecord.provider && this.usageRecord.selectedModelName) {
+      if (
+        this.usageRecord.responseStatus === 'success' &&
+        this.usageRecord.provider &&
+        this.usageRecord.selectedModelName
+      ) {
         // Fire-and-forget: updatePerformanceMetrics is async but _flush is synchronous
         // Attach error handler to prevent unhandled promise rejections
         this.usageStorage

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -177,12 +177,19 @@ export async function handleResponse(
   if (!unifiedResponse.stream && unifiedResponse.clientError) {
     const clientError = unifiedResponse.clientError;
     const responseBody = formatClientError(apiType, clientError);
-    usageRecord.responseStatus = 'error';
-    usageRecord.finishReason = clientError.code;
-    usageRecord.durationMs = Date.now() - startTime;
     DebugManager.getInstance().addTransformedResponse(usageRecord.requestId!, responseBody);
     DebugManager.getInstance().flush(usageRecord.requestId!);
-    usageStorage.saveRequest(usageRecord as UsageRecord);
+    await finalizeUsage(
+      usageRecord,
+      unifiedResponse,
+      usageStorage,
+      startTime,
+      pricing,
+      providerDiscount,
+      quotaEnforcer,
+      keyName,
+      { responseStatus: 'error', updatePerformanceMetrics: false }
+    );
     usageStorage.saveError(
       usageRecord.requestId!,
       new Error(clientError.message),
@@ -617,7 +624,8 @@ async function finalizeUsage(
   pricing: any,
   providerDiscount: any,
   quotaEnforcer?: QuotaEnforcer,
-  keyName?: string
+  keyName?: string,
+  options: { responseStatus?: 'success' | 'error'; updatePerformanceMetrics?: boolean } = {}
 ) {
   // Capture token usage if available in the response
   if (unifiedResponse.usage) {
@@ -630,7 +638,8 @@ async function finalizeUsage(
 
   // Capture response metadata
   usageRecord.toolCallsCount = unifiedResponse.tool_calls?.length ?? null;
-  usageRecord.finishReason = unifiedResponse.finishReason ?? null;
+  usageRecord.finishReason =
+    unifiedResponse.clientError?.code ?? unifiedResponse.finishReason ?? null;
 
   // Finalize costs and duration
   calculateCosts(usageRecord, pricing, providerDiscount);
@@ -659,7 +668,7 @@ async function finalizeUsage(
       applyUsageCostDetails(usageRecord, usageCostDetails);
     }
   }
-  usageRecord.responseStatus = 'success';
+  usageRecord.responseStatus = options.responseStatus ?? 'success';
   usageRecord.durationMs = Date.now() - startTime;
 
   // Populate performance metrics
@@ -694,7 +703,11 @@ async function finalizeUsage(
   await usageStorage.saveRequest(usageRecord as UsageRecord);
 
   // Update the performance sliding window for future routing decisions
-  if (usageRecord.provider && usageRecord.selectedModelName) {
+  if (
+    options.updatePerformanceMetrics !== false &&
+    usageRecord.provider &&
+    usageRecord.selectedModelName
+  ) {
     await usageStorage.updatePerformanceMetrics(
       usageRecord.provider,
       usageRecord.selectedModelName,

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -42,7 +42,7 @@ function shouldIncludePlaygroundRouting(request: FastifyRequest): boolean {
 }
 
 function formatClientError(
-  apiType: 'chat' | 'messages' | 'gemini' | 'responses',
+  apiType: 'chat' | 'messages' | 'gemini' | 'responses' | 'completions',
   error: NonNullable<UnifiedChatResponse['clientError']>
 ): Record<string, unknown> {
   if (apiType === 'gemini') {

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -21,6 +21,7 @@ import { recordQuotaUsage, buildQuotaHeaders } from '../quota/quota-middleware';
 import { CooldownManager } from '../runtime/cooldown-manager';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
 import { getApiBaseType } from '../../utils/api-format';
+import { rewriteGeminiMalformedFunctionCallStream } from '../../utils/gemini-malformed-function-call';
 
 function getHeaderValue(request: FastifyRequest, headerName: string): string | undefined {
   const value = request.headers?.[headerName];
@@ -38,6 +39,36 @@ function hasValidAdminKey(request: FastifyRequest): boolean {
 
 function shouldIncludePlaygroundRouting(request: FastifyRequest): boolean {
   return getHeaderValue(request, 'x-plexus-playground') === 'true' && hasValidAdminKey(request);
+}
+
+function formatClientError(
+  apiType: 'chat' | 'messages' | 'gemini' | 'responses',
+  error: NonNullable<UnifiedChatResponse['clientError']>
+): Record<string, unknown> {
+  if (apiType === 'gemini') {
+    return {
+      error: {
+        code: error.statusCode,
+        status: 'UNAVAILABLE',
+        message: error.message,
+      },
+    };
+  }
+
+  if (apiType === 'messages') {
+    return {
+      type: 'error',
+      error: { type: 'api_error', message: error.message },
+    };
+  }
+
+  return {
+    error: {
+      message: error.message,
+      type: 'server_error',
+      code: 'upstream_malformed_function_call',
+    },
+  };
 }
 /**
  * handleResponse
@@ -143,10 +174,37 @@ export async function handleResponse(
     }
   }
 
+  if (!unifiedResponse.stream && unifiedResponse.clientError) {
+    const clientError = unifiedResponse.clientError;
+    const responseBody = formatClientError(apiType, clientError);
+    usageRecord.responseStatus = 'error';
+    usageRecord.finishReason = clientError.code;
+    usageRecord.durationMs = Date.now() - startTime;
+    DebugManager.getInstance().addTransformedResponse(usageRecord.requestId!, responseBody);
+    DebugManager.getInstance().flush(usageRecord.requestId!);
+    usageStorage.saveRequest(usageRecord as UsageRecord);
+    usageStorage.saveError(
+      usageRecord.requestId!,
+      new Error(clientError.message),
+      {
+        apiType,
+        provider: usageRecord.provider,
+        targetModel: usageRecord.selectedModelName,
+        statusCode: clientError.statusCode,
+        code: clientError.code,
+        clientSignaled: true,
+      },
+      keyName
+    );
+    if (shouldEstimateTokens && !wasDebugEnabled) debugManager.setEnabled(false);
+    return reply.code(clientError.statusCode).send(responseBody);
+  }
+
   // --- Scenario A: Streaming Response ---
   if (unifiedResponse.stream) {
     let finalClientStream: ReadableStream;
     let rawStream = unifiedResponse.stream;
+    let hasSignaledGeminiMalformedFunctionCall = false;
 
     // TAP THE RAW STREAM for debugging/usage extraction
     // We always capture the stream BEFORE any transformation to enable usage extraction,
@@ -168,9 +226,36 @@ export async function handleResponse(
 
     rawStream = rawStream.pipeThrough(tapStream);
 
+    if (providerApiType === 'gemini') {
+      rawStream = rawStream.pipeThrough(
+        rewriteGeminiMalformedFunctionCallStream((defect) => {
+          if (hasSignaledGeminiMalformedFunctionCall) return;
+          hasSignaledGeminiMalformedFunctionCall = true;
+          usageRecord.responseStatus = 'error';
+          usageRecord.finishReason = defect.code;
+          usageStorage.saveError(
+            usageRecord.requestId!,
+            new Error(defect.message),
+            {
+              apiType,
+              provider: usageRecord.provider,
+              targetModel: usageRecord.selectedModelName,
+              statusCode: defect.statusCode,
+              code: defect.code,
+              clientSignaled: true,
+            },
+            keyName
+          );
+          logger.warn(
+            `[gemini] ${defect.code} detected in stream (textLeakDetected=${defect.textLeakDetected}); signaling client without failover or cooldown`
+          );
+        })
+      );
+    }
+
     if (unifiedResponse.bypassTransformation) {
-      // Direct pass-through: No changes to the provider's raw bytes
-      // Maximize performance and accuracy by avoiding unnecessary transformations
+      // Direct pass-through, except for retryable reclassification of Gemini's
+      // MALFORMED_FUNCTION_CALL terminal frame.
       finalClientStream = rawStream;
     } else {
       /**

--- a/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
@@ -581,4 +581,46 @@ describe('transformAnthropicStream tool call index remapping', () => {
     );
     expect(argChunksForBlock2[0].delta.tool_calls[0].index).toBe(1);
   });
+
+  test('formats transient upstream failures as terminal Anthropic error events', async () => {
+    const transformer = new AnthropicTransformer();
+    const stream = new ReadableStream<UnifiedChatStreamChunk>({
+      start(controller) {
+        controller.enqueue({
+          id: 'msg_error',
+          model: 'gemini-3.6-flash',
+          created: Date.now(),
+          event: 'error',
+          delta: {},
+          error: {
+            statusCode: 503,
+            code: 'MALFORMED_FUNCTION_CALL',
+            message:
+              'Upstream Gemini returned MALFORMED_FUNCTION_CALL — please retry your request. [503]',
+          },
+        });
+        controller.enqueue({
+          id: 'msg_error',
+          model: 'gemini-3.6-flash',
+          created: Date.now(),
+          event: 'done',
+          delta: {},
+        });
+        controller.close();
+      },
+    });
+
+    const reader = transformer.formatStream(stream).getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+
+    expect(output).toContain('event: error');
+    expect(output).toContain('please retry your request');
+    expect(output).not.toContain('event: message_stop');
+  });
 });

--- a/packages/backend/src/transformers/__tests__/gemini-openai-stream-regression.test.ts
+++ b/packages/backend/src/transformers/__tests__/gemini-openai-stream-regression.test.ts
@@ -103,6 +103,38 @@ describe('Gemini -> OpenAI stream regression', () => {
     expect(chunks.at(-1)).toBe('[DONE]');
   });
 
+  test('formats MALFORMED_FUNCTION_CALL as a retryable OpenAI stream error', async () => {
+    const geminiStream = createGeminiSSEStream([
+      JSON.stringify({
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Formattingcall:default_api:bash{command:bun run format}' }],
+            },
+            finishReason: 'MALFORMED_FUNCTION_CALL',
+            index: 0,
+          },
+        ],
+        responseId: 'resp_malformed',
+        modelVersion: 'gemini-3.6-flash',
+      }),
+      '[DONE]',
+    ]);
+
+    const unifiedStream = transformGeminiStream(geminiStream as ReadableStream);
+    const formattedStream = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formattedStream as ReadableStream<Uint8Array>);
+    const errorChunk = chunks.find((chunk) => chunk !== '[DONE]' && chunk.error);
+
+    expect(errorChunk.error).toEqual({
+      message: expect.stringContaining('please retry your request'),
+      type: 'server_error',
+      code: 'upstream_malformed_function_call',
+    });
+    expect(chunks).not.toContain('[DONE]');
+  });
+
   test('preserves upstream function call ids when Gemini provides them', async () => {
     const geminiStream = createGeminiSSEStream([
       JSON.stringify({

--- a/packages/backend/src/transformers/anthropic/stream-formatter.ts
+++ b/packages/backend/src/transformers/anthropic/stream-formatter.ts
@@ -41,6 +41,20 @@ export function formatAnthropicStream(stream: ReadableStream): ReadableStream {
         safeEnqueue(encode({ event, data: JSON.stringify(data) }));
       };
 
+      if (hasSentFinish) return;
+
+      if (chunk.event === 'error') {
+        sendEvent('error', {
+          type: 'error',
+          error: {
+            type: 'api_error',
+            message: chunk.error?.message,
+          },
+        });
+        hasSentFinish = true;
+        return;
+      }
+
       // Accumulate Usage
       if (chunk.usage) {
         lastUsage = chunk.usage;

--- a/packages/backend/src/transformers/gemini/__tests__/stream-transformer.test.ts
+++ b/packages/backend/src/transformers/gemini/__tests__/stream-transformer.test.ts
@@ -397,6 +397,36 @@ describe('transformGeminiStream', () => {
     expect(finishChunk?.finish_reason).toBe('recitation');
   });
 
+  test('should emit a retryable error event for MALFORMED_FUNCTION_CALL', async () => {
+    const sseData = [
+      JSON.stringify({
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Formattingcall:default_api:bash{command:bun run format}' }],
+            },
+            finishReason: 'MALFORMED_FUNCTION_CALL',
+            finishMessage: 'Malformed function call: Failed to parse function call',
+            index: 0,
+          },
+        ],
+        responseId: 'resp_malformed',
+        modelVersion: 'gemini-3.6-flash',
+      }),
+    ];
+
+    const chunks = await readAllChunks(transformGeminiStream(createSSEStream(sseData)));
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+
+    expect(errorChunk?.error).toEqual({
+      statusCode: 503,
+      code: 'MALFORMED_FUNCTION_CALL',
+      message: expect.stringContaining('please retry your request'),
+    });
+    expect(chunks.some((chunk) => chunk.finish_reason === 'malformed_function_call')).toBe(false);
+  });
+
   test('should handle usage-only chunk (no candidate)', async () => {
     const sseData = [
       '{"usageMetadata":{"promptTokenCount":123,"candidatesTokenCount":456,"totalTokenCount":579},"responseId":"resp_123","modelVersion":"gemini-1.5-flash"}',

--- a/packages/backend/src/transformers/gemini/response-transformer.ts
+++ b/packages/backend/src/transformers/gemini/response-transformer.ts
@@ -2,6 +2,7 @@ import { UnifiedChatResponse } from '../../types/unified';
 import { logger } from '../../utils/logger';
 import { isValidThoughtSignature } from './utils';
 import { normalizeGeminiUsage } from '../../utils/usage-normalizer';
+import { detectGeminiMalformedFunctionCall } from '../../utils/gemini-malformed-function-call';
 
 /**
  * Transforms a Gemini API response into unified format.
@@ -15,6 +16,13 @@ import { normalizeGeminiUsage } from '../../utils/usage-normalizer';
 export async function transformGeminiResponse(response: any): Promise<UnifiedChatResponse> {
   const candidate = response.candidates?.[0];
   const parts = candidate?.content?.parts || [];
+  const malformedFunctionCall = detectGeminiMalformedFunctionCall(response);
+
+  if (malformedFunctionCall) {
+    logger.warn(
+      `[gemini] ${malformedFunctionCall.code} detected in unary response (textLeakDetected=${malformedFunctionCall.textLeakDetected})`
+    );
+  }
 
   let content = '';
   let reasoning_content = '';
@@ -66,5 +74,12 @@ export async function transformGeminiResponse(response: any): Promise<UnifiedCha
     tool_calls: tool_calls.length > 0 ? tool_calls : undefined,
     finishReason,
     usage,
+    clientError: malformedFunctionCall
+      ? {
+          statusCode: malformedFunctionCall.statusCode,
+          code: malformedFunctionCall.code,
+          message: malformedFunctionCall.message,
+        }
+      : undefined,
   };
 }

--- a/packages/backend/src/transformers/gemini/stream-formatter.ts
+++ b/packages/backend/src/transformers/gemini/stream-formatter.ts
@@ -89,9 +89,12 @@ function buildGeminiFunctionCallPart(
 export function formatGeminiStream(stream: ReadableStream): ReadableStream {
   const encoder = new TextEncoder();
   const toolCallStates = new Map<string, PendingGeminiToolCall>();
+  let hasSentError = false;
 
   const transformer = new TransformStream({
     transform(chunk: any, controller) {
+      if (hasSentError) return;
+
       // Handle block lifecycle events
       if (chunk.event) {
         const eventName = chunk.event;
@@ -177,6 +180,13 @@ export function formatGeminiStream(stream: ReadableStream): ReadableStream {
                 },
               }
             : undefined;
+        } else if (eventName === 'error') {
+          hasSentError = true;
+          eventData.error = {
+            code: chunk.error?.statusCode || 503,
+            status: 'UNAVAILABLE',
+            message: chunk.error?.message,
+          };
         } else if (eventName === 'done') {
           eventData.type = 'done';
         }

--- a/packages/backend/src/transformers/gemini/stream-transformer.ts
+++ b/packages/backend/src/transformers/gemini/stream-transformer.ts
@@ -2,6 +2,7 @@ import { createParser, EventSourceMessage } from 'eventsource-parser';
 import { logger } from '../../utils/logger';
 import type { StreamBlockEventType } from '../../types/unified';
 import { normalizeGeminiUsage } from '../../utils/usage-normalizer';
+import { detectGeminiMalformedFunctionCall } from '../../utils/gemini-malformed-function-call';
 
 /**
  * Transforms a Gemini stream (Server-Sent Events) into unified stream format.
@@ -90,6 +91,7 @@ export function transformGeminiStream(stream: ReadableStream): ReadableStream {
 
             if (!candidate) return;
 
+            const malformedFunctionCall = detectGeminiMalformedFunctionCall(data);
             const parts = candidate.content?.parts || [];
 
             // Emit message_start on first valid candidate (even if parts is empty)
@@ -250,6 +252,24 @@ export function transformGeminiStream(stream: ReadableStream): ReadableStream {
                 );
                 controller.enqueue(endEvent);
                 activeBlockType = null;
+              }
+
+              if (malformedFunctionCall) {
+                controller.enqueue({
+                  id: data.responseId,
+                  model: data.modelVersion,
+                  created: Date.now(),
+                  event: 'error' as StreamBlockEventType,
+                  delta: {},
+                  error: {
+                    statusCode: malformedFunctionCall.statusCode,
+                    code: malformedFunctionCall.code,
+                    message: malformedFunctionCall.message,
+                  },
+                });
+                messageHasFunctionCalls = false;
+                streamedToolCallCount = 0;
+                return;
               }
 
               // Determine finish reason: if there are function calls, use the OpenAI-compatible

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -246,6 +246,7 @@ export class OpenAITransformer implements Transformer {
   formatStream(stream: ReadableStream): ReadableStream {
     const encoder = new TextEncoder();
     const reader = stream.getReader();
+    let hasSentError = false;
 
     return new ReadableStream({
       async start(controller) {
@@ -253,8 +254,30 @@ export class OpenAITransformer implements Transformer {
           while (true) {
             const { done, value: unifiedChunk } = await reader.read();
             if (done) {
-              controller.enqueue(encoder.encode(encode({ data: '[DONE]' })));
+              if (!hasSentError) {
+                controller.enqueue(encoder.encode(encode({ data: '[DONE]' })));
+              }
               break;
+            }
+
+            if (hasSentError) continue;
+
+            if (unifiedChunk.event === 'error') {
+              controller.enqueue(
+                encoder.encode(
+                  encode({
+                    data: JSON.stringify({
+                      error: {
+                        message: unifiedChunk.error?.message,
+                        type: 'server_error',
+                        code: 'upstream_malformed_function_call',
+                      },
+                    }),
+                  })
+                )
+              );
+              hasSentError = true;
+              continue;
             }
 
             const choice: any = {

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -235,6 +235,13 @@ export interface UnifiedChatResponse {
   rawResponse?: any;
   rawStream?: ReadableStream;
   finishReason?: string | null;
+  clientError?: UnifiedClientError;
+}
+
+export interface UnifiedClientError {
+  statusCode: number;
+  code: string;
+  message: string;
 }
 
 /**
@@ -255,6 +262,7 @@ export type StreamBlockEventType =
   | 'message_delta'
   | 'message_end'
   | 'usage'
+  | 'error'
   | 'done';
 
 export interface UnifiedChatStreamChunk {
@@ -284,6 +292,7 @@ export interface UnifiedChatStreamChunk {
   };
   finish_reason?: string | null;
   usage?: UnifiedUsage;
+  error?: UnifiedClientError;
 }
 
 // Unified Embeddings Request

--- a/packages/backend/src/utils/__tests__/gemini-malformed-function-call.test.ts
+++ b/packages/backend/src/utils/__tests__/gemini-malformed-function-call.test.ts
@@ -62,6 +62,11 @@ describe('Gemini MALFORMED_FUNCTION_CALL detection', () => {
     expect(await rewrite(input)).toBe(input);
   });
 
+  test('preserves ordinary CRLF bypass stream bytes exactly', async () => {
+    const input = 'data: {"candidates":[{"finishReason":"STOP"}]}\r\n\r\ndata: [DONE]\r\n\r\n';
+    expect(await rewrite(input)).toBe(input);
+  });
+
   test('rewrites only the malformed terminal frame with a retryable message', async () => {
     const onDetected = vi.fn();
     const payload = {

--- a/packages/backend/src/utils/__tests__/gemini-malformed-function-call.test.ts
+++ b/packages/backend/src/utils/__tests__/gemini-malformed-function-call.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  GEMINI_MALFORMED_FUNCTION_CALL_MESSAGE,
+  detectGeminiMalformedFunctionCall,
+  rewriteGeminiMalformedFunctionCallStream,
+} from '../gemini-malformed-function-call';
+
+async function rewrite(input: string, onDetected = vi.fn()): Promise<string> {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const midpoint = Math.floor(input.length / 2);
+      controller.enqueue(encoder.encode(input.slice(0, midpoint)));
+      controller.enqueue(encoder.encode(input.slice(midpoint)));
+      controller.close();
+    },
+  }).pipeThrough(rewriteGeminiMalformedFunctionCallStream(onDetected));
+
+  return new Response(stream).text();
+}
+
+describe('Gemini MALFORMED_FUNCTION_CALL detection', () => {
+  test('uses finishReason as the authoritative trigger and detects a glued text leak', () => {
+    const defect = detectGeminiMalformedFunctionCall({
+      candidates: [
+        {
+          finishReason: 'MALFORMED_FUNCTION_CALL',
+          content: {
+            parts: [
+              {
+                text: 'Format repository files with biome formatcall:default_api:bash{command:bun run format}',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(defect).toEqual({
+      code: 'MALFORMED_FUNCTION_CALL',
+      message: GEMINI_MALFORMED_FUNCTION_CALL_MESSAGE,
+      statusCode: 503,
+      textLeakDetected: true,
+    });
+  });
+
+  test('does not trigger from leaked text without the authoritative finish reason', () => {
+    expect(
+      detectGeminiMalformedFunctionCall({
+        candidates: [
+          {
+            finishReason: 'STOP',
+            content: { parts: [{ text: 'call:default_api:bash{command:bun run format}' }] },
+          },
+        ],
+      })
+    ).toBeNull();
+  });
+
+  test('preserves ordinary bypass stream bytes exactly', async () => {
+    const input = 'data: {"candidates":[{"finishReason":"STOP"}]}\n\ndata: [DONE]\n\n';
+    expect(await rewrite(input)).toBe(input);
+  });
+
+  test('rewrites only the malformed terminal frame with a retryable message', async () => {
+    const onDetected = vi.fn();
+    const payload = {
+      candidates: [
+        {
+          content: { parts: [{ text: 'call:default_api:bash{command:bun run format}' }] },
+          finishReason: 'MALFORMED_FUNCTION_CALL',
+          finishMessage: 'Malformed function call: Failed to parse function call',
+        },
+      ],
+    };
+    const output = await rewrite(`data: ${JSON.stringify(payload)}\n\n`, onDetected);
+    const rewritten = JSON.parse(output.slice('data: '.length).trim());
+
+    expect(rewritten.candidates[0].finishReason).toBe('MALFORMED_FUNCTION_CALL');
+    expect(rewritten.candidates[0].finishMessage).toBe(GEMINI_MALFORMED_FUNCTION_CALL_MESSAGE);
+    expect(onDetected).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/backend/src/utils/__tests__/response-handler.test.ts
+++ b/packages/backend/src/utils/__tests__/response-handler.test.ts
@@ -264,6 +264,14 @@ describe('handleResponse', () => {
         model: 'gemini-3.6-flash',
         apiType: 'gemini',
       },
+      usage: {
+        input_tokens: 100,
+        output_tokens: 12,
+        total_tokens: 112,
+        reasoning_tokens: 2,
+        cached_tokens: 0,
+        cache_creation_tokens: 0,
+      },
       clientError: {
         statusCode: 503,
         code: 'MALFORMED_FUNCTION_CALL',
@@ -272,6 +280,9 @@ describe('handleResponse', () => {
       },
     };
     const usageRecord: Partial<UsageRecord> = { requestId: 'req-malformed' };
+    const quotaEnforcer = {
+      recordUsage: vi.fn().mockResolvedValue(undefined),
+    };
 
     await handleResponse(
       mockRequest,
@@ -281,7 +292,11 @@ describe('handleResponse', () => {
       usageRecord,
       mockStorage,
       Date.now(),
-      'gemini'
+      'gemini',
+      false,
+      undefined,
+      quotaEnforcer as any,
+      'test-key'
     );
 
     expect(mockReply.code).toHaveBeenCalledWith(503);
@@ -293,7 +308,22 @@ describe('handleResponse', () => {
       },
     });
     expect(mockTransformer.formatResponse).not.toHaveBeenCalled();
-    expect(usageRecord.responseStatus).toBe('error');
+    expect(usageRecord).toEqual(
+      expect.objectContaining({
+        responseStatus: 'error',
+        finishReason: 'MALFORMED_FUNCTION_CALL',
+        tokensInput: 100,
+        tokensOutput: 12,
+        tokensReasoning: 2,
+      })
+    );
+    expect(quotaEnforcer.recordUsage).toHaveBeenCalledWith(
+      'test-key',
+      'google',
+      'gemini-3.6-flash',
+      expect.objectContaining({ tokensInput: 100, tokensOutput: 12, tokensReasoning: 2 })
+    );
+    expect(mockStorage.updatePerformanceMetrics).not.toHaveBeenCalled();
     expect(mockStorage.saveError).toHaveBeenCalledWith(
       'req-malformed',
       expect.any(Error),
@@ -301,7 +331,7 @@ describe('handleResponse', () => {
         code: 'MALFORMED_FUNCTION_CALL',
         clientSignaled: true,
       }),
-      undefined
+      'test-key'
     );
   });
 

--- a/packages/backend/src/utils/__tests__/response-handler.test.ts
+++ b/packages/backend/src/utils/__tests__/response-handler.test.ts
@@ -254,6 +254,57 @@ describe('handleResponse', () => {
     expect(usageRecord.provider).toBe('provider-2');
   });
 
+  test('signals unary transient client errors without formatting a successful response', async () => {
+    const unifiedResponse: UnifiedChatResponse = {
+      id: 'resp-malformed',
+      model: 'gemini-3.6-flash',
+      content: null,
+      plexus: {
+        provider: 'google',
+        model: 'gemini-3.6-flash',
+        apiType: 'gemini',
+      },
+      clientError: {
+        statusCode: 503,
+        code: 'MALFORMED_FUNCTION_CALL',
+        message:
+          'Upstream Gemini returned MALFORMED_FUNCTION_CALL — please retry your request. [503]',
+      },
+    };
+    const usageRecord: Partial<UsageRecord> = { requestId: 'req-malformed' };
+
+    await handleResponse(
+      mockRequest,
+      mockReply,
+      unifiedResponse,
+      mockTransformer,
+      usageRecord,
+      mockStorage,
+      Date.now(),
+      'gemini'
+    );
+
+    expect(mockReply.code).toHaveBeenCalledWith(503);
+    expect(mockReply.send).toHaveBeenCalledWith({
+      error: {
+        code: 503,
+        status: 'UNAVAILABLE',
+        message: expect.stringContaining('please retry your request'),
+      },
+    });
+    expect(mockTransformer.formatResponse).not.toHaveBeenCalled();
+    expect(usageRecord.responseStatus).toBe('error');
+    expect(mockStorage.saveError).toHaveBeenCalledWith(
+      'req-malformed',
+      expect.any(Error),
+      expect.objectContaining({
+        code: 'MALFORMED_FUNCTION_CALL',
+        clientSignaled: true,
+      }),
+      undefined
+    );
+  });
+
   describe('Usage Mapping Regression Tests', () => {
     test('should correctly map all usage fields in non-streaming response', async () => {
       const unifiedResponse: UnifiedChatResponse = {

--- a/packages/backend/src/utils/gemini-malformed-function-call.ts
+++ b/packages/backend/src/utils/gemini-malformed-function-call.ts
@@ -1,0 +1,72 @@
+export const GEMINI_MALFORMED_FUNCTION_CALL_CODE = 'MALFORMED_FUNCTION_CALL';
+export const GEMINI_MALFORMED_FUNCTION_CALL_MESSAGE =
+  'Upstream Gemini returned MALFORMED_FUNCTION_CALL (model emitted a text tool-call leak). This is a transient model defect — please retry your request. [503]';
+
+const GEMINI_TOOL_CALL_LEAK_PATTERN = /(?:print\()?call:\s*default_api[.:]|default_api\.\w+\s*\(/;
+
+export interface GeminiMalformedFunctionCall {
+  code: typeof GEMINI_MALFORMED_FUNCTION_CALL_CODE;
+  message: string;
+  statusCode: 503;
+  textLeakDetected: boolean;
+}
+
+export function detectGeminiMalformedFunctionCall(
+  payload: unknown
+): GeminiMalformedFunctionCall | null {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const candidate = (payload as any).candidates?.[0];
+  if (candidate?.finishReason !== GEMINI_MALFORMED_FUNCTION_CALL_CODE) return null;
+
+  const textLeakDetected = (candidate.content?.parts ?? []).some(
+    (part: any) => typeof part?.text === 'string' && GEMINI_TOOL_CALL_LEAK_PATTERN.test(part.text)
+  );
+
+  return {
+    code: GEMINI_MALFORMED_FUNCTION_CALL_CODE,
+    message: GEMINI_MALFORMED_FUNCTION_CALL_MESSAGE,
+    statusCode: 503,
+    textLeakDetected,
+  };
+}
+
+export function rewriteGeminiMalformedFunctionCallStream(
+  onDetected?: (defect: GeminiMalformedFunctionCall) => void
+): TransformStream<Uint8Array, Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = '';
+
+  const rewriteLine = (line: string): string => {
+    const match = /^(data:\s*)(.*)$/.exec(line);
+    if (!match || match[2] === '[DONE]') return line;
+
+    try {
+      const payload = JSON.parse(match[2]!);
+      const defect = detectGeminiMalformedFunctionCall(payload);
+      if (!defect) return line;
+
+      payload.candidates[0].finishMessage = defect.message;
+      onDetected?.(defect);
+      return `${match[1]}${JSON.stringify(payload)}`;
+    } catch {
+      return line;
+    }
+  };
+
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(`${rewriteLine(line)}\n`));
+      }
+    },
+    flush(controller) {
+      buffer += decoder.decode();
+      if (buffer) controller.enqueue(encoder.encode(rewriteLine(buffer)));
+    },
+  });
+}


### PR DESCRIPTION
## Summary
Detect Gemini `MALFORMED_FUNCTION_CALL` terminal responses and signal them to clients as transient, retryable upstream errors. This prevents tool-heavy Gemini sessions from ending with a terminal unknown error while deliberately avoiding Plexus failover and provider cooldown behavior.

## Why / Context
Gemini 3.x can intermittently leak an internal tool-call representation as text and terminate its own candidate with `MALFORMED_FUNCTION_CALL`. Forwarding that finish reason verbatim is non-retryable in clients such as pi even though regenerating the turn usually succeeds.

## Changes
- **Detection**: treat Gemini's terminal `finishReason` as authoritative and record leaked `default_api` call syntax as secondary telemetry, including calls glued to preceding text.
- **Unary responses**: return protocol-appropriate HTTP 503 errors for Gemini, OpenAI, Anthropic, and Responses clients.
- **Streaming responses**: emit terminal protocol-specific retryable errors instead of normal completion events.
- **Dispatcher bypass**: inspect Gemini streams before the `bypassTransformation` branch, preserving ordinary stream bytes and rewriting only malformed terminal frames with a retryable message.
- **Routing health**: record the defect as a client-signaled error without triggering failover, cooldown, or provider-failure handling.
- **Safety**: do not reconstruct or execute leaked tool calls whose Python-like argument syntax cannot be parsed reliably.

## Testing
- Added regression coverage for authoritative detection, glued text leaks, unchanged ordinary bypass streams, malformed bypass terminal rewriting, unary 503 responses, and OpenAI/Anthropic streaming error formats.
