### PR TITLE
fix(worktree): remove duplicate rebase step

### DIFF
--- a/scripts/init_worktree.ts
+++ b/scripts/init_worktree.ts
@@ -19,7 +19,6 @@ const commands: readonly Command[] = [
     cmd: ['git', 'fetch', 'origin', 'main:refs/remotes/origin/main'],
   },
   { label: 'Rebase worktree onto origin/main', cmd: ['git', 'rebase', 'origin/main'] },
-  { label: 'Rebase worktree onto origin/main', cmd: ['git', 'pull'] },
   { label: 'Trust mise configuration', cmd: ['mise', 'trust'] },
   { label: 'Install Bun dependencies', cmd: ['bun', 'install'] },
   { label: 'Build frontend', cmd: ['bun', 'run', 'build:frontend'] },


### PR DESCRIPTION
## Summary
Worktree initialization now rebases only once against `origin/main`. This removes the redundant follow-up pull and keeps setup deterministic.

## Changes
- **Worktree initialization**: remove the duplicate rebase-labelled `git pull` command after the explicit `git rebase origin/main` step.

## Testing
- Ran the pre-commit checks, including formatting, linting, migration validation, and workspace typechecking.
