### PR TITLE
feat(quota): support model- and surface-scoped weekly limits for Claude Code

### DIFF
--- a/packages/backend/src/services/quota/checkers/__tests__/claude-code-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/claude-code-checker.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMeterContext, isCheckerRegistered } from '../../checker-registry';
+import checkerDef from '../claude-code-checker';
+
+const makeCtx = (options: Record<string, unknown> = {}) =>
+  createMeterContext('claude-code-test', 'claude-code', {
+    apiKey: 'test-claude-token',
+    ...options,
+  });
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+function fableLimit(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: 'weekly_scoped',
+    group: 'weekly',
+    percent: 0,
+    severity: 'normal',
+    resets_at: '2026-06-04T00:00:00Z',
+    is_active: false,
+    scope: { model: { id: null, display_name: 'Fable' }, surface: null },
+    ...overrides,
+  };
+}
+
+describe('claude-code checker', () => {
+  let capturedAuth: string | undefined;
+
+  const setFetchMock = (response: Response): void => {
+    global.fetch = vi.fn(async (_input: unknown, init: unknown) => {
+      capturedAuth =
+        new Headers((init as RequestInit | undefined)?.headers).get('Authorization') ?? undefined;
+      return response;
+    }) as unknown as typeof fetch;
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    capturedAuth = undefined;
+  });
+
+  it('is registered under claude-code', () => {
+    expect(isCheckerRegistered('claude-code')).toBe(true);
+  });
+
+  it('parses five_hour and seven_day top-level windows', async () => {
+    setFetchMock(
+      jsonResponse({
+        five_hour: { utilization: 15, resets_at: '2026-06-01T21:00:00Z' },
+        seven_day: { utilization: 40, resets_at: '2026-06-04T00:00:00Z' },
+      })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+
+    expect(capturedAuth).toBe('Bearer test-claude-token');
+    expect(meters).toHaveLength(2);
+    expect(meters[0]).toMatchObject({
+      key: 'five_hour',
+      label: '5-hour quota',
+      used: 15,
+      remaining: 85,
+      resetsAt: '2026-06-01T21:00:00.000Z',
+    });
+    expect(meters[1]).toMatchObject({
+      key: 'weekly',
+      label: 'Weekly quota',
+      used: 40,
+      remaining: 60,
+      resetsAt: '2026-06-04T00:00:00.000Z',
+    });
+  });
+
+  it('renders a scoped weekly limit from limits[] as its own meter', async () => {
+    setFetchMock(
+      jsonResponse({
+        five_hour: { utilization: 6, resets_at: '2026-06-01T21:00:00Z' },
+        seven_day: { utilization: 23, resets_at: '2026-06-04T00:00:00Z' },
+        limits: [fableLimit({ percent: 12 })],
+      })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+
+    expect(meters.map((m) => m.key)).toEqual(['five_hour', 'weekly', 'weekly_model_fable']);
+
+    const fableMeter = meters.find((m) => m.key === 'weekly_model_fable');
+    expect(fableMeter).toMatchObject({
+      label: 'Weekly · Fable',
+      used: 12,
+      remaining: 88,
+      scope: 'model',
+      resetsAt: '2026-06-04T00:00:00.000Z',
+    });
+  });
+
+  it('renders a scoped window that is at zero percent', async () => {
+    setFetchMock(
+      jsonResponse({
+        seven_day: { utilization: 23, resets_at: '2026-06-04T00:00:00Z' },
+        limits: [fableLimit({ percent: 0, is_active: false })],
+      })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+
+    const fableMeter = meters.find((m) => m.key === 'weekly_model_fable');
+    expect(fableMeter).toMatchObject({
+      used: 0,
+      remaining: 100,
+    });
+  });
+
+  it('ignores session and weekly_all limit entries in limits[]', async () => {
+    setFetchMock(
+      jsonResponse({
+        five_hour: { utilization: 6, resets_at: '2026-06-01T21:00:00Z' },
+        seven_day: { utilization: 23, resets_at: '2026-06-04T00:00:00Z' },
+        limits: [
+          { kind: 'session', percent: 6, resets_at: '2026-06-01T21:00:00Z', scope: null },
+          { kind: 'weekly_all', percent: 23, resets_at: '2026-06-04T00:00:00Z', scope: null },
+          fableLimit(),
+        ],
+      })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+
+    expect(meters.map((m) => m.key)).toEqual(['five_hour', 'weekly', 'weekly_model_fable']);
+  });
+
+  it('labels a surface-scoped limit from its surface name', async () => {
+    setFetchMock(
+      jsonResponse({
+        seven_day: { utilization: 23, resets_at: '2026-06-04T00:00:00Z' },
+        limits: [
+          fableLimit({
+            scope: { model: null, surface: { id: 'code', display_name: 'Code' } },
+          }),
+        ],
+      })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+
+    expect(meters).toContainEqual(
+      expect.objectContaining({
+        key: 'weekly_surface_code',
+        label: 'Weekly · Code',
+        scope: 'surface',
+      })
+    );
+  });
+
+  it('keeps valid meters when a limits entry is malformed', async () => {
+    setFetchMock(
+      jsonResponse({
+        five_hour: { utilization: 6, resets_at: '2026-06-01T21:00:00Z' },
+        seven_day: { utilization: 23, resets_at: '2026-06-04T00:00:00Z' },
+        limits: [{ percent: 'not-a-valid-number' }, fableLimit()],
+      })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+
+    expect(meters.map((m) => m.key)).toEqual(['five_hour', 'weekly', 'weekly_model_fable']);
+  });
+
+  it('reconciles legacy seven_day_opus key with limits[] entry', async () => {
+    setFetchMock(
+      jsonResponse({
+        seven_day_opus: { utilization: 10, resets_at: '2026-06-04T00:00:00Z' },
+        limits: [
+          fableLimit({
+            percent: 25,
+            scope: { model: { id: 'claude-3-opus', display_name: 'Opus' }, surface: null },
+          }),
+        ],
+      })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+
+    expect(meters).toHaveLength(1);
+    expect(meters[0]).toMatchObject({
+      key: 'weekly_model_claude-3-opus',
+      label: 'Weekly · Opus',
+      used: 25,
+    });
+  });
+
+  it('distinguishes model and surface limits sharing the same name', async () => {
+    setFetchMock(
+      jsonResponse({
+        limits: [
+          fableLimit({
+            percent: 5,
+            scope: { model: { id: null, display_name: 'Code' }, surface: null },
+          }),
+          fableLimit({
+            percent: 15,
+            scope: { model: null, surface: { id: 'code', display_name: 'Code' } },
+          }),
+        ],
+      })
+    );
+
+    const meters = await checkerDef.check(makeCtx());
+
+    expect(meters.map((m) => m.key)).toEqual(['weekly_model_code', 'weekly_surface_code']);
+    expect(meters[0]).toMatchObject({ used: 5 });
+    expect(meters[1]).toMatchObject({ used: 15 });
+  });
+
+  it('throws for non-200 HTTP response', async () => {
+    setFetchMock(new Response('unauthorized', { status: 401, statusText: 'Unauthorized' }));
+
+    await expect(checkerDef.check(makeCtx())).rejects.toThrow('HTTP 401: Unauthorized');
+  });
+});

--- a/packages/backend/src/services/quota/checkers/claude-code-checker.ts
+++ b/packages/backend/src/services/quota/checkers/claude-code-checker.ts
@@ -4,15 +4,167 @@ import { OAuthAuthManager } from '../../oauth/oauth-auth-manager';
 import type { OAuthProvider } from '../../oauth/oauth-providers';
 import { logger } from '../../../utils/logger';
 
-interface UsageWindow {
-  utilization: number;
-  resets_at: string;
+const ClaudeUsageWindowSchema = z.object({
+  utilization: z.number(),
+  resets_at: z.string().nullish(),
+});
+
+const ClaudeScopeLabelSchema = z
+  .object({ id: z.string().nullish(), display_name: z.string().nullish() })
+  .nullish();
+
+const ClaudeLimitSchema = z.object({
+  kind: z.string(),
+  percent: z.number().nullish(),
+  resets_at: z.string().nullish(),
+  scope: z.object({ model: ClaudeScopeLabelSchema, surface: ClaudeScopeLabelSchema }).nullish(),
+});
+
+const ClaudeUsageResponseSchema = z.object({
+  five_hour: ClaudeUsageWindowSchema.nullish(),
+  seven_day: ClaudeUsageWindowSchema.nullish(),
+  seven_day_opus: ClaudeUsageWindowSchema.nullish(),
+  seven_day_omelette: ClaudeUsageWindowSchema.nullish(),
+  limits: z.array(z.unknown()).nullish(),
+});
+
+type ClaudeLimit = z.infer<typeof ClaudeLimitSchema>;
+type ClaudeUsageResponse = z.infer<typeof ClaudeUsageResponseSchema>;
+
+const SCOPED_WEEKLY_KIND = 'weekly_scoped';
+
+interface ScopedLimit {
+  dimension: 'model' | 'surface';
+  id: string | null;
+  name: string;
+  usedPct: number | null;
+  resetsAt: string | null;
 }
 
-interface OAuthUsageResponse {
-  five_hour: UsageWindow | null;
-  seven_day: UsageWindow | null;
-  [key: string]: unknown;
+const LEGACY_SCOPED_WINDOWS: ReadonlyArray<{
+  field: 'seven_day_opus' | 'seven_day_omelette';
+  name: string;
+}> = [
+  { field: 'seven_day_opus', name: 'Opus' },
+  { field: 'seven_day_omelette', name: 'Omelette' },
+];
+
+function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function isSameLimit(a: ScopedLimit, b: ScopedLimit): boolean {
+  if (a.dimension !== b.dimension) return false;
+  if (a.id && b.id) return a.id === b.id;
+  return normalizeName(a.name) === normalizeName(b.name);
+}
+
+function reconcileScopedLimits(
+  legacy: ScopedLimit[],
+  fromLimitsArray: ScopedLimit[]
+): ScopedLimit[] {
+  const reconciled = [...legacy];
+  for (const limit of fromLimitsArray) {
+    const index = reconciled.findIndex((candidate) => isSameLimit(candidate, limit));
+    if (index === -1) {
+      reconciled.push(limit);
+      continue;
+    }
+    const twin = reconciled[index];
+    reconciled[index] = {
+      ...limit,
+      usedPct: limit.usedPct ?? twin?.usedPct ?? null,
+      resetsAt: limit.resetsAt ?? twin?.resetsAt ?? null,
+    };
+  }
+  return reconciled;
+}
+
+function scopedLimitFromLegacy(
+  spec: (typeof LEGACY_SCOPED_WINDOWS)[number],
+  window: z.infer<typeof ClaudeUsageWindowSchema>
+): ScopedLimit {
+  return {
+    dimension: 'model',
+    id: null,
+    name: spec.name,
+    usedPct: window.utilization,
+    resetsAt: window.resets_at ?? null,
+  };
+}
+
+function scopedLimitFromEntry(limit: ClaudeLimit): ScopedLimit | null {
+  for (const dimension of ['model', 'surface'] as const) {
+    const entry = limit.scope?.[dimension];
+    const id = entry?.id?.trim() || null;
+    const name = entry?.display_name?.trim() || id;
+    if (name) {
+      return {
+        dimension,
+        id,
+        name,
+        usedPct: limit.percent ?? null,
+        resetsAt: limit.resets_at ?? null,
+      };
+    }
+  }
+  return null;
+}
+
+function scopedWindowKey(limit: ScopedLimit): string {
+  return `weekly_${limit.dimension}_${limit.id ?? normalizeName(limit.name)}`;
+}
+
+function uniqueWindowKey(candidate: string, taken: Set<string>): string {
+  if (!taken.has(candidate)) return candidate;
+  for (let suffix = 2; ; suffix += 1) {
+    const next = `${candidate}_${suffix}`;
+    if (!taken.has(next)) return next;
+  }
+}
+
+function legacyScopedLimits(resp: ClaudeUsageResponse): ScopedLimit[] {
+  const limits: ScopedLimit[] = [];
+  for (const spec of LEGACY_SCOPED_WINDOWS) {
+    const window = resp[spec.field];
+    if (window) limits.push(scopedLimitFromLegacy(spec, window));
+  }
+  return limits;
+}
+
+function scopedLimitsFromResponse(limits: unknown[] | null | undefined): ScopedLimit[] {
+  if (!limits || !Array.isArray(limits)) return [];
+
+  const parsed: ScopedLimit[] = [];
+  for (const entry of limits) {
+    const result = ClaudeLimitSchema.safeParse(entry);
+    if (!result.success) {
+      logger.warn(`Skipping unparseable Claude usage limit entry: ${result.error}`);
+      continue;
+    }
+    if (result.data.kind !== SCOPED_WEEKLY_KIND) continue;
+
+    const limit = scopedLimitFromEntry(result.data);
+    if (!limit) {
+      logger.warn('Skipping scoped Claude usage limit with no resolvable scope name');
+      continue;
+    }
+    parsed.push(limit);
+  }
+  return parsed;
+}
+
+function parseIsoDate(dateStr: string | null | undefined): string | undefined {
+  if (!dateStr) return undefined;
+  try {
+    const d = new Date(dateStr);
+    return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+  } catch {
+    return undefined;
+  }
 }
 
 async function resolveApiKey(ctx: {
@@ -63,8 +215,15 @@ export default defineChecker({
 
     if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
-    const usage = (await response.json()) as OAuthUsageResponse;
-    logger.silly(`Usage: ${JSON.stringify(usage)}`);
+    const rawData = await response.json();
+    logger.silly(`Usage: ${JSON.stringify(rawData)}`);
+
+    const parseResult = ClaudeUsageResponseSchema.safeParse(rawData);
+    if (!parseResult.success) {
+      logger.warn(`Failed to parse Claude usage response: ${parseResult.error}`);
+      return [];
+    }
+    const usage = parseResult.data;
 
     const meters = [];
 
@@ -75,11 +234,11 @@ export default defineChecker({
           label: '5-hour quota',
           unit: 'percentage',
           used: usage.five_hour.utilization,
-          remaining: 100 - usage.five_hour.utilization,
+          remaining: Math.max(0, 100 - usage.five_hour.utilization),
           periodValue: 5,
           periodUnit: 'hour',
           periodCycle: 'rolling',
-          resetsAt: new Date(usage.five_hour.resets_at).toISOString(),
+          resetsAt: parseIsoDate(usage.five_hour.resets_at),
         })
       );
     }
@@ -91,13 +250,44 @@ export default defineChecker({
           label: 'Weekly quota',
           unit: 'percentage',
           used: usage.seven_day.utilization,
-          remaining: 100 - usage.seven_day.utilization,
+          remaining: Math.max(0, 100 - usage.seven_day.utilization),
           periodValue: 7,
           periodUnit: 'day',
           periodCycle: 'rolling',
-          resetsAt: new Date(usage.seven_day.resets_at).toISOString(),
+          resetsAt: parseIsoDate(usage.seven_day.resets_at),
         })
       );
+    }
+
+    const scoped = reconcileScopedLimits(
+      legacyScopedLimits(usage),
+      scopedLimitsFromResponse(usage.limits)
+    );
+
+    const takenKeys = new Set<string>();
+    for (const limit of scoped) {
+      const key = uniqueWindowKey(scopedWindowKey(limit), takenKeys);
+      takenKeys.add(key);
+
+      const used = limit.usedPct ?? 0;
+      meters.push(
+        ctx.allowance({
+          key,
+          label: `Weekly · ${limit.name}`,
+          unit: 'percentage',
+          used,
+          remaining: limit.usedPct != null ? Math.max(0, 100 - limit.usedPct) : 100,
+          periodValue: 7,
+          periodUnit: 'day',
+          periodCycle: 'rolling',
+          resetsAt: parseIsoDate(limit.resetsAt),
+          scope: limit.dimension,
+        })
+      );
+    }
+
+    if (meters.length === 0) {
+      logger.warn('Claude usage response parsed but produced no meters');
     }
 
     logger.silly(`Returning ${meters.length} meters`);

--- a/packages/frontend/src/components/providers/ProviderQuotaEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderQuotaEditor.tsx
@@ -27,6 +27,7 @@ import { ExeDevQuotaConfig } from '../quota/ExeDevQuotaConfig';
 import { HyperQuotaConfig } from '../quota/HyperQuotaConfig';
 import { SakanaQuotaConfig } from '../quota/SakanaQuotaConfig';
 import { ClineQuotaConfig } from '../quota/ClineQuotaConfig';
+import { ClaudeCodeQuotaConfig } from '../quota/ClaudeCodeQuotaConfig';
 
 interface Props {
   editingProvider: Provider;
@@ -73,6 +74,7 @@ const QUOTA_CONFIG_MAP: Record<
   hyper: HyperQuotaConfig,
   sakana: SakanaQuotaConfig,
   cline: ClineQuotaConfig,
+  'claude-code': ClaudeCodeQuotaConfig,
 };
 
 export function ProviderQuotaEditor({

--- a/packages/frontend/src/components/quota/AllowanceMeterRow.tsx
+++ b/packages/frontend/src/components/quota/AllowanceMeterRow.tsx
@@ -84,7 +84,14 @@ export const AllowanceMeterRow: React.FC<AllowanceMeterRowProps> = ({
       onClick={onClick}
       title={onClick ? 'Click to view history' : undefined}
     >
-      <span className="text-xs text-text-secondary truncate">{meter.label}</span>
+      <div className="flex items-center justify-between gap-1 min-w-0">
+        <span className="text-xs text-text-secondary truncate">{meter.label}</span>
+        {meter.scope && (
+          <span className="text-[10px] text-text-muted px-1 bg-bg-subtle border border-border-glass/40 rounded uppercase tracking-wider font-mono">
+            {meter.scope}
+          </span>
+        )}
+      </div>
       {pct !== null && (
         <div className="h-1.5 rounded-full bg-bg-subtle overflow-hidden border border-border/30">
           <div

--- a/packages/frontend/src/components/quota/AllowanceMeterRow.tsx
+++ b/packages/frontend/src/components/quota/AllowanceMeterRow.tsx
@@ -85,9 +85,9 @@ export const AllowanceMeterRow: React.FC<AllowanceMeterRowProps> = ({
       title={onClick ? 'Click to view history' : undefined}
     >
       <div className="flex items-center justify-between gap-1 min-w-0">
-        <span className="text-xs text-text-secondary truncate">{meter.label}</span>
+        <span className="text-xs text-text-secondary truncate min-w-0 flex-1">{meter.label}</span>
         {meter.scope && (
-          <span className="text-[10px] text-text-muted px-1 bg-bg-subtle border border-border-glass/40 rounded uppercase tracking-wider font-mono">
+          <span className="text-[10px] text-text-muted px-1 bg-bg-subtle border border-border-glass/40 rounded uppercase tracking-wider font-mono shrink-0">
             {meter.scope}
           </span>
         )}

--- a/packages/frontend/src/components/quota/ClaudeCodeQuotaConfig.tsx
+++ b/packages/frontend/src/components/quota/ClaudeCodeQuotaConfig.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Input } from '../ui/Input';
+
+export interface ClaudeCodeQuotaConfigProps {
+  options: Record<string, unknown>;
+  onChange: (options: Record<string, unknown>) => void;
+}
+
+export const ClaudeCodeQuotaConfig: React.FC<ClaudeCodeQuotaConfigProps> = ({
+  options,
+  onChange,
+}) => {
+  const handleChange = (key: string, value: string) => {
+    onChange({ ...options, [key]: value });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-1">
+        <label className="font-body text-[13px] font-medium text-text-secondary">
+          Endpoint (optional)
+        </label>
+        <Input
+          value={(options.endpoint as string) ?? ''}
+          onChange={(e) => handleChange('endpoint', e.target.value)}
+          placeholder="https://api.anthropic.com/api/oauth/usage"
+        />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
Parses and reconciles model-scoped and surface-scoped weekly usage limits from Anthropic's OAuth usage response (`https://api.anthropic.com/api/oauth/usage`) in the Claude Code quota checker (`claude-code`). Also adds UI support for custom checker configuration and scope badges on allowance rows.

## Why / Context
Anthropic updated its OAuth usage response format to move model- and surface-scoped weekly limits into a `limits[]` array of objects (e.g. `kind === "weekly_scoped"`). Previously, Plexus only parsed `five_hour` and `seven_day` top-level keys, omitting model-specific limits (such as Opus, Sonnet, Fable, or Code surface caps).

## Changes
- **Backend Quota Checker**: Updated `claude-code-checker.ts` to safely parse `limits[]` items and reconcile them with legacy top-level scoped keys (`seven_day_opus`, `seven_day_omelette`). Uses single-entry `safeParse` validation so unexpected limit kinds don't break overall quota execution.
- **Backend Tests**: Added comprehensive unit test suite in `claude-code-checker.test.ts` covering top-level windows, scoped limits in `limits[]`, zero-utilization entries, malformed entry recovery, and reconciliation matrix.
- **Frontend Quota Config**: Created `ClaudeCodeQuotaConfig` and registered `'claude-code'` in `QUOTA_CONFIG_MAP` within `ProviderQuotaEditor` to allow endpoint configuration.
- **Frontend UI Display**: Updated `AllowanceMeterRow` to render a scope pill (`MODEL` / `SURFACE`) whenever a meter carries a `scope` tag.

## Testing
- Executed unit test suite (`bun run test:force claude-code-checker.test.ts`) covering all 10 reconciliation scenarios.
- Verified workspace typechecks (`bun run typecheck`), linting, and formatting (`bun run format:check && bun run lint:check`).
- Verified UI rendering via agent-browser against local dev stack (`bun run dev:agent`).
