### PR TITLE
fix(gateway): cross-format OAuth responses, Responses API param sanit…

### DIFF
--- a/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
+++ b/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
@@ -45,6 +45,32 @@ describe('resolveAdapters', () => {
     ]);
   });
 
+  it('auto-injects unsupported-option suppression for a provider-prefixed GPT-5 target model', () => {
+    // Target models routed through the pi-ai registry carry a provider prefix
+    // (e.g. an OpenLimits aggregator target for gpt-5.5), which the anchored
+    // legacy regex missed entirely.
+    const route: RouteResult = { ...makeRoute(), model: 'openai/gpt-5.5' };
+    expect(resolveAdapters(route).map((r) => r.adapter.name)).toEqual([
+      'suppress_unsupported_gpt5_options',
+    ]);
+  });
+
+  it('auto-injects unsupported-option suppression for gpt-5 and gpt-5-mini', () => {
+    for (const model of ['gpt-5', 'gpt-5-mini']) {
+      const route: RouteResult = { ...makeRoute(), model };
+      expect(resolveAdapters(route).map((r) => r.adapter.name)).toEqual([
+        'suppress_unsupported_gpt5_options',
+      ]);
+    }
+  });
+
+  it('does not auto-inject GPT-5 suppression for lookalike model ids', () => {
+    for (const model of ['gpt-55', 'chatgpt-5', 'my-gpt-5x']) {
+      const route: RouteResult = { ...makeRoute(), model };
+      expect(resolveAdapters(route)).toHaveLength(0);
+    }
+  });
+
   it('does not auto-inject GPT-5 suppression for other model families', () => {
     const route: RouteResult = { ...makeRoute(), model: 'gpt-4.1' };
     expect(resolveAdapters(route)).toHaveLength(0);

--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -112,4 +112,230 @@ describe('DebugLoggingInspector Reconstruction', () => {
     expect(snapshot).not.toBeNull();
     expect(snapshot.candidates[0].finishReason).toBe('STOP');
   });
+
+  describe('reconstructResponses streaming (Responses API)', () => {
+    const writeEvents = (stream: any, events: any[]) => {
+      for (const event of events) {
+        stream.write(Buffer.from(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      stream.end();
+    };
+
+    test('response.failed captures status, error, and usage (mid-stream failure)', async () => {
+      const failedRequestId = 'test-responses-failed';
+      const inspector = new DebugLoggingInspector(failedRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_test123',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'in_progress',
+            model: 'gpt-4o',
+            output: [],
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: '' }],
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          output_index: 0,
+          content_index: 0,
+          delta: 'Partial answer before it broke',
+        },
+        {
+          type: 'response.failed',
+          response: {
+            id: 'resp_test123',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'failed',
+            model: 'gpt-4o',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Partial answer before it broke' }],
+              },
+            ],
+            error: { code: 'server_error', message: 'The model response failed to complete.' },
+            usage: {
+              input_tokens: 42,
+              output_tokens: 8,
+              total_tokens: 50,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens_details: { reasoning_tokens: 0 },
+            },
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const dm = DebugManager.getInstance();
+      const snapshot = dm.getReconstructedRawResponse(failedRequestId);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.status).toBe('failed');
+      expect(snapshot.error).toEqual({
+        code: 'server_error',
+        message: 'The model response failed to complete.',
+      });
+      expect(snapshot.usage).toEqual({
+        input_tokens: 42,
+        output_tokens: 8,
+        total_tokens: 50,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      });
+    });
+
+    test('response.incomplete captures status, incomplete_details, and usage (max_output_tokens truncation)', async () => {
+      const incompleteRequestId = 'test-responses-incomplete';
+      const inspector = new DebugLoggingInspector(incompleteRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_test789',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'in_progress',
+            model: 'gpt-4o',
+            output: [],
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: '' }],
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          output_index: 0,
+          content_index: 0,
+          delta: 'Truncated answer that ran out of ',
+        },
+        {
+          type: 'response.incomplete',
+          response: {
+            id: 'resp_test789',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'incomplete',
+            model: 'gpt-4o',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Truncated answer that ran out of ' }],
+              },
+            ],
+            incomplete_details: { reason: 'max_output_tokens' },
+            usage: {
+              input_tokens: 30,
+              output_tokens: 16,
+              total_tokens: 46,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens_details: { reasoning_tokens: 0 },
+            },
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const dm = DebugManager.getInstance();
+      const snapshot = dm.getReconstructedRawResponse(incompleteRequestId);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.status).toBe('incomplete');
+      expect(snapshot.incomplete_details).toEqual({ reason: 'max_output_tokens' });
+      expect(snapshot.usage).toEqual({
+        input_tokens: 30,
+        output_tokens: 16,
+        total_tokens: 46,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      });
+    });
+
+    test('response.completed still captures status and usage (regression)', async () => {
+      const completedRequestId = 'test-responses-completed';
+      const inspector = new DebugLoggingInspector(completedRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_test456',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'in_progress',
+            model: 'gpt-4o',
+            output: [],
+          },
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_test456',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'completed',
+            model: 'gpt-4o',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Full answer' }],
+              },
+            ],
+            usage: {
+              input_tokens: 42,
+              output_tokens: 20,
+              total_tokens: 62,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens_details: { reasoning_tokens: 0 },
+            },
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const dm = DebugManager.getInstance();
+      const snapshot = dm.getReconstructedRawResponse(completedRequestId);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.status).toBe('completed');
+      expect(snapshot.error).toBeUndefined();
+      expect(snapshot.usage).toEqual({
+        input_tokens: 42,
+        output_tokens: 20,
+        total_tokens: 62,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      });
+    });
+  });
 });

--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -201,6 +201,79 @@ describe('DebugLoggingInspector Reconstruction', () => {
       });
     });
 
+    test('response.failed with NO usage captures status and error, and absent usage stays absent', async () => {
+      const failedNoUsageRequestId = 'test-responses-failed-no-usage';
+      const inspector = new DebugLoggingInspector(failedNoUsageRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_nousage_1',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'in_progress',
+            model: 'gpt-4o',
+            output: [],
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: '' }],
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          output_index: 0,
+          content_index: 0,
+          delta: 'Partial answer before it broke',
+        },
+        {
+          type: 'response.failed',
+          response: {
+            id: 'resp_nousage_1',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'failed',
+            model: 'gpt-4o',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Partial answer before it broke' }],
+              },
+            ],
+            error: { code: 'server_error', message: 'The model response failed to complete.' },
+            // No usage at all — the upstream failed before reporting any.
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const dm = DebugManager.getInstance();
+      const snapshot = dm.getReconstructedRawResponse(failedNoUsageRequestId);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.status).toBe('failed');
+      expect(snapshot.error).toEqual({
+        code: 'server_error',
+        message: 'The model response failed to complete.',
+      });
+      // Usage was never reported anywhere in the stream: it must stay
+      // ABSENT on the snapshot (no phantom `usage` own property either),
+      // locking in the optional-usage contract downstream consumers
+      // (usage-logging) rely on.
+      expect(snapshot.usage).toBeUndefined();
+      expect(snapshot).not.toHaveProperty('usage');
+    });
+
     test('response.incomplete captures status, incomplete_details, and usage (max_output_tokens truncation)', async () => {
       const incompleteRequestId = 'test-responses-incomplete';
       const inspector = new DebugLoggingInspector(incompleteRequestId, 'raw');

--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -4,6 +4,19 @@ import { Dispatcher } from '../dispatch/dispatcher';
 import * as piAiRegistry from '../pi-ai/registry';
 import type { RouteResult } from '../routing/router';
 import type { UnifiedChatRequest } from '../../types/unified';
+import {
+  createUnsupportedParamStripState,
+  deleteDottedPath,
+  matchUnsupportedParameter,
+  planUnsupportedParamStrip,
+  MAX_UNSUPPORTED_PARAM_STRIP_RETRIES,
+  createThinkingSignatureStripState,
+  isAnthropicMessagesPayload,
+  matchThinkingSignatureError,
+  planThinkingSignatureStrip,
+  stripThinkingSignatureBlocks,
+  MAX_THINKING_SIGNATURE_STRIP_RETRIES,
+} from '../dispatch/dispatcher-auto-compat';
 
 function route(overrides: Partial<RouteResult> = {}): RouteResult {
   return {
@@ -197,5 +210,653 @@ describe('Dispatcher registry auto-compat', () => {
     );
 
     expect(result.payload.reasoning_effort).toBe('low');
+  });
+});
+
+describe('matchUnsupportedParameter', () => {
+  test('extracts the param name from a {"detail": "..."} body', () => {
+    expect(matchUnsupportedParameter('{"detail":"Unsupported parameter: safety_identifier"}')).toBe(
+      'safety_identifier'
+    );
+  });
+
+  test('extracts the param name from a {"error":{"message": "..."}} body with quotes', () => {
+    expect(
+      matchUnsupportedParameter(
+        '{"error":{"message":"Unsupported parameter: \'prompt_cache_key\'"}}'
+      )
+    ).toBe('prompt_cache_key');
+  });
+
+  test('extracts dotted-path param names', () => {
+    expect(
+      matchUnsupportedParameter(
+        '{"error":{"message":"Unsupported parameter: \'reasoning.summary\'"}}'
+      )
+    ).toBe('reasoning.summary');
+  });
+
+  test('returns undefined when the body does not name an unsupported parameter', () => {
+    expect(matchUnsupportedParameter('{"error":{"message":"Invalid request"}}')).toBeUndefined();
+  });
+
+  test('returns undefined for an empty body', () => {
+    expect(matchUnsupportedParameter('')).toBeUndefined();
+  });
+});
+
+describe('deleteDottedPath', () => {
+  test('deletes a top-level field and returns deleted:true with a new payload object', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5', safety_identifier: 'abc' };
+    const result = deleteDottedPath(payload, 'safety_identifier');
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({ model: 'gpt-5.5' });
+    // Copy-on-write: the ORIGINAL argument object is never mutated.
+    expect(payload).toEqual({ model: 'gpt-5.5', safety_identifier: 'abc' });
+    expect(result.payload).not.toBe(payload);
+  });
+
+  test('deletes a nested field via a dotted path, preserving siblings', () => {
+    const payload: Record<string, any> = {
+      reasoning: { effort: 'high', summary: 'auto' },
+    };
+    const result = deleteDottedPath(payload, 'reasoning.summary');
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({ reasoning: { effort: 'high' } });
+    // Original untouched.
+    expect(payload).toEqual({ reasoning: { effort: 'high', summary: 'auto' } });
+  });
+
+  test('returns deleted:false and leaves the payload untouched when the field is absent', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5' };
+    const result = deleteDottedPath(payload, 'safety_identifier');
+    expect(result.deleted).toBe(false);
+    expect(result.payload).toEqual({ model: 'gpt-5.5' });
+    expect(payload).toEqual({ model: 'gpt-5.5' });
+  });
+
+  test('returns deleted:false without throwing when an intermediate segment does not exist', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5' };
+    const result = deleteDottedPath(payload, 'reasoning.summary');
+    expect(result.deleted).toBe(false);
+    expect(result.payload).toEqual({ model: 'gpt-5.5' });
+  });
+
+  test('returns deleted:false without throwing when an intermediate segment is not an object', () => {
+    const payload: Record<string, any> = { reasoning: 'not-an-object' };
+    const result = deleteDottedPath(payload, 'reasoning.summary');
+    expect(result.deleted).toBe(false);
+    expect(result.payload).toEqual({ reasoning: 'not-an-object' });
+  });
+
+  // --- SECURITY: prototype-pollution hardening -------------------------------
+  //
+  // `path` is attacker-influenced: it comes from parsing an UPSTREAM PROVIDER's
+  // error message (matchUnsupportedParameter's `[\w.]+` capture group matches
+  // dots AND underscores, so a malicious/compromised upstream can name
+  // `__proto__.toString` as the "unsupported parameter"). The OLD
+  // implementation traversed with `segment in target` (true for INHERITED
+  // properties too) and mutated in place — `payload.__proto__` resolves via
+  // the inherited accessor to the REAL `Object.prototype`, so
+  // `deleteDottedPath({}, '__proto__.toString')` would delete the global
+  // `Object.prototype.toString` for the entire process, permanently, for
+  // every subsequent request.
+  describe('prototype-pollution hardening', () => {
+    test('rejects a `__proto__.<leaf>` path and leaves Object.prototype.toString intact', () => {
+      const originalToString = Object.prototype.toString;
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+
+      const result = deleteDottedPath(payload, '__proto__.toString');
+
+      expect(result.deleted).toBe(false);
+      expect(result.payload).toEqual({ model: 'gpt-5.5' });
+      // The actual attack: prove global state survived, not just that the
+      // function returned a particular value.
+      expect(Object.prototype.toString).toBe(originalToString);
+      expect(typeof Object.prototype.toString).toBe('function');
+      expect({}.toString()).toBe('[object Object]');
+    });
+
+    test('rejects a bare top-level `__proto__` path', () => {
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+      const result = deleteDottedPath(payload, '__proto__');
+      expect(result.deleted).toBe(false);
+      expect(Object.getPrototypeOf(payload)).toBe(Object.prototype);
+    });
+
+    test('rejects `constructor.prototype.<leaf>` (classic gadget path)', () => {
+      const originalToString = Object.prototype.toString;
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+
+      const result = deleteDottedPath(payload, 'constructor.prototype.toString');
+
+      expect(result.deleted).toBe(false);
+      expect(Object.prototype.toString).toBe(originalToString);
+      expect(typeof Object.prototype.toString).toBe('function');
+    });
+
+    test('rejects a dangerous segment appearing in the middle of the path, not just at the edges', () => {
+      const payload: Record<string, any> = { a: { __proto__: { b: 'x' } } };
+      const result = deleteDottedPath(payload, 'a.__proto__.b');
+      expect(result.deleted).toBe(false);
+    });
+
+    test('rejects `prototype` as a segment name', () => {
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+      const result = deleteDottedPath(payload, 'prototype.polluted');
+      expect(result.deleted).toBe(false);
+    });
+
+    test('traverses only OWN enumerable properties — inherited properties are never walked', () => {
+      // `toString` is never an OWN property of a plain object literal; it's
+      // inherited from Object.prototype. `in` (the old check) would say
+      // true; hasOwnProperty must say false.
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+      const result = deleteDottedPath(payload, 'toString');
+      expect(result.deleted).toBe(false);
+      expect(typeof payload.toString).toBe('function');
+    });
+  });
+
+  // --- Copy-on-write: shared nested objects must never be mutated ------------
+  //
+  // `providerPayload.reasoning` can be the SAME object reference as the
+  // long-lived `UnifiedChatRequest.reasoning` (see
+  // `payload.reasoning = request.reasoning` in transformers/responses.ts).
+  // Mutating it in place would corrupt that shared object for every OTHER
+  // failover target built from the same request afterward.
+  describe('copy-on-write (shared nested object references)', () => {
+    test('does not mutate a nested object shared by reference with another source object', () => {
+      const sharedReasoning = { effort: 'high', summary: 'auto' };
+      const request = { reasoning: sharedReasoning };
+      // Mirrors `payload.reasoning = request.reasoning` — same reference, not a clone.
+      const payload: Record<string, any> = { model: 'gpt-5.5', reasoning: request.reasoning };
+      expect(payload.reasoning).toBe(sharedReasoning);
+
+      const result = deleteDottedPath(payload, 'reasoning.summary');
+
+      expect(result.deleted).toBe(true);
+      expect(result.payload).toEqual({ model: 'gpt-5.5', reasoning: { effort: 'high' } });
+
+      // Assert BY REFERENCE: the source object binding is untouched...
+      expect(request.reasoning).toBe(sharedReasoning);
+      // ...AND by deep equality: its CONTENT was never mutated in place.
+      expect(request.reasoning).toEqual({ effort: 'high', summary: 'auto' });
+      expect(sharedReasoning).toEqual({ effort: 'high', summary: 'auto' });
+
+      // The original `payload` argument itself is also untouched.
+      expect(payload).toEqual({ model: 'gpt-5.5', reasoning: sharedReasoning });
+      expect(payload.reasoning).toBe(sharedReasoning);
+
+      // The returned payload's reasoning object is a NEW object, not the shared one.
+      expect(result.payload.reasoning).not.toBe(sharedReasoning);
+    });
+
+    test('sibling nested objects on the payload are shared (not cloned) since they are never touched', () => {
+      const untouchedSibling = { foo: 'bar' };
+      const payload: Record<string, any> = {
+        reasoning: { effort: 'high', summary: 'auto' },
+        metadata: untouchedSibling,
+      };
+
+      const result = deleteDottedPath(payload, 'reasoning.summary');
+
+      expect(result.deleted).toBe(true);
+      // Untouched branch of the object tree is the SAME reference (only the
+      // path actually being modified gets cloned).
+      expect(result.payload.metadata).toBe(untouchedSibling);
+    });
+  });
+});
+
+describe('planUnsupportedParamStrip', () => {
+  test('strips a newly-named param and records the attempt', () => {
+    const state = createUnsupportedParamStripState();
+    const result = planUnsupportedParamStrip(
+      '{"detail":"Unsupported parameter: safety_identifier"}',
+      state
+    );
+    expect(result).toBe('safety_identifier');
+    expect(state.attempts).toBe(1);
+    expect(state.strippedParams.has('safety_identifier')).toBe(true);
+  });
+
+  test('allows up to MAX_UNSUPPORTED_PARAM_STRIP_RETRIES distinct params, then stops', () => {
+    expect(MAX_UNSUPPORTED_PARAM_STRIP_RETRIES).toBe(2);
+    const state = createUnsupportedParamStripState();
+
+    expect(
+      planUnsupportedParamStrip('{"detail":"Unsupported parameter: safety_identifier"}', state)
+    ).toBe('safety_identifier');
+    expect(
+      planUnsupportedParamStrip('{"detail":"Unsupported parameter: prompt_cache_key"}', state)
+    ).toBe('prompt_cache_key');
+
+    // Bound reached — a THIRD distinct param must not trigger another retry.
+    expect(
+      planUnsupportedParamStrip('{"detail":"Unsupported parameter: reasoning.summary"}', state)
+    ).toBeUndefined();
+    expect(state.attempts).toBe(2);
+  });
+
+  test('stops immediately (no infinite loop) when upstream keeps naming the same param', () => {
+    const state = createUnsupportedParamStripState();
+    const body = '{"detail":"Unsupported parameter: safety_identifier"}';
+
+    expect(planUnsupportedParamStrip(body, state)).toBe('safety_identifier');
+    // Upstream 400s again naming the SAME param even after it was stripped —
+    // stop rather than burning through the retry bound on a no-op.
+    expect(planUnsupportedParamStrip(body, state)).toBeUndefined();
+    expect(planUnsupportedParamStrip(body, state)).toBeUndefined();
+    expect(state.attempts).toBe(1);
+  });
+
+  test('returns undefined when the body does not name an unsupported parameter', () => {
+    const state = createUnsupportedParamStripState();
+    expect(
+      planUnsupportedParamStrip('{"error":{"message":"Invalid request"}}', state)
+    ).toBeUndefined();
+    expect(state.attempts).toBe(0);
+  });
+});
+
+// prompt_cache_key is intentionally NOT in the static
+// suppress_unsupported_gpt5_options strip list (the Codex-OAuth native path
+// derives session-id/x-client-request-id headers from it, and no upstream
+// has been observed rejecting it) — so the reactive path is the ONLY
+// mechanism that removes it, and only when an upstream actually 400s naming
+// it. These tests exercise the full match -> plan -> delete pipeline on a
+// realistic provider payload, for both a plain and a dotted-path occurrence
+// of the field.
+describe('reactive strip-and-retry handles prompt_cache_key (not statically stripped)', () => {
+  test('strips a plain top-level prompt_cache_key named in a 400', () => {
+    const state = createUnsupportedParamStripState();
+    const payload: Record<string, any> = {
+      model: 'openai/gpt-5.5',
+      input: 'hello',
+      prompt_cache_key: 'cache-key-123',
+    };
+
+    const paramToStrip = planUnsupportedParamStrip(
+      '{"detail":"Unsupported parameter: prompt_cache_key"}',
+      state
+    );
+
+    expect(paramToStrip).toBe('prompt_cache_key');
+    const result = deleteDottedPath(payload, paramToStrip!);
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({ model: 'openai/gpt-5.5', input: 'hello' });
+  });
+
+  test('strips a dotted-path prompt_cache_key named in a 400', () => {
+    const state = createUnsupportedParamStripState();
+    const payload: Record<string, any> = {
+      model: 'openai/gpt-5.5',
+      input: 'hello',
+      metadata: { prompt_cache_key: 'cache-key-123', session: 's1' },
+    };
+
+    const paramToStrip = planUnsupportedParamStrip(
+      '{"error":{"message":"Unsupported parameter: \'metadata.prompt_cache_key\'"}}',
+      state
+    );
+
+    expect(paramToStrip).toBe('metadata.prompt_cache_key');
+    const result = deleteDottedPath(payload, paramToStrip!);
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({
+      model: 'openai/gpt-5.5',
+      input: 'hello',
+      metadata: { session: 's1' },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3: thinking-signature failover recovery
+// ---------------------------------------------------------------------------
+//
+// Alias-level failover can replay a conversation containing `thinking` /
+// `redacted_thinking` blocks signed by one Claude model against a different
+// Claude model (e.g. cc/claude-opus-5 -> cc/claude-opus-4-8). Anthropic
+// rejects the stale signature with a 400 naming it specifically; every
+// remaining target would reject the same replayed signature the same way, so
+// failing over doesn't help — strip the thinking blocks and retry the SAME
+// target instead.
+
+describe('matchThinkingSignatureError', () => {
+  test('matches the exact production error body', () => {
+    const body = JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'messages.3.content.0: Invalid `signature` in `thinking` block',
+      },
+      request_id: 'req_test123',
+    });
+    expect(matchThinkingSignatureError(body)).toBe(true);
+  });
+
+  test('matches without backtick quoting around signature/thinking', () => {
+    expect(
+      matchThinkingSignatureError('{"error":{"message":"Invalid signature in thinking block"}}')
+    ).toBe(true);
+  });
+
+  test('matches regardless of case', () => {
+    expect(matchThinkingSignatureError('INVALID SIGNATURE IN THINKING BLOCK')).toBe(true);
+  });
+
+  test('returns false for an unrelated 400 body', () => {
+    expect(
+      matchThinkingSignatureError('{"error":{"message":"Invalid request: missing model"}}')
+    ).toBe(false);
+  });
+
+  test('returns false for a thinking-adjacent but unrelated error', () => {
+    expect(
+      matchThinkingSignatureError('{"error":{"message":"thinking.budget_tokens must be positive"}}')
+    ).toBe(false);
+  });
+
+  test('returns false for an empty body', () => {
+    expect(matchThinkingSignatureError('')).toBe(false);
+  });
+});
+
+describe('isAnthropicMessagesPayload', () => {
+  test('true when the payload has a messages array', () => {
+    expect(isAnthropicMessagesPayload({ model: 'claude-x', messages: [] })).toBe(true);
+  });
+
+  test('false when messages is missing (e.g. a Responses API payload)', () => {
+    expect(isAnthropicMessagesPayload({ model: 'gpt-5.5', input: 'hi' })).toBe(false);
+  });
+
+  test('false when messages is present but not an array', () => {
+    expect(isAnthropicMessagesPayload({ messages: 'not-an-array' })).toBe(false);
+  });
+
+  test('false for null, undefined, and non-object payloads', () => {
+    expect(isAnthropicMessagesPayload(null)).toBe(false);
+    expect(isAnthropicMessagesPayload(undefined)).toBe(false);
+    expect(isAnthropicMessagesPayload('a string')).toBe(false);
+  });
+});
+
+describe('stripThinkingSignatureBlocks', () => {
+  test('removes a thinking block preceding text, preserving ordering', () => {
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
+            { type: 'text', text: 'the answer' },
+          ],
+        },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(1);
+    expect(payload.messages).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'the answer' }] },
+    ]);
+  });
+
+  test('removes a thinking block preceding a tool_use, preserving ordering', () => {
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'do the thing' }] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
+            { type: 'tool_use', id: 'tool-1', name: 'search', input: { q: 'x' } },
+          ],
+        },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(1);
+    expect(payload.messages[1].content).toEqual([
+      { type: 'tool_use', id: 'tool-1', name: 'search', input: { q: 'x' } },
+    ]);
+    // Ordering/other messages untouched.
+    expect(payload.messages[0]).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: 'do the thing' }],
+    });
+  });
+
+  test('removes a redacted_thinking block, preserving sibling content', () => {
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'redacted_thinking', data: 'opaque-encrypted-payload' },
+            { type: 'text', text: 'the answer' },
+          ],
+        },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(1);
+    expect(payload.messages).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'the answer' }] },
+    ]);
+  });
+
+  test('removes both thinking and redacted_thinking blocks in the same message', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'a', signature: 'sig-a' },
+            { type: 'redacted_thinking', data: 'b' },
+            { type: 'text', text: 'the answer' },
+          ],
+        },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(2);
+    expect(payload.messages[0].content).toEqual([{ type: 'text', text: 'the answer' }]);
+  });
+
+  test('leaves non-array content (plain string messages) untouched', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi there' },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(0);
+    expect(payload.messages).toEqual([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi there' },
+    ]);
+  });
+
+  test('is a no-op when the payload has no messages array', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5', input: 'hi' };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(0);
+    expect(payload).toEqual({ model: 'gpt-5.5', input: 'hi' });
+  });
+
+  test('drops a thinking-only assistant message at the end of the conversation (no alternation break, nothing to orphan)', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+        },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(1);
+    expect(payload.messages).toEqual([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]);
+  });
+
+  test('replaces a thinking-only assistant message with a placeholder when dropping it would break user/assistant alternation', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'first' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'second' }] },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(1);
+    expect(payload.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'first' }] },
+      { role: 'assistant', content: [{ type: 'text', text: '[reasoning elided]' }] },
+      { role: 'user', content: [{ type: 'text', text: 'second' }] },
+    ]);
+  });
+
+  test('replaces a thinking-only message with a placeholder when dropping it would orphan a tool_result (no matching tool_use adjacent)', () => {
+    // Deliberately constructed so the alternation check alone would NOT catch
+    // this (prev='assistant', next='user' — different roles) — isolating the
+    // tool_result-orphan guard: `next` carries a tool_result but `prev` does
+    // NOT carry the tool_use it would need to correspond to, so dropping the
+    // thinking-only message would leave that tool_result dangling.
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'q' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'partial answer, no tool call' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+        },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(1);
+    expect(payload.messages[2]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: '[reasoning elided]' }],
+    });
+    // Everything else is untouched.
+    expect(payload.messages[0]).toEqual({ role: 'user', content: [{ type: 'text', text: 'q' }] });
+    expect(payload.messages[1]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'partial answer, no tool call' }],
+    });
+    expect(payload.messages[3]).toEqual({
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+    });
+  });
+
+  test('drops a thinking-only message when the next tool_result correctly pairs with a preceding tool_use', () => {
+    // Here dropping the empty message actually restores correct adjacency
+    // between the tool_use and its tool_result, so it is safe to drop.
+    const payload: Record<string, any> = {
+      messages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tool-1', name: 'search', input: {} }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+        },
+      ],
+    };
+
+    const strippedCount = stripThinkingSignatureBlocks(payload);
+
+    expect(strippedCount).toBe(1);
+    expect(payload.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'search', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+      },
+    ]);
+  });
+});
+
+describe('planThinkingSignatureStrip', () => {
+  const signatureBody = JSON.stringify({
+    error: { message: 'messages.3.content.0: Invalid `signature` in `thinking` block' },
+  });
+  const anthropicPayload = { model: 'claude-x', messages: [] };
+
+  test('MAX_THINKING_SIGNATURE_STRIP_RETRIES is exactly 1 (one strip-retry per target)', () => {
+    expect(MAX_THINKING_SIGNATURE_STRIP_RETRIES).toBe(1);
+  });
+
+  test('plans a strip-retry on the first matching 400 for an Anthropic messages payload', () => {
+    const state = createThinkingSignatureStripState();
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('does not plan a retry when the body does not name a signature error', () => {
+    const state = createThinkingSignatureStripState();
+    expect(
+      planThinkingSignatureStrip('{"error":{"message":"Invalid request"}}', anthropicPayload, state)
+    ).toBe(false);
+    expect(state.attempts).toBe(0);
+  });
+
+  test('does not plan a retry when the outbound payload is not Anthropic-messages-shaped', () => {
+    const state = createThinkingSignatureStripState();
+    const responsesPayload = { model: 'gpt-5.5', input: 'hi' };
+    expect(planThinkingSignatureStrip(signatureBody, responsesPayload, state)).toBe(false);
+    expect(state.attempts).toBe(0);
+  });
+
+  test('retry bound: a second signature 400 on the same target does not plan a second strip-retry', () => {
+    const state = createThinkingSignatureStripState();
+
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(true);
+    // Upstream 400s again with the SAME (or another) signature error — the
+    // one-per-target bound is already used up, so normal failover must
+    // proceed instead of stripping again.
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(false);
+    expect(state.attempts).toBe(1);
   });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -14,6 +14,7 @@ import {
   isAnthropicMessagesPayload,
   matchThinkingSignatureError,
   planThinkingSignatureStrip,
+  refundThinkingSignatureStrip,
   stripThinkingSignatureBlocks,
   MAX_THINKING_SIGNATURE_STRIP_RETRIES,
 } from '../dispatch/dispatcher-auto-compat';
@@ -236,6 +237,17 @@ describe('matchUnsupportedParameter', () => {
     ).toBe('reasoning.summary');
   });
 
+  test('extracts a bracket-notation param name, normalized to canonical dotted form', () => {
+    // The old `[\w.]+` capture stopped at the `[`, truncating
+    // `messages[0].name` to `messages` — and the paired deleteDottedPath call
+    // then deleted the ENTIRE conversation from the retry payload.
+    expect(
+      matchUnsupportedParameter(
+        '{"error":{"message":"Unsupported parameter: \'messages[0].name\'"}}'
+      )
+    ).toBe('messages.0.name');
+  });
+
   test('returns undefined when the body does not name an unsupported parameter', () => {
     expect(matchUnsupportedParameter('{"error":{"message":"Invalid request"}}')).toBeUndefined();
   });
@@ -407,6 +419,133 @@ describe('deleteDottedPath', () => {
       expect(result.payload.metadata).toBe(untouchedSibling);
     });
   });
+
+  // --- Array containers: numeric path segments must preserve Array-ness ------
+  //
+  // matchUnsupportedParameter's `[\w.]+` capture CAN name a path through an
+  // array (an upstream 400 like "Unsupported parameter: messages.0.some_field").
+  // The copy-on-write rebuild must keep every array on the path an ARRAY —
+  // an unconditional `{ ...target }` would turn `messages` into an
+  // object-shaped `{"0": {...}, "1": {...}}` and produce a malformed retry
+  // payload that every upstream rejects.
+  describe('array container preservation', () => {
+    test('deleting a field inside an array element keeps the array an array', () => {
+      const payload: Record<string, any> = {
+        model: 'gpt-5.5',
+        messages: [
+          { role: 'user', content: 'hi', some_field: 'x' },
+          { role: 'assistant', content: 'yo' },
+        ],
+      };
+      const snapshot = structuredClone(payload);
+
+      const result = deleteDottedPath(payload, 'messages.0.some_field');
+
+      expect(result.deleted).toBe(true);
+      expect(Array.isArray(result.payload.messages)).toBe(true);
+      expect(result.payload.messages).toEqual([
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'yo' },
+      ]);
+      // Copy-on-write extends to array levels: original untouched...
+      expect(payload).toEqual(snapshot);
+      expect(result.payload.messages).not.toBe(payload.messages);
+      // ...and the untouched sibling element is shared, not cloned.
+      expect(result.payload.messages[1]).toBe(payload.messages[1]);
+    });
+
+    test('an array-index leaf removes the element splice-style (no hole, no null)', () => {
+      const t0 = { type: 'function', name: 'a' };
+      const t1 = { type: 'function', name: 'b' };
+      const t2 = { type: 'function', name: 'c' };
+      const payload: Record<string, any> = { model: 'gpt-5.5', tools: [t0, t1, t2] };
+
+      const result = deleteDottedPath(payload, 'tools.2');
+
+      expect(result.deleted).toBe(true);
+      expect(Array.isArray(result.payload.tools)).toBe(true);
+      expect(result.payload.tools).toEqual([t0, t1]);
+      expect(result.payload.tools).toHaveLength(2);
+      // No hole left behind: `delete arr[2]` would keep length 3 and
+      // serialize the gap as null — every index must be an own property.
+      expect(Object.keys(result.payload.tools)).toEqual(['0', '1']);
+      // Original untouched.
+      expect(payload.tools).toHaveLength(3);
+      expect(payload.tools[2]).toBe(t2);
+    });
+
+    test('removing a MIDDLE array element shifts later elements left (no hole)', () => {
+      const payload: Record<string, any> = { tools: ['a', 'b', 'c'] };
+
+      const result = deleteDottedPath(payload, 'tools.1');
+
+      expect(result.deleted).toBe(true);
+      expect(result.payload.tools).toEqual(['a', 'c']);
+      expect(Object.keys(result.payload.tools)).toEqual(['0', '1']);
+      expect(payload.tools).toEqual(['a', 'b', 'c']);
+    });
+
+    test('preserves arrays at intermediate depths of a longer path', () => {
+      const payload: Record<string, any> = {
+        messages: [{ role: 'user', meta: { keep: 1, drop: 2 } }],
+      };
+
+      const result = deleteDottedPath(payload, 'messages.0.meta.drop');
+
+      expect(result.deleted).toBe(true);
+      expect(Array.isArray(result.payload.messages)).toBe(true);
+      expect(result.payload.messages[0].meta).toEqual({ keep: 1 });
+      expect(payload.messages[0].meta).toEqual({ keep: 1, drop: 2 });
+    });
+
+    test('does not mutate an array shared by reference with another holder', () => {
+      const sharedMessages = [{ role: 'user', content: 'hi', bad_field: 1 }];
+      const request = { messages: sharedMessages };
+      // Mirrors payload.messages = request.messages — same reference.
+      const payload: Record<string, any> = { model: 'claude-x', messages: request.messages };
+
+      const result = deleteDottedPath(payload, 'messages.0.bad_field');
+
+      expect(result.deleted).toBe(true);
+      expect(request.messages).toBe(sharedMessages);
+      expect(sharedMessages).toEqual([{ role: 'user', content: 'hi', bad_field: 1 }]);
+      expect(result.payload.messages).not.toBe(sharedMessages);
+      expect(result.payload.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    });
+
+    test('returns deleted:false for an out-of-bounds array index', () => {
+      const payload: Record<string, any> = { tools: ['a'] };
+
+      const result = deleteDottedPath(payload, 'tools.5');
+
+      expect(result.deleted).toBe(false);
+      expect(result.payload).toBe(payload);
+    });
+
+    test('returns deleted:false for a non-index own property on an array (e.g. length) instead of corrupting the array', () => {
+      // Arrays have `length` as an OWN property, so hasOwnProperty alone
+      // would let "messages.length" through — and the rebuild would turn the
+      // array into an object. Only canonical in-bounds indices are valid
+      // array segments; anything else is refused untouched.
+      const payload: Record<string, any> = { messages: [{ role: 'user', content: 'hi' }] };
+
+      const result = deleteDottedPath(payload, 'messages.length');
+
+      expect(result.deleted).toBe(false);
+      expect(result.payload).toBe(payload);
+      expect(Array.isArray(payload.messages)).toBe(true);
+      expect(payload.messages).toHaveLength(1);
+    });
+
+    test('rejects a non-canonical numeric segment ("01") on an array', () => {
+      const payload: Record<string, any> = { tools: ['a', 'b'] };
+
+      const result = deleteDottedPath(payload, 'tools.01');
+
+      expect(result.deleted).toBe(false);
+      expect(result.payload).toBe(payload);
+    });
+  });
 });
 
 describe('planUnsupportedParamStrip', () => {
@@ -457,6 +596,184 @@ describe('planUnsupportedParamStrip', () => {
       planUnsupportedParamStrip('{"error":{"message":"Invalid request"}}', state)
     ).toBeUndefined();
     expect(state.attempts).toBe(0);
+  });
+
+  test('structural guard: refuses to strip the whole messages/input/model field, consuming no budget', () => {
+    // Deleting any of these wholesale guarantees a malformed request — every
+    // retry would 400 on a missing-conversation/missing-model error instead,
+    // so the plan must refuse outright (normal failover proceeds) and must
+    // NOT burn a strip attempt doing so.
+    const state = createUnsupportedParamStripState();
+    for (const field of ['messages', 'input', 'model']) {
+      expect(
+        planUnsupportedParamStrip(`{"detail":"Unsupported parameter: ${field}"}`, state)
+      ).toBeUndefined();
+    }
+    expect(state.attempts).toBe(0);
+    expect(state.strippedParams.size).toBe(0);
+  });
+
+  test('structural guard is exact-match only: sub-paths inside messages stay strippable', () => {
+    const state = createUnsupportedParamStripState();
+    expect(
+      planUnsupportedParamStrip('{"detail":"Unsupported parameter: messages.0.name"}', state)
+    ).toBe('messages.0.name');
+    expect(state.attempts).toBe(1);
+  });
+
+  describe('structural array elements (messages[N] / input[N]) are refused budget-free', () => {
+    // `Unsupported parameter: messages[0]` normalizes to `messages.0`, which
+    // dodges the exact-name guard — and the paired deleteDottedPath would
+    // splice an ENTIRE message out of the conversation. A numeric leaf
+    // directly under a structural root deletes a whole conversation item,
+    // so it gets the same budget-free refusal as the whole-field guard:
+    // normal failover proceeds, no strip attempt is consumed.
+    test('a 400 naming messages[0] (bracket form) is refused, consuming no budget', () => {
+      const state = createUnsupportedParamStripState();
+      expect(
+        planUnsupportedParamStrip(
+          '{"error":{"message":"Unsupported parameter: \'messages[0]\'"}}',
+          state
+        )
+      ).toBeUndefined();
+      expect(state.attempts).toBe(0);
+      expect(state.strippedParams.size).toBe(0);
+    });
+
+    test('a 400 naming input[2] (bracket form) is refused, consuming no budget', () => {
+      const state = createUnsupportedParamStripState();
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: input[2]"}', state)
+      ).toBeUndefined();
+      expect(state.attempts).toBe(0);
+      expect(state.strippedParams.size).toBe(0);
+    });
+
+    test('the already-dotted spelling (messages.0) is refused identically', () => {
+      const state = createUnsupportedParamStripState();
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: messages.0"}', state)
+      ).toBeUndefined();
+      expect(state.attempts).toBe(0);
+    });
+
+    test('a refusal leaves the full budget for later legitimately-strippable params', () => {
+      const state = createUnsupportedParamStripState();
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: messages[0]"}', state)
+      ).toBeUndefined();
+      // Both retry slots must still be available afterwards.
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: safety_identifier"}', state)
+      ).toBe('safety_identifier');
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: prompt_cache_key"}', state)
+      ).toBe('prompt_cache_key');
+      expect(state.attempts).toBe(2);
+    });
+
+    test('deeper paths under a structural element (messages.0.name) remain strippable', () => {
+      const state = createUnsupportedParamStripState();
+      const payload: Record<string, any> = {
+        model: 'gpt-4o',
+        messages: [
+          { role: 'user', content: 'hi', name: 'bob!' },
+          { role: 'assistant', content: 'yo' },
+        ],
+      };
+
+      const paramToStrip = planUnsupportedParamStrip(
+        '{"error":{"message":"Unsupported parameter: \'messages[0].name\'"}}',
+        state
+      );
+      expect(paramToStrip).toBe('messages.0.name');
+
+      const result = deleteDottedPath(payload, paramToStrip!);
+      expect(result.deleted).toBe(true);
+      expect(result.payload.messages).toEqual([
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'yo' },
+      ]);
+    });
+
+    test('numeric leaves under NON-structural arrays (tools[2]) stay splice-deletable', () => {
+      const state = createUnsupportedParamStripState();
+      const payload: Record<string, any> = {
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+      };
+
+      const paramToStrip = planUnsupportedParamStrip(
+        '{"detail":"Unsupported parameter: tools[2]"}',
+        state
+      );
+      expect(paramToStrip).toBe('tools.2');
+      expect(state.attempts).toBe(1);
+
+      const result = deleteDottedPath(payload, paramToStrip!);
+      expect(result.deleted).toBe(true);
+      expect(result.payload.tools).toEqual([{ name: 'a' }, { name: 'b' }]);
+      expect(Array.isArray(result.payload.tools)).toBe(true);
+    });
+  });
+});
+
+// The production bug this pipeline guards against: an upstream 400 naming
+// `messages[0].name` was truncated by the old `[\w.]+` matcher to `messages`,
+// so the strip-and-retry deleted the WHOLE conversation and retried a
+// guaranteed-malformed payload. Bracket segments must be captured, normalized
+// to canonical dotted form, and land on the array ELEMENT's field.
+describe('bracket-notation unsupported params (match -> plan -> delete pipeline)', () => {
+  test('a 400 naming messages[0].name deletes only that element field — the conversation array survives', () => {
+    const state = createUnsupportedParamStripState();
+    const payload: Record<string, any> = {
+      model: 'gpt-4o',
+      messages: [
+        { role: 'user', content: 'hi', name: 'bob!' },
+        { role: 'assistant', content: 'yo' },
+      ],
+    };
+
+    const paramToStrip = planUnsupportedParamStrip(
+      '{"error":{"message":"Unsupported parameter: \'messages[0].name\'"}}',
+      state
+    );
+
+    expect(paramToStrip).toBe('messages.0.name');
+
+    const result = deleteDottedPath(payload, paramToStrip!);
+    expect(result.deleted).toBe(true);
+    expect(Array.isArray(result.payload.messages)).toBe(true);
+    expect(result.payload.messages).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'yo' },
+    ]);
+  });
+
+  test('other whole top-level fields (tools) are still strippable', () => {
+    // The structural guard is a narrow deny-list (messages/input/model), not
+    // a blanket "no whole fields" rule: stripping a whole `tools` (or
+    // `safety_identifier`, etc.) leaves a well-formed request.
+    const state = createUnsupportedParamStripState();
+    const payload: Record<string, any> = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [{ type: 'function', function: { name: 'f' } }],
+    };
+
+    const paramToStrip = planUnsupportedParamStrip(
+      '{"detail":"Unsupported parameter: tools"}',
+      state
+    );
+
+    expect(paramToStrip).toBe('tools');
+    const result = deleteDottedPath(payload, paramToStrip!);
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
   });
 });
 
@@ -598,13 +915,16 @@ describe('stripThinkingSignatureBlocks', () => {
         },
       ],
     };
+    const snapshot = structuredClone(payload);
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(1);
-    expect(payload.messages).toEqual([
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
       { role: 'assistant', content: [{ type: 'text', text: 'the answer' }] },
     ]);
+    // Copy-on-write: the ORIGINAL payload argument is never mutated.
+    expect(payload).toEqual(snapshot);
   });
 
   test('removes a thinking block preceding a tool_use, preserving ordering', () => {
@@ -622,14 +942,14 @@ describe('stripThinkingSignatureBlocks', () => {
       ],
     };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(1);
-    expect(payload.messages[1].content).toEqual([
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages[1].content).toEqual([
       { type: 'tool_use', id: 'tool-1', name: 'search', input: { q: 'x' } },
     ]);
     // Ordering/other messages untouched.
-    expect(payload.messages[0]).toEqual({
+    expect(result.payload.messages[0]).toEqual({
       role: 'user',
       content: [{ type: 'text', text: 'do the thing' }],
     });
@@ -649,10 +969,10 @@ describe('stripThinkingSignatureBlocks', () => {
       ],
     };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(1);
-    expect(payload.messages).toEqual([
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
       { role: 'assistant', content: [{ type: 'text', text: 'the answer' }] },
     ]);
   });
@@ -671,13 +991,13 @@ describe('stripThinkingSignatureBlocks', () => {
       ],
     };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(2);
-    expect(payload.messages[0].content).toEqual([{ type: 'text', text: 'the answer' }]);
+    expect(result.strippedCount).toBe(2);
+    expect(result.payload.messages[0].content).toEqual([{ type: 'text', text: 'the answer' }]);
   });
 
-  test('leaves non-array content (plain string messages) untouched', () => {
+  test('leaves non-array content (plain string messages) untouched and returns the SAME payload reference', () => {
     const payload: Record<string, any> = {
       messages: [
         { role: 'user', content: 'hello' },
@@ -685,22 +1005,74 @@ describe('stripThinkingSignatureBlocks', () => {
       ],
     };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(0);
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
     expect(payload.messages).toEqual([
       { role: 'user', content: 'hello' },
       { role: 'assistant', content: 'hi there' },
     ]);
   });
 
-  test('is a no-op when the payload has no messages array', () => {
+  test('is a no-op (same payload reference) when the payload has no messages array', () => {
     const payload: Record<string, any> = { model: 'gpt-5.5', input: 'hi' };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(0);
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
     expect(payload).toEqual({ model: 'gpt-5.5', input: 'hi' });
+  });
+
+  test('no-op contract: an Anthropic-shaped payload with array content but no thinking blocks returns strippedCount 0 and the SAME reference', () => {
+    // The structural isAnthropicMessagesPayload check also matches OpenAI
+    // chat-completions payloads (they have a `messages` array too). This is
+    // the known false-positive shape the dispatch loop must NOT retry on:
+    // strippedCount 0 + identical payload reference is the signal.
+    const payload: Record<string, any> = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    };
+    const snapshot = structuredClone(payload);
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
+    expect(payload).toEqual(snapshot);
+  });
+
+  test('copy-on-write: never mutates the input payload, its messages array, or untouched message objects', () => {
+    const untouchedMessage = { role: 'user', content: [{ type: 'text', text: 'hi' }] };
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        untouchedMessage,
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'stale', signature: 'sig-a' },
+            { type: 'text', text: 'answer' },
+          ],
+        },
+      ],
+    };
+    const originalMessages = payload.messages;
+    const snapshot = structuredClone(payload);
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    // A NEW root object with a NEW messages array is returned...
+    expect(result.payload).not.toBe(payload);
+    expect(result.payload.messages).not.toBe(originalMessages);
+    // ...while the input payload keeps its original array and full content.
+    expect(payload.messages).toBe(originalMessages);
+    expect(payload).toEqual(snapshot);
+    // Untouched messages are shared (not cloned), mirroring deleteDottedPath's
+    // "untouched sibling branches are shared" copy-on-write behavior.
+    expect(result.payload.messages[0]).toBe(untouchedMessage);
   });
 
   test('drops a thinking-only assistant message at the end of the conversation (no alternation break, nothing to orphan)', () => {
@@ -714,10 +1086,12 @@ describe('stripThinkingSignatureBlocks', () => {
       ],
     };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(1);
-    expect(payload.messages).toEqual([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]);
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    ]);
   });
 
   test('replaces a thinking-only assistant message with a placeholder when dropping it would break user/assistant alternation', () => {
@@ -732,10 +1106,10 @@ describe('stripThinkingSignatureBlocks', () => {
       ],
     };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(1);
-    expect(payload.messages).toEqual([
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
       { role: 'user', content: [{ type: 'text', text: 'first' }] },
       { role: 'assistant', content: [{ type: 'text', text: '[reasoning elided]' }] },
       { role: 'user', content: [{ type: 'text', text: 'second' }] },
@@ -763,20 +1137,23 @@ describe('stripThinkingSignatureBlocks', () => {
       ],
     };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(1);
-    expect(payload.messages[2]).toEqual({
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages[2]).toEqual({
       role: 'assistant',
       content: [{ type: 'text', text: '[reasoning elided]' }],
     });
     // Everything else is untouched.
-    expect(payload.messages[0]).toEqual({ role: 'user', content: [{ type: 'text', text: 'q' }] });
-    expect(payload.messages[1]).toEqual({
+    expect(result.payload.messages[0]).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: 'q' }],
+    });
+    expect(result.payload.messages[1]).toEqual({
       role: 'assistant',
       content: [{ type: 'text', text: 'partial answer, no tool call' }],
     });
-    expect(payload.messages[3]).toEqual({
+    expect(result.payload.messages[3]).toEqual({
       role: 'user',
       content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
     });
@@ -802,10 +1179,10 @@ describe('stripThinkingSignatureBlocks', () => {
       ],
     };
 
-    const strippedCount = stripThinkingSignatureBlocks(payload);
+    const result = stripThinkingSignatureBlocks(payload);
 
-    expect(strippedCount).toBe(1);
-    expect(payload.messages).toEqual([
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
       {
         role: 'assistant',
         content: [{ type: 'tool_use', id: 'tool-1', name: 'search', input: {} }],
@@ -858,5 +1235,30 @@ describe('planThinkingSignatureStrip', () => {
     // proceed instead of stripping again.
     expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(false);
     expect(state.attempts).toBe(1);
+  });
+
+  test('refundThinkingSignatureStrip returns the budget after a 0-strip plan, so a later genuine signature 400 can still strip-retry', () => {
+    // Sequence mirrors the dispatch loop's false-positive path: the plan
+    // fires (structural check matched an OpenAI-shaped payload), the strip
+    // turns out to be a no-op (0 blocks), NO retry happens — so the attempt
+    // is refunded and the one-per-target budget stays available.
+    const state = createThinkingSignatureStripState();
+
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+
+    refundThinkingSignatureStrip(state);
+    expect(state.attempts).toBe(0);
+
+    // The budget is intact: a later signature 400 on the same target still
+    // gets its strip-and-retry.
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('refundThinkingSignatureStrip never drives attempts below zero', () => {
+    const state = createThinkingSignatureStripState();
+    refundThinkingSignatureStrip(state);
+    expect(state.attempts).toBe(0);
   });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-empty-completion.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-empty-completion.test.ts
@@ -536,4 +536,37 @@ describe('Dispatcher empty-completion failover (T5)', () => {
     expect(meta?.attemptCount).toBe(1);
     expect(meta?.finalAttemptProvider).toBe('p1');
   });
+
+  test('an image_generation_call-only completion on the TRANSFORMED path (chat client -> responses provider) is not retried as empty', async () => {
+    setConfigForTesting(makeResponsesConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => imageOnlyResponsesResponse())
+      .mockImplementationOnce(async () => {
+        throw new Error('should not be called — failing over here would be the bug');
+      });
+
+    const dispatcher = new Dispatcher();
+    // A CHAT-format client request against the responses-target alias:
+    // incoming 'chat' !== target 'responses' means NO passthrough/bypass, so
+    // the unified response is the TRANSFORMED one — PURE content (null, no
+    // baked image markdown), typed `image_generation_calls`, no rawResponse.
+    // The typed empty-completion signal is the only thing keeping this from
+    // being misclassified as empty and failed over.
+    const response = await dispatcher.dispatch({
+      model: 'responses-alias',
+      messages: [{ role: 'user', content: 'draw a cat' }],
+      incomingApiType: 'chat',
+      stream: false,
+    } as UnifiedChatRequest);
+    const meta = (response as any).plexus;
+
+    // A single fetch call proves NO failover happened.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+    // Transformed path, not bypass: pure content + typed carry.
+    expect(response.bypassTransformation).toBeUndefined();
+    expect(response.content).toBeNull();
+    expect(response.image_generation_calls?.[0]?.result).toBe('base64-image-data');
+  });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-empty-completion.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-empty-completion.test.ts
@@ -1,0 +1,539 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { Dispatcher } from '../dispatch/dispatcher';
+import { setConfigForTesting } from '../../config';
+import type { UnifiedChatRequest } from '../../types/unified';
+import { CooldownManager } from '../runtime/cooldown-manager';
+import { EMPTY_COMPLETION_REASON } from '../dispatch/empty-completion';
+
+// T5 — dispatch-level empty-completion failover.
+//
+// Fixture setup mirrors dispatcher-failover.test.ts (same style: makeConfig
+// builds an `in_order` alias with N targets, fetchMock stands in for
+// upstream HTTP). Kept in its own file rather than appended to
+// dispatcher-failover.test.ts because that file has unrelated in-flight
+// changes from other tasks in the working tree.
+
+const fetchMock: any = vi.fn(async (): Promise<any> => {
+  throw new Error('fetch mock not configured for test');
+});
+
+global.fetch = fetchMock as any;
+
+function makeConfig(options?: { failoverEnabled?: boolean; targetCount?: number }) {
+  const failoverEnabled = options?.failoverEnabled ?? true;
+  const targetCount = options?.targetCount ?? 2;
+
+  const providers: Record<string, any> = {
+    p1: {
+      type: 'chat',
+      api_base_url: 'https://p1.example.com/v1',
+      api_key: 'test-key-p1',
+      models: { 'model-1': {} },
+    },
+    p2: {
+      type: 'chat',
+      api_base_url: 'https://p2.example.com/v1',
+      api_key: 'test-key-p2',
+      models: { 'model-2': {} },
+    },
+    p3: {
+      type: 'chat',
+      api_base_url: 'https://p3.example.com/v1',
+      api_key: 'test-key-p3',
+      models: { 'model-3': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+    { provider: 'p3', model: 'model-3' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'test-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: failoverEnabled,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+function makeChatRequest(): UnifiedChatRequest {
+  return {
+    model: 'test-alias',
+    messages: [{ role: 'user', content: 'hello' }],
+    incomingApiType: 'chat',
+    stream: false,
+  };
+}
+
+/** A 200 OpenAI chat completion whose message has visible text content. */
+function contentChatResponse(model: string, content = 'ok') {
+  return new Response(
+    JSON.stringify({
+      id: `chatcmpl-${model}`,
+      object: 'chat.completion',
+      created: 1,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+/**
+ * A 200 OpenAI chat completion with zero visible output: no text, no tool
+ * calls, no reasoning. This is the "upstream 200 but empty" case the task
+ * targets — e.g. LobeHub `ModelEmptyCompletion` / KiloCode blank replies.
+ */
+function emptyChatResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: `chatcmpl-${model}`,
+      object: 'chat.completion',
+      created: 1,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: '' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+// --- Fix round 2: image_generation_call output is visible output -----------
+
+/**
+ * A single-target Responses-API alias config. `api_base_url` uses the
+ * record/map form (`{ responses: <url> }`) so getProviderTypes() resolves
+ * the 'responses' API type explicitly (mirrors makeAnthropicMessagesConfig's
+ * `{ messages: <url> }` / makeGeminiConfig's `{ gemini: <url> }` pattern).
+ */
+function makeResponsesConfig(options?: { targetCount?: number }) {
+  const targetCount = options?.targetCount ?? 2;
+
+  const providers: Record<string, any> = {
+    p1: {
+      api_base_url: { responses: 'https://p1.example.com' },
+      api_key: 'test-key-p1',
+      models: { 'model-1': {} },
+    },
+    p2: {
+      api_base_url: { responses: 'https://p2.example.com' },
+      api_key: 'test-key-p2',
+      models: { 'model-2': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'responses-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+// incomingApiType === targetApiType ('responses') with `originalBody` set
+// satisfies shouldUsePassThrough (request-payload-builder.ts) -> bypassTransformation
+// true -> dispatcher.ts's handleNonStreamingResponse attaches the ORIGINAL
+// parsed body as `unifiedResponse.rawResponse`, which is exactly the seam
+// getResponseVisibilitySignals reads image_generation_call items from.
+function makeResponsesRequest(): UnifiedChatRequest {
+  return {
+    model: 'responses-alias',
+    messages: [{ role: 'user', content: 'draw a cat' }],
+    incomingApiType: 'responses',
+    stream: false,
+    originalBody: {
+      model: 'responses-alias',
+      input: 'draw a cat',
+    },
+  } as any;
+}
+
+/** A 200 Responses API completion whose ONLY output item is an image_generation_call — no message, no text. */
+function imageOnlyResponsesResponse() {
+  return new Response(
+    JSON.stringify({
+      id: 'resp_img_1',
+      object: 'response',
+      created_at: 1,
+      status: 'completed',
+      model: 'model-1',
+      output: [
+        {
+          type: 'image_generation_call',
+          id: 'ig_1',
+          status: 'completed',
+          result: 'base64-image-data',
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+/**
+ * A 200 OpenAI chat completion with null content AND a terminal
+ * `content_filter` finish reason — a deliberate provider safety decision,
+ * not "the model produced nothing". Must NOT be classified as an empty
+ * completion (must not fail over to another provider).
+ */
+function contentFilterChatResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: `chatcmpl-${model}`,
+      object: 'chat.completion',
+      created: 1,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: null },
+          finish_reason: 'content_filter',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+// --- Fix round 1: clientError must take precedence over empty-completion retry ---
+//
+// transformGeminiResponse (transformers/gemini/response-transformer.ts) sets
+// `clientError` on a non-streaming UnifiedChatResponse for Gemini's
+// MALFORMED_FUNCTION_CALL defect — a response that also has zero visible
+// output (no text, no tool_calls). response-handler.ts's
+// `!unifiedResponse.stream && unifiedResponse.clientError` branch signals
+// that to the client directly, deliberately WITHOUT failover or cooldown.
+// This config/request pair drives a real request through the real
+// GeminiTransformer (not the 'chat'/OpenAI one used above) so the fixture
+// below exercises production code, not a hand-rolled stand-in.
+function makeGeminiConfig(options?: { targetCount?: number }) {
+  const targetCount = options?.targetCount ?? 2;
+
+  const providers: Record<string, any> = {
+    p1: {
+      api_base_url: { gemini: 'https://p1.example.com' },
+      api_key: 'test-key-p1',
+      models: { 'model-1': {} },
+    },
+    p2: {
+      api_base_url: { gemini: 'https://p2.example.com' },
+      api_key: 'test-key-p2',
+      models: { 'model-2': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'gemini-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+// Incoming type is deliberately 'chat' (not 'gemini') so selectTargetApiType
+// falls through to the only available provider type ('gemini') via the
+// normal transform pipeline (bypassTransformation stays false — pass-through
+// requires incomingApiType === targetApiType, see shouldUsePassThrough in
+// request-payload-builder.ts) — i.e. the REAL GeminiTransformer.transformResponse
+// runs on the mocked upstream body below, exactly as production would.
+function makeGeminiRequest(): UnifiedChatRequest {
+  return {
+    model: 'gemini-alias',
+    messages: [{ role: 'user', content: 'hello' }],
+    incomingApiType: 'chat',
+    stream: false,
+  };
+}
+
+/**
+ * A 200 Gemini response whose only candidate ends in MALFORMED_FUNCTION_CALL
+ * — detectGeminiMalformedFunctionCall (utils/gemini-malformed-function-call.ts)
+ * fires on finishReason alone, regardless of parts content. Empty `parts`
+ * means transformGeminiResponse also produces zero visible output (content
+ * null, no tool_calls) — the exact collision this test locks down.
+ */
+function geminiMalformedFunctionCallResponse() {
+  return new Response(
+    JSON.stringify({
+      candidates: [
+        {
+          finishReason: 'MALFORMED_FUNCTION_CALL',
+          content: { parts: [] },
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+/** A normal 200 Gemini response with visible text — used to prove failover would have "worked" if it fired. */
+function geminiContentResponse(text = 'ok') {
+  return new Response(
+    JSON.stringify({
+      candidates: [
+        {
+          finishReason: 'STOP',
+          content: { parts: [{ text }] },
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+describe('Dispatcher empty-completion failover (T5)', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+    setConfigForTesting(makeConfig());
+    CooldownManager.resetForTesting();
+  });
+
+  test('empty completion (200, no visible output) on target 1 fails over to target 2', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => emptyChatResponse('model-1'))
+      .mockImplementationOnce(async () => contentChatResponse('model-2'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+    const meta = (response as any).plexus;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.attemptCount).toBe(2);
+    expect(meta?.finalAttemptProvider).toBe('p2');
+    expect(response.content).toBe('ok');
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(2);
+    expect(retryHistory[0]?.status).toBe('failed');
+    expect(retryHistory[0]?.reason).toBe(EMPTY_COMPLETION_REASON);
+    expect(retryHistory[0]?.retryable).toBe(true);
+    expect(retryHistory[1]?.status).toBe('success');
+  });
+
+  test('all targets empty: returns the last empty response as-is (200), does not throw', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 3 }));
+    fetchMock
+      .mockImplementationOnce(async () => emptyChatResponse('model-1'))
+      .mockImplementationOnce(async () => emptyChatResponse('model-2'))
+      .mockImplementationOnce(async () => emptyChatResponse('model-3'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+    const meta = (response as any).plexus;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(meta?.attemptCount).toBe(3);
+    expect(meta?.finalAttemptProvider).toBe('p3');
+    // Empty completion means the transformed content is null (empty string
+    // normalizes to null in the OpenAI chat transformer) — returned as-is,
+    // not converted into a 5xx.
+    expect(response.content).toBeNull();
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(3);
+    expect(retryHistory[0]?.status).toBe('failed');
+    expect(retryHistory[1]?.status).toBe('failed');
+    expect(retryHistory[2]?.status).toBe('success');
+  });
+
+  test('single target, empty completion: no next target to fail over to, returns as-is', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementationOnce(async () => emptyChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+    const meta = (response as any).plexus;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(response.content).toBeNull();
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(1);
+    expect(retryHistory[0]?.status).toBe('success');
+  });
+
+  test('empty-completion failover does NOT trigger provider cooldown', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => emptyChatResponse('model-1'))
+      .mockImplementationOnce(async () => contentChatResponse('model-2'));
+
+    const dispatcher = new Dispatcher();
+    const cm = CooldownManager.getInstance();
+    await cm.clearCooldown();
+
+    await dispatcher.dispatch(makeChatRequest());
+
+    // p1 returned an empty completion (not a provider health failure) — it
+    // must not be on cooldown, mirroring how caller-errors (400 non-quota,
+    // 413, 422) skip markProviderFailure.
+    const cooldowns = cm.getCooldowns();
+    expect(cooldowns).toHaveLength(0);
+  });
+
+  test('no failover when failover is disabled: empty completion from the only target returns as-is', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2, failoverEnabled: false }));
+    fetchMock.mockImplementation(async () => emptyChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.content).toBeNull();
+  });
+
+  test('intermediate empty-completion failure is saved during failover', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => emptyChatResponse('model-1'))
+      .mockImplementationOnce(async () => contentChatResponse('model-2'));
+
+    const saveErrorSpy = vi.fn();
+    const dispatcher = new Dispatcher();
+    dispatcher.setUsageStorage({
+      saveError: saveErrorSpy,
+      recordFailedAttempt: vi.fn(),
+      recordSuccessfulAttempt: vi.fn(),
+      emitUpdatedAsync: vi.fn(),
+    } as any);
+
+    await dispatcher.dispatch({ ...makeChatRequest(), requestId: 'req-empty-intermediate' });
+
+    expect(saveErrorSpy).toHaveBeenCalledTimes(1);
+    const [savedRequestId, savedError] = saveErrorSpy.mock.calls[0] as any[];
+    expect(savedRequestId).toBe('req-empty-intermediate');
+    expect(savedError?.message).toBe(EMPTY_COMPLETION_REASON);
+  });
+
+  test('a clientError-carrying response (e.g. Gemini MALFORMED_FUNCTION_CALL) is NEVER retried as an empty completion, even with a next target available', async () => {
+    setConfigForTesting(makeGeminiConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => geminiMalformedFunctionCallResponse())
+      .mockImplementationOnce(async () => geminiContentResponse());
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeGeminiRequest());
+    const meta = (response as any).plexus;
+
+    // A single fetch call proves NO failover happened — target 2 (which
+    // would have returned visible content) was never reached.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+
+    // The response still has zero visible output (this is precisely why the
+    // bug existed: isEmptyUnifiedResponse alone would say "empty") AND still
+    // carries clientError intact for response-handler.ts's dedicated
+    // no-failover/no-cooldown handling to pick up downstream.
+    expect(response.content).toBeNull();
+    expect(response.tool_calls).toBeUndefined();
+    expect(response.clientError?.statusCode).toBe(503);
+    expect(response.clientError?.code).toBe('MALFORMED_FUNCTION_CALL');
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(1);
+    expect(retryHistory[0]?.status).toBe('success');
+  });
+
+  // --- Fix round 2: terminal finish reasons must never be classified empty ---
+  test('a content_filter completion (null content, terminal finish reason) is NEVER retried as an empty completion, even with a next target available', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => contentFilterChatResponse('model-1'))
+      .mockImplementationOnce(async () => contentChatResponse('model-2'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+    const meta = (response as any).plexus;
+
+    // A single fetch call proves NO failover happened — target 2 (which
+    // would have returned visible content) was never reached: routing
+    // around a content-filter decision via failover would be exactly the
+    // bug this guards against.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+    expect(response.content).toBeNull();
+    expect(response.finishReason).toBe('content_filter');
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(1);
+    expect(retryHistory[0]?.status).toBe('success');
+  });
+
+  test('an image_generation_call-only Responses API completion is NEVER retried as an empty completion, even with a next target available', async () => {
+    setConfigForTesting(makeResponsesConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => imageOnlyResponsesResponse())
+      .mockImplementationOnce(async () => {
+        throw new Error('should not be called — failing over here would be the bug');
+      });
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeResponsesRequest());
+    const meta = (response as any).plexus;
+
+    // A single fetch call proves NO failover happened.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+  });
+});

--- a/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
@@ -68,6 +68,32 @@ function makeChatRequest(stream = false): UnifiedChatRequest {
   };
 }
 
+/**
+ * A chat request whose outbound provider payload actually CONTAINS the
+ * fields the same-target strip-and-retry tests below name as "unsupported"
+ * (`safety_identifier`, `prompt_cache_key`) — via `originalBody`, since
+ * OpenAITransformer.transformRequest only carries unmapped fields through
+ * when `incomingApiType === 'chat'` (same-format) AND `originalBody` is set.
+ * Needed so `deleteDottedPath` actually finds and removes something
+ * (`deleted: true`); the call site now correctly refuses to retry a strip
+ * that didn't remove anything, so a fixture that never put the field in the
+ * payload in the first place would no longer exercise the retry at all.
+ */
+function makeChatRequestWithUnsupportedParams(): UnifiedChatRequest {
+  return {
+    model: 'test-alias',
+    messages: [{ role: 'user', content: 'hello' }],
+    incomingApiType: 'chat',
+    stream: false,
+    originalBody: {
+      model: 'test-alias',
+      messages: [{ role: 'user', content: 'hello' }],
+      safety_identifier: 'safety-abc',
+      prompt_cache_key: 'cache-key-123',
+    },
+  } as any;
+}
+
 function successChatResponse(model: string) {
   return new Response(
     JSON.stringify({
@@ -93,6 +119,112 @@ function errorResponse(status: number, message: string) {
     status,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+// --- T3: thinking-signature failover recovery helpers -----------------------
+
+function makeAnthropicMessagesConfig(options?: { targetCount?: number }) {
+  const targetCount = options?.targetCount ?? 1;
+  // api_base_url uses the record/map form ({ messages: <url> }) rather than a
+  // bare string so getProviderTypes()/resolveProviderBaseUrl() resolve the
+  // 'messages' API type explicitly (the string-URL inference path only
+  // recognizes 'messages' for URLs containing "anthropic.com" — see
+  // config.ts's getProviderTypes()).
+  const providers: Record<string, any> = {
+    p1: {
+      api_base_url: { messages: 'https://p1.example.com' },
+      api_key: 'test-key-p1',
+      useClaudeMasking: false,
+      models: { 'model-1': {} },
+    },
+    p2: {
+      api_base_url: { messages: 'https://p2.example.com' },
+      api_key: 'test-key-p2',
+      useClaudeMasking: false,
+      models: { 'model-2': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'claude-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+function makeMessagesRequest(messages: any[]): UnifiedChatRequest {
+  return {
+    model: 'claude-alias',
+    // Unified `messages` is required by the type but unused on the
+    // pass-through path — the bypass path clones `originalBody` verbatim.
+    messages: [{ role: 'user', content: 'hello' }],
+    incomingApiType: 'messages',
+    originalBody: {
+      model: 'claude-alias',
+      max_tokens: 1024,
+      messages,
+    },
+  } as any;
+}
+
+function thinkingSignatureErrorResponse() {
+  // Verbatim production body from the task brief.
+  return new Response(
+    JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'messages.3.content.0: Invalid `signature` in `thinking` block',
+      },
+      request_id: 'req_test123',
+    }),
+    { status: 400, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function successMessagesResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: 'msg-1',
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'ok' }],
+      model,
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function messagesWithStaleThinking() {
+  return [
+    { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
+        { type: 'text', text: 'answer' },
+      ],
+    },
+    { role: 'user', content: [{ type: 'text', text: 'follow up' }] },
+  ];
 }
 
 describe('Dispatcher Failover', () => {
@@ -161,7 +293,9 @@ describe('Dispatcher Failover', () => {
       throw new Error('expected dispatch to fail');
     } catch (error: any) {
       expect(error.message).toContain('All targets failed');
-      expect(error.message).toContain('p1/model-1, p2/model-2');
+      // T6: the client-visible message now carries each attempt's own HTTP
+      // status code (500 from p1, 503 from p2) instead of a bare provider list.
+      expect(error.message).toContain('p1/model-1 (500), p2/model-2 (503)');
       expect(error.routingContext?.attemptCount).toBe(2);
     }
   });
@@ -425,6 +559,183 @@ describe('Dispatcher Failover', () => {
       expect(error.routingContext?.attemptCount).toBe(1);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     }
+  });
+
+  test('same-target retry: strips a named unsupported parameter and retries instead of failing over', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () =>
+        errorResponse(400, 'Unsupported parameter: safety_identifier')
+      )
+      .mockImplementationOnce(async () => successChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequestWithUnsupportedParams());
+    const meta = (response as any).plexus;
+
+    // Single configured target — a second fetch call can only mean the
+    // SAME target was retried after stripping the offending field, not a
+    // failover to a different provider (there isn't one).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+
+    // The field was ACTUALLY removed from the retried payload, not just a
+    // retry regardless of outcome.
+    const retriedBody = JSON.parse((fetchMock.mock.calls[1] as any[])[1].body as string);
+    expect(retriedBody.safety_identifier).toBeUndefined();
+  });
+
+  test('same-target retry: gives up after the retry bound and fails normally when the upstream keeps naming a NEW unsupported param', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () =>
+        errorResponse(400, 'Unsupported parameter: safety_identifier')
+      )
+      .mockImplementationOnce(async () =>
+        errorResponse(400, "Unsupported parameter: 'prompt_cache_key'")
+      )
+      .mockImplementationOnce(async () =>
+        errorResponse(400, "Unsupported parameter: 'reasoning.summary'")
+      );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequestWithUnsupportedParams());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    // 1 initial attempt + 2 bounded strip-retries = 3 fetch calls, then give
+    // up rather than stripping a 3rd distinct param.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('same-target retry: a prototype-pollution attempt (__proto__.toString) is rejected — no retry, global state intact', async () => {
+    // A malicious/compromised upstream can name ANY dotted string via the
+    // "Unsupported parameter: X" 400 body (matchUnsupportedParameter's regex
+    // captures dots and underscores). This proves the reactive strip-and-retry
+    // path cannot be turned into a prototype-pollution gadget: the attempt
+    // must be rejected (no field actually removed), so the call site must NOT
+    // resend the identical payload — single target, single fetch call.
+    const originalToString = Object.prototype.toString;
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () =>
+      errorResponse(400, "Unsupported parameter: '__proto__.toString'")
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    // No retry happened: deleteDottedPath rejected the dangerous path, so
+    // nothing was actually stripped, so the call site must not resend an
+    // identical payload to the same target. A single configured target with
+    // failover on but a non-retryable 400 means exactly one fetch call.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The actual attack: prove global state survived, not just that dispatch
+    // failed for some other reason.
+    expect(Object.prototype.toString).toBe(originalToString);
+    expect(typeof Object.prototype.toString).toBe('function');
+    expect({}.toString()).toBe('[object Object]');
+  });
+
+  test('same-target retry: a no-op strip (named field not actually present) does not retry', async () => {
+    // The upstream names a field that plainly isn't in the outbound payload
+    // at all — deleteDottedPath finds nothing to remove. Retrying here would
+    // just resend the exact same payload and get the exact same 400 again;
+    // the call site must respect the `deleted` return value and skip the retry.
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () =>
+      errorResponse(400, 'Unsupported parameter: totally_fake_field_xyz')
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('same-target retry: stops immediately (no infinite loop) when the upstream keeps naming the SAME unsupported param', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () =>
+      errorResponse(400, 'Unsupported parameter: safety_identifier')
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequestWithUnsupportedParams());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    // First 400 strips safety_identifier and retries; the second 400 names
+    // the SAME already-stripped param, so the loop stops there instead of
+    // spinning until the retry bound is exhausted.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('same-target retry: strips stale thinking-block signatures and retries instead of failing over', async () => {
+    setConfigForTesting(makeAnthropicMessagesConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () => thinkingSignatureErrorResponse())
+      .mockImplementationOnce(async () => successMessagesResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeMessagesRequest(messagesWithStaleThinking()));
+    const meta = (response as any).plexus;
+
+    // Single configured target — a second fetch call can only mean the SAME
+    // target was retried after stripping the stale thinking blocks, not a
+    // failover to a different provider (there isn't one).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+
+    const retriedBody = JSON.parse((fetchMock.mock.calls[1] as any[])[1].body as string);
+    expect(Array.isArray(retriedBody.messages)).toBe(true);
+    for (const message of retriedBody.messages) {
+      const content = Array.isArray(message.content) ? message.content : [];
+      expect(
+        content.some(
+          (block: any) => block.type === 'thinking' || block.type === 'redacted_thinking'
+        )
+      ).toBe(false);
+    }
+    // Non-thinking content survives the strip.
+    expect(retriedBody.messages[1].content).toEqual([{ type: 'text', text: 'answer' }]);
+  });
+
+  test('same-target retry: gives up after the one-shot thinking-signature retry bound and fails normally when the signature error persists', async () => {
+    setConfigForTesting(makeAnthropicMessagesConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () => thinkingSignatureErrorResponse());
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeMessagesRequest(messagesWithStaleThinking()));
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    // 1 initial attempt + exactly 1 bounded signature strip-retry = 2 fetch
+    // calls, then give up rather than looping forever on a persistent error.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test('embeddings failover', async () => {

--- a/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
@@ -3,6 +3,9 @@ import { Dispatcher } from '../dispatch/dispatcher';
 import { setConfigForTesting } from '../../config';
 import type { UnifiedChatRequest } from '../../types/unified';
 import { CooldownManager } from '../runtime/cooldown-manager';
+// Globally mocked in test/vitest.setup.ts — imported here only to assert on
+// the warn calls the strip-and-retry paths emit.
+import { logger } from '../../utils/logger';
 
 const fetchMock: any = vi.fn(async (): Promise<any> => {
   throw new Error('fetch mock not configured for test');
@@ -583,6 +586,17 @@ describe('Dispatcher Failover', () => {
     // retry regardless of outcome.
     const retriedBody = JSON.parse((fetchMock.mock.calls[1] as any[])[1].body as string);
     expect(retriedBody.safety_identifier).toBeUndefined();
+
+    // The strip warn is the only operator-visible trace that the outbound
+    // payload was modified mid-request — it must name both the target
+    // (provider/model) and the exact param that was removed.
+    const paramStripWarn = vi
+      .mocked(logger.warn)
+      .mock.calls.map((call) => String(call[0]))
+      .find((message) => message.includes('rejected unsupported parameter'));
+    expect(paramStripWarn).toBeDefined();
+    expect(paramStripWarn).toContain('p1/model-1');
+    expect(paramStripWarn).toContain("'safety_identifier'");
   });
 
   test('same-target retry: gives up after the retry bound and fails normally when the upstream keeps naming a NEW unsupported param', async () => {
@@ -645,6 +659,58 @@ describe('Dispatcher Failover', () => {
     expect(Object.prototype.toString).toBe(originalToString);
     expect(typeof Object.prototype.toString).toBe('function');
     expect({}.toString()).toBe('[object Object]');
+  });
+
+  test('same-target retry: refuses to strip the whole `messages` field — no strip, no retry', async () => {
+    // Deleting the entire conversation wholesale guarantees a malformed
+    // request, so the structural guard must refuse: exactly one fetch (no
+    // same-target retry with a messages-less payload), then normal failure.
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () => errorResponse(400, 'Unsupported parameter: messages'));
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('same-target retry: bracket notation (messages[0].name) strips only that element field and retries with the conversation intact', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () =>
+        errorResponse(400, "Unsupported parameter: 'messages[0].name'")
+      )
+      .mockImplementationOnce(async () => successChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch({
+      model: 'test-alias',
+      messages: [{ role: 'user', content: 'hello' }],
+      incomingApiType: 'chat',
+      stream: false,
+      originalBody: {
+        model: 'test-alias',
+        messages: [{ role: 'user', content: 'hello', name: 'bob!' }],
+      },
+    } as any);
+    const meta = (response as any).plexus;
+
+    // Single configured target — the second fetch is a same-target retry.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+
+    const retriedBody = JSON.parse((fetchMock.mock.calls[1] as any[])[1].body as string);
+    // The delete landed on the array ELEMENT's field (bracket segments
+    // normalized to canonical indices) — the old truncating matcher instead
+    // deleted `messages` wholesale from the retry payload.
+    expect(Array.isArray(retriedBody.messages)).toBe(true);
+    expect(retriedBody.messages).toEqual([{ role: 'user', content: 'hello' }]);
   });
 
   test('same-target retry: a no-op strip (named field not actually present) does not retry', async () => {
@@ -718,6 +784,18 @@ describe('Dispatcher Failover', () => {
     }
     // Non-thinking content survives the strip.
     expect(retriedBody.messages[1].content).toEqual([{ type: 'text', text: 'answer' }]);
+
+    // The strip warn is the only operator-visible trace that conversation
+    // content was modified mid-request — it must name the target
+    // (provider/model) and how many thinking blocks were stripped (the
+    // fixture carries exactly one).
+    const signatureStripWarn = vi
+      .mocked(logger.warn)
+      .mock.calls.map((call) => String(call[0]))
+      .find((message) => message.includes('stale thinking-block'));
+    expect(signatureStripWarn).toBeDefined();
+    expect(signatureStripWarn).toContain('p1/model-1');
+    expect(signatureStripWarn).toContain('stripped 1 thinking block(s)');
   });
 
   test('same-target retry: gives up after the one-shot thinking-signature retry bound and fails normally when the signature error persists', async () => {

--- a/packages/backend/src/services/__tests__/dispatcher-oauth-passthrough.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-oauth-passthrough.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
 import { setConfigForTesting } from '../../config';
 import { OAuthAuthManager } from '../oauth/oauth-auth-manager';
 import { registerSpy } from '../../../test/test-utils';
-import type { UnifiedChatRequest } from '../../types/unified';
+import { TransformerFactory } from '../dispatch/transformer-factory';
+import type { UnifiedChatRequest, UnifiedChatResponse } from '../../types/unified';
 
 // Regression test for issue #162 (dispatcher-level):
 //   a multi-turn conversation routed to Claude Code OAuth must succeed, not
@@ -123,5 +124,286 @@ describe('Dispatcher OAuth pass-through regression (issue #162)', () => {
     expect(headers.Authorization).toBe('Bearer sk-ant-oat-fake-token-for-test');
     expect(headers['anthropic-beta']).toBeTruthy();
     expect(headers['x-app']).toBe('cli');
+  });
+});
+
+// Regression coverage for the production defect where OpenAI-format clients
+// (chat/responses) routed to an OAuth-Anthropic native target received RAW
+// Anthropic SSE back (empty completions — no `choices`, no `data: [DONE]`).
+// Root cause: the native-OAuth response bypass in request-payload-builder.ts
+// was unconditional (`true`) for the Anthropic branch, regardless of the
+// incoming client's API format. Fix mirrors the identical Codex defect fixed
+// in commit 4f74c1c6 ("fix(oauth): translate cross-format Codex responses"):
+// scope the bypass to same-format (`messages`) clients only; chat/responses
+// clients must flow through the standard transform pipeline.
+
+function oauthAnthropicCrossFormatConfig() {
+  return {
+    providers: {
+      Claude: {
+        type: 'oauth',
+        api_base_url: 'oauth://anthropic',
+        oauth_provider: 'anthropic',
+        oauth_account: 'test-account',
+        models: {
+          'claude-test': {
+            pricing: { source: 'simple', input: 0, output: 0 },
+            access_via: ['chat', 'messages', 'responses'],
+          },
+        },
+      },
+    },
+    models: {
+      'test-alias': {
+        targets: [{ provider: 'Claude', model: 'claude-test' }],
+      },
+    },
+    keys: {},
+  } as any;
+}
+
+// A realistic upstream Anthropic Messages SSE stream: message_start ->
+// content_block_start/delta (text) -> content_block_stop -> message_delta
+// (stop_reason: end_turn) -> message_stop. Whitespace/shape kept exactly as
+// a real Anthropic response would send it — the messages-inbound regression
+// guard asserts byte-for-byte equality against this constant.
+const UPSTREAM_ANTHROPIC_SSE = [
+  'event: message_start',
+  'data: {"type":"message_start","message":{"id":"msg_test123","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}',
+  '',
+  'event: content_block_start',
+  'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+  '',
+  'event: content_block_delta',
+  'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from Claude"}}',
+  '',
+  'event: content_block_stop',
+  'data: {"type":"content_block_stop","index":0}',
+  '',
+  'event: message_delta',
+  'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":4}}',
+  '',
+  'event: message_stop',
+  'data: {"type":"message_stop"}',
+  '',
+  '',
+].join('\n');
+
+function chatStreamingRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'test-alias',
+    stream: true,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'test-alias',
+    messages: body.messages,
+    stream: true,
+    incomingApiType: 'chat',
+    originalBody: body,
+  } as any;
+}
+
+function responsesStreamingRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'test-alias',
+    stream: true,
+    input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+  };
+  return {
+    model: 'test-alias',
+    messages: [{ role: 'user', content: 'hi' }],
+    stream: true,
+    incomingApiType: 'responses',
+    originalBody: body,
+  } as any;
+}
+
+function messagesStreamingRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'test-alias',
+    max_tokens: 256,
+    stream: true,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'test-alias',
+    messages: body.messages,
+    max_tokens: 256,
+    stream: true,
+    incomingApiType: 'messages',
+    originalBody: body,
+  } as any;
+}
+
+function nonStreamingChatRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'test-alias',
+    stream: false,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'test-alias',
+    messages: body.messages,
+    stream: false,
+    incomingApiType: 'chat',
+    originalBody: body,
+  } as any;
+}
+
+async function drainBytes(stream: ReadableStream): Promise<string> {
+  const reader = stream.getReader();
+  const dec = new TextDecoder();
+  let out = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out += typeof value === 'string' ? value : dec.decode(value);
+  }
+  return out;
+}
+
+/** Extracts every SSE frame's JSON `data:` payload, dropping the `[DONE]` sentinel. */
+function parseSseDataPayloads(text: string): any[] {
+  return text
+    .split('\n\n')
+    .map((block) => block.split('\n').find((line) => line.startsWith('data:')))
+    .filter((line): line is string => !!line)
+    .map((line) => line.replace(/^data:\s*/, ''))
+    .filter((data) => data !== '[DONE]')
+    .map((data) => JSON.parse(data));
+}
+
+describe('Dispatcher OAuth pass-through — cross-format Anthropic response translation (regression)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    OAuthAuthManager.resetForTesting();
+    registerSpy(OAuthAuthManager.getInstance(), 'getApiKey').mockResolvedValue(
+      'sk-ant-oat-fake-token-for-test'
+    );
+    fetchSpy = registerSpy(global, 'fetch').mockResolvedValue(
+      new Response(UPSTREAM_ANTHROPIC_SSE, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    OAuthAuthManager.resetForTesting();
+  });
+
+  /**
+   * Mirrors the standard dispatch pipeline in response-handler.ts (~lines
+   * 274-284): raw provider SSE -> providerTransformer.transformStream ->
+   * unified chunks -> clientTransformer.formatStream -> client SSE bytes.
+   * The dispatcher itself never runs this pipeline (it only decides, via
+   * `bypassTransformation`, whether response-handler.ts should) so the test
+   * replicates it to prove cross-format clients actually get a well-formed,
+   * translated stream rather than just checking the boolean flag.
+   */
+  async function translatedClientBytes(
+    response: UnifiedChatResponse,
+    incomingApiType: string
+  ): Promise<string> {
+    const providerTransformer = TransformerFactory.getTransformer('messages');
+    const clientTransformer = TransformerFactory.getTransformer(incomingApiType);
+    const unifiedStream = providerTransformer.transformStream!(response.stream!);
+    const clientStream = clientTransformer.formatStream!(unifiedStream);
+    return drainBytes(clientStream);
+  }
+
+  test('chat-inbound + oauth-anthropic target, streaming: translates to OpenAI chunks, no raw Anthropic frames', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    const response = await new Dispatcher().dispatch(chatStreamingRequest());
+
+    // Sanity: the upstream leg always speaks native Anthropic Messages.
+    expect(response.plexus?.apiType).toBe('messages');
+    // The actual fix: response leg must NOT bypass for a chat-inbound client.
+    expect(response.bypassTransformation).toBe(false);
+    expect(response.stream).toBeDefined();
+
+    const clientBytes = await translatedClientBytes(response, 'chat');
+    const payloads = parseSseDataPayloads(clientBytes);
+
+    const contentChunk = payloads.find((p) => p.choices?.[0]?.delta?.content);
+    expect(contentChunk?.choices[0].delta.content).toBe('Hello from Claude');
+
+    const finishChunk = payloads.find((p) => p.choices?.[0]?.finish_reason);
+    expect(finishChunk?.choices[0].finish_reason).toBe('stop');
+
+    expect(clientBytes.trim().endsWith('data: [DONE]')).toBe(true);
+    // No raw Anthropic SSE frames leaked to the client (OpenAI chunks never
+    // use a named `event:` line).
+    expect(clientBytes).not.toMatch(/^event:/m);
+    expect(clientBytes).not.toContain('message_start');
+    expect(clientBytes).not.toContain('content_block_delta');
+  });
+
+  test('responses-inbound + oauth-anthropic target, streaming: translates to Responses events, no raw Anthropic frames', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    const response = await new Dispatcher().dispatch(responsesStreamingRequest());
+
+    expect(response.plexus?.apiType).toBe('messages');
+    expect(response.bypassTransformation).toBe(false);
+    expect(response.stream).toBeDefined();
+
+    const clientBytes = await translatedClientBytes(response, 'responses');
+    const payloads = parseSseDataPayloads(clientBytes);
+
+    const deltaEvent = payloads.find((p) => p.type === 'response.output_text.delta');
+    expect(deltaEvent?.delta).toBe('Hello from Claude');
+    expect(payloads.some((p) => p.type === 'response.completed')).toBe(true);
+
+    expect(clientBytes).toContain('event: response.output_text.delta');
+    expect(clientBytes).not.toContain('event: message_start');
+    expect(clientBytes).not.toContain('event: content_block_delta');
+    expect(clientBytes).not.toContain('event: message_delta');
+    expect(clientBytes).not.toContain('event: message_stop');
+  });
+
+  test('messages-inbound + oauth-anthropic target, streaming: raw Anthropic SSE passthrough unchanged (regression guard)', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    const response = await new Dispatcher().dispatch(messagesStreamingRequest());
+
+    expect(response.bypassTransformation).toBe(true);
+    expect(response.stream).toBeDefined();
+
+    const clientBytes = await drainBytes(response.stream!);
+    // Byte-for-byte: Claude Code traffic depends on zero re-serialization.
+    expect(clientBytes).toBe(UPSTREAM_ANTHROPIC_SSE);
+  });
+
+  test('chat-inbound + oauth-anthropic target, non-streaming: same scoping applies (bypass disabled, JSON translated)', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'msg_test123',
+          type: 'message',
+          role: 'assistant',
+          model: 'claude-test',
+          content: [{ type: 'text', text: 'Hello from Claude' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 4 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    const response = await new Dispatcher().dispatch(nonStreamingChatRequest());
+
+    // Non-streaming's non-bypass branch (dispatcher.ts handleNonStreamingResponse)
+    // returns transformer.transformResponse(...) as-is without stamping an
+    // explicit `bypassTransformation: false` (only the bypass=true branch stamps
+    // it). response-handler.ts only ever does a truthy check on this flag, so
+    // `undefined` and `false` are behaviorally identical — assert falsy rather
+    // than a stricter equality the surrounding code doesn't actually guarantee.
+    expect(response.bypassTransformation).toBeFalsy();
+
+    const formatted = await TransformerFactory.getTransformer('chat').formatResponse(response);
+    expect(formatted.choices[0].message.content).toBe('Hello from Claude');
   });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-oauth-passthrough.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-oauth-passthrough.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import type { FastifyReply, FastifyRequest } from 'fastify';
 import { setConfigForTesting } from '../../config';
 import { OAuthAuthManager } from '../oauth/oauth-auth-manager';
 import { registerSpy } from '../../../test/test-utils';
 import { TransformerFactory } from '../dispatch/transformer-factory';
+import { handleResponse } from '../responses/response-handler';
+import type { UsageStorageService } from '../observability/usage-storage';
 import type { UnifiedChatRequest, UnifiedChatResponse } from '../../types/unified';
+import type { UsageRecord } from '../../types/usage';
 
 // Regression test for issue #162 (dispatcher-level):
 //   a multi-turn conversation routed to Claude Code OAuth must succeed, not
@@ -405,5 +409,96 @@ describe('Dispatcher OAuth pass-through — cross-format Anthropic response tran
 
     const formatted = await TransformerFactory.getTransformer('chat').formatResponse(response);
     expect(formatted.choices[0].message.content).toBe('Hello from Claude');
+  });
+
+  // End-to-end lock for the scenario the manual `translatedClientBytes` tests
+  // above only approximate: drive `handleResponse` ITSELF (the code that runs
+  // in production) with the dispatcher's real cross-format result and let it
+  // resolve the REAL provider transformer (AnthropicTransformer, via the
+  // un-mocked TransformerFactory) and the REAL client transformer
+  // (OpenAITransformer). Asserts the exact bytes a chat client receives.
+  test('chat-inbound + oauth-anthropic target, streaming: END-TO-END through handleResponse yields OpenAI chunks', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    const response = await new Dispatcher().dispatch(chatStreamingRequest());
+
+    // Preconditions (same dispatcher decisions the manual tests assert).
+    expect(response.plexus?.apiType).toBe('messages');
+    expect(response.bypassTransformation).toBe(false);
+    expect(response.stream).toBeDefined();
+
+    const clientTransformer = TransformerFactory.getTransformer('chat');
+    const usageRecord: Partial<UsageRecord> = { requestId: 'req-e2e-cross-format' };
+    const usageStorage = {
+      saveRequest: vi.fn(),
+      saveError: vi.fn(),
+      updatePerformanceMetrics: vi.fn(),
+    } as unknown as UsageStorageService;
+    const sentBodies: any[] = [];
+    const reply = {
+      header: vi.fn(function (this: any) {
+        return this;
+      }),
+      code: vi.fn(function (this: any) {
+        return this;
+      }),
+      send: vi.fn(function (this: any, body: any) {
+        sentBodies.push(body);
+        return this;
+      }),
+    } as unknown as FastifyReply;
+    const fastifyRequest = { id: 'req-e2e-cross-format', headers: {} } as unknown as FastifyRequest;
+
+    await handleResponse(
+      fastifyRequest,
+      reply,
+      response,
+      clientTransformer,
+      usageRecord,
+      usageStorage,
+      Date.now(),
+      'chat'
+    );
+
+    expect(reply.header).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+
+    // handleResponse sends a Node Readable pipeline — collect the exact bytes
+    // a client would receive over the wire.
+    const pipeline = sentBodies.at(-1);
+    expect(pipeline).toBeDefined();
+    const clientBytes: string = await new Promise((resolve, reject) => {
+      let out = '';
+      pipeline.on('data', (chunk: any) => {
+        out += chunk.toString();
+      });
+      pipeline.once('end', () => resolve(out));
+      pipeline.once('error', reject);
+    });
+    // Let fire-and-forget completion work (UsageInspector flush) settle.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Structured SSE parsing: every data frame must be an OpenAI chat chunk.
+    const payloads = parseSseDataPayloads(clientBytes);
+    expect(payloads.length).toBeGreaterThan(0);
+    for (const payload of payloads) {
+      expect(payload.object).toBe('chat.completion.chunk');
+    }
+
+    const contentChunk = payloads.find((p) => p.choices?.[0]?.delta?.content);
+    expect(contentChunk?.choices[0].delta.content).toBe('Hello from Claude');
+
+    const finishChunk = payloads.find((p) => p.choices?.[0]?.finish_reason);
+    expect(finishChunk?.choices[0].finish_reason).toBe('stop');
+
+    expect(clientBytes.trim().endsWith('data: [DONE]')).toBe(true);
+
+    // No raw Anthropic SSE frames may leak through the real pipeline.
+    expect(clientBytes).not.toMatch(/^event:/m);
+    expect(clientBytes).not.toContain('message_start');
+    expect(clientBytes).not.toContain('content_block_delta');
+
+    // Pipeline bookkeeping: the stream had visible output and was transformed.
+    expect(usageRecord.responseStatus).toBe('success');
+    expect(usageRecord.isPassthrough).toBe(false);
+    expect(usageStorage.saveRequest).toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
+++ b/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
@@ -16,9 +16,14 @@
  * See packages/backend/src/__tests__/disconnect-detection/ for the exploratory
  * test scripts that established these findings.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Readable } from 'node:stream';
 import { PassThrough } from 'node:stream';
+import { handleResponse } from '../responses/response-handler';
+import { OpenAITransformer } from '../../transformers/openai';
+import { DebugManager } from '../observability/debug-manager';
+import type { UnifiedChatResponse } from '../../types/unified';
+import type { UsageRecord } from '../../types/usage';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -269,5 +274,124 @@ describe('nodeStream destruction state', () => {
 
     expect(wasCancelled()).toBe(true);
     expect(nodeStream.destroyed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: cancellation mid-stream still records usage
+// ---------------------------------------------------------------------------
+//
+// The debug taps' snapshots (which UsageInspector's _destroy fallback reads)
+// used to be written ONLY by the taps' flush/'end' handlers — and a client
+// disconnect/timeout cancels the web TransformStreams WITHOUT running flush,
+// so production cancellations finalized with no usage at all (the earlier
+// tests pre-seeded the snapshots and never noticed). This exercises the REAL
+// path end-to-end through handleResponse: provider SSE with usage-bearing
+// chunks -> abort mid-stream (no flush anywhere) -> the saved record must
+// still carry the observed usage, via the teardown's explicit finalize.
+describe('handleResponse cancellation records usage from live captures (no pre-seeding)', () => {
+  beforeEach(() => {
+    DebugManager.getInstance().resetForTesting();
+  });
+
+  it('a client disconnect after usage-bearing chunks finalizes the record WITH usage and costs', async () => {
+    const encoder = new TextEncoder();
+    // Chat-format provider SSE: role/content chunk, then the usage-bearing
+    // final chunk — and then the stream stays OPEN (no [DONE], no close):
+    // the client disconnects first, so no flush ever runs anywhere. (In
+    // production the upstream fetch is killed by the abort signal +
+    // nodeStream.destroy(); this test asserts the usage RECORD, which is
+    // what cancellations used to lose.)
+    const providerStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl_e2e","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}\n\n'
+          )
+        );
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl_e2e","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":50,"completion_tokens":9,"total_tokens":59}}\n\n'
+          )
+        );
+        // Deliberately NOT closed.
+      },
+    });
+
+    const unifiedResponse: UnifiedChatResponse = {
+      id: 'resp-cancel-e2e',
+      model: 'gpt-4o',
+      content: null,
+      stream: providerStream,
+      plexus: {
+        provider: 'test-provider',
+        model: 'gpt-4o',
+        apiType: 'chat',
+        pricing: { source: 'simple', input: 1000, output: 2000 },
+      },
+    };
+
+    const usageRecord: Partial<UsageRecord> = { requestId: 'req-cancel-e2e' };
+    const savedRecords: UsageRecord[] = [];
+    const mockStorage = {
+      saveRequest: vi.fn(async (record: UsageRecord) => {
+        savedRecords.push(record);
+      }),
+      updatePerformanceMetrics: vi.fn(async () => {}),
+      saveError: vi.fn(),
+    };
+    const reply = {
+      header: vi.fn(function (this: any) {
+        return this;
+      }),
+      send: vi.fn((pipeline: any) => pipeline),
+      code: vi.fn(function (this: any) {
+        return this;
+      }),
+    };
+    const request = { headers: {}, raw: {} };
+    const abortController = new AbortController();
+
+    await handleResponse(
+      request as any,
+      reply as any,
+      unifiedResponse,
+      new OpenAITransformer(),
+      usageRecord,
+      mockStorage as any,
+      Date.now(),
+      'chat',
+      false,
+      undefined,
+      undefined,
+      undefined,
+      abortController,
+      null
+    );
+
+    const pipeline = (reply.send as any).mock.calls.at(-1)[0];
+    pipeline.on('data', () => {});
+    pipeline.on('error', () => {});
+
+    // Let the chunks flow through the full production pipeline (provider SSE
+    // -> raw tap -> unified -> client SSE -> transformed tap), then
+    // disconnect the client mid-stream.
+    await wait(80);
+    abortController.abort();
+    // Long enough for the teardown to finish AND for the disconnect poll to
+    // observe the destroyed pipeline and clear itself.
+    await wait(300);
+
+    expect(savedRecords).toHaveLength(1);
+    const record = savedRecords[0]!;
+    expect(record.responseStatus).toBe('cancelled');
+    // The usage the provider streamed BEFORE the disconnect must be on the
+    // record — this is exactly what production cancellations lost when the
+    // snapshots were only written on flush.
+    expect(record.tokensInput).toBe(50);
+    expect(record.tokensOutput).toBe(9);
+    // 50/1M * $1000 + 9/1M * $2000 = $0.068.
+    expect(record.costSource).toBe('simple');
+    expect(record.costTotal).toBeCloseTo(0.068, 10);
   });
 });

--- a/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
@@ -194,4 +194,160 @@ describe('UsageInspector Metadata Robustness', () => {
     expect(record?.toolCallsCount).toBe(2);
     expect(record?.finishReason).toBe('something_else');
   });
+
+  describe('Responses API status → finishReason mapping', () => {
+    // Mirrors the reconstructed snapshot shape produced by
+    // DebugLoggingInspector.updateResponsesSnapshot for the same
+    // response.created -> response.output_text.delta -> response.failed
+    // stream exercised in debug-logging-reconstruction.test.ts.
+    it('should map a failed Responses API stream to finishReason "error" with non-zero usage', async () => {
+      const requestId = 'responses-failed-stream';
+      const snapshot = {
+        id: 'resp_test123',
+        object: 'response',
+        status: 'failed',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Partial answer before it broke' }],
+          },
+        ],
+        error: { code: 'server_error', message: 'The model response failed to complete.' },
+        usage: {
+          input_tokens: 42,
+          output_tokens: 8,
+          total_tokens: 50,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('error');
+      expect(record?.tokensInput).toBe(42);
+      expect(record?.tokensOutput).toBe(8);
+    });
+
+    // Mirrors the reconstructed snapshot shape produced by
+    // DebugLoggingInspector.updateResponsesSnapshot for the same
+    // response.created -> response.output_text.delta -> response.incomplete
+    // stream exercised in debug-logging-reconstruction.test.ts.
+    it('should map an incomplete Responses API stream (max_output_tokens) to finishReason "length" with non-zero usage', async () => {
+      const requestId = 'responses-incomplete-max-tokens-stream';
+      const snapshot = {
+        id: 'resp_test789',
+        object: 'response',
+        status: 'incomplete',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Truncated answer that ran out of ' }],
+          },
+        ],
+        incomplete_details: { reason: 'max_output_tokens' },
+        usage: {
+          input_tokens: 30,
+          output_tokens: 16,
+          total_tokens: 46,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('length');
+      expect(record?.tokensInput).toBe(30);
+      expect(record?.tokensOutput).toBe(16);
+    });
+
+    it('should map an incomplete Responses API stream (content_filter) to finishReason "content_filter"', async () => {
+      const requestId = 'responses-incomplete-content-filter-stream';
+      const snapshot = {
+        id: 'resp_test999',
+        object: 'response',
+        status: 'incomplete',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Cut off by the content filter' }],
+          },
+        ],
+        incomplete_details: { reason: 'content_filter' },
+        usage: {
+          input_tokens: 25,
+          output_tokens: 4,
+          total_tokens: 29,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('content_filter');
+      expect(record?.tokensInput).toBe(25);
+      expect(record?.tokensOutput).toBe(4);
+    });
+
+    it('should default an incomplete Responses API stream with an unknown/absent reason to finishReason "length"', async () => {
+      const requestId = 'responses-incomplete-unknown-reason-stream';
+      const snapshot = {
+        id: 'resp_test000',
+        object: 'response',
+        status: 'incomplete',
+        model: 'gpt-4o',
+        output: [],
+        // No incomplete_details at all — must still default sensibly instead
+        // of leaking 'incomplete' or throwing on the optional chain.
+        usage: {
+          input_tokens: 12,
+          output_tokens: 1,
+          total_tokens: 13,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('length');
+    });
+
+    it('should still map a completed Responses API stream to finishReason "stop" (regression)', async () => {
+      const requestId = 'responses-completed-stream';
+      const snapshot = {
+        id: 'resp_test456',
+        object: 'response',
+        status: 'completed',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Full answer' }],
+          },
+        ],
+        usage: {
+          input_tokens: 42,
+          output_tokens: 20,
+          total_tokens: 62,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('stop');
+      expect(record?.tokensInput).toBe(42);
+      expect(record?.tokensOutput).toBe(20);
+    });
+  });
 });

--- a/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { registerSpy } from '../../../test/test-utils';
 import { PassThrough } from 'stream';
 import { UsageInspector } from '../inspectors/usage-logging';
+import { DebugLoggingInspector } from '../inspectors/debug-logging';
 import { DebugManager } from '../observability/debug-manager';
 import type { UsageRecord } from '../../types/usage';
 import { DEFAULT_GPU_PARAMS, DEFAULT_MODEL } from '@plexus/shared';
@@ -20,6 +21,7 @@ describe('UsageInspector Metadata Robustness', () => {
       outputCostPerToken: 0,
     };
     const dm = DebugManager.getInstance();
+    dm.resetForTesting();
     dm.setEnabled(true);
   });
 
@@ -320,6 +322,35 @@ describe('UsageInspector Metadata Robustness', () => {
       expect(record?.finishReason).toBe('length');
     });
 
+    it('should record a failed Responses API stream carrying NO usage with finishReason "error" and zero tokens (optional-usage behavior locked in)', async () => {
+      // Mirrors the response.failed-without-usage stream exercised in
+      // debug-logging-reconstruction.test.ts: the reconstruction keeps usage
+      // absent, so usage-logging must record no tokens (and must not throw).
+      const requestId = 'responses-failed-no-usage-stream';
+      const snapshot = {
+        id: 'resp_nousage_1',
+        object: 'response',
+        status: 'failed',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Partial answer before it broke' }],
+          },
+        ],
+        error: { code: 'server_error', message: 'The model response failed to complete.' },
+        // No usage at all — the upstream failed before reporting any.
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('error');
+      expect(record?.tokensInput).toBe(0);
+      expect(record?.tokensOutput).toBe(0);
+      expect(record?.tokensReasoning).toBe(0);
+    });
+
     it('should still map a completed Responses API stream to finishReason "stop" (regression)', async () => {
       const requestId = 'responses-completed-stream';
       const snapshot = {
@@ -348,6 +379,511 @@ describe('UsageInspector Metadata Robustness', () => {
       expect(record?.finishReason).toBe('stop');
       expect(record?.tokensInput).toBe(42);
       expect(record?.tokensOutput).toBe(20);
+    });
+  });
+
+  describe('usage fallback to the transformed-mode snapshot', () => {
+    // The raw-mode reconstruction stays authoritative; the transformed-mode
+    // snapshot (written by the client-facing DebugLoggingInspector, keyed by
+    // the CLIENT api type) is only consulted when raw yields no usage at all.
+    const runInspectorWithSnapshots = async (
+      requestId: string,
+      options: {
+        providerApiType: string;
+        incomingApiType?: string;
+        rawSnapshot?: any;
+        transformedSnapshot?: any;
+      }
+    ): Promise<UsageRecord | null> => {
+      const inspector = new UsageInspector(
+        requestId,
+        mockStorage,
+        { requestId } as Partial<UsageRecord>,
+        mockPricing,
+        undefined,
+        Date.now(),
+        false,
+        options.providerApiType,
+        options.incomingApiType,
+        undefined,
+        DEFAULT_GPU_PARAMS,
+        DEFAULT_MODEL
+      );
+
+      const dm = DebugManager.getInstance();
+      dm.startLog(requestId, {});
+      if (options.rawSnapshot !== undefined) {
+        dm.addReconstructedRawResponse(requestId, options.rawSnapshot);
+      }
+      if (options.transformedSnapshot !== undefined) {
+        dm.addTransformedResponseSnapshot(requestId, options.transformedSnapshot);
+      }
+
+      let capturedRecord: UsageRecord | null = null;
+      registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+        capturedRecord = record;
+        return Promise.resolve();
+      });
+
+      const mockStream = new PassThrough();
+      mockStream.pipe(inspector);
+      mockStream.end();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return capturedRecord;
+    };
+
+    const responsesRawSnapshotWithUsage = () => ({
+      id: 'resp_raw_1',
+      object: 'response',
+      status: 'completed',
+      model: 'gpt-4o',
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Full answer' }],
+        },
+      ],
+      usage: {
+        input_tokens: 42,
+        output_tokens: 8,
+        total_tokens: 50,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      },
+    });
+
+    // Transformed snapshot as reconstructed for a CHAT-format client.
+    const chatTransformedSnapshotWithUsage = () => ({
+      id: 'chatcmpl_t1',
+      object: 'chat.completion.chunk',
+      model: 'gpt-4o',
+      choices: [{ index: 0, delta: { role: 'assistant', content: 'Full answer' } }],
+      usage: { prompt_tokens: 21, completion_tokens: 7, total_tokens: 28 },
+    });
+
+    it('raw reconstruction with usage stays authoritative — the transformed snapshot is ignored', async () => {
+      const record = await runInspectorWithSnapshots('fallback-raw-authoritative', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        rawSnapshot: responsesRawSnapshotWithUsage(),
+        transformedSnapshot: chatTransformedSnapshotWithUsage(),
+      });
+
+      expect(record?.tokensInput).toBe(42);
+      expect(record?.tokensOutput).toBe(8);
+    });
+
+    it('falls back to the transformed-mode snapshot when NO raw reconstruction exists', async () => {
+      const record = await runInspectorWithSnapshots('fallback-raw-absent', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        transformedSnapshot: chatTransformedSnapshotWithUsage(),
+      });
+
+      expect(record?.tokensInput).toBe(21);
+      expect(record?.tokensOutput).toBe(7);
+    });
+
+    it('falls back when the raw reconstruction exists but carries no usage (metadata still from raw)', async () => {
+      const record = await runInspectorWithSnapshots('fallback-raw-usageless', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'resp_raw_2',
+          object: 'response',
+          status: 'failed',
+          model: 'gpt-4o',
+          output: [],
+          error: { code: 'server_error', message: 'boom' },
+          // No usage block at all.
+        },
+        transformedSnapshot: chatTransformedSnapshotWithUsage(),
+      });
+
+      // Tokens from the transformed snapshot...
+      expect(record?.tokensInput).toBe(21);
+      expect(record?.tokensOutput).toBe(7);
+      // ...while response metadata still comes from the raw reconstruction.
+      expect(record?.finishReason).toBe('error');
+    });
+
+    it('records no tokens when both snapshots are absent (current behavior unchanged)', async () => {
+      const record = await runInspectorWithSnapshots('fallback-both-absent', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+      });
+
+      expect(record).not.toBeNull();
+      expect(record?.tokensInput).toBeUndefined();
+      expect(record?.tokensOutput).toBeUndefined();
+    });
+
+    it('records no tokens when the raw reconstruction is usage-less and no transformed snapshot exists (current behavior unchanged)', async () => {
+      const record = await runInspectorWithSnapshots('fallback-raw-usageless-no-transformed', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'resp_raw_3',
+          object: 'response',
+          status: 'failed',
+          model: 'gpt-4o',
+          output: [],
+          error: { code: 'server_error', message: 'boom' },
+        },
+      });
+
+      expect(record?.tokensInput).toBe(0);
+      expect(record?.tokensOutput).toBe(0);
+      expect(record?.finishReason).toBe('error');
+    });
+
+    describe('destroyed/cancelled streams (_destroy) use the same raw-then-transformed read', () => {
+      // Same scenarios as runInspectorWithSnapshots, but the stream is
+      // DESTROYED (client disconnect/cancel) instead of ending normally, so
+      // finalization goes through _destroy rather than _flush — and the
+      // snapshots are produced through the REAL write path: provider/client
+      // bytes written through DebugLoggingInspector taps that are
+      // `finalize()`d before the destroy, exactly as response-handler.ts's
+      // onDisconnect teardown does. (Pre-seeding the DebugManager directly
+      // would paper over the production gap this guards against: a cancelled
+      // web TransformStream never runs its flush, so the taps' 'end' handlers
+      // never fire — without the explicit finalize, _destroy would find NO
+      // snapshots at all on a real cancellation.) `pricing` (default
+      // mockPricing) lets tests assert whether calculateCosts ran: when it
+      // runs it always stamps costSource/costTotal, when it doesn't both
+      // stay undefined.
+      const runDestroyedInspectorWithCapturedBodies = async (
+        requestId: string,
+        options: {
+          providerApiType: string;
+          incomingApiType?: string;
+          /** Provider-format body written through the RAW debug tap. */
+          rawBody?: string;
+          /** Client-format body written through the TRANSFORMED debug tap. */
+          transformedBody?: string;
+          pricing?: any;
+        }
+      ): Promise<UsageRecord | null> => {
+        const inspector = new UsageInspector(
+          requestId,
+          mockStorage,
+          { requestId } as Partial<UsageRecord>,
+          options.pricing ?? mockPricing,
+          undefined,
+          Date.now(),
+          false,
+          options.providerApiType,
+          options.incomingApiType,
+          undefined,
+          DEFAULT_GPU_PARAMS,
+          DEFAULT_MODEL
+        );
+
+        const dm = DebugManager.getInstance();
+        dm.startLog(requestId, {});
+
+        const rawDebugLogging = new DebugLoggingInspector(requestId, 'raw');
+        const rawTap = rawDebugLogging.createInspector(options.providerApiType);
+        if (options.rawBody !== undefined) {
+          rawTap.write(options.rawBody);
+        }
+
+        const transformedDebugLogging = new DebugLoggingInspector(requestId, 'transformed');
+        const transformedTap = transformedDebugLogging.createInspector(
+          options.incomingApiType ?? 'chat'
+        );
+        if (options.transformedBody !== undefined) {
+          transformedTap.write(options.transformedBody);
+        }
+
+        let capturedRecord: UsageRecord | null = null;
+        registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+          capturedRecord = record;
+          return Promise.resolve();
+        });
+
+        // Mirror response-handler.ts onDisconnect(): the taps' 'end' events
+        // never fire on a cancellation, so the captures are finalized
+        // explicitly BEFORE the usage inspector is destroyed.
+        rawDebugLogging.finalize();
+        transformedDebugLogging.finalize();
+        inspector.destroy();
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return capturedRecord;
+      };
+
+      const responsesRawBodyWithUsage = () => JSON.stringify(responsesRawSnapshotWithUsage());
+
+      const responsesRawBodyWithoutUsage = () =>
+        JSON.stringify({
+          id: 'resp_raw_d1',
+          object: 'response',
+          status: 'failed',
+          model: 'gpt-4o',
+          output: [],
+          error: { code: 'server_error', message: 'boom' },
+          // No usage block at all.
+        });
+
+      // Client-facing chat SSE, as the transformed tap sees it — the usage
+      // arrives on the final chunk, but the stream is destroyed before the
+      // tap's flush would ever run.
+      const chatTransformedSseWithUsage = () =>
+        'data: {"id":"chatcmpl_t1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Full answer"}}]}\n\n' +
+        'data: {"id":"chatcmpl_t1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":21,"completion_tokens":7,"total_tokens":28}}\n\n';
+
+      it('raw reconstruction with usage stays authoritative on a destroyed stream (regression)', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies('destroy-raw-authoritative', {
+          providerApiType: 'responses',
+          incomingApiType: 'chat',
+          rawBody: responsesRawBodyWithUsage(),
+          transformedBody: chatTransformedSseWithUsage(),
+        });
+
+        expect(record?.responseStatus).toBe('cancelled');
+        expect(record?.tokensInput).toBe(42);
+        expect(record?.tokensOutput).toBe(8);
+      });
+
+      it('falls back to the transformed-mode snapshot when NO raw reconstruction exists', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies('destroy-raw-absent', {
+          providerApiType: 'responses',
+          incomingApiType: 'chat',
+          transformedBody: chatTransformedSseWithUsage(),
+          pricing: { source: 'simple', input: 1000, output: 2000 },
+        });
+
+        expect(record?.responseStatus).toBe('cancelled');
+        expect(record?.tokensInput).toBe(21);
+        expect(record?.tokensOutput).toBe(7);
+        // Costs are calculated over the fallback tokens too — "tokens
+        // recorded" must mean a fully finalized record, not tokens with a
+        // missing cost: 21/1M * $1000 + 7/1M * $2000 = $0.035.
+        expect(record?.costSource).toBe('simple');
+        expect(record?.costTotal).toBe(0.035);
+      });
+
+      it('falls back when the raw reconstruction exists but carries no usage', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies('destroy-raw-usageless', {
+          providerApiType: 'responses',
+          incomingApiType: 'chat',
+          rawBody: responsesRawBodyWithoutUsage(),
+          transformedBody: chatTransformedSseWithUsage(),
+        });
+
+        expect(record?.tokensInput).toBe(21);
+        expect(record?.tokensOutput).toBe(7);
+      });
+
+      it('records no tokens when nothing was captured on either tap (current behavior unchanged)', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies('destroy-both-absent', {
+          providerApiType: 'responses',
+          incomingApiType: 'chat',
+          pricing: { source: 'simple', input: 1000, output: 2000 },
+        });
+
+        expect(record).not.toBeNull();
+        expect(record?.responseStatus).toBe('cancelled');
+        expect(record?.tokensInput).toBeUndefined();
+        expect(record?.tokensOutput).toBeUndefined();
+        // With neither source, cost calculation must not run at all — even
+        // with pricing configured (calculateCosts always stamps costSource
+        // when it runs).
+        expect(record?.costSource).toBeUndefined();
+        expect(record?.costTotal).toBeUndefined();
+      });
+
+      it('a usage-less raw reconstruction with no transformed snapshot still runs cost calculation (current behavior preserved)', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies(
+          'destroy-raw-usageless-no-transformed',
+          {
+            providerApiType: 'responses',
+            incomingApiType: 'chat',
+            rawBody: responsesRawBodyWithoutUsage(),
+            pricing: { source: 'simple', input: 1000, output: 2000 },
+          }
+        );
+
+        // No tokens from anywhere...
+        expect(record?.tokensInput).toBeUndefined();
+        // ...but calculateCosts still ran over the (zero) token counts,
+        // exactly as it did before the readObservedUsage refactor whenever a
+        // raw reconstruction existed.
+        expect(record?.costSource).toBe('simple');
+        expect(record?.costTotal).toBe(0);
+      });
+
+      it('finalize() is idempotent — a later stream end after the teardown finalize does not double-capture', async () => {
+        const requestId = 'destroy-finalize-idempotent';
+        const dm = DebugManager.getInstance();
+        dm.startLog(requestId, {});
+
+        const transformedDebugLogging = new DebugLoggingInspector(requestId, 'transformed');
+        const tap = transformedDebugLogging.createInspector('chat');
+        tap.write(chatTransformedSseWithUsage());
+
+        transformedDebugLogging.finalize();
+        const first = dm.getPendingLog(requestId)?.transformedResponseSnapshot;
+        expect(first?.usage?.prompt_tokens).toBe(21);
+
+        // A straggler write + end() after the teardown finalize must not
+        // corrupt or re-run the capture.
+        tap.write('data: {"bogus":true}\n\n');
+        tap.end();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const second = dm.getPendingLog(requestId)?.transformedResponseSnapshot;
+        expect(second).toBe(first);
+      });
+    });
+  });
+
+  describe('estimation must not overwrite extracted usage (estimateTokens: true)', () => {
+    // When `estimateTokens: true` is configured for a provider, estimation is
+    // a FALLBACK for responses that carried no usage at all — it must never
+    // replace real usage extracted from the raw reconstruction or the
+    // transformed-snapshot fallback. (For a 'responses' provider the
+    // estimator has no dialect support and returns zeros, so the overwrite
+    // corrupted costs/quota to zero output tokens.)
+    const runEstimatingInspectorWithSnapshots = async (
+      requestId: string,
+      options: {
+        providerApiType: string;
+        incomingApiType?: string;
+        rawSnapshot?: any;
+        transformedSnapshot?: any;
+        pricing?: any;
+      }
+    ): Promise<UsageRecord | null> => {
+      const inspector = new UsageInspector(
+        requestId,
+        mockStorage,
+        { requestId } as Partial<UsageRecord>,
+        options.pricing ?? mockPricing,
+        undefined,
+        Date.now(),
+        true, // shouldEstimateTokens
+        options.providerApiType,
+        options.incomingApiType,
+        undefined,
+        DEFAULT_GPU_PARAMS,
+        DEFAULT_MODEL
+      );
+
+      const dm = DebugManager.getInstance();
+      dm.startLog(requestId, {});
+      if (options.rawSnapshot !== undefined) {
+        dm.addReconstructedRawResponse(requestId, options.rawSnapshot);
+      }
+      if (options.transformedSnapshot !== undefined) {
+        dm.addTransformedResponseSnapshot(requestId, options.transformedSnapshot);
+      }
+
+      let capturedRecord: UsageRecord | null = null;
+      registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+        capturedRecord = record;
+        return Promise.resolve();
+      });
+
+      const mockStream = new PassThrough();
+      mockStream.pipe(inspector);
+      mockStream.end();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return capturedRecord;
+    };
+
+    it('transformed-snapshot usage survives estimation (raw usage-less responses reconstruction)', async () => {
+      const record = await runEstimatingInspectorWithSnapshots('estimate-transformed-survives', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'resp_est_1',
+          object: 'response',
+          status: 'completed',
+          model: 'gpt-4o',
+          output: [
+            {
+              id: 'msg_1',
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'Full answer' }],
+            },
+          ],
+          // No usage block at all.
+        },
+        transformedSnapshot: {
+          id: 'chatcmpl_est_1',
+          object: 'chat.completion.chunk',
+          model: 'gpt-4o',
+          choices: [{ index: 0, delta: { role: 'assistant', content: 'Full answer' } }],
+          usage: { prompt_tokens: 21, completion_tokens: 7, total_tokens: 28 },
+        },
+        pricing: { source: 'simple', input: 1000, output: 2000 },
+      });
+
+      // The transformed-snapshot counts survive (the 'responses' estimator
+      // would have zeroed them)...
+      expect(record?.tokensInput).toBe(21);
+      expect(record?.tokensOutput).toBe(7);
+      // ...they are not flagged as estimated...
+      expect(record?.tokensEstimated).not.toBe(1);
+      // ...and costs are computed from them:
+      // 21/1M * $1000 + 7/1M * $2000 = $0.035.
+      expect(record?.costSource).toBe('simple');
+      expect(record?.costTotal).toBe(0.035);
+    });
+
+    it('raw-reconstruction usage survives estimation (chat provider that DID report usage)', async () => {
+      const record = await runEstimatingInspectorWithSnapshots('estimate-raw-survives', {
+        providerApiType: 'chat',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'chatcmpl_est_2',
+          object: 'chat.completion',
+          model: 'gpt-4o',
+          choices: [
+            { index: 0, message: { role: 'assistant', content: 'Hello!' }, finish_reason: 'stop' },
+          ],
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        },
+      });
+
+      expect(record?.tokensInput).toBe(100);
+      expect(record?.tokensOutput).toBe(50);
+      expect(record?.tokensEstimated).not.toBe(1);
+    });
+
+    it('estimation still runs when NO usage was extracted from either source (fallback preserved)', async () => {
+      // Streamed-reconstruction shape (delta-based) — the shape the chat
+      // estimator reads content from.
+      const record = await runEstimatingInspectorWithSnapshots('estimate-still-runs', {
+        providerApiType: 'chat',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'chatcmpl_est_3',
+          object: 'chat.completion.chunk',
+          model: 'gpt-4o',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: 'assistant',
+                content: 'A reasonably long answer with enough words to estimate.',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          // No usage block anywhere, and no transformed snapshot.
+        },
+      });
+
+      expect(record?.tokensEstimated).toBe(1);
+      expect(record?.tokensOutput).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/backend/src/services/__tests__/usage-logging.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging.test.ts
@@ -394,7 +394,13 @@ describe('UsageInspector', () => {
 
       expect(capturedRecord).not.toBeNull();
       expect(capturedRecord!.tokensInput).toBeGreaterThan(0);
-      expect(capturedRecord!.tokensEstimated).toBe(1);
+      // The provider DID report output usage (candidatesTokenCount: 12), so
+      // output estimation must NOT run (and must not overwrite the real
+      // count) — the record is not flagged as estimated; only the
+      // input-token fallback (which fires whenever the provider reports 0
+      // input tokens) filled in tokensInput above.
+      expect(capturedRecord!.tokensOutput).toBe(12);
+      expect(capturedRecord!.tokensEstimated).not.toBe(1);
     });
 
     it('does not update performance metrics for errored streams', async () => {

--- a/packages/backend/src/services/dispatch/__tests__/attempt-history.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/attempt-history.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendFailureAttempt,
+  appendSkippedAttempt,
+  buildAllTargetsFailedError,
+  type ErrorSummaryFormatter,
+  type FailureReasonFormatter,
+} from '../attempt-history';
+import type { RouteResult } from '../../routing/router';
+import type { RetryAttemptRecord } from '../dispatcher-types';
+
+// Minimal RouteResult factory — attempt-history only reads `provider`/`model`,
+// so `config` is stubbed out (mirrors adapter-resolver.test.ts's makeRoute).
+function makeRoute(provider: string, model: string): RouteResult {
+  return {
+    provider,
+    model,
+    config: {} as any,
+  } as RouteResult;
+}
+
+function httpError(statusCode: number, message: string) {
+  const error = new Error(message) as any;
+  error.routingContext = { statusCode };
+  return error;
+}
+
+// Pass-through stand-ins for the real Dispatcher.formatFailureReason /
+// compactProviderErrorSummary — buildAllTargetsFailedError takes both as
+// injected dependencies, so tests don't need the real implementations.
+const formatFailureReason: FailureReasonFormatter = (error) =>
+  error?.message ?? 'Unknown provider error';
+const compactErrorSummary: ErrorSummaryFormatter = (value) => String(value);
+
+describe('buildAllTargetsFailedError', () => {
+  it('includes the HTTP status code recorded for each attempt in the provider list', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const routeA = makeRoute('openai', 'gpt-5.5');
+    const routeB = makeRoute('OpenLimits/openai', 'gpt-5.5');
+
+    appendFailureAttempt(retryHistory, routeA, httpError(400, 'bad request'), formatFailureReason);
+    appendFailureAttempt(retryHistory, routeB, httpError(400, 'bad request'), formatFailureReason);
+
+    const error = buildAllTargetsFailedError(
+      httpError(400, 'bad request'),
+      ['openai/gpt-5.5', 'OpenLimits/openai/gpt-5.5'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe(
+      'All targets failed: openai/gpt-5.5 (400), OpenLimits/openai/gpt-5.5 (400). Last error: bad request'
+    );
+  });
+
+  it('uses the status code recorded for each attempt, not just the last error', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const routeA = makeRoute('p1', 'model-1');
+    const routeB = makeRoute('p2', 'model-2');
+
+    appendFailureAttempt(retryHistory, routeA, httpError(400, 'first failed'), formatFailureReason);
+    appendFailureAttempt(
+      retryHistory,
+      routeB,
+      httpError(503, 'second failed'),
+      formatFailureReason
+    );
+
+    const error = buildAllTargetsFailedError(
+      httpError(503, 'second failed'),
+      ['p1/model-1', 'p2/model-2'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe(
+      'All targets failed: p1/model-1 (400), p2/model-2 (503). Last error: second failed'
+    );
+  });
+
+  it('tags a network/transport failure that has no status code as (network)', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const route = makeRoute('p1', 'model-1');
+    const networkError = new Error('fetch failed');
+
+    appendFailureAttempt(retryHistory, route, networkError, formatFailureReason);
+
+    const error = buildAllTargetsFailedError(
+      networkError,
+      ['p1/model-1'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe(
+      'All targets failed: p1/model-1 (network). Last error: fetch failed'
+    );
+  });
+
+  it('tags a stalled attempt as (stall) instead of (network)', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const route = makeRoute('p1', 'model-1');
+    const stallError = new Error('Stream stalled: TTFB timeout - no response within 5000ms');
+
+    appendFailureAttempt(retryHistory, route, stallError, formatFailureReason, undefined, true);
+
+    const error = buildAllTargetsFailedError(
+      stallError,
+      ['p1/model-1'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe(
+      'All targets failed: p1/model-1 (stall). Last error: Stream stalled: TTFB timeout - no response within 5000ms'
+    );
+  });
+
+  it('excludes a skipped attempt from the summary, matching attemptedProviders as-is (current dispatch behavior)', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const skippedRoute = makeRoute('p1', 'model-1');
+    const attemptedRoute = makeRoute('p2', 'model-2');
+
+    appendSkippedAttempt(retryHistory, skippedRoute, 'Provider p1/model-1 is on cooldown');
+    appendFailureAttempt(retryHistory, attemptedRoute, httpError(500, 'boom'), formatFailureReason);
+
+    // Only p2/model-2 was actually attempted — the dispatch loop never adds
+    // a skipped target (p1/model-1) to attemptedProviders, and the summary
+    // must not grow to include it either.
+    const error = buildAllTargetsFailedError(
+      httpError(500, 'boom'),
+      ['p2/model-2'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: p2/model-2 (500). Last error: boom');
+    expect(error.message).not.toContain('p1/model-1');
+  });
+
+  it('renders (skipped) for a joined-list entry whose recorded attempt was a skip', () => {
+    // Defensive/future-proofing case from the T6 brief: today's dispatch
+    // loops never put a skipped target into attemptedProviders, but if a
+    // future caller did, the summary should label it (skipped) rather than
+    // a bogus status tag.
+    const retryHistory: RetryAttemptRecord[] = [];
+    const skippedRoute = makeRoute('p1', 'model-1');
+    appendSkippedAttempt(retryHistory, skippedRoute, 'Provider p1/model-1 is on cooldown');
+
+    const error = buildAllTargetsFailedError(
+      new Error('boom'),
+      ['p1/model-1'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: p1/model-1 (skipped). Last error: boom');
+  });
+
+  it('keeps the "All targets failed: " prefix, ". Last error: " suffix, and the "none" fallback', () => {
+    const error = buildAllTargetsFailedError(
+      new Error('boom'),
+      [],
+      [],
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: none. Last error: boom');
+  });
+});

--- a/packages/backend/src/services/dispatch/__tests__/attempt-history.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/attempt-history.test.ts
@@ -6,6 +6,7 @@ import {
   type ErrorSummaryFormatter,
   type FailureReasonFormatter,
 } from '../attempt-history';
+import { EMPTY_COMPLETION_REASON } from '../empty-completion';
 import type { RouteResult } from '../../routing/router';
 import type { RetryAttemptRecord } from '../dispatcher-types';
 
@@ -22,6 +23,15 @@ function makeRoute(provider: string, model: string): RouteResult {
 function httpError(statusCode: number, message: string) {
   const error = new Error(message) as any;
   error.routingContext = { statusCode };
+  return error;
+}
+
+// Mirrors the failed attempt the empty-completion failover records in
+// standard-attempt-request.ts: the HTTP call itself succeeded (statusCode
+// 200) but the completion carried no visible output.
+function emptyCompletionError() {
+  const error = new Error(EMPTY_COMPLETION_REASON) as any;
+  error.routingContext = { statusCode: 200, cooldownTriggered: false };
   return error;
 }
 
@@ -80,6 +90,35 @@ describe('buildAllTargetsFailedError', () => {
     );
   });
 
+  it('tags an empty-completion failover attempt as (empty), not the misleading (200)', () => {
+    // A failed attempt whose HTTP status was 200 can only mean the call
+    // succeeded but the completion was unusable — rendering the raw "(200)"
+    // next to real failure codes reads like a contradiction to clients.
+    const retryHistory: RetryAttemptRecord[] = [];
+    const emptyRoute = makeRoute('p1', 'm1');
+    const failedRoute = makeRoute('p2', 'm2');
+
+    appendFailureAttempt(
+      retryHistory,
+      emptyRoute,
+      emptyCompletionError(),
+      formatFailureReason,
+      undefined,
+      true
+    );
+    appendFailureAttempt(retryHistory, failedRoute, httpError(500, 'boom'), formatFailureReason);
+
+    const error = buildAllTargetsFailedError(
+      httpError(500, 'boom'),
+      ['p1/m1', 'p2/m2'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: p1/m1 (empty), p2/m2 (500). Last error: boom');
+  });
+
   it('tags a network/transport failure that has no status code as (network)', () => {
     const retryHistory: RetryAttemptRecord[] = [];
     const route = makeRoute('p1', 'model-1');
@@ -103,7 +142,9 @@ describe('buildAllTargetsFailedError', () => {
   it('tags a stalled attempt as (stall) instead of (network)', () => {
     const retryHistory: RetryAttemptRecord[] = [];
     const route = makeRoute('p1', 'model-1');
-    const stallError = new Error('Stream stalled: TTFB timeout - no response within 5000ms');
+    // Em-dash matches the production stall message verbatim (see
+    // standard-attempt-request.ts's "Stream stalled: TTFB timeout — ...").
+    const stallError = new Error('Stream stalled: TTFB timeout — no response within 5000ms');
 
     appendFailureAttempt(retryHistory, route, stallError, formatFailureReason, undefined, true);
 
@@ -116,7 +157,7 @@ describe('buildAllTargetsFailedError', () => {
     );
 
     expect(error.message).toBe(
-      'All targets failed: p1/model-1 (stall). Last error: Stream stalled: TTFB timeout - no response within 5000ms'
+      'All targets failed: p1/model-1 (stall). Last error: Stream stalled: TTFB timeout — no response within 5000ms'
     );
   });
 

--- a/packages/backend/src/services/dispatch/__tests__/attempt-history.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/attempt-history.test.ts
@@ -143,11 +143,15 @@ describe('buildAllTargetsFailedError', () => {
     expect(error.message).not.toContain('p1/model-1');
   });
 
-  it('renders (skipped) for a joined-list entry whose recorded attempt was a skip', () => {
+  it('renders a joined-list entry untagged when its only recorded retryHistory attempt was a skip', () => {
     // Defensive/future-proofing case from the T6 brief: today's dispatch
-    // loops never put a skipped target into attemptedProviders, but if a
-    // future caller did, the summary should label it (skipped) rather than
-    // a bogus status tag.
+    // loops never put a skipped target into attemptedProviders. Skipped
+    // retryHistory entries are excluded from the FIFO provider/model queues
+    // (see formatAttemptedProvidersSummary) precisely so a skip can never be
+    // matched up with a LATER real attempt that shares its key. If a future
+    // caller did list a skipped-only target in attemptedProviders, there is
+    // now no matching queued record to tag it with, so it renders untagged
+    // rather than mislabeled as the wrong outcome.
     const retryHistory: RetryAttemptRecord[] = [];
     const skippedRoute = makeRoute('p1', 'model-1');
     appendSkippedAttempt(retryHistory, skippedRoute, 'Provider p1/model-1 is on cooldown');
@@ -160,7 +164,35 @@ describe('buildAllTargetsFailedError', () => {
       compactErrorSummary
     );
 
-    expect(error.message).toBe('All targets failed: p1/model-1 (skipped). Last error: boom');
+    expect(error.message).toBe('All targets failed: p1/model-1. Last error: boom');
+  });
+
+  it('renders the real attempt tag, not (skipped), when a skip shares a provider/model key with a later real attempt', () => {
+    // The bug this guards: formatAttemptedProvidersSummary used to build its
+    // FIFO provider/model queues from ALL retryHistory entries, including
+    // skips. A skip recorded for a key that a LATER real attempt reuses
+    // (e.g. the same target skipped once via cooldown, then actually
+    // dispatched — and rejected — as the final failover candidate) would
+    // occupy the front of that queue, so the real attempt's `.shift()`
+    // consumed the skip entry instead and rendered `(skipped)` in place of
+    // the real HTTP status. Production only ever lists the REAL attempt in
+    // `attemptedProviders` for this key (skips never reach it), so the
+    // summary must reflect the real attempt's outcome.
+    const retryHistory: RetryAttemptRecord[] = [];
+    const route = makeRoute('p1', 'model-1');
+
+    appendSkippedAttempt(retryHistory, route, 'Provider p1/model-1 is on cooldown');
+    appendFailureAttempt(retryHistory, route, httpError(400, 'bad request'), formatFailureReason);
+
+    const error = buildAllTargetsFailedError(
+      httpError(400, 'bad request'),
+      ['p1/model-1'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: p1/model-1 (400). Last error: bad request');
   });
 
   it('keeps the "All targets failed: " prefix, ". Last error: " suffix, and the "none" fallback', () => {

--- a/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createStreamVisibilityTracker,
+  EMPTY_COMPLETION_REASON,
+  getResponseVisibilitySignals,
+  isEmptyCompletion,
+  isEmptyUnifiedResponse,
+  isStreamEmpty,
+  observeStreamChunk,
+  type StreamVisibilityTracker,
+} from '../empty-completion';
+import type { UnifiedChatResponse } from '../../../types/unified';
+
+// A bare, all-absent UnifiedChatResponse — the "truly empty" fixture shared
+// by several tests below.
+function emptyResponse(): UnifiedChatResponse {
+  return {
+    id: 'resp-1',
+    model: 'model-1',
+    content: null,
+  };
+}
+
+describe('isEmptyCompletion (pure signal decision)', () => {
+  it('text-only is non-empty', () => {
+    expect(isEmptyCompletion({ hasText: true })).toBe(false);
+  });
+
+  it('tool-call-only is non-empty', () => {
+    expect(isEmptyCompletion({ toolCallCount: 1 })).toBe(false);
+  });
+
+  it('reasoning-only is non-empty', () => {
+    expect(isEmptyCompletion({ hasReasoning: true })).toBe(false);
+  });
+
+  it('image-only is non-empty', () => {
+    expect(isEmptyCompletion({ imageCount: 1 })).toBe(false);
+  });
+
+  it('citations-only (annotation-only) is non-empty', () => {
+    expect(isEmptyCompletion({ annotationCount: 1 })).toBe(false);
+  });
+
+  it('truly empty (no signals at all) is empty', () => {
+    expect(isEmptyCompletion({})).toBe(true);
+  });
+
+  it('all-zero/false signals explicitly are still empty', () => {
+    expect(
+      isEmptyCompletion({
+        hasText: false,
+        hasReasoning: false,
+        toolCallCount: 0,
+        annotationCount: 0,
+        imageCount: 0,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('getResponseVisibilitySignals / isEmptyUnifiedResponse (non-streaming adapter)', () => {
+  it('text-only response is non-empty', () => {
+    const response: UnifiedChatResponse = { ...emptyResponse(), content: 'Hello there' };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+    expect(getResponseVisibilitySignals(response).hasText).toBe(true);
+  });
+
+  it('whitespace-only content is still treated as empty text', () => {
+    const response: UnifiedChatResponse = { ...emptyResponse(), content: '   \n\t  ' };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('tool-call-only response is non-empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      tool_calls: [
+        { id: 'call_1', type: 'function', function: { name: 'lookup', arguments: '{}' } },
+      ],
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('reasoning-only (reasoning_content) response is non-empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      reasoning_content: 'thinking it through...',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('reasoning-only (thinking.content) response is non-empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      thinking: { content: 'pondering...' },
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('image-only response is non-empty (forward-compatible `images` field)', () => {
+    // UnifiedChatResponse has no `images` field today — no transformer
+    // populates one — but the signals adapter reads it defensively so a
+    // future multimodal chat-output field is picked up without code changes
+    // here. Cast to exercise that path directly.
+    const response = {
+      ...emptyResponse(),
+      images: [{ data: 'base64...' }],
+    } as UnifiedChatResponse & {
+      images: unknown[];
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('citations-only (annotations) response is non-empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      annotations: [
+        {
+          type: 'url_citation',
+          url_citation: {
+            url: 'https://example.com',
+            title: 'Example',
+            content: 'snippet',
+            start_index: 0,
+            end_index: 10,
+          },
+        },
+      ],
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('truly empty response (no text/tool-calls/reasoning/images/annotations) is empty', () => {
+    expect(isEmptyUnifiedResponse(emptyResponse())).toBe(true);
+  });
+
+  it('empty string content, empty tool_calls array, and empty annotations array are still empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: '',
+      tool_calls: [],
+      annotations: [],
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+});
+
+describe('isEmptyUnifiedResponse — terminal finish reasons are never retryable-empty', () => {
+  // A `content_filter` (or other terminal) response with null content is a
+  // deliberate provider/safety decision, NOT "the model produced nothing on
+  // an ordinary turn" — classifying it as empty routes the request around
+  // that decision via failover to a different provider instead of relaying
+  // it to the client, which is exactly the bug this guards against.
+  it('content_filter finish reason with no visible output is NOT empty (no failover)', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: 'content_filter',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('length finish reason with no visible output is NOT empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: 'length',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('an error/refusal-shaped finish reason with no visible output is NOT empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: 'error',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+
+    const refusal: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: 'refusal',
+    };
+    expect(isEmptyUnifiedResponse(refusal)).toBe(false);
+  });
+
+  it('a terminal finish reason takes precedence even if a signal WOULD otherwise look empty', () => {
+    // Guards against a future refactor accidentally checking signals first.
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: '',
+      tool_calls: [],
+      finishReason: 'content_filter',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('absent finish reason with no visible output STILL fails over (existing behavior guarded)', () => {
+    // No finishReason set at all (undefined) — the pre-existing "truly
+    // empty" case. Must remain retryable-empty.
+    expect(isEmptyUnifiedResponse(emptyResponse())).toBe(true);
+  });
+
+  it('null finish reason with no visible output STILL fails over (existing behavior guarded)', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: null,
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('"stop" finish reason with no visible output STILL fails over (existing behavior guarded)', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: '',
+      finishReason: 'stop',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('"end_turn" (Anthropic-style stop) finish reason with no visible output STILL fails over', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: '',
+      finishReason: 'end_turn',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('a terminal finish reason does not suppress a genuinely non-empty response either way', () => {
+    // Sanity check: a content_filter response that DOES have visible text
+    // (e.g. a partial answer before the cutoff) is non-empty regardless.
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: 'partial answer before cutoff',
+      finishReason: 'content_filter',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+});
+
+describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — image_generation_call visibility', () => {
+  // The Responses API returns `image_generation_call` output items
+  // (types/responses.ts ResponsesBuiltInToolCallItem). The unified response
+  // shape has no field for image outputs (no transformer populates one
+  // today — see the `images` forward-compat note), so an image-only
+  // Responses API completion would otherwise read as completely empty.
+  // `rawResponse` (populated on the bypass-transformation path — see
+  // dispatcher.ts's handleNonStreamingResponse) is the ORIGINAL body
+  // available at the call seam; detect the built-in tool call there.
+  it('image_generation_call-only rawResponse is non-empty (no failover)', () => {
+    const response = {
+      ...emptyResponse(),
+      rawResponse: {
+        id: 'resp-img-1',
+        object: 'response',
+        output: [
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: 'base64-image-data',
+          },
+        ],
+      },
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(1);
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('a rawResponse with no image_generation_call items contributes zero imageCount', () => {
+    const response = {
+      ...emptyResponse(),
+      rawResponse: {
+        id: 'resp-text-1',
+        object: 'response',
+        output: [{ type: 'message', id: 'msg_1', status: 'completed', content: [] }],
+      },
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(0);
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('multiple image_generation_call items are all counted', () => {
+    const response = {
+      ...emptyResponse(),
+      rawResponse: {
+        output: [
+          { type: 'image_generation_call', id: 'ig_1', status: 'completed' },
+          { type: 'image_generation_call', id: 'ig_2', status: 'completed' },
+        ],
+      },
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+
+  it('a rawResponse with no output array (or no rawResponse at all) does not throw and counts zero', () => {
+    expect(getResponseVisibilitySignals(emptyResponse()).imageCount).toBe(0);
+    expect(
+      getResponseVisibilitySignals({ ...emptyResponse(), rawResponse: {} } as UnifiedChatResponse)
+        .imageCount
+    ).toBe(0);
+    expect(
+      getResponseVisibilitySignals({
+        ...emptyResponse(),
+        rawResponse: { output: 'not-an-array' },
+      } as UnifiedChatResponse).imageCount
+    ).toBe(0);
+  });
+
+  it('the forward-compat `images` array field and rawResponse image_generation_call items both contribute to imageCount', () => {
+    const response = {
+      ...emptyResponse(),
+      images: [{ data: 'base64...' }],
+      rawResponse: {
+        output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
+      },
+    } as UnifiedChatResponse & { images: unknown[] };
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+});
+
+describe('createStreamVisibilityTracker / observeStreamChunk / isStreamEmpty (streaming adapter)', () => {
+  it('starts empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+
+  it('a content delta marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: { content: 'Hi' } } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('a whitespace-only content delta does NOT mark the tracker non-empty by itself', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: { content: '   ' } } as any);
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+
+  it('a tool-call delta marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: { tool_calls: [{ index: 0, function: { name: 'lookup' } }] },
+    } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('a reasoning delta marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: { reasoning_content: 'hmm' } } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('a thinking delta marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: { thinking: { content: 'hmm' } } } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('chunks with no delta at all leave the tracker empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {} as any);
+    observeStreamChunk(tracker, { delta: {} } as any);
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+
+  it('accumulates across multiple chunks: only the last chunk carries content', () => {
+    const tracker: StreamVisibilityTracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: {} } as any);
+    observeStreamChunk(tracker, { delta: {} } as any);
+    observeStreamChunk(tracker, { delta: { content: 'answer' } } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+});
+
+describe('EMPTY_COMPLETION_REASON', () => {
+  it('is the exact reason string documented in the task brief', () => {
+    expect(EMPTY_COMPLETION_REASON).toBe('Empty completion (no visible output)');
+  });
+});

--- a/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
@@ -380,6 +380,69 @@ describe('createStreamVisibilityTracker / observeStreamChunk / isStreamEmpty (st
   });
 });
 
+describe('observeStreamChunk — chunk-level annotations/images branches (forward-compat contract)', () => {
+  // No current transformer streams chunk-level `annotations` or `images`,
+  // but the tracker reads both defensively so a future transformer that does
+  // is picked up without changes here. These tests pin that contract with
+  // synthetic unified chunks. Note both branches sit AFTER the `delta`
+  // presence guard, so the synthetic chunks carry an (empty) delta object.
+  it('a chunk-level annotations array marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: {},
+      annotations: [
+        {
+          type: 'url_citation',
+          url_citation: { url: 'https://example.com', title: 'Example' },
+        },
+      ],
+    } as any);
+
+    expect(tracker.annotationCount).toBe(1);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('a chunk-level images array marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: {},
+      images: [{ data: 'base64...' }],
+    } as any);
+
+    expect(tracker.imageCount).toBe(1);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('annotation and image counts accumulate across chunks', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: {},
+      annotations: [{ type: 'url_citation' }, { type: 'url_citation' }],
+    } as any);
+    observeStreamChunk(tracker, { delta: {}, annotations: [{ type: 'url_citation' }] } as any);
+    observeStreamChunk(tracker, { delta: {}, images: [{ data: 'a' }, { data: 'b' }] } as any);
+    observeStreamChunk(tracker, { delta: {}, images: [{ data: 'c' }] } as any);
+
+    expect(tracker.annotationCount).toBe(3);
+    expect(tracker.imageCount).toBe(3);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('empty annotations/images arrays (and non-array values) leave the tracker empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: {}, annotations: [], images: [] } as any);
+    observeStreamChunk(tracker, {
+      delta: {},
+      annotations: 'not-an-array',
+      images: { data: 'not-an-array' },
+    } as any);
+
+    expect(tracker.annotationCount).toBe(0);
+    expect(tracker.imageCount).toBe(0);
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+});
+
 describe('EMPTY_COMPLETION_REASON', () => {
   it('is the exact reason string documented in the task brief', () => {
     expect(EMPTY_COMPLETION_REASON).toBe('Empty completion (no visible output)');

--- a/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
@@ -9,6 +9,7 @@ import {
   observeStreamChunk,
   type StreamVisibilityTracker,
 } from '../empty-completion';
+import { ResponsesTransformer } from '../../../transformers/responses';
 import type { UnifiedChatResponse } from '../../../types/unified';
 
 // A bare, all-absent UnifiedChatResponse — the "truly empty" fixture shared
@@ -241,15 +242,14 @@ describe('isEmptyUnifiedResponse — terminal finish reasons are never retryable
   });
 });
 
-describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — image_generation_call visibility', () => {
+describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — image_generation_call visibility (rawResponse / bypass path)', () => {
   // The Responses API returns `image_generation_call` output items
-  // (types/responses.ts ResponsesBuiltInToolCallItem). The unified response
-  // shape has no field for image outputs (no transformer populates one
-  // today — see the `images` forward-compat note), so an image-only
-  // Responses API completion would otherwise read as completely empty.
-  // `rawResponse` (populated on the bypass-transformation path — see
-  // dispatcher.ts's handleNonStreamingResponse) is the ORIGINAL body
-  // available at the call seam; detect the built-in tool call there.
+  // (types/responses.ts ResponsesBuiltInToolCallItem). On the
+  // bypass-transformation path the unified response carries no typed items —
+  // `rawResponse` (populated by dispatcher.ts's handleNonStreamingResponse)
+  // is the ORIGINAL body available at the call seam; detect the built-in
+  // tool call there. It also covers result-less items, which get no typed
+  // carry on the transformed path but still prove the model produced output.
   it('image_generation_call-only rawResponse is non-empty (no failover)', () => {
     const response = {
       ...emptyResponse(),
@@ -323,6 +323,83 @@ describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — image_genera
     } as UnifiedChatResponse & { images: unknown[] };
 
     expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+});
+
+describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — typed image_generation_calls signal (transformed path)', () => {
+  // With PURE unified content (image markdown is composed by the
+  // client-facing formatters, never baked into `content`), an image-only
+  // TRANSFORMED (non-bypass) response has no text and no rawResponse — the
+  // typed `image_generation_calls` carry is its only visibility signal.
+  it('typed image_generation_calls with a non-empty result count as visible output (no failover)', () => {
+    const response = {
+      ...emptyResponse(),
+      image_generation_calls: [{ id: 'ig_1', status: 'completed', result: 'aGVsbG8=' }],
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(1);
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('multiple typed entries are all counted', () => {
+    const response = {
+      ...emptyResponse(),
+      image_generation_calls: [
+        { id: 'ig_1', status: 'completed', result: 'aGVsbG8=' },
+        { id: 'ig_2', status: 'completed', result: 'd29ybGQ=' },
+      ],
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+
+  it('typed entries with an empty or missing result contribute zero (defensive)', () => {
+    const response = {
+      ...emptyResponse(),
+      image_generation_calls: [{ id: 'ig_1', status: 'completed', result: '' }, { id: 'ig_2' }],
+    } as any;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(0);
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('typed entries combine with the rawResponse count (bypass path unchanged)', () => {
+    const response = {
+      ...emptyResponse(),
+      image_generation_calls: [{ id: 'ig_1', status: 'completed', result: 'aGVsbG8=' }],
+      rawResponse: {
+        output: [{ type: 'image_generation_call', id: 'ig_2', status: 'completed' }],
+      },
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+
+  // End-to-end across the two layers: a REAL ResponsesTransformer transform
+  // of an image-only completion (the transformed/non-bypass dispatch path —
+  // no rawResponse attached) must read as non-empty purely via the typed
+  // carry, since pure unified content gives it no text signal. This is the
+  // regression lock for the production empty-completion bug: if the typed
+  // signal ever regresses, image-only completions would be misclassified as
+  // empty and failed over again.
+  it('a real transformed image-only Responses completion is NOT empty (typed carry is the only signal)', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_transformed',
+      object: 'response',
+      created_at: 1,
+      status: 'completed',
+      model: 'image-model',
+      output: [
+        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: 'aGVsbG8=' },
+      ],
+    });
+
+    // Pure content, no raw body: the typed carry must be what keeps this
+    // visible.
+    expect(unified.content).toBeNull();
+    expect(unified.rawResponse).toBeUndefined();
+    expect(getResponseVisibilitySignals(unified).imageCount).toBe(1);
+    expect(isEmptyUnifiedResponse(unified)).toBe(false);
   });
 });
 

--- a/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerSpy } from '../../../../test/test-utils';
+import {
+  deriveProbeStallConfig,
+  executeStandardAttempt,
+  type StandardAttemptContext,
+} from '../standard-attempt-request';
+import type { RequestManagerHost } from '../request-manager';
+import type { RouteResult } from '../../routing/router';
+import type { UnifiedChatRequest } from '../../../types/unified';
+import type { StallConfig } from '../../inspectors/stall-inspector';
+
+function makeStallConfig(overrides: Partial<StallConfig> = {}): StallConfig {
+  return {
+    ttfbMs: 5000,
+    ttfbBytes: 1024,
+    minBytesPerSecond: null,
+    windowMs: 1000,
+    gracePeriodMs: 0,
+    ...overrides,
+  };
+}
+
+describe('deriveProbeStallConfig', () => {
+  it('returns the pristine config unchanged when no fetch time has elapsed', () => {
+    const pristine = makeStallConfig({ ttfbMs: 5000 });
+    expect(deriveProbeStallConfig(pristine, 0)).toEqual(pristine);
+  });
+
+  it('nulls out ttfbMs once elapsed time meets or exceeds the full budget', () => {
+    const pristine = makeStallConfig({ ttfbMs: 5000 });
+    expect(deriveProbeStallConfig(pristine, 5000)).toEqual({ ...pristine, ttfbMs: null });
+    expect(deriveProbeStallConfig(pristine, 6000)).toEqual({ ...pristine, ttfbMs: null });
+  });
+
+  it('reduces ttfbMs by the elapsed time for a partial budget', () => {
+    const pristine = makeStallConfig({ ttfbMs: 5000 });
+    expect(deriveProbeStallConfig(pristine, 4900)).toEqual({ ...pristine, ttfbMs: 100 });
+  });
+
+  it('passes a null/undefined pristine config through unchanged', () => {
+    expect(deriveProbeStallConfig(null, 1000)).toBeNull();
+    expect(deriveProbeStallConfig(undefined, 1000)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch-level seam: `host.probeStreamingStart` is the injected "probe
+// config receiver" — executeStandardAttempt calls it exactly once, after the
+// same-target strip-and-retry while(true) loop breaks, with whatever
+// `effectiveStallConfig` the FINAL iteration computed. That makes it the
+// only clean spy-able point to prove which ttfbMs budget a given iteration
+// actually derived from (there is no host method that observes the *armed*
+// per-iteration TTFB timer directly — it's a local `setTimeout`, not passed
+// through the host).
+// ---------------------------------------------------------------------------
+
+function makeRoute(): RouteResult {
+  return { provider: 'p1', model: 'model-1', config: {} as any } as RouteResult;
+}
+
+function makeStreamingRequest(): UnifiedChatRequest {
+  return {
+    requestId: 'req-1',
+    model: 'model-1',
+    messages: [{ role: 'user', content: 'hi' } as any],
+    stream: true,
+    incomingApiType: 'chat',
+  };
+}
+
+function makeHost(overrides: Partial<RequestManagerHost> = {}): RequestManagerHost {
+  return {
+    appendFailureAttempt: vi.fn(),
+    appendSkippedAttempt: vi.fn(),
+    appendSuccessAttempt: vi.fn(),
+    attachAttemptMetadata: vi.fn(),
+    buildAllTargetsFailedError: vi.fn(() => new Error('all targets failed')),
+    buildCancelledError: vi.fn(() => new Error('cancelled')),
+    buildRequestUrl: vi.fn(() => 'https://example.test/v1/chat/completions'),
+    buildTimeoutError: vi.fn(() => new Error('timeout')),
+    createAttemptTimeout: vi.fn(),
+    emitRoutingUpdate: vi.fn(),
+    executeProviderRequest: vi.fn(),
+    formatFailureReason: vi.fn((error: any) => error?.message ?? 'error'),
+    getUsageStorage: vi.fn(() => undefined),
+    handleNonStreamingResponse: vi.fn(async () => ({}) as any),
+    handleProviderError: vi.fn(),
+    handleStreamingResponse: vi.fn(() => ({}) as any),
+    isPiAiRoute: vi.fn(() => false),
+    isRetryableNetworkError: vi.fn(() => false),
+    isRetryableStatus: vi.fn(() => false),
+    probeStreamingStart: vi.fn(),
+    recordAttemptMetric: vi.fn(async () => {}),
+    recordStickySession: vi.fn(),
+    saveIntermediateError: vi.fn(),
+    selectTargetApiType: vi.fn(() => ({ selectionReason: 'test' })),
+    setupHeaders: vi.fn(() => ({})),
+    transformRequestPayload: vi.fn(async () => ({ payload: {}, bypassTransformation: false })),
+    ...overrides,
+  };
+}
+
+describe('executeStandardAttempt — per-fetch TTFB budget reset', () => {
+  it("gives a same-target strip-and-retry attempt the full pristine TTFB budget instead of the previous attempt's reduced one", async () => {
+    const dateSpy = registerSpy(Date, 'now');
+    // Sequence matches the exact Date.now() read sites for this scenario:
+    // iter1 dispatchStartTime, iter1 post-fetch (fetchElapsed calc), iter2
+    // dispatchStartTime, iter2 post-fetch (fetchElapsed calc). The strip
+    // path taken between iter1 and iter2 doesn't call Date.now() itself, and
+    // the synthetic probeStreamingStart failure below short-circuits the
+    // function before any later (CooldownManager-driven) Date.now() calls.
+    dateSpy
+      .mockReturnValueOnce(1_000_000) // iter1 dispatchStartTime
+      .mockReturnValueOnce(1_004_900) // iter1 post-fetch => fetchElapsed 4900ms (near the 5000ms budget)
+      .mockReturnValueOnce(2_000_000) // iter2 dispatchStartTime
+      .mockReturnValueOnce(2_000_050); // iter2 post-fetch => fetchElapsed 50ms
+
+    const badRequestResponse = new Response(
+      JSON.stringify({ error: { message: "Unsupported parameter: 'safety_identifier'" } }),
+      { status: 400 }
+    );
+    const okResponse = new Response(null, { status: 200 });
+
+    const executeProviderRequest = vi
+      .fn()
+      .mockResolvedValueOnce(badRequestResponse)
+      .mockResolvedValueOnce(okResponse);
+
+    const probeStopError = new Error('test-stop-after-probe');
+    const probeStreamingStart = vi.fn().mockResolvedValue({
+      ok: false,
+      streamStarted: true,
+      error: probeStopError,
+    });
+
+    const host = makeHost({ executeProviderRequest, probeStreamingStart });
+    const route = makeRoute();
+    const request = makeStreamingRequest();
+
+    // originalBody-less payload carrying the exact field the synthetic 400
+    // names, so planUnsupportedParamStrip's paired deleteDottedPath actually
+    // removes something (`deleted: true`) — otherwise the strip is refused
+    // and the loop falls through to normal failover instead of retrying the
+    // same target, which is the scenario this test needs.
+    const providerPayload = { model: 'model-1', safety_identifier: 'abc' };
+
+    const context: StandardAttemptContext = {
+      host,
+      providerPayload,
+      request,
+      requestWithTargetModel: request,
+      route,
+      targetApiType: 'chat',
+      transformer: { name: 'test-transformer' },
+      bypassTransformation: false,
+      adapters: [],
+      stallConfig: makeStallConfig({ ttfbMs: 5000 }),
+      attemptTimeout: {
+        signal: new AbortController().signal,
+        isTimedOut: () => false,
+        cleanup: vi.fn(),
+      },
+      failoverEnabled: true,
+      hasNextTarget: true,
+      retryableStatusCodes: [500, 502, 503],
+      retryableErrors: [],
+      retryHistory: [],
+      attemptedProviders: [],
+      sessionKey: null,
+      release: vi.fn(),
+    };
+
+    await expect(executeStandardAttempt(context)).rejects.toThrow('test-stop-after-probe');
+
+    // Same target dispatched twice: the initial attempt, then the
+    // strip-and-retry after the 400.
+    expect(executeProviderRequest).toHaveBeenCalledTimes(2);
+    expect(probeStreamingStart).toHaveBeenCalledTimes(1);
+
+    const [, receivedStallConfig] = probeStreamingStart.mock.calls[0]!;
+    // Pristine ttfbMs is 5000ms. Iteration 2's own fetch took 50ms (per the
+    // Date.now() sequence above), so a correctly-reset budget leaves
+    // 4950ms for the probe. Before the fix, iteration 2 inherited
+    // iteration 1's already-reduced ttfbMs (100ms, left over from a
+    // 4900ms first fetch against the same 5000ms budget) and derived only
+    // 50ms from THAT — starving the probe of nearly its whole budget.
+    expect(receivedStallConfig.ttfbMs).toBe(4950);
+  });
+});

--- a/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
@@ -188,3 +188,134 @@ describe('executeStandardAttempt — per-fetch TTFB budget reset', () => {
     expect(receivedStallConfig.ttfbMs).toBe(4950);
   });
 });
+
+describe('executeStandardAttempt — thinking-signature strip-and-retry', () => {
+  const signature400Body = JSON.stringify({
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'messages.3.content.0: Invalid `signature` in `thinking` block',
+    },
+  });
+
+  function makeNonStreamingRequest(): UnifiedChatRequest {
+    return {
+      requestId: 'req-1',
+      model: 'model-1',
+      messages: [{ role: 'user', content: 'hi' } as any],
+      stream: false,
+      incomingApiType: 'chat',
+    };
+  }
+
+  function makeContext(
+    host: RequestManagerHost,
+    providerPayload: any,
+    overrides: Partial<StandardAttemptContext> = {}
+  ): StandardAttemptContext {
+    const request = makeNonStreamingRequest();
+    return {
+      host,
+      providerPayload,
+      request,
+      requestWithTargetModel: request,
+      route: makeRoute(),
+      targetApiType: 'messages',
+      transformer: { name: 'test-transformer' },
+      bypassTransformation: false,
+      adapters: [],
+      stallConfig: null,
+      attemptTimeout: {
+        signal: new AbortController().signal,
+        isTimedOut: () => false,
+        cleanup: vi.fn(),
+      },
+      failoverEnabled: true,
+      hasNextTarget: true,
+      retryableStatusCodes: [500, 502, 503],
+      retryableErrors: [],
+      retryHistory: [],
+      attemptedProviders: [],
+      sessionKey: null,
+      release: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it('does not retry the same target when a signature-matching 400 hits a payload with no thinking blocks (single fetch, normal failover)', async () => {
+    // Fresh Response per call: a Response body is single-read, so a shared
+    // instance would throw on a second (buggy) fetch's .text() and mask the
+    // real assertion failure.
+    const executeProviderRequest = vi.fn(
+      async () => new Response(signature400Body, { status: 400 })
+    );
+    const handleProviderError = vi.fn(async () => {
+      throw new Error('HTTP 400: invalid signature');
+    });
+    const isRetryableStatus = vi.fn(() => true);
+    const host = makeHost({ executeProviderRequest, handleProviderError, isRetryableStatus });
+
+    // The known false-positive shape: an OpenAI-chat-format payload also has
+    // a `messages` array (so the structural Anthropic-payload check matches)
+    // but carries NO thinking blocks — a strip would remove zero blocks and
+    // a retry would resend a byte-identical request.
+    const providerPayload = {
+      model: 'model-1',
+      messages: [{ role: 'user', content: 'hi' }],
+    };
+    const snapshot = structuredClone(providerPayload);
+
+    const result = await executeStandardAttempt(makeContext(host, providerPayload));
+
+    // Normal failover proceeds (retry outcome hands control back to the
+    // caller's next-target loop)...
+    expect(result.outcome).toBe('retry');
+    // ...but the SAME target was fetched exactly once: the zero-block strip
+    // must not burn a same-target retry on an identical payload.
+    expect(executeProviderRequest).toHaveBeenCalledTimes(1);
+    // Nothing was stripped, so the payload is untouched.
+    expect(providerPayload).toEqual(snapshot);
+  });
+
+  it('strips thinking blocks copy-on-write on a genuine signature 400: original payload object never mutated, retried payload stripped', async () => {
+    const executeProviderRequest = vi
+      .fn()
+      .mockImplementationOnce(async () => new Response(signature400Body, { status: 400 }))
+      .mockImplementationOnce(async () => new Response('{"id":"msg_1"}', { status: 200 }));
+    const handleNonStreamingResponse = vi.fn(async () => ({ content: 'ok' }) as any);
+    const host = makeHost({ executeProviderRequest, handleNonStreamingResponse });
+
+    const providerPayload = {
+      model: 'model-1',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'stale', signature: 'sig-a' },
+            { type: 'text', text: 'answer' },
+          ],
+        },
+      ],
+    };
+    const snapshot = structuredClone(providerPayload);
+
+    const result = await executeStandardAttempt(makeContext(host, providerPayload));
+
+    expect(result.outcome).toBe('success');
+    expect(executeProviderRequest).toHaveBeenCalledTimes(2);
+
+    // First fetch sent the original payload object...
+    expect(executeProviderRequest.mock.calls[0]![2]).toBe(providerPayload);
+    // ...the same-target retry sent a NEW payload with the blocks stripped...
+    const retriedPayload = executeProviderRequest.mock.calls[1]![2];
+    expect(retriedPayload).not.toBe(providerPayload);
+    expect(retriedPayload.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'answer' }] },
+    ]);
+    // ...and the ORIGINAL payload (which can share `messages` with the
+    // long-lived request) was never mutated in place.
+    expect(providerPayload).toEqual(snapshot);
+  });
+});

--- a/packages/backend/src/services/dispatch/adapter-resolver.ts
+++ b/packages/backend/src/services/dispatch/adapter-resolver.ts
@@ -82,5 +82,9 @@ function resolveImplicitAdapters(route: RouteResult): AdapterEntry[] {
 }
 
 function isGpt5Model(model: string): boolean {
-  return /^gpt-5(?:[.-]|$)/i.test(model);
+  // Matches bare ids ("gpt-5", "gpt-5.2", "gpt-5-mini") AND provider-prefixed
+  // target ids ("openai/gpt-5.5") used by pi-ai-registry-backed targets (e.g.
+  // an OpenLimits aggregator route). Must not match lookalikes like "gpt-55",
+  // "chatgpt-5", or "my-gpt-5x".
+  return /(?:^|\/)gpt-5(?:[.-]|$)/i.test(model);
 }

--- a/packages/backend/src/services/dispatch/attempt-history.ts
+++ b/packages/backend/src/services/dispatch/attempt-history.ts
@@ -93,6 +93,59 @@ export function attachAttemptMetadata(
   } as any;
 }
 
+/**
+ * Per-attempt annotation for a single `attemptedProviders` entry: an HTTP
+ * status code when the failure carried one, a short reason tag when it
+ * didn't (network/transport errors, mid-stream or TTFB stalls), `skipped`
+ * for a target that was never actually dispatched, or `undefined` when
+ * there's nothing worth surfacing (e.g. no matching retryHistory record).
+ */
+function describeAttemptTag(entry: RetryAttemptRecord | undefined): string | undefined {
+  if (!entry) return undefined;
+  if (entry.status === 'skipped') return 'skipped';
+  if (entry.status !== 'failed') return undefined;
+  if (typeof entry.statusCode === 'number') return String(entry.statusCode);
+  return /stall/i.test(entry.reason || '') ? 'stall' : 'network';
+}
+
+/**
+ * Renders the "provider/model (tag), provider/model (tag)" summary for the
+ * client-visible failover error. `attemptedProviders` stays the single
+ * source of truth for WHICH targets are listed and in what order — this
+ * only decorates each entry with a tag drawn from its matching retryHistory
+ * record, it never adds or removes targets.
+ *
+ * Dispatch loops push to `attemptedProviders` and append the corresponding
+ * retryHistory record (skipped targets never reach `attemptedProviders`) in
+ * lockstep, so matching by `provider/model` key — consumed in encountered
+ * order to stay correct even if the same target is attempted twice — lines
+ * each summary entry up with its own outcome instead of the last one seen.
+ */
+function formatAttemptedProvidersSummary(
+  attemptedProviders: string[],
+  retryHistory: RetryAttemptRecord[]
+): string {
+  if (attemptedProviders.length === 0) return 'none';
+
+  const byProviderModel = new Map<string, RetryAttemptRecord[]>();
+  for (const entry of retryHistory) {
+    const key = `${entry.provider}/${entry.model}`;
+    const queue = byProviderModel.get(key);
+    if (queue) {
+      queue.push(entry);
+    } else {
+      byProviderModel.set(key, [entry]);
+    }
+  }
+
+  return attemptedProviders
+    .map((provider) => {
+      const tag = describeAttemptTag(byProviderModel.get(provider)?.shift());
+      return tag ? `${provider} (${tag})` : provider;
+    })
+    .join(', ');
+}
+
 export function buildAllTargetsFailedError(
   lastError: any,
   attemptedProviders: string[],
@@ -100,7 +153,7 @@ export function buildAllTargetsFailedError(
   formatFailureReason: FailureReasonFormatter,
   compactErrorSummary: ErrorSummaryFormatter
 ): Error {
-  const summary = attemptedProviders.length > 0 ? attemptedProviders.join(', ') : 'none';
+  const summary = formatAttemptedProvidersSummary(attemptedProviders, retryHistory);
   const baseMessage = compactErrorSummary(
     formatFailureReason(lastError) || lastError?.message || 'Unknown provider error'
   );

--- a/packages/backend/src/services/dispatch/attempt-history.ts
+++ b/packages/backend/src/services/dispatch/attempt-history.ts
@@ -95,17 +95,25 @@ export function attachAttemptMetadata(
 
 /**
  * Per-attempt annotation for a single `attemptedProviders` entry: an HTTP
- * status code when the failure carried one, a short reason tag when it
- * didn't (network/transport errors, mid-stream or TTFB stalls), `skipped`
- * for a target that was never actually dispatched, or `undefined` when
- * there's nothing worth surfacing (e.g. no matching retryHistory record).
+ * status code when the failure carried one, `empty` for a failed attempt
+ * recorded with HTTP 200 (the empty-completion failover — the call itself
+ * succeeded but the completion carried no visible output, so echoing the
+ * raw "(200)" next to real failure codes would read like a contradiction;
+ * a malformed/unparseable body on an HTTP 200 also lands here, since
+ * dispatcher.ts's parse-failure path stamps the attempt with statusCode
+ * 200 — same story: the call "succeeded" but yielded nothing usable),
+ * a short reason tag when there's no status code (network/transport errors,
+ * mid-stream or TTFB stalls), `skipped` for a target that was never
+ * actually dispatched, or `undefined` when there's nothing worth surfacing
+ * (e.g. no matching retryHistory record).
  */
 function describeAttemptTag(entry: RetryAttemptRecord | undefined): string | undefined {
   if (!entry) return undefined;
   if (entry.status === 'skipped') return 'skipped';
   if (entry.status !== 'failed') return undefined;
+  if (entry.statusCode === 200) return 'empty';
   if (typeof entry.statusCode === 'number') return String(entry.statusCode);
-  return /stall/i.test(entry.reason || '') ? 'stall' : 'network';
+  return /stall/i.test(entry.reason) ? 'stall' : 'network';
 }
 
 /**

--- a/packages/backend/src/services/dispatch/attempt-history.ts
+++ b/packages/backend/src/services/dispatch/attempt-history.ts
@@ -129,6 +129,13 @@ function formatAttemptedProvidersSummary(
 
   const byProviderModel = new Map<string, RetryAttemptRecord[]>();
   for (const entry of retryHistory) {
+    // Skipped targets never reach `attemptedProviders` (every skip path
+    // `continue`s before pushing to it), so they must never occupy a FIFO
+    // slot here either. Otherwise a skip that shares a provider/model key
+    // with a LATER real attempt would have its slot consumed first,
+    // rendering that real attempt's outcome as `(skipped)` instead of its
+    // actual status/tag.
+    if (entry.status === 'skipped') continue;
     const key = `${entry.provider}/${entry.model}`;
     const queue = byProviderModel.get(key);
     if (queue) {

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -412,3 +412,360 @@ export function applyRegistryAutoCompat(
 
   return nextPayload;
 }
+
+// ---------------------------------------------------------------------------
+// Reactive auto-compat: strip-and-retry on named unsupported params
+// ---------------------------------------------------------------------------
+//
+// Some upstreams 400 naming one *specific* parameter rather than rejecting the
+// whole request (e.g. OpenAI-compatible Responses API providers reject a
+// client-sent `safety_identifier` or `prompt_cache_key` with
+// `{"detail":"Unsupported parameter: safety_identifier"}` or
+// `{"error":{"message":"Unsupported parameter: 'foo'"}}`). Failing over to the
+// next configured target doesn't help when the *client* sent the offending
+// field — every target would reject it the same way. Instead, the dispatch
+// loop (see standard-attempt-request.ts) strips the named field from the
+// outbound payload and retries the SAME target.
+
+/**
+ * Matches both `{"detail":"Unsupported parameter: X"}` and
+ * `{"error":{"message":"Unsupported parameter: 'X'"}}` shapes. The captured
+ * group also matches dotted paths (e.g. `reasoning.summary`), since some
+ * providers name a nested field that way.
+ */
+const UNSUPPORTED_PARAMETER_PATTERN = /unsupported parameter[:\s]+['"]?([\w.]+)['"]?/i;
+
+/**
+ * Extracts the offending parameter name from an upstream error response body,
+ * or `undefined` when the body doesn't name an unsupported parameter.
+ */
+export function matchUnsupportedParameter(responseBody: string): string | undefined {
+  if (!responseBody) return undefined;
+  return UNSUPPORTED_PARAMETER_PATTERN.exec(responseBody)?.[1];
+}
+
+/** Segment names that must never be traversed — see `deleteDottedPath`. */
+const DANGEROUS_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export interface DeleteDottedPathResult {
+  /**
+   * The payload with the field removed. A NEW object (copy-on-write) when
+   * `deleted` is true: every object on the affected path, from the root down
+   * to the leaf's immediate parent, is shallow-cloned before the leaf is
+   * deleted, so nothing shared with another reference is ever mutated.
+   * Identical to the input `payload` reference when `deleted` is false
+   * (rejected path or no-op — nothing to rebuild).
+   */
+  payload: Record<string, any>;
+  /**
+   * Whether a field was actually removed. `false` for a rejected dangerous
+   * segment, an absent field, or a non-object intermediate segment — callers
+   * MUST treat `false` as "nothing changed" and skip any retry that assumes
+   * the payload is now different.
+   */
+  deleted: boolean;
+}
+
+/**
+ * Deletes a (possibly dotted, e.g. "reasoning.summary") field path from a
+ * payload object. Returns the (possibly new) payload plus whether a field
+ * was actually removed.
+ *
+ * SECURITY: `path` is attacker-influenced — it is parsed out of an upstream
+ * provider's error message (see `matchUnsupportedParameter`, whose
+ * `[\w.]+` capture matches dots AND underscores), and the upstream is not a
+ * trusted party. Two independent defenses prevent prototype pollution:
+ *   1. Any segment named `__proto__`, `constructor`, or `prototype` is
+ *      rejected outright, before any traversal. Without this, a path like
+ *      `__proto__.toString` would resolve `payload.__proto__` via the
+ *      INHERITED accessor to the real `Object.prototype` (typical payload
+ *      objects have no OWN property by that name), and the previous
+ *      in-place `delete target[leaf]` would then delete the global
+ *      `Object.prototype.toString` for the entire process, permanently,
+ *      across every subsequent request.
+ *   2. Traversal only ever follows OWN enumerable properties
+ *      (`hasOwnProperty`), never inherited ones (the previous `segment in
+ *      target` check matched inherited properties too), so even a segment
+ *      not on the deny-list can't walk onto something inherited from the
+ *      prototype chain.
+ *
+ * COPY-ON-WRITE: the input `payload`, and every nested object on the
+ * traversed path, is never mutated in place. `providerPayload` can share a
+ * nested object BY REFERENCE with the long-lived `UnifiedChatRequest` (e.g.
+ * `payload.reasoning = request.reasoning` in transformers/responses.ts) —
+ * mutating that object in place would corrupt it for every OTHER failover
+ * target built from the same request afterward. Instead, every object from
+ * the root down to the leaf's immediate parent is shallow-cloned and a NEW
+ * payload is returned; untouched sibling branches are shared, not cloned.
+ */
+export function deleteDottedPath(
+  payload: Record<string, any>,
+  path: string
+): DeleteDottedPathResult {
+  const segments = path.split('.');
+
+  if (segments.some((segment) => DANGEROUS_PATH_SEGMENTS.has(segment))) {
+    return { payload, deleted: false };
+  }
+
+  // Walk the path, recording the (object, key) pair at each level so the
+  // chain can be rebuilt with clones afterward. Bail out — no traversal
+  // beyond this point, no mutation, no clone — the instant a segment isn't
+  // an own enumerable property: an absent field or non-object intermediate
+  // means there's nothing to strip.
+  const chain: Array<{ obj: Record<string, any>; key: string }> = [];
+  let target: any = payload;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i]!;
+    if (
+      target == null ||
+      typeof target !== 'object' ||
+      !Object.prototype.hasOwnProperty.call(target, segment)
+    ) {
+      return { payload, deleted: false };
+    }
+    chain.push({ obj: target, key: segment });
+    target = target[segment];
+  }
+
+  const leaf = segments[segments.length - 1]!;
+  if (
+    target == null ||
+    typeof target !== 'object' ||
+    !Object.prototype.hasOwnProperty.call(target, leaf)
+  ) {
+    return { payload, deleted: false };
+  }
+
+  // Rebuild the chain bottom-up with shallow clones so nothing shared with
+  // another reference is mutated.
+  let rebuilt: Record<string, any> = { ...target };
+  delete rebuilt[leaf];
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const { obj, key } = chain[i]!;
+    rebuilt = { ...obj, [key]: rebuilt };
+  }
+
+  return { payload: rebuilt, deleted: true };
+}
+
+/** Per-target, per-request bound: at most this many strip-and-retry cycles. */
+export const MAX_UNSUPPORTED_PARAM_STRIP_RETRIES = 2;
+
+/** Tracks strip-and-retry progress for a single target within one request. */
+export interface UnsupportedParamStripState {
+  attempts: number;
+  strippedParams: Set<string>;
+}
+
+export function createUnsupportedParamStripState(): UnsupportedParamStripState {
+  return { attempts: 0, strippedParams: new Set() };
+}
+
+/**
+ * Decides whether an upstream 400 body naming an unsupported parameter should
+ * trigger another strip-and-retry cycle against the same target, recording
+ * the attempt in `state` when it does.
+ *
+ * Returns the parameter name to strip, or `undefined` when the retry should
+ * NOT happen because:
+ *   - the body doesn't name an unsupported parameter, OR
+ *   - the MAX_UNSUPPORTED_PARAM_STRIP_RETRIES bound has been reached, OR
+ *   - the named parameter was already stripped on an earlier attempt for this
+ *     target — an upstream that keeps rejecting the same field after it's
+ *     been removed can't be fixed by retrying, so stop immediately rather
+ *     than burning through the retry bound on a no-op loop.
+ */
+export function planUnsupportedParamStrip(
+  responseBody: string,
+  state: UnsupportedParamStripState
+): string | undefined {
+  if (state.attempts >= MAX_UNSUPPORTED_PARAM_STRIP_RETRIES) return undefined;
+
+  const paramName = matchUnsupportedParameter(responseBody);
+  if (!paramName || state.strippedParams.has(paramName)) return undefined;
+
+  state.attempts++;
+  state.strippedParams.add(paramName);
+  return paramName;
+}
+
+// ---------------------------------------------------------------------------
+// Reactive auto-compat: strip-and-retry on stale Anthropic thinking-block
+// signatures
+// ---------------------------------------------------------------------------
+//
+// Alias-level failover can replay a conversation containing `thinking` /
+// `redacted_thinking` blocks signed by one Claude model against a DIFFERENT
+// Claude model (e.g. cc/claude-opus-5 -> cc/claude-opus-4-8 -> cc/claude-opus-4-7).
+// Anthropic rejects a thinking-block signature produced by another
+// model/session with a 400 naming the signature specifically, e.g.:
+//   {"type":"error","error":{"type":"invalid_request_error",
+//    "message":"messages.3.content.0: Invalid `signature` in `thinking` block"}}
+// Failing over to the next target doesn't help — every remaining Claude
+// target rejects the same stale signature the same way. Instead strip the
+// thinking/redacted_thinking blocks from the outbound Anthropic Messages
+// payload and retry the SAME target once.
+
+/**
+ * Matches Anthropic's stale/invalid thinking-block-signature 400, e.g.
+ * `messages.3.content.0: Invalid \`signature\` in \`thinking\` block`.
+ * Backtick-quoting of "signature"/"thinking" is optional since not every
+ * upstream quotes them identically.
+ */
+const THINKING_SIGNATURE_ERROR_PATTERN = /invalid\s+`?signature`?\s+in\s+`?thinking`?\s+block/i;
+
+/**
+ * True when an upstream error response body names an invalid/stale
+ * thinking-block signature.
+ */
+export function matchThinkingSignatureError(responseBody: string): boolean {
+  if (!responseBody) return false;
+  return THINKING_SIGNATURE_ERROR_PATTERN.test(responseBody);
+}
+
+/**
+ * True when the outbound payload is Anthropic-Messages-API-shaped (has a
+ * `messages` array) — the only shape that can carry `thinking` /
+ * `redacted_thinking` blocks in the first place. Note this is a structural
+ * check only: an OpenAI chat-completions payload also has a `messages`
+ * array, so this alone doesn't prove the target is Anthropic. In practice
+ * that's harmless here — the paired body match
+ * (`matchThinkingSignatureError`) only fires on Anthropic's specific
+ * signature-rejection wording, which a non-Anthropic upstream won't emit.
+ */
+export function isAnthropicMessagesPayload(payload: any): boolean {
+  return !!payload && typeof payload === 'object' && Array.isArray(payload.messages);
+}
+
+function isThinkingBlock(block: any): boolean {
+  return (
+    !!block &&
+    typeof block === 'object' &&
+    (block.type === 'thinking' || block.type === 'redacted_thinking')
+  );
+}
+
+function contentHasBlockType(content: any, type: string): boolean {
+  return (
+    Array.isArray(content) &&
+    content.some((block: any) => block && typeof block === 'object' && block.type === type)
+  );
+}
+
+// A fresh array/object is allocated per call (not a shared module-level
+// constant) so multiple placeholder messages in the same payload never end
+// up aliasing the same mutable content array.
+function reasoningElidedPlaceholder(): Array<{ type: 'text'; text: string }> {
+  return [{ type: 'text', text: '[reasoning elided]' }];
+}
+
+/**
+ * Removes every `thinking` / `redacted_thinking` block from every message's
+ * `content` array, mutating `payload.messages` in place (replacing the
+ * array; individual message objects that need changes are shallow-cloned,
+ * not mutated). When a message's `content` becomes empty as a result of the
+ * strip, the message is dropped entirely UNLESS doing so would:
+ *   - break strict user/assistant role alternation — the nearest retained
+ *     message before it and the message right after it would end up with
+ *     the same role, or
+ *   - orphan a `tool_result` — the next message carries a `tool_result` but
+ *     the nearest retained message before the drop does NOT carry the
+ *     matching `tool_use`, so removing the bridge would leave that
+ *     `tool_result` without its paired call.
+ * In either case the emptied content is replaced with a
+ * `[{"type":"text","text":"[reasoning elided]"}]` placeholder instead of
+ * dropping the message, so the conversation shape stays valid.
+ *
+ * Non-array `content` (e.g. plain-string messages) is left untouched.
+ * Returns the number of thinking/redacted_thinking blocks actually removed
+ * (0 when the payload isn't Anthropic-messages-shaped, or had none to strip).
+ */
+export function stripThinkingSignatureBlocks(payload: Record<string, any>): number {
+  if (!isAnthropicMessagesPayload(payload)) return 0;
+
+  let strippedCount = 0;
+  const perMessage: Array<{ message: any; content: any; isArrayContent: boolean }> =
+    payload.messages.map((message: any) => {
+      if (!message || !Array.isArray(message.content)) {
+        return { message, content: message?.content, isArrayContent: false };
+      }
+      const kept = message.content.filter((block: any) => {
+        if (isThinkingBlock(block)) {
+          strippedCount++;
+          return false;
+        }
+        return true;
+      });
+      return { message, content: kept, isArrayContent: true };
+    });
+
+  if (strippedCount === 0) return 0;
+
+  const result: any[] = [];
+  for (let i = 0; i < perMessage.length; i++) {
+    const { message, content, isArrayContent } = perMessage[i]!;
+
+    if (!isArrayContent || content.length > 0) {
+      result.push(isArrayContent ? { ...message, content } : message);
+      continue;
+    }
+
+    // Content became empty after stripping — decide drop vs. placeholder.
+    const prevMessage = result[result.length - 1];
+    const nextMessage = perMessage[i + 1]?.message;
+
+    const wouldBreakAlternation =
+      !!prevMessage && !!nextMessage && prevMessage.role === nextMessage.role;
+    const nextHasToolResult = contentHasBlockType(nextMessage?.content, 'tool_result');
+    const prevHasToolUse = contentHasBlockType(prevMessage?.content, 'tool_use');
+    const wouldOrphanToolResult = nextHasToolResult && !prevHasToolUse;
+
+    if (wouldBreakAlternation || wouldOrphanToolResult) {
+      result.push({ ...message, content: reasoningElidedPlaceholder() });
+    }
+    // else: drop — push nothing for this message.
+  }
+
+  payload.messages = result;
+  return strippedCount;
+}
+
+/** Per-target, per-request bound: at most one signature-strip-and-retry cycle. */
+export const MAX_THINKING_SIGNATURE_STRIP_RETRIES = 1;
+
+/** Tracks signature-strip-and-retry progress for a single target within one request. */
+export interface ThinkingSignatureStripState {
+  attempts: number;
+}
+
+export function createThinkingSignatureStripState(): ThinkingSignatureStripState {
+  return { attempts: 0 };
+}
+
+/**
+ * Decides whether an upstream 400 body naming an invalid thinking-block
+ * signature should trigger a strip-and-retry cycle against the same target,
+ * recording the attempt in `state` when it does. Returns `false` when the
+ * retry should NOT happen because:
+ *   - the body doesn't name a thinking-signature error, OR
+ *   - the outbound payload isn't Anthropic-messages-shaped (no `messages`
+ *     array to strip thinking blocks from), OR
+ *   - MAX_THINKING_SIGNATURE_STRIP_RETRIES has already been used for this
+ *     target (bounded to exactly one retry — unlike the unsupported-param
+ *     strip, there's no "new param" escape hatch here: once the thinking
+ *     blocks are gone, a repeat 400 means stripping them didn't fix it, so
+ *     normal failover should proceed rather than retrying again).
+ */
+export function planThinkingSignatureStrip(
+  responseBody: string,
+  payload: any,
+  state: ThinkingSignatureStripState
+): boolean {
+  if (state.attempts >= MAX_THINKING_SIGNATURE_STRIP_RETRIES) return false;
+  if (!matchThinkingSignatureError(responseBody)) return false;
+  if (!isAnthropicMessagesPayload(payload)) return false;
+
+  state.attempts++;
+  return true;
+}

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -430,22 +430,53 @@ export function applyRegistryAutoCompat(
 /**
  * Matches both `{"detail":"Unsupported parameter: X"}` and
  * `{"error":{"message":"Unsupported parameter: 'X'"}}` shapes. The captured
- * group also matches dotted paths (e.g. `reasoning.summary`), since some
- * providers name a nested field that way.
+ * group also matches dotted paths (e.g. `reasoning.summary`) and
+ * bracket-notation paths (e.g. `messages[0].name`), since providers name
+ * nested fields both ways. A capture that stopped at `[` would truncate
+ * `messages[0].name` to `messages` — and the paired delete would then remove
+ * the ENTIRE conversation from the retry payload.
  */
-const UNSUPPORTED_PARAMETER_PATTERN = /unsupported parameter[:\s]+['"]?([\w.]+)['"]?/i;
+const UNSUPPORTED_PARAMETER_PATTERN = /unsupported parameter[:\s]+['"]?([\w.[\]]+)['"]?/i;
 
 /**
- * Extracts the offending parameter name from an upstream error response body,
- * or `undefined` when the body doesn't name an unsupported parameter.
+ * Canonicalizes bracket-notation segments to dotted form
+ * (`messages[0].name` → `messages.0.name`) so `deleteDottedPath` — which
+ * only understands dot-separated segments — receives the path in the form
+ * its array handling expects, and so the same field can't dodge
+ * already-stripped dedup by being spelled two ways across retries.
+ */
+function normalizeBracketSegments(path: string): string {
+  return path.replace(/\[(\w+)\]/g, '.$1');
+}
+
+/**
+ * Extracts the offending parameter name from an upstream error response body
+ * (normalized to canonical dotted form — see `normalizeBracketSegments`), or
+ * `undefined` when the body doesn't name an unsupported parameter.
  */
 export function matchUnsupportedParameter(responseBody: string): string | undefined {
   if (!responseBody) return undefined;
-  return UNSUPPORTED_PARAMETER_PATTERN.exec(responseBody)?.[1];
+  const paramName = UNSUPPORTED_PARAMETER_PATTERN.exec(responseBody)?.[1];
+  return paramName === undefined ? undefined : normalizeBracketSegments(paramName);
 }
 
 /** Segment names that must never be traversed — see `deleteDottedPath`. */
 const DANGEROUS_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** Canonical decimal index: "0", "7", "12" — never "01", "length", "-1". */
+const CANONICAL_ARRAY_INDEX_PATTERN = /^(0|[1-9]\d*)$/;
+
+/**
+ * True when `segment` addresses an in-bounds element of `array` in canonical
+ * decimal form. Arrays participate in `deleteDottedPath` ONLY through such
+ * segments: `hasOwnProperty` alone would also admit `length` (an OWN
+ * property of every array) and expando keys, and rebuilding around those
+ * would corrupt the array into an object. Anything non-canonical is refused
+ * (deleted:false) rather than guessed at.
+ */
+function isCanonicalArrayIndex(segment: string, array: readonly unknown[]): boolean {
+  return CANONICAL_ARRAY_INDEX_PATTERN.test(segment) && Number(segment) < array.length;
+}
 
 export interface DeleteDottedPathResult {
   /**
@@ -473,8 +504,9 @@ export interface DeleteDottedPathResult {
  *
  * SECURITY: `path` is attacker-influenced — it is parsed out of an upstream
  * provider's error message (see `matchUnsupportedParameter`, whose
- * `[\w.]+` capture matches dots AND underscores), and the upstream is not a
- * trusted party. Two independent defenses prevent prototype pollution:
+ * `[\w.[\]]+` capture matches dots, underscores, AND bracket segments,
+ * normalized to dotted form), and the upstream is not a trusted party. Two
+ * independent defenses prevent prototype pollution:
  *   1. Any segment named `__proto__`, `constructor`, or `prototype` is
  *      rejected outright, before any traversal. Without this, a path like
  *      `__proto__.toString` would resolve `payload.__proto__` via the
@@ -489,14 +521,25 @@ export interface DeleteDottedPathResult {
  *      not on the deny-list can't walk onto something inherited from the
  *      prototype chain.
  *
- * COPY-ON-WRITE: the input `payload`, and every nested object on the
+ * COPY-ON-WRITE: the input `payload`, and every nested container on the
  * traversed path, is never mutated in place. `providerPayload` can share a
  * nested object BY REFERENCE with the long-lived `UnifiedChatRequest` (e.g.
  * `payload.reasoning = request.reasoning` in transformers/responses.ts) —
  * mutating that object in place would corrupt it for every OTHER failover
- * target built from the same request afterward. Instead, every object from
- * the root down to the leaf's immediate parent is shallow-cloned and a NEW
- * payload is returned; untouched sibling branches are shared, not cloned.
+ * target built from the same request afterward. Instead, every container
+ * from the root down to the leaf's immediate parent is shallow-cloned and a
+ * NEW payload is returned; untouched sibling branches are shared, not
+ * cloned.
+ *
+ * ARRAYS: numeric segments CAN traverse arrays (an upstream 400 naming e.g.
+ * `messages.0.some_field` is capturable by `matchUnsupportedParameter`), and
+ * every array on the path is rebuilt AS an array — never spread into an
+ * object-shaped `{"0": ...}` payload. Arrays only participate via canonical
+ * in-bounds indices (see `isCanonicalArrayIndex`; `length`/expando segments
+ * are refused untouched). When the LEAF itself is an array index, the
+ * element is removed splice-style — later elements shift left — because
+ * `delete arr[i]` would leave a hole that serializes as `null`, which is
+ * just as malformed as the object-shaped payload.
  */
 export function deleteDottedPath(
   payload: Record<string, any>,
@@ -508,11 +551,12 @@ export function deleteDottedPath(
     return { payload, deleted: false };
   }
 
-  // Walk the path, recording the (object, key) pair at each level so the
+  // Walk the path, recording the (container, key) pair at each level so the
   // chain can be rebuilt with clones afterward. Bail out — no traversal
   // beyond this point, no mutation, no clone — the instant a segment isn't
-  // an own enumerable property: an absent field or non-object intermediate
-  // means there's nothing to strip.
+  // an own enumerable property (or, for arrays, a canonical in-bounds
+  // index): an absent field or non-object intermediate means there's
+  // nothing to strip.
   const chain: Array<{ obj: Record<string, any>; key: string }> = [];
   let target: any = payload;
   for (let i = 0; i < segments.length - 1; i++) {
@@ -520,7 +564,8 @@ export function deleteDottedPath(
     if (
       target == null ||
       typeof target !== 'object' ||
-      !Object.prototype.hasOwnProperty.call(target, segment)
+      !Object.prototype.hasOwnProperty.call(target, segment) ||
+      (Array.isArray(target) && !isCanonicalArrayIndex(segment, target))
     ) {
       return { payload, deleted: false };
     }
@@ -532,18 +577,32 @@ export function deleteDottedPath(
   if (
     target == null ||
     typeof target !== 'object' ||
-    !Object.prototype.hasOwnProperty.call(target, leaf)
+    !Object.prototype.hasOwnProperty.call(target, leaf) ||
+    (Array.isArray(target) && !isCanonicalArrayIndex(leaf, target))
   ) {
     return { payload, deleted: false };
   }
 
   // Rebuild the chain bottom-up with shallow clones so nothing shared with
-  // another reference is mutated.
-  let rebuilt: Record<string, any> = { ...target };
-  delete rebuilt[leaf];
+  // another reference is mutated, preserving each level's container kind.
+  let rebuilt: any;
+  if (Array.isArray(target)) {
+    // Array-index leaf: splice-style removal (no hole — see doc comment).
+    const index = Number(leaf);
+    rebuilt = [...target.slice(0, index), ...target.slice(index + 1)];
+  } else {
+    rebuilt = { ...target };
+    delete rebuilt[leaf];
+  }
   for (let i = chain.length - 1; i >= 0; i--) {
     const { obj, key } = chain[i]!;
-    rebuilt = { ...obj, [key]: rebuilt };
+    if (Array.isArray(obj)) {
+      const clone = [...obj];
+      clone[Number(key)] = rebuilt;
+      rebuilt = clone;
+    } else {
+      rebuilt = { ...obj, [key]: rebuilt };
+    }
   }
 
   return { payload: rebuilt, deleted: true };
@@ -551,6 +610,41 @@ export function deleteDottedPath(
 
 /** Per-target, per-request bound: at most this many strip-and-retry cycles. */
 export const MAX_UNSUPPORTED_PARAM_STRIP_RETRIES = 2;
+
+/**
+ * Top-level fields the strip-and-retry mechanism must never delete
+ * WHOLESALE: removing the entire conversation (`messages` / `input`) or the
+ * `model` guarantees a malformed request that every upstream rejects, so an
+ * upstream 400 naming one of these EXACTLY (full normalized path, no
+ * sub-path) gets normal failover instead of a doomed strip-retry. Sub-paths
+ * within them (e.g. `messages.0.name`) and other whole fields (`tools`,
+ * `safety_identifier`, ...) remain strippable.
+ */
+const UNSTRIPPABLE_STRUCTURAL_FIELDS = new Set(['messages', 'input', 'model']);
+
+/**
+ * Structural roots whose DIRECT numeric elements are entire conversation
+ * items. `Unsupported parameter: messages[0]` normalizes to `messages.0`,
+ * which dodges the exact-name guard above — but the paired deleteDottedPath
+ * would splice a whole message/input item out of the conversation, mutilating
+ * the request as surely as deleting the whole field. `model` is a string, so
+ * it has no element paths to guard.
+ */
+const STRUCTURAL_ARRAY_ROOTS = new Set(['messages', 'input']);
+
+/**
+ * True when the normalized path is exactly `<structural root>.<number>` — a
+ * numeric leaf DIRECTLY under a structural array (`messages.0`, `input.12`).
+ * Deeper paths (`messages.0.name`) address a field WITHIN the item and stay
+ * strippable; numeric leaves under non-structural arrays (`tools.2`) stay
+ * splice-deletable.
+ */
+function isStructuralArrayElementPath(path: string): boolean {
+  const segments = path.split('.');
+  return (
+    segments.length === 2 && STRUCTURAL_ARRAY_ROOTS.has(segments[0]!) && /^\d+$/.test(segments[1]!)
+  );
+}
 
 /** Tracks strip-and-retry progress for a single target within one request. */
 export interface UnsupportedParamStripState {
@@ -567,9 +661,16 @@ export function createUnsupportedParamStripState(): UnsupportedParamStripState {
  * trigger another strip-and-retry cycle against the same target, recording
  * the attempt in `state` when it does.
  *
- * Returns the parameter name to strip, or `undefined` when the retry should
- * NOT happen because:
+ * Returns the parameter name to strip (in canonical dotted form), or
+ * `undefined` when the retry should NOT happen because:
  *   - the body doesn't name an unsupported parameter, OR
+ *   - the named parameter is a protected structural field
+ *     (UNSTRIPPABLE_STRUCTURAL_FIELDS) whose wholesale deletion guarantees a
+ *     malformed request — refused before any budget is consumed, OR
+ *   - the named parameter is a numeric element directly under a structural
+ *     array (`messages.0` / `input[2]` — see isStructuralArrayElementPath):
+ *     splice-deleting an entire conversation item is as destructive as
+ *     deleting the whole field, so it gets the same budget-free refusal, OR
  *   - the MAX_UNSUPPORTED_PARAM_STRIP_RETRIES bound has been reached, OR
  *   - the named parameter was already stripped on an earlier attempt for this
  *     target — an upstream that keeps rejecting the same field after it's
@@ -583,7 +684,9 @@ export function planUnsupportedParamStrip(
   if (state.attempts >= MAX_UNSUPPORTED_PARAM_STRIP_RETRIES) return undefined;
 
   const paramName = matchUnsupportedParameter(responseBody);
-  if (!paramName || state.strippedParams.has(paramName)) return undefined;
+  if (!paramName || UNSTRIPPABLE_STRUCTURAL_FIELDS.has(paramName)) return undefined;
+  if (isStructuralArrayElementPath(paramName)) return undefined;
+  if (state.strippedParams.has(paramName)) return undefined;
 
   state.attempts++;
   state.strippedParams.add(paramName);
@@ -660,12 +763,37 @@ function reasoningElidedPlaceholder(): Array<{ type: 'text'; text: string }> {
   return [{ type: 'text', text: '[reasoning elided]' }];
 }
 
+export interface ThinkingSignatureStripResult {
+  /**
+   * The payload with every `thinking` / `redacted_thinking` block removed.
+   * A NEW object (copy-on-write) when `strippedCount` > 0: the root is
+   * shallow-cloned with a NEW `messages` array, and each message whose
+   * content changed is shallow-cloned — the input payload, its `messages`
+   * array, and every original message object are never mutated (the payload
+   * can share `messages`/message objects by reference with the long-lived
+   * `UnifiedChatRequest`; see `deleteDottedPath`'s copy-on-write rationale).
+   * Untouched messages are shared, not cloned. Identical to the input
+   * `payload` reference when `strippedCount` is 0 — nothing to rebuild.
+   */
+  payload: Record<string, any>;
+  /**
+   * Number of thinking/redacted_thinking blocks actually removed (0 when
+   * the payload isn't Anthropic-messages-shaped, or had none to strip).
+   * Callers MUST treat 0 as "nothing changed" and skip any retry that
+   * assumes the payload is now different — the structural
+   * `isAnthropicMessagesPayload` gate also matches OpenAI chat-completions
+   * payloads (they have a `messages` array too), which never carry thinking
+   * blocks, so a 0-strip retry would resend a byte-identical request.
+   */
+  strippedCount: number;
+}
+
 /**
  * Removes every `thinking` / `redacted_thinking` block from every message's
- * `content` array, mutating `payload.messages` in place (replacing the
- * array; individual message objects that need changes are shallow-cloned,
- * not mutated). When a message's `content` becomes empty as a result of the
- * strip, the message is dropped entirely UNLESS doing so would:
+ * `content` array, copy-on-write (see `ThinkingSignatureStripResult` — the
+ * input payload is never mutated). When a message's `content` becomes empty
+ * as a result of the strip, the message is dropped entirely UNLESS doing so
+ * would:
  *   - break strict user/assistant role alternation — the nearest retained
  *     message before it and the message right after it would end up with
  *     the same role, or
@@ -678,36 +806,47 @@ function reasoningElidedPlaceholder(): Array<{ type: 'text'; text: string }> {
  * dropping the message, so the conversation shape stays valid.
  *
  * Non-array `content` (e.g. plain-string messages) is left untouched.
- * Returns the number of thinking/redacted_thinking blocks actually removed
- * (0 when the payload isn't Anthropic-messages-shaped, or had none to strip).
  */
-export function stripThinkingSignatureBlocks(payload: Record<string, any>): number {
-  if (!isAnthropicMessagesPayload(payload)) return 0;
+export function stripThinkingSignatureBlocks(
+  payload: Record<string, any>
+): ThinkingSignatureStripResult {
+  if (!isAnthropicMessagesPayload(payload)) return { payload, strippedCount: 0 };
 
   let strippedCount = 0;
-  const perMessage: Array<{ message: any; content: any; isArrayContent: boolean }> =
-    payload.messages.map((message: any) => {
-      if (!message || !Array.isArray(message.content)) {
-        return { message, content: message?.content, isArrayContent: false };
+  const perMessage: Array<{
+    message: any;
+    content: any;
+    isArrayContent: boolean;
+    changed: boolean;
+  }> = payload.messages.map((message: any) => {
+    if (!message || !Array.isArray(message.content)) {
+      return { message, content: message?.content, isArrayContent: false, changed: false };
+    }
+    const kept = message.content.filter((block: any) => {
+      if (isThinkingBlock(block)) {
+        strippedCount++;
+        return false;
       }
-      const kept = message.content.filter((block: any) => {
-        if (isThinkingBlock(block)) {
-          strippedCount++;
-          return false;
-        }
-        return true;
-      });
-      return { message, content: kept, isArrayContent: true };
+      return true;
     });
+    return {
+      message,
+      content: kept,
+      isArrayContent: true,
+      changed: kept.length !== message.content.length,
+    };
+  });
 
-  if (strippedCount === 0) return 0;
+  if (strippedCount === 0) return { payload, strippedCount: 0 };
 
   const result: any[] = [];
   for (let i = 0; i < perMessage.length; i++) {
-    const { message, content, isArrayContent } = perMessage[i]!;
+    const { message, content, isArrayContent, changed } = perMessage[i]!;
 
     if (!isArrayContent || content.length > 0) {
-      result.push(isArrayContent ? { ...message, content } : message);
+      // Only messages that actually lost a block are cloned; untouched
+      // messages are shared by reference (copy-on-write).
+      result.push(changed ? { ...message, content } : message);
       continue;
     }
 
@@ -727,8 +866,7 @@ export function stripThinkingSignatureBlocks(payload: Record<string, any>): numb
     // else: drop — push nothing for this message.
   }
 
-  payload.messages = result;
-  return strippedCount;
+  return { payload: { ...payload, messages: result }, strippedCount };
 }
 
 /** Per-target, per-request bound: at most one signature-strip-and-retry cycle. */
@@ -768,4 +906,25 @@ export function planThinkingSignatureStrip(
 
   state.attempts++;
   return true;
+}
+
+/**
+ * Refunds the attempt recorded by the most recent `planThinkingSignatureStrip`
+ * when the paired `stripThinkingSignatureBlocks` turned out to be a no-op
+ * (`strippedCount` 0 — the structural `messages`-array check matched an
+ * OpenAI-format payload that carries no thinking blocks). No retry happened,
+ * so the budget must not be consumed: a LATER genuine signature 400 on the
+ * same target must still get its one strip-and-retry.
+ *
+ * Loop safety: the refund is issued only on the signature branch's no-strip
+ * path, which itself never `continue`s — so a refund can never re-arm the
+ * signature retry it was issued for. The refunding ITERATION may still
+ * `continue` via the unsupported-param handling in the latter half of the
+ * same `response.status === 400` guard, but that retry consumes an attempt
+ * from the param-strip budget, so the combined fetch bound in
+ * standard-attempt-request.ts holds: every extra fetch consumes an
+ * un-refunded attempt from one of the two strip budgets.
+ */
+export function refundThinkingSignatureStrip(state: ThinkingSignatureStripState): void {
+  if (state.attempts > 0) state.attempts--;
 }

--- a/packages/backend/src/services/dispatch/empty-completion.ts
+++ b/packages/backend/src/services/dispatch/empty-completion.ts
@@ -1,0 +1,210 @@
+import type { UnifiedChatResponse, UnifiedChatStreamChunk } from '../../types/unified';
+
+/**
+ * T5 — Empty-completion detection.
+ *
+ * Plexus never used to inspect completion content: an upstream 200 whose
+ * transformed completion has zero user-visible output (no text, no tool
+ * calls, no reasoning, no images, no citations) was returned to the client
+ * as a successful empty turn. Clients like LobeHub (`ModelEmptyCompletion`)
+ * and KiloCode treat that as a hard error.
+ *
+ * This module is a small, pure, unit-testable core: given a set of
+ * "did any visible output show up" signals, decide whether the completion
+ * counts as empty. It mirrors the spirit of LobeChat's
+ * `isEmptyModelCompletion` — a completion is empty only when NONE of the
+ * visible-output categories are present. Grounding/citation-only responses
+ * are treated as non-empty as long as at least one annotation/citation is
+ * present.
+ *
+ * Two call sites feed this:
+ *   - `standard-attempt-request.ts` (non-streaming): a fully-materialized
+ *     `UnifiedChatResponse` is available, so `isEmptyUnifiedResponse` reads
+ *     signals straight off it.
+ *   - `response-handler.ts` (streaming): the response is consumed
+ *     incrementally, so `createStreamVisibilityTracker`/`observeStreamChunk`
+ *     accumulate presence flags (never the actual text — see the
+ *     buffering-for-retry note in response-handler.ts) as unified stream
+ *     chunks pass through, and `isStreamEmpty` makes the same decision once
+ *     the stream ends.
+ */
+
+/** Reason string used for the non-streaming failover path (attempt-history reason, log messages). */
+export const EMPTY_COMPLETION_REASON = 'Empty completion (no visible output)';
+
+/**
+ * Presence signals used to decide whether a completion produced any
+ * user-visible output. Each flag/count is truthy when that category of
+ * output was present anywhere in the completion (a single non-streaming
+ * response, or accumulated across an entire stream).
+ */
+export interface CompletionVisibilitySignals {
+  hasText?: boolean;
+  hasReasoning?: boolean;
+  toolCallCount?: number;
+  annotationCount?: number;
+  imageCount?: number;
+}
+
+/**
+ * Pure decision function — no I/O, no side effects. A completion is
+ * "empty" only when none of the visible-output signals are present.
+ */
+export function isEmptyCompletion(signals: CompletionVisibilitySignals): boolean {
+  return !(
+    signals.hasText ||
+    signals.hasReasoning ||
+    (signals.toolCallCount ?? 0) > 0 ||
+    (signals.annotationCount ?? 0) > 0 ||
+    (signals.imageCount ?? 0) > 0
+  );
+}
+
+/** True when `value` is a string containing at least one non-whitespace character. */
+function hasVisibleText(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Shape read from a fully-materialized non-streaming response. Widened
+ * (rather than `UnifiedChatResponse` verbatim) so forward-compatible fields
+ * not yet on the unified type — e.g. a future `images` array for multimodal
+ * chat output — are picked up defensively without requiring a type change
+ * here. No current transformer populates `images`; until one does, image
+ * detection is a no-op (imageCount stays 0), which is why the "image-only"
+ * unit test below exercises it directly rather than via a real transformer
+ * fixture.
+ */
+type VisibilityCheckableResponse = Pick<
+  UnifiedChatResponse,
+  'content' | 'reasoning_content' | 'thinking' | 'tool_calls' | 'annotations' | 'finishReason'
+> & { images?: unknown[] | null; rawResponse?: unknown };
+
+/**
+ * Counts `image_generation_call` built-in-tool-call output items
+ * (types/responses.ts `ResponsesBuiltInToolCallItem`) on a raw (pre-transform)
+ * Responses API body. The unified response shape has no field for image
+ * outputs today — no transformer extracts `image_generation_call` items from
+ * `response.output` into anything on `UnifiedChatResponse` — so an
+ * image-only Responses API completion would otherwise carry zero visibility
+ * signals. `rawResponse` is populated on the bypass-transformation path (see
+ * dispatcher.ts's `handleNonStreamingResponse`), which is the ORIGINAL body
+ * available at the empty-completion call seam; this only prevents the false
+ * "empty" classification for that response — full cross-format
+ * transformation of image outputs (carrying them through the unified shape
+ * for every path, not just bypass) is explicitly out of scope here.
+ */
+function countRawImageGenerationCalls(rawResponse: unknown): number {
+  const output = (rawResponse as { output?: unknown })?.output;
+  if (!Array.isArray(output)) return 0;
+  return output.filter((item: any) => item?.type === 'image_generation_call').length;
+}
+
+/** Extracts visibility signals from a fully-materialized non-streaming response. */
+export function getResponseVisibilitySignals(
+  response: VisibilityCheckableResponse
+): CompletionVisibilitySignals {
+  return {
+    hasText: hasVisibleText(response.content),
+    hasReasoning:
+      hasVisibleText(response.reasoning_content) || hasVisibleText(response.thinking?.content),
+    toolCallCount: response.tool_calls?.length ?? 0,
+    annotationCount: response.annotations?.length ?? 0,
+    imageCount:
+      (Array.isArray(response.images) ? response.images.length : 0) +
+      countRawImageGenerationCalls(response.rawResponse),
+  };
+}
+
+/**
+ * Finish reasons that represent a NORMAL, retryable-if-empty completion —
+ * the model simply produced no visible output on an otherwise-ordinary
+ * turn. Absent/null covers responses (and transformers) that don't set a
+ * finish reason at all — the pre-existing "truly empty" case, which must
+ * stay retryable.
+ */
+function isRetryableEmptyFinishReason(finishReason: string | null | undefined): boolean {
+  return finishReason == null || finishReason === 'stop' || finishReason === 'end_turn';
+}
+
+/**
+ * Convenience wrapper for the non-streaming dispatch seam
+ * (standard-attempt-request.ts). A completion is only "empty" (and thus
+ * retryable via failover) when BOTH:
+ *   - none of the visible-output signals are present, AND
+ *   - the finish reason is a normal one (absent/null/'stop'/'end_turn').
+ * Any other finish reason (content_filter, refusal, length, error, etc.) is
+ * a TERMINAL, provider-chosen outcome: the provider deliberately ended the
+ * turn for a reason unrelated to "the model produced nothing", so treating
+ * it as an empty-completion failover would silently route around a
+ * safety/terminal decision (e.g. resending a content-filtered prompt to a
+ * different provider) instead of relaying it to the client as intended.
+ */
+export function isEmptyUnifiedResponse(response: VisibilityCheckableResponse): boolean {
+  if (!isRetryableEmptyFinishReason(response.finishReason)) return false;
+  return isEmptyCompletion(getResponseVisibilitySignals(response));
+}
+
+/**
+ * Mutable per-stream accumulator for the streaming seam. Tracks only
+ * PRESENCE (booleans/counts) — it never holds accumulated text, so it
+ * cannot be used to reconstruct or retry the response (streaming can't
+ * fail over anyway; headers are already sent by the time this runs).
+ */
+export interface StreamVisibilityTracker {
+  hasText: boolean;
+  hasReasoning: boolean;
+  toolCallCount: number;
+  annotationCount: number;
+  imageCount: number;
+}
+
+export function createStreamVisibilityTracker(): StreamVisibilityTracker {
+  return {
+    hasText: false,
+    hasReasoning: false,
+    toolCallCount: 0,
+    annotationCount: 0,
+    imageCount: 0,
+  };
+}
+
+/**
+ * Observes a single unified stream chunk, updating the tracker in place.
+ * Only inspects `delta.content` / `delta.tool_calls` / `delta.reasoning_content`
+ * / `delta.thinking` (plus a defensive, forward-compatible `annotations`/
+ * `images` check — no current transformer streams either) — it never
+ * stores the actual delta text anywhere.
+ */
+export function observeStreamChunk(
+  tracker: StreamVisibilityTracker,
+  chunk: Pick<UnifiedChatStreamChunk, 'delta'> & {
+    annotations?: unknown[] | null;
+    images?: unknown[] | null;
+  }
+): void {
+  const delta = chunk?.delta;
+  if (!delta) return;
+
+  if (hasVisibleText(delta.content)) tracker.hasText = true;
+  if (hasVisibleText(delta.reasoning_content) || hasVisibleText(delta.thinking?.content)) {
+    tracker.hasReasoning = true;
+  }
+  if (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0) {
+    // Exact count doesn't matter — isEmptyCompletion only checks for > 0 —
+    // so over-counting across multiple arg-delta chunks for the same tool
+    // call is harmless.
+    tracker.toolCallCount += delta.tool_calls.length;
+  }
+  if (Array.isArray(chunk.annotations) && chunk.annotations.length > 0) {
+    tracker.annotationCount += chunk.annotations.length;
+  }
+  if (Array.isArray(chunk.images) && chunk.images.length > 0) {
+    tracker.imageCount += chunk.images.length;
+  }
+}
+
+/** Convenience wrapper for the streaming observability seam (response-handler.ts). */
+export function isStreamEmpty(tracker: StreamVisibilityTracker): boolean {
+  return isEmptyCompletion(tracker);
+}

--- a/packages/backend/src/services/dispatch/empty-completion.ts
+++ b/packages/backend/src/services/dispatch/empty-completion.ts
@@ -70,34 +70,52 @@ function hasVisibleText(value: string | null | undefined): boolean {
  * (rather than `UnifiedChatResponse` verbatim) so forward-compatible fields
  * not yet on the unified type — e.g. a future `images` array for multimodal
  * chat output — are picked up defensively without requiring a type change
- * here. No current transformer populates the `images` array (the Responses
- * transformer renders image outputs as markdown TEXT content instead — see
- * countRawImageGenerationCalls below), so the `images`-array contribution is
- * exercised directly by the unit tests rather than via a real transformer
+ * here. No current transformer populates the `images` array (Responses image
+ * output travels on the typed `image_generation_calls` carry — see
+ * countTypedImageGenerationCalls below), so the `images`-array contribution
+ * is exercised directly by the unit tests rather than via a real transformer
  * fixture.
  */
 type VisibilityCheckableResponse = Pick<
   UnifiedChatResponse,
-  'content' | 'reasoning_content' | 'thinking' | 'tool_calls' | 'annotations' | 'finishReason'
+  | 'content'
+  | 'reasoning_content'
+  | 'thinking'
+  | 'tool_calls'
+  | 'annotations'
+  | 'finishReason'
+  | 'image_generation_calls'
 > & { images?: unknown[] | null; rawResponse?: unknown };
+
+/**
+ * Counts typed `image_generation_calls` entries with a non-empty base64
+ * `result` on the unified response (see UnifiedImageGenerationCall in
+ * types/unified.ts). This is the PRIMARY image signal on the transformed
+ * (non-bypass) path: unified `content` stays PURE authored text (image
+ * markdown is composed per client format by the renderers, never baked into
+ * content — see transformers/image-rendering.ts), so an image-only
+ * completion has no text and this typed count is what proves the model
+ * produced visible output. Without it, image-only completions would be
+ * misclassified as empty and needlessly failed over.
+ */
+function countTypedImageGenerationCalls(
+  imageGenerationCalls: UnifiedChatResponse['image_generation_calls']
+): number {
+  if (!Array.isArray(imageGenerationCalls)) return 0;
+  return imageGenerationCalls.filter(
+    (imageCall) => typeof imageCall?.result === 'string' && imageCall.result.length > 0
+  ).length;
+}
 
 /**
  * Counts `image_generation_call` built-in-tool-call output items
  * (types/responses.ts `ResponsesBuiltInToolCallItem`) on a raw (pre-transform)
- * Responses API body. On the transformed (non-bypass) path this count is no
- * longer the only image signal: ResponsesTransformer.transformResponse now
- * renders completed items with a base64 `result` as markdown text on the
- * unified `content` (a data-URI image, or an omission placeholder above the
- * inline size limit), so `hasText` covers image-only completions there. This
- * raw count covers what that rendering cannot see: the bypass-transformation
- * path (`rawResponse` is populated by dispatcher.ts's
- * `handleNonStreamingResponse`, the ORIGINAL body available at the
- * empty-completion call seam) and result-less items (an
- * `image_generation_call` without a base64 `result` renders no markdown but
- * still proves the model produced output). Full cross-format transformation
- * of image outputs (carrying them through the unified shape as structured
- * image fields for every path, not just bypass) is explicitly out of scope
- * here.
+ * Responses API body. This raw count covers what the typed carry above
+ * cannot see: the bypass-transformation path (`rawResponse` is populated by
+ * dispatcher.ts's `handleNonStreamingResponse`, the ORIGINAL body available
+ * at the empty-completion call seam) and result-less items (an
+ * `image_generation_call` without a base64 `result` gets no typed carry but
+ * still proves the model produced output).
  */
 function countRawImageGenerationCalls(rawResponse: unknown): number {
   const output = (rawResponse as { output?: unknown })?.output;
@@ -116,6 +134,7 @@ export function getResponseVisibilitySignals(
     toolCallCount: response.tool_calls?.length ?? 0,
     annotationCount: response.annotations?.length ?? 0,
     imageCount:
+      countTypedImageGenerationCalls(response.image_generation_calls) +
       (Array.isArray(response.images) ? response.images.length : 0) +
       countRawImageGenerationCalls(response.rawResponse),
   };

--- a/packages/backend/src/services/dispatch/empty-completion.ts
+++ b/packages/backend/src/services/dispatch/empty-completion.ts
@@ -70,9 +70,10 @@ function hasVisibleText(value: string | null | undefined): boolean {
  * (rather than `UnifiedChatResponse` verbatim) so forward-compatible fields
  * not yet on the unified type — e.g. a future `images` array for multimodal
  * chat output — are picked up defensively without requiring a type change
- * here. No current transformer populates `images`; until one does, image
- * detection is a no-op (imageCount stays 0), which is why the "image-only"
- * unit test below exercises it directly rather than via a real transformer
+ * here. No current transformer populates the `images` array (the Responses
+ * transformer renders image outputs as markdown TEXT content instead — see
+ * countRawImageGenerationCalls below), so the `images`-array contribution is
+ * exercised directly by the unit tests rather than via a real transformer
  * fixture.
  */
 type VisibilityCheckableResponse = Pick<
@@ -83,16 +84,20 @@ type VisibilityCheckableResponse = Pick<
 /**
  * Counts `image_generation_call` built-in-tool-call output items
  * (types/responses.ts `ResponsesBuiltInToolCallItem`) on a raw (pre-transform)
- * Responses API body. The unified response shape has no field for image
- * outputs today — no transformer extracts `image_generation_call` items from
- * `response.output` into anything on `UnifiedChatResponse` — so an
- * image-only Responses API completion would otherwise carry zero visibility
- * signals. `rawResponse` is populated on the bypass-transformation path (see
- * dispatcher.ts's `handleNonStreamingResponse`), which is the ORIGINAL body
- * available at the empty-completion call seam; this only prevents the false
- * "empty" classification for that response — full cross-format
- * transformation of image outputs (carrying them through the unified shape
- * for every path, not just bypass) is explicitly out of scope here.
+ * Responses API body. On the transformed (non-bypass) path this count is no
+ * longer the only image signal: ResponsesTransformer.transformResponse now
+ * renders completed items with a base64 `result` as markdown text on the
+ * unified `content` (a data-URI image, or an omission placeholder above the
+ * inline size limit), so `hasText` covers image-only completions there. This
+ * raw count covers what that rendering cannot see: the bypass-transformation
+ * path (`rawResponse` is populated by dispatcher.ts's
+ * `handleNonStreamingResponse`, the ORIGINAL body available at the
+ * empty-completion call seam) and result-less items (an
+ * `image_generation_call` without a base64 `result` renders no markdown but
+ * still proves the model produced output). Full cross-format transformation
+ * of image outputs (carrying them through the unified shape as structured
+ * image fields for every path, not just bypass) is explicitly out of scope
+ * here.
  */
 function countRawImageGenerationCalls(rawResponse: unknown): number {
   const output = (rawResponse as { output?: unknown })?.output;

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -201,15 +201,19 @@ export async function buildRequestPayload(
     );
     // Codex CLI and Responses clients receive the native Responses stream.
     // Cross-format Codex requests must translate the response back to the
-    // incoming client format. Anthropic remains raw pass-through, while
-    // Copilot honors its computed same-format decision.
+    // incoming client format. Anthropic bypasses only for same-format
+    // (Messages) clients — chat/responses clients get the response
+    // translated by the standard pipeline (mirrors the identical Codex fix,
+    // commit 4f74c1c6). Copilot honors its computed same-format decision.
     const incomingIsResponses =
       getApiBaseType(request.incomingApiType?.toLowerCase() ?? '') === 'responses';
+    const incomingIsMessages =
+      getApiBaseType(request.incomingApiType?.toLowerCase() ?? '') === 'messages';
     const nativeBypass = codexNative
       ? codexCliPassthrough || incomingIsResponses
       : copilotNative
         ? bypassTransformation
-        : true;
+        : incomingIsMessages;
     return { payload: prepared.body, bypassTransformation: nativeBypass };
   }
 

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -205,10 +205,9 @@ export async function buildRequestPayload(
     // (Messages) clients — chat/responses clients get the response
     // translated by the standard pipeline (mirrors the identical Codex fix,
     // commit 4f74c1c6). Copilot honors its computed same-format decision.
-    const incomingIsResponses =
-      getApiBaseType(request.incomingApiType?.toLowerCase() ?? '') === 'responses';
-    const incomingIsMessages =
-      getApiBaseType(request.incomingApiType?.toLowerCase() ?? '') === 'messages';
+    const incomingBaseType = getApiBaseType(request.incomingApiType?.toLowerCase() ?? '');
+    const incomingIsResponses = incomingBaseType === 'responses';
+    const incomingIsMessages = incomingBaseType === 'messages';
     const nativeBypass = codexNative
       ? codexCliPassthrough || incomingIsResponses
       : copilotNative

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -6,6 +6,17 @@ import type { RetryAttemptRecord } from './dispatcher-types';
 import type { StallConfig } from '../inspectors/stall-inspector';
 import { CooldownManager } from '../runtime/cooldown-manager';
 import type { RequestManagerHost } from './request-manager';
+import {
+  createThinkingSignatureStripState,
+  createUnsupportedParamStripState,
+  deleteDottedPath,
+  planThinkingSignatureStrip,
+  planUnsupportedParamStrip,
+  stripThinkingSignatureBlocks,
+  MAX_THINKING_SIGNATURE_STRIP_RETRIES,
+  MAX_UNSUPPORTED_PARAM_STRIP_RETRIES,
+} from './dispatcher-auto-compat';
+import { EMPTY_COMPLETION_REASON, isEmptyUnifiedResponse } from './empty-completion';
 
 export type StandardAttemptResult =
   | { outcome: 'success'; response: UnifiedChatResponse }
@@ -40,7 +51,6 @@ export async function executeStandardAttempt(
 ): Promise<StandardAttemptResult> {
   const {
     host,
-    providerPayload,
     request: currentRequest,
     requestWithTargetModel,
     route,
@@ -60,6 +70,10 @@ export async function executeStandardAttempt(
     sessionKey,
     release: doRelease,
   } = context;
+  // Mutable (not const): the unsupported-param strip-and-retry path below
+  // rebuilds this via copy-on-write (deleteDottedPath) rather than mutating
+  // in place, so a successful strip must reassign this binding.
+  let providerPayload = context.providerPayload;
   let effectiveStallConfig = initialStallConfig;
 
   const incomingApi = currentRequest.incomingApiType || 'unknown';
@@ -70,161 +84,233 @@ export async function executeStandardAttempt(
     `Dispatching ${currentRequest.model} to ${route.provider}:${route.model} ${incomingApi} <-> ${transformer.name}`
   );
 
-  logger.silly('Upstream Request Payload', providerPayload);
+  // Reactive auto-compat: bounded per-target state so a strip-and-retry
+  // cycle (see the 400 handling below) can't loop forever (see
+  // dispatcher-auto-compat.ts for the matching/bound logic). Two independent
+  // mechanisms, two independent budgets — neither resets the other's
+  // counter, so the combined worst case for this target is bounded at
+  // exactly 1 (initial attempt) + MAX_THINKING_SIGNATURE_STRIP_RETRIES +
+  // MAX_UNSUPPORTED_PARAM_STRIP_RETRIES fetches, however the two mechanisms
+  // interleave — they can't ping-pong into an unbounded loop.
+  const paramStripState = createUnsupportedParamStripState();
+  const thinkingStripState = createThinkingSignatureStripState();
 
-  // When TTFB stall detection is configured for streaming requests, wrap
-  // the fetch + probe in a single timeout that covers the entire TTFB
-  // window (from request dispatch to receiving ttfbBytes of body data).
-  // This handles the case where fetch() itself blocks for a long time
-  // waiting for HTTP response headers from a slow provider.
+  // Looped so a strip-and-retry can redo the fetch against the SAME target
+  // without returning to the caller's failover loop — failing over would
+  // just hit the same "client sent an unsupported param" problem on the
+  // next provider too. Logging the payload inside the loop means a
+  // strip-retry's silly-level log reflects the field that was actually
+  // removed, not just the original request.
   let response: Response;
-  let stallAbortController: AbortController | undefined;
-  let ttfbTimerId: ReturnType<typeof setTimeout> | undefined;
-  const dispatchStartTime = Date.now();
+  while (true) {
+    logger.silly('Upstream Request Payload', providerPayload);
 
-  if (currentRequest.stream && effectiveStallConfig?.ttfbMs != null) {
-    // Create a separate AbortController for the TTFB stall timeout.
-    // We don't use the route's abortController because an abort there
-    // means the client disconnected — we need a distinct signal for
-    // "provider is too slow to start responding".
-    stallAbortController = new AbortController();
-    const combinedSignal = AbortSignal.any([attemptTimeout.signal, stallAbortController.signal]);
+    let stallAbortController: AbortController | undefined;
+    let ttfbTimerId: ReturnType<typeof setTimeout> | undefined;
+    const dispatchStartTime = Date.now();
 
-    const ttfbMs = effectiveStallConfig.ttfbMs!;
-    ttfbTimerId = setTimeout(() => {
-      stallAbortController!.abort(
-        new DOMException(
-          `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`,
-          'TimeoutError'
-        )
-      );
-    }, ttfbMs);
-    ttfbTimerId.unref?.();
+    // When TTFB stall detection is configured for streaming requests, wrap
+    // the fetch + probe in a single timeout that covers the entire TTFB
+    // window (from request dispatch to receiving ttfbBytes of body data).
+    // This handles the case where fetch() itself blocks for a long time
+    // waiting for HTTP response headers from a slow provider.
+    if (currentRequest.stream && effectiveStallConfig?.ttfbMs != null) {
+      // Create a separate AbortController for the TTFB stall timeout.
+      // We don't use the route's abortController because an abort there
+      // means the client disconnected — we need a distinct signal for
+      // "provider is too slow to start responding".
+      stallAbortController = new AbortController();
+      const combinedSignal = AbortSignal.any([attemptTimeout.signal, stallAbortController.signal]);
 
-    try {
-      response = await host.executeProviderRequest(url, headers, providerPayload, combinedSignal);
-    } catch (fetchError: any) {
-      // Client disconnected takes priority over stall detection —
-      // if the client is gone, no point retrying.
-      if (signal?.aborted) {
-        clearTimeout(ttfbTimerId);
-        throw host.buildCancelledError(signal);
+      const ttfbMs = effectiveStallConfig.ttfbMs!;
+      ttfbTimerId = setTimeout(() => {
+        stallAbortController!.abort(
+          new DOMException(
+            `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`,
+            'TimeoutError'
+          )
+        );
+      }, ttfbMs);
+      ttfbTimerId.unref?.();
+
+      try {
+        response = await host.executeProviderRequest(url, headers, providerPayload, combinedSignal);
+      } catch (fetchError: any) {
+        // Client disconnected takes priority over stall detection —
+        // if the client is gone, no point retrying.
+        if (signal?.aborted) {
+          clearTimeout(ttfbTimerId);
+          throw host.buildCancelledError(signal);
+        }
+
+        // If the error was caused by our TTFB stall timeout, synthesize
+        // a stall result instead of treating it as a generic network error.
+        if (stallAbortController.signal.aborted) {
+          clearTimeout(ttfbTimerId);
+          const stallError = new Error(
+            `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`
+          );
+
+          const canRetryStall =
+            failoverEnabled &&
+            hasNextTarget &&
+            (host.isRetryableNetworkError(stallError, retryableErrors) ||
+              stallError.message?.includes('stalled'));
+
+          if (canRetryStall) {
+            attemptTimeout.cleanup();
+            await host.recordAttemptMetric(route, currentRequest.requestId, false, {
+              isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+              isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+              visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
+            });
+            host.appendFailureAttempt(retryHistory, route, stallError, targetApiType, true);
+            CooldownManager.getInstance().markProviderStallFailure(
+              route.provider,
+              route.model,
+              host.formatFailureReason(stallError)
+            );
+            host.saveIntermediateError(
+              currentRequest.requestId,
+              targetApiType || 'chat',
+              stallError
+            );
+            logger.info(
+              `TTFB stall: fetch timed out after ${ttfbMs}ms for ${route.provider}/${route.model}, retrying with next provider`
+            );
+            doRelease();
+            return { outcome: 'retry', error: stallError };
+          }
+          doRelease();
+          throw stallError;
+        }
+        throw fetchError;
       }
 
-      // If the error was caused by our TTFB stall timeout, synthesize
-      // a stall result instead of treating it as a generic network error.
-      if (stallAbortController.signal.aborted) {
-        clearTimeout(ttfbTimerId);
-        const stallError = new Error(
-          `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`
+      // Fetch returned — clear the TTFB timer (we beat the timeout)
+      clearTimeout(ttfbTimerId);
+      ttfbTimerId = undefined;
+
+      // Adjust the stall config's ttfbMs for the probe — subtract the time
+      // already spent waiting for fetch() to return. The probe only needs
+      // to cover the remaining time until the byte threshold is met.
+      const fetchElapsed = Date.now() - dispatchStartTime;
+      const remainingTtfbMs = Math.max(0, ttfbMs - fetchElapsed);
+      if (remainingTtfbMs <= 0 && effectiveStallConfig) {
+        // Fetch returned just barely within the TTFB window — no time left
+        // for the probe. Skip the probe and let the pipeline handle it.
+        effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: null };
+      } else if (effectiveStallConfig) {
+        effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: remainingTtfbMs };
+      }
+    } else {
+      response = await host.executeProviderRequest(
+        url,
+        headers,
+        providerPayload,
+        attemptTimeout.signal
+      );
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+
+      // Reactive auto-compat: alias-level failover can replay a conversation
+      // whose `thinking`/`redacted_thinking` blocks were signed by a
+      // DIFFERENT Claude model/session than the one we're now targeting.
+      // Anthropic 400s naming the stale signature specifically — every
+      // remaining Claude target would reject the same replayed signature
+      // the same way, so strip the thinking blocks and retry the SAME
+      // target rather than failing over.
+      if (response.status === 400) {
+        if (planThinkingSignatureStrip(errorText, providerPayload, thinkingStripState)) {
+          const strippedBlockCount = stripThinkingSignatureBlocks(providerPayload);
+          logger.warn(
+            `Auto-compat: ${route.provider}/${route.model} rejected a stale thinking-block ` +
+              `signature — stripped ${strippedBlockCount} thinking block(s) and retrying the ` +
+              `same target (attempt ${thinkingStripState.attempts}/${MAX_THINKING_SIGNATURE_STRIP_RETRIES})`
+          );
+          continue;
+        }
+      }
+
+      // Reactive auto-compat: some upstreams 400 naming one specific
+      // unsupported parameter (e.g. LobeHub's gpt-5.5 traffic sending
+      // safety_identifier / prompt_cache_key that a provider rejects).
+      // Strip that field and retry the SAME target rather than falling
+      // through to normal failover, which wouldn't help — every target
+      // would reject the same client-sent field the same way.
+      if (response.status === 400) {
+        const paramToStrip = planUnsupportedParamStrip(errorText, paramStripState);
+        if (paramToStrip) {
+          const stripResult = deleteDottedPath(providerPayload, paramToStrip);
+          if (stripResult.deleted) {
+            providerPayload = stripResult.payload;
+            logger.warn(
+              `Auto-compat: ${route.provider}/${route.model} rejected unsupported parameter ` +
+                `'${paramToStrip}' — stripping it and retrying the same target ` +
+                `(attempt ${paramStripState.attempts}/${MAX_UNSUPPORTED_PARAM_STRIP_RETRIES})`
+            );
+            continue;
+          }
+          // Nothing was actually removed (a rejected __proto__/constructor/
+          // prototype segment, or the named field wasn't present) —
+          // resending the SAME payload would just repeat the identical
+          // upstream rejection, so fall through to normal failover/error
+          // handling below instead of retrying this target again.
+        }
+      }
+
+      const canRetry =
+        failoverEnabled &&
+        hasNextTarget &&
+        host.isRetryableStatus(response.status, retryableStatusCodes);
+
+      try {
+        await host.handleProviderError(
+          response,
+          route,
+          errorText,
+          url,
+          headers,
+          targetApiType,
+          currentRequest.requestId
         );
+      } catch (e: any) {
+        if (signal?.aborted) throw host.buildCancelledError(signal);
+        host.appendFailureAttempt(retryHistory, route, e, targetApiType, canRetry);
 
-        const canRetryStall =
-          failoverEnabled &&
-          hasNextTarget &&
-          (host.isRetryableNetworkError(stallError, retryableErrors) ||
-            stallError.message?.includes('stalled'));
-
-        if (canRetryStall) {
+        if (canRetry) {
           attemptTimeout.cleanup();
+          doRelease();
           await host.recordAttemptMetric(route, currentRequest.requestId, false, {
             isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
             isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
             visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
           });
-          host.appendFailureAttempt(retryHistory, route, stallError, targetApiType, true);
-          CooldownManager.getInstance().markProviderStallFailure(
-            route.provider,
-            route.model,
-            host.formatFailureReason(stallError)
+          // Only mark as failed if the error actually triggered a cooldown (i.e., it's not a caller error like validation)
+          // Caller errors (400 validation errors, 413, 422) should not cause cooldown
+          if (e?.routingContext?.cooldownTriggered) {
+            CooldownManager.getInstance().markProviderFailure(
+              route.provider,
+              route.model,
+              undefined,
+              host.formatFailureReason(e, true)
+            );
+          }
+          host.saveIntermediateError(currentRequest.requestId, targetApiType || 'chat', e);
+          logger.warn(
+            `Failover: retrying after HTTP ${response.status} from ${route.provider}/${route.model}`
           );
-          host.saveIntermediateError(currentRequest.requestId, targetApiType || 'chat', stallError);
-          logger.info(
-            `TTFB stall: fetch timed out after ${ttfbMs}ms for ${route.provider}/${route.model}, retrying with next provider`
-          );
-          doRelease();
-          return { outcome: 'retry', error: stallError };
+          return { outcome: 'retry', error: e };
         }
+
         doRelease();
-        throw stallError;
+        throw e;
       }
-      throw fetchError;
     }
 
-    // Fetch returned — clear the TTFB timer (we beat the timeout)
-    clearTimeout(ttfbTimerId);
-    ttfbTimerId = undefined;
-
-    // Adjust the stall config's ttfbMs for the probe — subtract the time
-    // already spent waiting for fetch() to return. The probe only needs
-    // to cover the remaining time until the byte threshold is met.
-    const fetchElapsed = Date.now() - dispatchStartTime;
-    const remainingTtfbMs = Math.max(0, ttfbMs - fetchElapsed);
-    if (remainingTtfbMs <= 0 && effectiveStallConfig) {
-      // Fetch returned just barely within the TTFB window — no time left
-      // for the probe. Skip the probe and let the pipeline handle it.
-      effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: null };
-    } else if (effectiveStallConfig) {
-      effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: remainingTtfbMs };
-    }
-  } else {
-    response = await host.executeProviderRequest(
-      url,
-      headers,
-      providerPayload,
-      attemptTimeout.signal
-    );
-  }
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    const canRetry =
-      failoverEnabled &&
-      hasNextTarget &&
-      host.isRetryableStatus(response.status, retryableStatusCodes);
-
-    try {
-      await host.handleProviderError(
-        response,
-        route,
-        errorText,
-        url,
-        headers,
-        targetApiType,
-        currentRequest.requestId
-      );
-    } catch (e: any) {
-      if (signal?.aborted) throw host.buildCancelledError(signal);
-      host.appendFailureAttempt(retryHistory, route, e, targetApiType, canRetry);
-
-      if (canRetry) {
-        attemptTimeout.cleanup();
-        doRelease();
-        await host.recordAttemptMetric(route, currentRequest.requestId, false, {
-          isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
-          isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
-          visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
-        });
-        // Only mark as failed if the error actually triggered a cooldown (i.e., it's not a caller error like validation)
-        // Caller errors (400 validation errors, 413, 422) should not cause cooldown
-        if (e?.routingContext?.cooldownTriggered) {
-          CooldownManager.getInstance().markProviderFailure(
-            route.provider,
-            route.model,
-            undefined,
-            host.formatFailureReason(e, true)
-          );
-        }
-        host.saveIntermediateError(currentRequest.requestId, targetApiType || 'chat', e);
-        logger.warn(
-          `Failover: retrying after HTTP ${response.status} from ${route.provider}/${route.model}`
-        );
-        return { outcome: 'retry', error: e };
-      }
-
-      doRelease();
-      throw e;
-    }
+    break;
   }
 
   // 5. Handle Response
@@ -351,6 +437,63 @@ export async function executeStandardAttempt(
     bypassTransformation,
     adapters
   );
+
+  // T5: empty-completion failover (see empty-completion.ts). An upstream 200
+  // whose transformed completion has zero visible output (no text, tool
+  // calls, reasoning, images, or citations) reads as a hard error to clients
+  // like LobeHub (`ModelEmptyCompletion`) / KiloCode. Treat it as a
+  // retryable target failure so normal failover proceeds to the next
+  // candidate — UNLESS this is the last target, in which case the empty
+  // response is returned as-is: an empty 200 from every candidate is still a
+  // valid upstream answer, so failover-exhaustion semantics must stay
+  // unchanged (no conversion into a 5xx).
+  //
+  // `clientError` is excluded on purpose: some transformers (e.g. Gemini's
+  // MALFORMED_FUNCTION_CALL — transformGeminiResponse) deliberately populate
+  // a clientError-carrying response with no visible output — a distinct,
+  // pre-existing "signal the client directly, no failover, no cooldown"
+  // mechanism handled later in response-handler.ts (see its
+  // `!unifiedResponse.stream && unifiedResponse.clientError` branch). Letting
+  // empty-completion failover fire here would silently discard that specific
+  // diagnostic and introduce retries where they were deliberately excluded,
+  // so any clientError takes precedence and is never treated as empty.
+  const canRetryEmptyCompletion =
+    failoverEnabled &&
+    hasNextTarget &&
+    !nonStreamingResponse.clientError &&
+    isEmptyUnifiedResponse(nonStreamingResponse);
+  if (canRetryEmptyCompletion) {
+    attemptTimeout.cleanup();
+    doRelease();
+    await host.recordAttemptMetric(route, currentRequest.requestId, false, {
+      isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+      isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+      visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
+    });
+    const emptyCompletionError = new Error(EMPTY_COMPLETION_REASON) as any;
+    emptyCompletionError.routingContext = {
+      provider: route.provider,
+      targetModel: route.model,
+      targetApiType,
+      statusCode: 200,
+      // Not a provider-health issue — the HTTP call itself succeeded, it
+      // just carried no visible output — so cooldown must be skipped here,
+      // mirroring how caller-errors (400 non-quota, 413, 422) skip
+      // CooldownManager.markProviderFailure above.
+      cooldownTriggered: false,
+    };
+    host.appendFailureAttempt(retryHistory, route, emptyCompletionError, targetApiType, true);
+    host.saveIntermediateError(
+      currentRequest.requestId,
+      targetApiType || 'chat',
+      emptyCompletionError
+    );
+    logger.warn(
+      `Failover: retrying after empty completion (no visible output) from ${route.provider}/${route.model}`
+    );
+    return { outcome: 'retry', error: emptyCompletionError };
+  }
+
   await host.recordAttemptMetric(route, currentRequest.requestId, true, {
     isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
     isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -12,6 +12,7 @@ import {
   deleteDottedPath,
   planThinkingSignatureStrip,
   planUnsupportedParamStrip,
+  refundThinkingSignatureStrip,
   stripThinkingSignatureBlocks,
   MAX_THINKING_SIGNATURE_STRIP_RETRIES,
   MAX_UNSUPPORTED_PARAM_STRIP_RETRIES,
@@ -249,32 +250,47 @@ export async function executeStandardAttempt(
     if (!response.ok) {
       const errorText = await response.text();
 
-      // Reactive auto-compat: alias-level failover can replay a conversation
-      // whose `thinking`/`redacted_thinking` blocks were signed by a
-      // DIFFERENT Claude model/session than the one we're now targeting.
-      // Anthropic 400s naming the stale signature specifically — every
-      // remaining Claude target would reject the same replayed signature
-      // the same way, so strip the thinking blocks and retry the SAME
-      // target rather than failing over.
+      // Reactive auto-compat: a 400 can name a problem that failing over
+      // won't fix — every remaining target would reject the same request
+      // the same way — so both mechanisms below strip the offending content
+      // and retry the SAME target instead. Checked in order:
+      //
+      //   1. Stale thinking-block signatures: alias-level failover can
+      //      replay a conversation whose `thinking`/`redacted_thinking`
+      //      blocks were signed by a DIFFERENT Claude model/session than
+      //      the one we're now targeting, and Anthropic 400s naming the
+      //      stale signature specifically.
+      //   2. Unsupported parameters: some upstreams 400 naming one specific
+      //      client-sent field (e.g. LobeHub's gpt-5.5 traffic sending
+      //      safety_identifier / prompt_cache_key that a provider rejects).
       if (response.status === 400) {
         if (planThinkingSignatureStrip(errorText, providerPayload, thinkingStripState)) {
-          const strippedBlockCount = stripThinkingSignatureBlocks(providerPayload);
-          logger.warn(
-            `Auto-compat: ${route.provider}/${route.model} rejected a stale thinking-block ` +
-              `signature — stripped ${strippedBlockCount} thinking block(s) and retrying the ` +
-              `same target (attempt ${thinkingStripState.attempts}/${MAX_THINKING_SIGNATURE_STRIP_RETRIES})`
-          );
-          continue;
+          const stripResult = stripThinkingSignatureBlocks(providerPayload);
+          if (stripResult.strippedCount > 0) {
+            // Copy-on-write, like the unsupported-param strip below: the
+            // strip returns a NEW payload and never mutates the original
+            // (whose `messages` can be shared by reference with the
+            // long-lived request), so a successful strip reassigns the
+            // binding.
+            providerPayload = stripResult.payload;
+            logger.warn(
+              `Auto-compat: ${route.provider}/${route.model} rejected a stale thinking-block ` +
+                `signature — stripped ${stripResult.strippedCount} thinking block(s) and retrying the ` +
+                `same target (attempt ${thinkingStripState.attempts}/${MAX_THINKING_SIGNATURE_STRIP_RETRIES})`
+            );
+            continue;
+          }
+          // Zero blocks stripped — planThinkingSignatureStrip's structural
+          // `messages`-array check also matches OpenAI-format payloads,
+          // which never carry thinking blocks. Retrying would resend a
+          // byte-identical request, so fall through to the unsupported-param
+          // check / normal failover handling below instead of retrying this
+          // target — and refund the planned attempt: no retry happened, so
+          // the one-per-target budget stays available for a later genuine
+          // signature 400. Loop-safe because this branch never `continue`s.
+          refundThinkingSignatureStrip(thinkingStripState);
         }
-      }
 
-      // Reactive auto-compat: some upstreams 400 naming one specific
-      // unsupported parameter (e.g. LobeHub's gpt-5.5 traffic sending
-      // safety_identifier / prompt_cache_key that a provider rejects).
-      // Strip that field and retry the SAME target rather than falling
-      // through to normal failover, which wouldn't help — every target
-      // would reject the same client-sent field the same way.
-      if (response.status === 400) {
         const paramToStrip = planUnsupportedParamStrip(errorText, paramStripState);
         if (paramToStrip) {
           const stripResult = deleteDottedPath(providerPayload, paramToStrip);

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -22,6 +22,33 @@ export type StandardAttemptResult =
   | { outcome: 'success'; response: UnifiedChatResponse }
   | { outcome: 'retry'; error: any };
 
+/**
+ * Derives the stall config to hand the post-fetch streaming probe: the
+ * pristine (full, per-request-configured) TTFB budget minus however long
+ * fetch() itself already took to return headers. Pure function of the
+ * PRISTINE config — never of a previously-derived one — so calling it again
+ * for a later retry iteration can't compound an earlier iteration's
+ * reduction (see the reset in `executeStandardAttempt`'s retry loop).
+ *
+ * `null`/`undefined` pass through unchanged (TTFB stall detection disabled
+ * for this request). When `pristineConfig.ttfbMs` is itself `null`, the
+ * config is returned as-is too — there's no budget to subtract from.
+ */
+export function deriveProbeStallConfig(
+  pristineConfig: StallConfig | null | undefined,
+  fetchElapsedMs: number
+): StallConfig | null | undefined {
+  if (!pristineConfig || pristineConfig.ttfbMs == null) return pristineConfig;
+
+  const remainingTtfbMs = Math.max(0, pristineConfig.ttfbMs - fetchElapsedMs);
+  // Fetch returned just barely within (or beyond) the TTFB window — no time
+  // left for the probe. Signal "skip the probe" via null and let the
+  // pipeline handle it, rather than arming a probe with ~0ms to work with.
+  return remainingTtfbMs <= 0
+    ? { ...pristineConfig, ttfbMs: null }
+    : { ...pristineConfig, ttfbMs: remainingTtfbMs };
+}
+
 export interface StandardAttemptContext {
   host: RequestManagerHost;
   providerPayload: any;
@@ -74,7 +101,14 @@ export async function executeStandardAttempt(
   // rebuilds this via copy-on-write (deleteDottedPath) rather than mutating
   // in place, so a successful strip must reassign this binding.
   let providerPayload = context.providerPayload;
-  let effectiveStallConfig = initialStallConfig;
+  // Pristine snapshot taken once, outside the loop. Every retry iteration
+  // below resets `effectiveStallConfig` from THIS rather than carrying
+  // forward whatever the previous iteration's post-fetch adjustment left it
+  // as — otherwise a same-target strip-and-retry (thinking-signature or
+  // unsupported-param, below) would inherit a reduced or null ttfbMs from
+  // the failed attempt instead of the full configured budget.
+  const pristineStallConfig = initialStallConfig;
+  let effectiveStallConfig = pristineStallConfig;
 
   const incomingApi = currentRequest.incomingApiType || 'unknown';
   const url = host.buildRequestUrl(route, transformer, requestWithTargetModel, targetApiType);
@@ -103,6 +137,10 @@ export async function executeStandardAttempt(
   // removed, not just the original request.
   let response: Response;
   while (true) {
+    // Reset to the pristine, full TTFB budget at the start of every
+    // iteration — see the comment on `pristineStallConfig` above.
+    effectiveStallConfig = pristineStallConfig;
+
     logger.silly('Upstream Request Payload', providerPayload);
 
     let stallAbortController: AbortController | undefined;
@@ -193,16 +231,12 @@ export async function executeStandardAttempt(
 
       // Adjust the stall config's ttfbMs for the probe — subtract the time
       // already spent waiting for fetch() to return. The probe only needs
-      // to cover the remaining time until the byte threshold is met.
+      // to cover the remaining time until the byte threshold is met. Always
+      // derived from the PRISTINE snapshot (never from the possibly
+      // already-reduced `effectiveStallConfig`), so a value computed on a
+      // previous retry iteration can never compound into this one.
       const fetchElapsed = Date.now() - dispatchStartTime;
-      const remainingTtfbMs = Math.max(0, ttfbMs - fetchElapsed);
-      if (remainingTtfbMs <= 0 && effectiveStallConfig) {
-        // Fetch returned just barely within the TTFB window — no time left
-        // for the probe. Skip the probe and let the pipeline handle it.
-        effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: null };
-      } else if (effectiveStallConfig) {
-        effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: remainingTtfbMs };
-      }
+      effectiveStallConfig = deriveProbeStallConfig(pristineStallConfig, fetchElapsed);
     } else {
       response = await host.executeProviderRequest(
         url,

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -767,6 +767,29 @@ export class DebugLoggingInspector extends BaseInspector {
           Object.assign(acc, event.response);
         }
         break;
+
+      case 'response.failed':
+        // Upstream/client-facing hard failure. Same merge semantics as
+        // response.completed: absorb the final response object (status
+        // 'failed', error, and usage-if-present) so failed/truncated
+        // streams don't get stuck reporting a stale snapshot (usually
+        // 'in_progress') with zero usage.
+        if (event.response) {
+          Object.assign(acc, event.response);
+        }
+        break;
+
+      case 'response.incomplete':
+        // Upstream ended the response early (e.g. max_output_tokens or a
+        // content filter). Same merge semantics as response.completed /
+        // response.failed: absorb the final response object (status
+        // 'incomplete', incomplete_details, and usage-if-present) so
+        // truncated streams don't get stuck reporting a stale snapshot
+        // with zero usage.
+        if (event.response) {
+          Object.assign(acc, event.response);
+        }
+        break;
     }
 
     return acc;

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -8,6 +8,14 @@ const MAX_DEBUG_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB
 export class DebugLoggingInspector extends BaseInspector {
   private debugManager = DebugManager.getInstance();
   private mode: 'raw' | 'transformed';
+  // Capture state lives on the INSTANCE (not in createInspector closures) so
+  // finalize() can run the reconstruction from outside the stream lifecycle —
+  // see finalize() below for why that matters on cancellations.
+  private providerApiType: string = 'unknown';
+  private bodyChunks: string[] = [];
+  private totalSize = 0;
+  private truncated = false;
+  private finalized = false;
 
   constructor(requestId: string, mode: 'raw' | 'transformed' = 'raw') {
     super(requestId);
@@ -15,91 +23,123 @@ export class DebugLoggingInspector extends BaseInspector {
   }
 
   createInspector(providerApiType: string): PassThrough {
-    const inspector =
-      providerApiType === 'oauth' ? new PassThrough({ objectMode: true }) : new PassThrough();
+    this.providerApiType = providerApiType;
 
-    const bodyChunks: string[] = [];
-    let totalSize = 0;
-    let truncated = false;
-
-    inspector.on('data', (chunk: any) => {
-      logger.silly(
-        `[Inspector:${this.mode}] Request ${this.requestId} received chunk, length: ${chunk.length || chunk.toString().length}: ${chunk.toString()}`
-      );
-
-      if (truncated) return;
-
-      let chunkStr: string;
-      if (typeof chunk === 'string') {
-        chunkStr = chunk;
-      } else if (Buffer.isBuffer(chunk)) {
-        chunkStr = chunk.toString('utf8');
-      } else if (chunk instanceof Uint8Array) {
-        chunkStr = new TextDecoder().decode(chunk);
-      } else if (chunk && typeof chunk === 'object') {
-        chunkStr = `${JSON.stringify(chunk)}\n`;
-      } else {
-        try {
-          chunkStr = String(chunk);
-        } catch (e) {
-          logger.warn(`[${this.mode}] Failed to convert chunk to string`);
-          return;
-        }
-      }
-
-      const newSize = totalSize + chunkStr.length;
-
-      if (newSize > MAX_DEBUG_BUFFER_SIZE) {
-        truncated = true;
-        bodyChunks.push('\n\n[DEBUG OUTPUT TRUNCATED - Exceeded 10MB limit]');
-        logger.warn(`Request ${this.requestId} debug output truncated at ${totalSize} bytes`);
-        return;
-      }
-
-      totalSize = newSize;
-      bodyChunks.push(chunkStr);
+    // Capture happens synchronously in the transform hook (i.e. at write()
+    // time), NOT in a 'data' listener: 'data' emission for the very first
+    // writes is deferred to the tick after resume() starts the flow, so a
+    // teardown-time finalize() could miss bytes that were already written.
+    // With write-time capture, finalize() deterministically sees every chunk
+    // written up to the instant it runs.
+    const inspector = new PassThrough({
+      ...(providerApiType === 'oauth' ? { objectMode: true } : {}),
+      transform: (chunk: any, _encoding, callback) => {
+        this.captureChunk(chunk);
+        callback(null, chunk);
+      },
     });
 
-    inspector.on('end', () => {
-      const rawBody = bodyChunks.join('');
-      logger.silly(
-        `[Inspector:${this.mode}] Request ${this.requestId} stream ended, captured ${bodyChunks.length} chunks, total size: ${rawBody.length} bytes`
-      );
-      try {
-        let reconstructed: any = null;
-        switch (providerApiType) {
-          case 'chat':
-            reconstructed = this.reconstructChatCompletions(rawBody);
-            break;
-          case 'responses':
-            reconstructed = this.reconstructResponses(rawBody);
-            break;
-          case 'messages':
-            reconstructed = this.reconstructMessages(rawBody);
-            break;
-          case 'gemini':
-            reconstructed = this.reconstructGemini(rawBody);
-            break;
-          case 'oauth':
-            reconstructed = this.reconstructOAuth(rawBody);
-            break;
-          case 'unknown':
-            break;
-          default:
-            logger.warn(`Unknown providerApiType: ${providerApiType}`);
-        }
-        // Always save to memory for usage extraction/estimation
-        this.saveReconstructedResponse(reconstructed);
+    // Nothing external ever reads this tap's readable side — keep it flowing
+    // (into zero listeners) so pushed chunks never accumulate to the
+    // high-water mark and stall the transform hook above.
+    inspector.resume();
 
-        // DebugManager applies global/key/alias/provider capture policy.
-        this.saveRawResponse(rawBody);
-      } catch (err) {
-        logger.error(`[Inspector:${this.mode}] Reconstruction failed: ${err}`);
-        this.saveRawResponse(rawBody);
-      }
-    });
+    inspector.on('end', () => this.finalize());
 
     return inspector;
+  }
+
+  private captureChunk(chunk: any): void {
+    logger.silly(
+      `[Inspector:${this.mode}] Request ${this.requestId} received chunk, length: ${chunk.length || chunk.toString().length}: ${chunk.toString()}`
+    );
+
+    if (this.truncated) return;
+
+    let chunkStr: string;
+    if (typeof chunk === 'string') {
+      chunkStr = chunk;
+    } else if (Buffer.isBuffer(chunk)) {
+      chunkStr = chunk.toString('utf8');
+    } else if (chunk instanceof Uint8Array) {
+      chunkStr = new TextDecoder().decode(chunk);
+    } else if (chunk && typeof chunk === 'object') {
+      chunkStr = `${JSON.stringify(chunk)}\n`;
+    } else {
+      try {
+        chunkStr = String(chunk);
+      } catch (e) {
+        logger.warn(`[${this.mode}] Failed to convert chunk to string`);
+        return;
+      }
+    }
+
+    const newSize = this.totalSize + chunkStr.length;
+
+    if (newSize > MAX_DEBUG_BUFFER_SIZE) {
+      this.truncated = true;
+      this.bodyChunks.push('\n\n[DEBUG OUTPUT TRUNCATED - Exceeded 10MB limit]');
+      logger.warn(`Request ${this.requestId} debug output truncated at ${this.totalSize} bytes`);
+      return;
+    }
+
+    this.totalSize = newSize;
+    this.bodyChunks.push(chunkStr);
+  }
+
+  /**
+   * Reconstructs and persists everything captured so far (snapshot to memory
+   * always; raw body per capture policy). One-shot: the stream's natural
+   * 'end' event and any explicit teardown call share the same guard, so
+   * whichever runs first wins and later calls are no-ops.
+   *
+   * PUBLIC because stream flush is not guaranteed to run: a client
+   * disconnect/timeout cancels the web TransformStream pipeline WITHOUT
+   * running its flush, so this tap's 'end' never fires — response-handler's
+   * cancellation teardown calls finalize() explicitly BEFORE destroying the
+   * usage inspector, so UsageInspector._destroy's snapshot fallback reads a
+   * live capture instead of nothing.
+   */
+  finalize(): void {
+    if (this.finalized) return;
+    this.finalized = true;
+
+    const rawBody = this.bodyChunks.join('');
+    logger.silly(
+      `[Inspector:${this.mode}] Request ${this.requestId} capture finalized, captured ${this.bodyChunks.length} chunks, total size: ${rawBody.length} bytes`
+    );
+    try {
+      let reconstructed: any = null;
+      switch (this.providerApiType) {
+        case 'chat':
+          reconstructed = this.reconstructChatCompletions(rawBody);
+          break;
+        case 'responses':
+          reconstructed = this.reconstructResponses(rawBody);
+          break;
+        case 'messages':
+          reconstructed = this.reconstructMessages(rawBody);
+          break;
+        case 'gemini':
+          reconstructed = this.reconstructGemini(rawBody);
+          break;
+        case 'oauth':
+          reconstructed = this.reconstructOAuth(rawBody);
+          break;
+        case 'unknown':
+          break;
+        default:
+          logger.warn(`Unknown providerApiType: ${this.providerApiType}`);
+      }
+      // Always save to memory for usage extraction/estimation
+      this.saveReconstructedResponse(reconstructed);
+
+      // DebugManager applies global/key/alias/provider capture policy.
+      this.saveRawResponse(rawBody);
+    } catch (err) {
+      logger.error(`[Inspector:${this.mode}] Reconstruction failed: ${err}`);
+      this.saveRawResponse(rawBody);
+    }
   }
 
   private saveRawResponse(fullBody: string): void {

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -448,8 +448,23 @@ export class UsageInspector extends PassThrough {
             (item: any) => item.type === 'function_call'
           ).length;
         }
-        // Responses API doesn't have a direct finish_reason, use status instead
-        const finishReason = reconstructed.status === 'completed' ? 'stop' : reconstructed.status;
+        // Responses API doesn't have a direct finish_reason, use status instead.
+        // 'failed' maps to 'error' so failed/truncated streams are recorded as
+        // errors instead of leaking the raw Responses API status string.
+        // 'incomplete' maps from incomplete_details.reason: 'content_filter'
+        // stays 'content_filter', everything else (including
+        // 'max_output_tokens' and any unknown/absent reason) defaults to
+        // 'length', matching the OpenAI-compatible finish reason vocabulary.
+        const finishReason =
+          reconstructed.status === 'completed'
+            ? 'stop'
+            : reconstructed.status === 'failed'
+              ? 'error'
+              : reconstructed.status === 'incomplete'
+                ? reconstructed.incomplete_details?.reason === 'content_filter'
+                  ? 'content_filter'
+                  : 'length'
+                : reconstructed.status;
         return { toolCallsCount: toolCallsCount > 0 ? toolCallsCount : null, finishReason };
       }
       case 'messages': {

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -99,7 +99,12 @@ export class UsageInspector extends PassThrough {
   private providerDiscount?: number;
   private startTime: number;
   private shouldEstimateTokens: boolean;
-  private apiType: string;
+  /** API type of the UPSTREAM PROVIDER's raw response stream — keys how the
+   * raw-mode reconstruction is read (usage/metadata extraction dialect). */
+  private providerApiType: string;
+  /** API type the CLIENT is speaking (matches `request.incomingApiType`
+   * elsewhere) — keys input-token estimation over the original request and
+   * how the transformed-mode (client-facing) snapshot is read. */
   private incomingApiType: string;
   private originalRequest?: any;
   private firstChunk = true;
@@ -118,7 +123,7 @@ export class UsageInspector extends PassThrough {
     providerDiscount: number | undefined,
     startTime: number,
     shouldEstimateTokens: boolean = false,
-    apiType: string = 'chat',
+    providerApiType: string = 'chat',
     incomingApiType?: string,
     originalRequest?: any,
     gpuParams: GpuParams = DEFAULT_GPU_PARAMS,
@@ -133,8 +138,8 @@ export class UsageInspector extends PassThrough {
     this.providerDiscount = providerDiscount;
     this.startTime = startTime;
     this.shouldEstimateTokens = shouldEstimateTokens;
-    this.apiType = apiType;
-    this.incomingApiType = incomingApiType || apiType;
+    this.providerApiType = providerApiType;
+    this.incomingApiType = incomingApiType || providerApiType;
     this.originalRequest = originalRequest;
     this.gpuParams = gpuParams;
     this.modelParams = modelParams;
@@ -164,9 +169,9 @@ export class UsageInspector extends PassThrough {
     try {
       const debugManager = DebugManager.getInstance();
       const reconstructed = debugManager.getReconstructedRawResponse(this.usageRecord.requestId!);
+      const usage = this.readObservedUsage(debugManager, reconstructed);
 
-      if (reconstructed) {
-        const usage = extractUsageFromReconstructed(reconstructed, this.apiType);
+      if (reconstructed || usage) {
         if (usage) {
           stats.inputTokens = usage.inputTokens || 0;
           stats.outputTokens = usage.outputTokens || 0;
@@ -175,27 +180,44 @@ export class UsageInspector extends PassThrough {
           stats.reasoningTokens = usage.reasoningTokens || 0;
         }
 
-        // Extract response metadata (tool calls count and finish reason)
-        const responseMetadata = this.extractResponseMetadataFromReconstructed(
-          reconstructed,
-          this.apiType
-        );
-        this.usageRecord.toolCallsCount = responseMetadata.toolCallsCount;
-        this.usageRecord.finishReason = responseMetadata.finishReason;
+        if (reconstructed) {
+          // Extract response metadata (tool calls count and finish reason) —
+          // raw-mode only: the transformed snapshot never feeds metadata.
+          const responseMetadata = this.extractResponseMetadataFromReconstructed(
+            reconstructed,
+            this.providerApiType
+          );
+          this.usageRecord.toolCallsCount = responseMetadata.toolCallsCount;
+          this.usageRecord.finishReason = responseMetadata.finishReason;
 
-        if (this.shouldEstimateTokens) {
-          logger.debug(
-            `No usage data found for ${this.usageRecord.requestId}, attempting estimation`
-          );
-          const estimated = estimateTokensFromReconstructed(reconstructed, this.apiType);
-          stats.outputTokens = estimated.output;
-          stats.reasoningTokens = estimated.reasoning;
-          this.usageRecord.tokensEstimated = 1;
-          logger.debug(
-            `Estimated tokens for ${this.usageRecord.requestId}: ` +
-              `output=${stats.outputTokens}, reasoning=${stats.reasoningTokens}`
-          );
-          debugManager.discardEphemeral(this.usageRecord.requestId!);
+          if (this.shouldEstimateTokens) {
+            // Estimation is a FALLBACK for responses that carried no usage at
+            // all: it must never overwrite real usage extracted from the raw
+            // reconstruction or the transformed-snapshot fallback above (for
+            // a 'responses' provider the estimator has no dialect support
+            // and returns zeros — the overwrite would zero out real counts
+            // and corrupt costs/quota).
+            if (!usage) {
+              logger.debug(
+                `No usage data found for ${this.usageRecord.requestId}, attempting estimation`
+              );
+              const estimated = estimateTokensFromReconstructed(
+                reconstructed,
+                this.providerApiType
+              );
+              stats.outputTokens = estimated.output;
+              stats.reasoningTokens = estimated.reasoning;
+              this.usageRecord.tokensEstimated = 1;
+              logger.debug(
+                `Estimated tokens for ${this.usageRecord.requestId}: ` +
+                  `output=${stats.outputTokens}, reasoning=${stats.reasoningTokens}`
+              );
+            }
+            // The ephemeral capture was made solely for this estimation pass —
+            // discard it whether estimation ran or real usage won, so the
+            // marker doesn't leak past this request.
+            debugManager.discardEphemeral(this.usageRecord.requestId!);
+          }
         }
 
         if (this.originalRequest && stats.inputTokens === 0) {
@@ -353,15 +375,19 @@ export class UsageInspector extends PassThrough {
 
       const debugManager = DebugManager.getInstance();
       const reconstructed = debugManager.getReconstructedRawResponse(this.usageRecord.requestId!);
-      if (reconstructed) {
-        const usage = extractUsageFromReconstructed(reconstructed, this.apiType);
-        if (usage) {
-          this.usageRecord.tokensInput = usage.inputTokens || null;
-          this.usageRecord.tokensOutput = usage.outputTokens || null;
-          this.usageRecord.tokensCached = usage.cachedTokens || null;
-          this.usageRecord.tokensCacheWrite = usage.cacheWriteTokens || null;
-          this.usageRecord.tokensReasoning = usage.reasoningTokens || null;
-        }
+      // Same read-raw-then-fallback as _flush (readObservedUsage): a stream
+      // destroyed mid-flight can have usage only in the transformed-mode
+      // snapshot, and without the fallback the cancelled/timeout record
+      // would finalize with no tokens at all.
+      const usage = this.readObservedUsage(debugManager, reconstructed);
+      if (usage) {
+        this.usageRecord.tokensInput = usage.inputTokens || null;
+        this.usageRecord.tokensOutput = usage.outputTokens || null;
+        this.usageRecord.tokensCached = usage.cachedTokens || null;
+        this.usageRecord.tokensCacheWrite = usage.cacheWriteTokens || null;
+        this.usageRecord.tokensReasoning = usage.reasoningTokens || null;
+      }
+      if (reconstructed || usage) {
         calculateCosts(this.usageRecord, this.pricing, this.providerDiscount);
       }
 
@@ -378,6 +404,30 @@ export class UsageInspector extends PassThrough {
     }
 
     callback(err);
+  }
+
+  /**
+   * Reads observed usage for this request, shared by BOTH finalization paths
+   * (_flush for streams that end normally, _destroy for cancelled/timed-out
+   * streams). The raw-mode reconstruction is AUTHORITATIVE for usage. Only
+   * when it yields no usage at all (no reconstruction, or a reconstruction
+   * without a usage block) fall back to the transformed-mode snapshot — the
+   * client-facing stream reconstruction the transformed DebugLoggingInspector
+   * writes — mirroring the raw extraction per api type (the transformed
+   * snapshot is keyed by the CLIENT api type).
+   */
+  private readObservedUsage(
+    debugManager: DebugManager,
+    reconstructed: any
+  ): ExtractedObservedUsage | null {
+    let usage = extractUsageFromReconstructed(reconstructed, this.providerApiType);
+    if (!usage) {
+      const transformedSnapshot = debugManager.getPendingLog(
+        this.usageRecord.requestId!
+      )?.transformedResponseSnapshot;
+      usage = extractUsageFromReconstructed(transformedSnapshot, this.incomingApiType);
+    }
+    return usage;
   }
 
   private extractResponseMetadataFromReconstructed(

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -22,6 +22,11 @@ import { CooldownManager } from '../runtime/cooldown-manager';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
 import { getApiBaseType } from '../../utils/api-format';
 import { rewriteGeminiMalformedFunctionCallStream } from '../../utils/gemini-malformed-function-call';
+import {
+  createStreamVisibilityTracker,
+  isStreamEmpty,
+  observeStreamChunk,
+} from '../dispatch/empty-completion';
 
 function getHeaderValue(request: FastifyRequest, headerName: string): string | undefined {
   const value = request.headers?.[headerName];
@@ -262,7 +267,11 @@ export async function handleResponse(
 
     if (unifiedResponse.bypassTransformation) {
       // Direct pass-through, except for retryable reclassification of Gemini's
-      // MALFORMED_FUNCTION_CALL terminal frame.
+      // MALFORMED_FUNCTION_CALL terminal frame. T5 empty-completion detection
+      // (below) does not run on this path: bypass mode never produces unified
+      // chunk objects to inspect (the client receives raw provider bytes
+      // verbatim), and re-parsing every provider's raw SSE format just to
+      // detect emptiness is out of scope here.
       finalClientStream = rawStream;
     } else {
       /**
@@ -278,10 +287,64 @@ export async function handleResponse(
         ? providerTransformer.transformStream(rawStream)
         : rawStream;
 
+      // T5: empty-completion observability. Streaming can't fail over —
+      // headers are already sent by the time we'd know the completion was
+      // empty — so this is log/metadata only: tap the UNIFIED chunk stream
+      // (the actual UnifiedChatStreamChunk objects `formatStream` is about to
+      // consume, not client-encoded bytes) and count content/tool-call/
+      // reasoning presence as chunks pass through. Only counts are kept
+      // (see empty-completion.ts) — the delta text itself is never buffered,
+      // so this can't be (and isn't meant to be) used to retry/replay the
+      // response; buffering the full stream purely to support a retry is
+      // explicitly out of scope for T5.
+      //
+      // Only attached when transformStream() actually produced unified chunk
+      // objects (the same condition step 1 above already branches on) —
+      // otherwise `unifiedStream === rawStream` (raw bytes) and there is
+      // nothing chunk-shaped to inspect.
+      const visibilityTracker = createStreamVisibilityTracker();
+      const observedUnifiedStream = providerTransformer.transformStream
+        ? unifiedStream.pipeThrough(
+            new TransformStream({
+              transform(chunk, controller) {
+                observeStreamChunk(visibilityTracker, chunk);
+                // A unified error chunk (response.failed/response.incomplete/
+                // a mid-stream provider error — however transformStream
+                // renders it) means the completion did not finish cleanly.
+                // Mark the usage record accordingly (once) so it's never
+                // reported as a plain success, nor — via the flush's
+                // empty-downgrade below, which only ever upgrades a
+                // 'success' into 'empty' — silently reclassified as merely
+                // "empty" once the stream ends.
+                if (chunk?.event === 'error' && usageRecord.responseStatus !== 'error') {
+                  usageRecord.responseStatus = 'error';
+                }
+                controller.enqueue(chunk);
+              },
+              flush() {
+                // Only ever downgrade a plain 'success' into 'empty' — never
+                // clobber a more specific status (e.g. 'error', set above
+                // when a unified error chunk passed through, or 'error' from
+                // the Gemini MALFORMED_FUNCTION_CALL tap above) that may have
+                // already been set while this stream was flowing.
+                if (isStreamEmpty(visibilityTracker) && usageRecord.responseStatus === 'success') {
+                  usageRecord.responseStatus = 'empty';
+                  logger.warn(
+                    `Empty completion (no visible output) streamed to client for ` +
+                      `${usageRecord.provider ?? 'unknown'}/${usageRecord.selectedModelName ?? 'unknown'} ` +
+                      `(alias=${usageRecord.canonicalModelName ?? usageRecord.incomingModelAlias ?? 'n/a'}, ` +
+                      `requestId=${usageRecord.requestId})`
+                  );
+                }
+              },
+            })
+          )
+        : unifiedStream;
+
       // Step 2: Unified internal objects -> Client SSE format
       finalClientStream = clientTransformer.formatStream
-        ? clientTransformer.formatStream(unifiedStream)
-        : unifiedStream;
+        ? clientTransformer.formatStream(observedUnifiedStream)
+        : observedUnifiedStream;
     }
 
     // TAP THE TRANSFORMED STREAM for debugging

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -309,15 +309,27 @@ export async function handleResponse(
             new TransformStream({
               transform(chunk, controller) {
                 observeStreamChunk(visibilityTracker, chunk);
-                // A unified error chunk (response.failed/response.incomplete/
-                // a mid-stream provider error — however transformStream
-                // renders it) means the completion did not finish cleanly.
-                // Mark the usage record accordingly (once) so it's never
-                // reported as a plain success, nor — via the flush's
-                // empty-downgrade below, which only ever upgrades a
+                // A unified error chunk WITHOUT a finish_reason
+                // (response.failed / a mid-stream provider error — however
+                // transformStream renders it) means the completion did not
+                // finish cleanly. Mark the usage record accordingly (once)
+                // so it's never reported as a plain success, nor — via the
+                // flush's empty-downgrade below, which only ever upgrades a
                 // 'success' into 'empty' — silently reclassified as merely
-                // "empty" once the stream ends.
-                if (chunk?.event === 'error' && usageRecord.responseStatus !== 'error') {
+                // "empty" once the stream ends. Error chunks that DO carry
+                // a finish_reason are "ended incomplete" outcomes
+                // (response.incomplete → 'length'/'content_filter'): they
+                // ride the unified error channel for routing but are
+                // rendered as a normal finish for chat clients (and as
+                // response.incomplete for Responses clients) — a
+                // successful-if-truncated turn, not an error — so they keep
+                // 'success' (or, when the truncation left zero visible
+                // output, the flush's 'empty' downgrade below).
+                if (
+                  chunk?.event === 'error' &&
+                  !chunk.finish_reason &&
+                  usageRecord.responseStatus !== 'error'
+                ) {
                   usageRecord.responseStatus = 'error';
                 }
                 controller.enqueue(chunk);

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -221,10 +221,11 @@ export async function handleResponse(
     // TAP THE RAW STREAM for debugging/usage extraction
     // We always capture the stream BEFORE any transformation to enable usage extraction,
     // even with pass-through optimization. Debug mode only controls DB persistence.
-    const rawLogInspector = new DebugLoggingInspector(
-      usageRecord.requestId!,
-      'raw'
-    ).createInspector(providerApiType);
+    // The DebugLoggingInspector INSTANCE is kept (not just its tap stream):
+    // the cancellation teardown below must finalize() the capture explicitly,
+    // because a cancelled pipeline never runs the tap's flush.
+    const rawDebugLogging = new DebugLoggingInspector(usageRecord.requestId!, 'raw');
+    const rawLogInspector = rawDebugLogging.createInspector(providerApiType);
 
     const tapStream = new TransformStream({
       transform(chunk, controller) {
@@ -349,10 +350,11 @@ export async function handleResponse(
 
     // TAP THE TRANSFORMED STREAM for debugging
     // This captures what is actually sent to the client
-    const transformedLogInspector = new DebugLoggingInspector(
+    const transformedDebugLogging = new DebugLoggingInspector(
       usageRecord.requestId!,
       'transformed'
-    ).createInspector(apiType);
+    );
+    const transformedLogInspector = transformedDebugLogging.createInspector(apiType);
 
     const transformedTapStream = new TransformStream({
       transform(chunk, controller) {
@@ -542,6 +544,17 @@ export async function handleResponse(
       } else if (isTimeout) {
         usageRecord.responseStatus = 'timeout';
       }
+      // Flush both debug captures BEFORE tearing the pipeline down: a
+      // cancelled web TransformStream never runs its flush(), so the
+      // raw/transformed taps' 'end' handlers never fire on a real
+      // disconnect/timeout/stall — without this, the snapshots would never
+      // be written and UsageInspector._destroy's usage fallback would find
+      // nothing (cancelled/timeout records finalized with zero tokens).
+      // finalize() is synchronous and idempotent (a later natural 'end' is a
+      // no-op), and it must run before pipeline.destroy(), which invokes
+      // UsageInspector._destroy synchronously.
+      rawDebugLogging.finalize();
+      transformedDebugLogging.finalize();
       // Destroy without passing the error — calling .destroy(err) causes Node.js to
       // emit 'error' on the stream, which becomes an uncaught exception since
       // these streams don't have error listeners. The cancellation still works:

--- a/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, describe } from 'vitest';
 import { AnthropicTransformer } from '../anthropic';
 import { transformAnthropicStream } from '../anthropic/stream-transformer';
+import { OpenAITransformer } from '../openai';
 import { UnifiedChatStreamChunk } from '../../types/unified';
 
 describe('AnthropicTransformer Stream Formatting', () => {
@@ -622,5 +623,125 @@ describe('transformAnthropicStream tool call index remapping', () => {
     expect(output).toContain('event: error');
     expect(output).toContain('please retry your request');
     expect(output).not.toContain('event: message_stop');
+  });
+
+  test('maps an Anthropic error event to a unified error chunk', async () => {
+    const sseEvents = [
+      {
+        event: 'message_start',
+        data: {
+          type: 'message_start',
+          message: {
+            id: 'msg_err',
+            model: 'claude-sonnet-4-6',
+            role: 'assistant',
+            content: [],
+            usage: { input_tokens: 10, output_tokens: 0 },
+          },
+        },
+      },
+      {
+        event: 'error',
+        data: {
+          type: 'error',
+          error: { type: 'overloaded_error', message: 'Overloaded: please retry later.' },
+        },
+      },
+    ];
+
+    const rawStream = makeAnthropicSSE(sseEvents);
+    const unifiedStream = transformAnthropicStream(rawStream);
+    const chunks = await drainUnifiedStream(unifiedStream);
+
+    const errorChunk = chunks.find((c) => c.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.message).toBe('Overloaded: please retry later.');
+    expect(errorChunk.error.code).toBe('overloaded_error');
+    expect(errorChunk.id).toBe('msg_err');
+    expect(errorChunk.model).toBe('claude-sonnet-4-6');
+  });
+
+  test('OpenAI client sees the Anthropic error chunk and terminates cleanly with [DONE]', async () => {
+    const sseEvents = [
+      {
+        event: 'message_start',
+        data: {
+          type: 'message_start',
+          message: { id: 'msg_err2', model: 'claude-sonnet-4-6', role: 'assistant', content: [] },
+        },
+      },
+      {
+        event: 'error',
+        data: { type: 'error', error: { type: 'api_error', message: 'Internal server error.' } },
+      },
+    ];
+
+    const rawStream = makeAnthropicSSE(sseEvents);
+    const unifiedStream = transformAnthropicStream(rawStream);
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+
+    const reader = formatted.getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+
+    const dataLines = output
+      .split('\n\n')
+      .filter(Boolean)
+      .map((block) => block.replace(/^data:\s*/, ''));
+
+    const errorLine = dataLines.find((line) => line !== '[DONE]' && JSON.parse(line).error);
+    expect(errorLine).toBeDefined();
+    const errorPayload = JSON.parse(errorLine as string);
+    expect(errorPayload.error.message).toBe('Internal server error.');
+    // Propagates Anthropic's own error type as the code — not Gemini's
+    // hardcoded legacy `upstream_malformed_function_call` sentinel.
+    expect(errorPayload.error.code).toBe('api_error');
+    expect(output.trim().endsWith('data: [DONE]')).toBe(true);
+  });
+
+  test('OpenAI client still gets a final finish_reason chunk when the stream ends after message_start with no message_delta', async () => {
+    const sseEvents = [
+      {
+        event: 'message_start',
+        data: {
+          type: 'message_start',
+          message: {
+            id: 'msg_abrupt',
+            model: 'claude-sonnet-4-6',
+            role: 'assistant',
+            content: [],
+          },
+        },
+      },
+    ];
+
+    const rawStream = makeAnthropicSSE(sseEvents);
+    const unifiedStream = transformAnthropicStream(rawStream);
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+
+    const reader = formatted.getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+
+    const dataLines = output
+      .split('\n\n')
+      .filter(Boolean)
+      .map((block) => block.replace(/^data:\s*/, ''));
+
+    const finishLine = dataLines.find(
+      (line) => line !== '[DONE]' && JSON.parse(line).choices?.[0]?.finish_reason === 'stop'
+    );
+    expect(finishLine).toBeDefined();
+    expect(dataLines.at(-1)).toBe('[DONE]');
   });
 });

--- a/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, describe } from 'vitest';
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
 import { AnthropicTransformer } from '../anthropic';
 import { transformAnthropicStream } from '../anthropic/stream-transformer';
 import { OpenAITransformer } from '../openai';
@@ -611,18 +612,37 @@ describe('transformAnthropicStream tool call index remapping', () => {
       },
     });
 
+    // Parse the SSE frames structurally (same approach as
+    // openai-stream.test.ts's readOpenAISSEChunks) and assert on the parsed
+    // error object instead of raw-output substrings.
     const reader = transformer.formatStream(stream).getReader();
     const decoder = new TextDecoder();
-    let output = '';
+    const events: { event: string | undefined; data: any }[] = [];
+    const parser = createParser({
+      onEvent(event: EventSourceMessage) {
+        events.push({ event: event.event, data: JSON.parse(event.data) });
+      },
+    });
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-      output += decoder.decode(value);
+      parser.feed(decoder.decode(value, { stream: true }));
     }
 
-    expect(output).toContain('event: error');
-    expect(output).toContain('please retry your request');
-    expect(output).not.toContain('event: message_stop');
+    const errorEvents = events.filter((e) => e.event === 'error');
+    expect(errorEvents).toHaveLength(1);
+    // Full parsed Anthropic error payload: `error.type` is the wire "code"
+    // and `error.message` carries the upstream message verbatim.
+    expect(errorEvents[0]?.data).toEqual({
+      type: 'error',
+      error: {
+        type: 'api_error',
+        message:
+          'Upstream Gemini returned MALFORMED_FUNCTION_CALL — please retry your request. [503]',
+      },
+    });
+    // The terminal error must not be followed by a normal stop.
+    expect(events.some((e) => e.event === 'message_stop')).toBe(false);
   });
 
   test('maps an Anthropic error event to a unified error chunk', async () => {

--- a/packages/backend/src/transformers/__tests__/image-content-composition.test.ts
+++ b/packages/backend/src/transformers/__tests__/image-content-composition.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'vitest';
+import { composeContentWithImageMarkdown } from '../image-rendering';
+import { OpenAITransformer } from '../openai';
+import { AnthropicTransformer } from '../anthropic';
+import { GeminiTransformer } from '../gemini';
+import { OllamaTransformer } from '../ollama';
+import { OpenAICompletionTransformer } from '../completions';
+import type { UnifiedChatResponse } from '../../types/unified';
+
+// Consumer audit for the pure-content split: unified `content` carries ONLY
+// authored text, and every CHAT-FORMAT unary formatter (chat, anthropic
+// messages, gemini, ollama, legacy completions) composes the size-guarded
+// image markdown itself from the typed `image_generation_calls` carry — the
+// exact client-visible bytes the pre-split design baked into unified content.
+// The responses-facing formatter is the one format that must NOT compose
+// (native re-emit instead) — covered in responses-stream.test.ts.
+
+const TINY_IMAGE_B64 = 'aGVsbG8=';
+const TINY_IMAGE_MARKDOWN = `![generated image](data:image/png;base64,${TINY_IMAGE_B64})`;
+
+function unifiedWithImage(content: string | null): UnifiedChatResponse {
+  return {
+    id: 'resp_compose',
+    model: 'image-model',
+    created: 1234567890,
+    content,
+    image_generation_calls: [{ id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 }],
+    usage: {
+      input_tokens: 5,
+      output_tokens: 1,
+      total_tokens: 6,
+      reasoning_tokens: 0,
+      cached_tokens: 0,
+      cache_creation_tokens: 0,
+    },
+  };
+}
+
+describe('composeContentWithImageMarkdown (shared helper)', () => {
+  test('appends one markdown segment per typed item after the authored text, joined with \\n', () => {
+    const composed = composeContentWithImageMarkdown('Here you go:', [
+      { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      { id: 'ig_2', status: 'completed', result: TINY_IMAGE_B64 },
+    ]);
+    expect(composed).toBe(`Here you go:\n${TINY_IMAGE_MARKDOWN}\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('null/empty content with images renders the markdown alone', () => {
+    expect(composeContentWithImageMarkdown(null, [{ id: 'ig_1', result: TINY_IMAGE_B64 }])).toBe(
+      TINY_IMAGE_MARKDOWN
+    );
+    expect(composeContentWithImageMarkdown('', [{ id: 'ig_1', result: TINY_IMAGE_B64 }])).toBe(
+      TINY_IMAGE_MARKDOWN
+    );
+  });
+
+  test('no images (undefined, empty array, or result-less entries) returns content UNCHANGED', () => {
+    expect(composeContentWithImageMarkdown('text', undefined)).toBe('text');
+    expect(composeContentWithImageMarkdown('text', [])).toBe('text');
+    expect(composeContentWithImageMarkdown('text', [{ result: '' } as any])).toBe('text');
+    // Byte-transparency for image-less responses: null stays null, empty
+    // string stays empty string, undefined stays undefined — no coercion.
+    expect(composeContentWithImageMarkdown(null, undefined)).toBeNull();
+    expect(composeContentWithImageMarkdown('', undefined)).toBe('');
+    expect(composeContentWithImageMarkdown(undefined, undefined)).toBeUndefined();
+  });
+
+  test('an oversized result composes the omission placeholder, never the base64', () => {
+    const oversized = 'B'.repeat(2 * 8 * 1024 * 1024);
+    const composed = composeContentWithImageMarkdown('note', [{ id: 'ig_big', result: oversized }]);
+    expect(composed).toBe('note\n[generated image omitted: 12.0 MB exceeds inline limit]');
+  });
+});
+
+describe('every chat-format unary formatter composes image markdown from the typed carry', () => {
+  test('chat (OpenAITransformer.formatResponse)', async () => {
+    const formatted = await new OpenAITransformer().formatResponse(unifiedWithImage('Here:'));
+    expect(formatted.choices[0].message.content).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('anthropic messages (AnthropicTransformer.formatResponse)', async () => {
+    const formatted = await new AnthropicTransformer().formatResponse(unifiedWithImage('Here:'));
+    const textBlocks = formatted.content.filter((block: any) => block.type === 'text');
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0].text).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('anthropic messages renders a text block even for an image-only response', async () => {
+    const formatted = await new AnthropicTransformer().formatResponse(unifiedWithImage(null));
+    const textBlocks = formatted.content.filter((block: any) => block.type === 'text');
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0].text).toBe(TINY_IMAGE_MARKDOWN);
+  });
+
+  test('gemini (GeminiTransformer.formatResponse)', async () => {
+    const formatted = await new GeminiTransformer().formatResponse(unifiedWithImage('Here:'));
+    const textParts = formatted.candidates[0].content.parts.filter(
+      (part: any) => typeof part.text === 'string' && !part.thought
+    );
+    expect(textParts).toHaveLength(1);
+    expect(textParts[0].text).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('ollama (OllamaTransformer.formatResponse)', async () => {
+    const formatted = await new OllamaTransformer().formatResponse(unifiedWithImage('Here:'));
+    expect(formatted.choices[0].message.content).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('legacy completions (OpenAICompletionTransformer.formatResponse)', async () => {
+    const formatted = await new OpenAICompletionTransformer().formatResponse(
+      unifiedWithImage('Here:')
+    );
+    expect(formatted.choices[0].text).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('image-less responses stay byte-identical through the chat formatter (null content passthrough)', async () => {
+    const formatted = await new OpenAITransformer().formatResponse({
+      id: 'resp_plain',
+      model: 'text-model',
+      content: null,
+    } as UnifiedChatResponse);
+    expect(formatted.choices[0].message.content).toBeNull();
+  });
+});

--- a/packages/backend/src/transformers/__tests__/openai-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/openai-stream.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, test } from 'vitest';
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
+import { OpenAITransformer } from '../openai';
+import { GEMINI_MALFORMED_FUNCTION_CALL_CODE } from '../../utils/gemini-malformed-function-call';
+
+function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+async function readOpenAISSEChunks(stream: ReadableStream<Uint8Array>): Promise<any[]> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const chunks: any[] = [];
+
+  const parser = createParser({
+    onEvent(event: EventSourceMessage) {
+      if (event.data === '[DONE]') {
+        chunks.push('[DONE]');
+        return;
+      }
+      chunks.push(JSON.parse(event.data));
+    },
+  });
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parser.feed(decoder.decode(value, { stream: true }));
+  }
+
+  return chunks;
+}
+
+describe('OpenAITransformer.formatStream robustness', () => {
+  test('emits a synthesized stop finish chunk before [DONE] when the source ends with no finish_reason', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_1',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'Hi' },
+        finish_reason: null,
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    expect(chunks.at(-1)).toBe('[DONE]');
+
+    const finishChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason);
+    expect(finishChunks).toHaveLength(1);
+    expect(finishChunks[0].choices[0].finish_reason).toBe('stop');
+    expect(finishChunks[0].choices[0].delta).toEqual({});
+  });
+
+  test('does not synthesize an extra finish chunk when one already arrived', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_2',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { content: 'Hi' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_2',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: {},
+        finish_reason: 'stop',
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const finishChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason);
+    expect(finishChunks).toHaveLength(1);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('renders a unified error chunk carrying a recognizable finish_reason (length) as a normal finish, not an error payload', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_3',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_3',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'length',
+        error: {
+          statusCode: 500,
+          code: 'max_output_tokens',
+          message: 'Response ended incomplete: max_output_tokens',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeUndefined();
+
+    const finishChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'length'
+    );
+    expect(finishChunk).toBeDefined();
+    expect(finishChunk.choices[0].delta).toEqual({});
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('renders a hard unified error chunk (no finish_reason) as an error payload and still terminates with [DONE]', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_4',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_4',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 500,
+          code: 'response_failed',
+          message: 'The model response failed.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.message).toBe('The model response failed.');
+    expect(errorChunk.error.type).toBe('server_error');
+    // The rendered code must be the real upstream code, not Gemini's
+    // hardcoded legacy sentinel (see the MALFORMED_FUNCTION_CALL test below).
+    expect(errorChunk.error.code).toBe('response_failed');
+    expect(chunks.at(-1)).toBe('[DONE]');
+
+    // Never emit two finish/terminal chunks.
+    const terminalChunks = chunks.filter(
+      (c) => c !== '[DONE]' && (c.error || c.choices?.[0]?.finish_reason)
+    );
+    expect(terminalChunks).toHaveLength(1);
+  });
+
+  test('falls back to a neutral generic error code when the upstream error carries none', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_4b',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 500,
+          message: 'Something went wrong upstream with no code attached.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.code).toBe('upstream_error');
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('preserves existing behavior: MALFORMED_FUNCTION_CALL errors keep their exact code and still suppress [DONE]', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_5',
+        model: 'gemini-3.6-flash',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 503,
+          code: GEMINI_MALFORMED_FUNCTION_CALL_CODE,
+          message: 'Upstream Gemini returned MALFORMED_FUNCTION_CALL — please retry your request.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    expect(chunks).not.toContain('[DONE]');
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    // Unchanged legacy rendering — NOT the raw `MALFORMED_FUNCTION_CALL` code.
+    expect(errorChunk.error.code).toBe('upstream_malformed_function_call');
+  });
+
+  test('closes the door after an error-channel length finish: a stray chunk afterward produces no second terminal payload', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_6',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_6',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'length',
+        error: {
+          statusCode: 500,
+          code: 'max_output_tokens',
+          message: 'Response ended incomplete: max_output_tokens',
+        },
+      },
+      // Stray/duplicate chunk arriving after the terminal signal (e.g. a
+      // late or duplicated upstream error) must never reach the client.
+      {
+        id: 'chatcmpl_6',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 500,
+          code: 'response_failed',
+          message: 'This must never reach the client.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const terminalChunks = chunks.filter(
+      (c) => c !== '[DONE]' && (c.error || c.choices?.[0]?.finish_reason)
+    );
+    expect(terminalChunks).toHaveLength(1);
+    expect(terminalChunks[0].choices?.[0]?.finish_reason).toBe('length');
+    expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
+
+    const doneCount = chunks.filter((c) => c === '[DONE]').length;
+    expect(doneCount).toBe(1);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('round-trips a raw stream_options.include_usage fixture: content, one finish, one usage, one [DONE]', async () => {
+    // Mirrors the real OpenAI-compatible wire shape Plexus itself requests
+    // for Copilot-native streaming (services/oauth/oauth-native-request.ts
+    // `adornCopilotBody`): a trailing `{choices: [], usage: {...}}` frame
+    // arrives AFTER the real finish chunk.
+    const rawSSE = [
+      JSON.stringify({
+        id: 'chatcmpl-abc',
+        model: 'gpt-4o',
+        created: 1234567890,
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'Hi' }, finish_reason: null }],
+      }),
+      JSON.stringify({
+        id: 'chatcmpl-abc',
+        model: 'gpt-4o',
+        created: 1234567890,
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      }),
+      JSON.stringify({
+        id: 'chatcmpl-abc',
+        model: 'gpt-4o',
+        created: 1234567890,
+        choices: [],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }),
+    ];
+
+    const rawStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const line of rawSSE) {
+          controller.enqueue(encoder.encode(`data: ${line}\n\n`));
+        }
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.close();
+      },
+    });
+
+    const transformer = new OpenAITransformer();
+    const unifiedStream = transformer.transformStream(rawStream);
+    const formatted = transformer.formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const contentChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.delta?.content === 'Hi'
+    );
+    expect(contentChunk).toBeDefined();
+
+    const finishChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason);
+    expect(finishChunks).toHaveLength(1);
+    expect(finishChunks[0].choices[0].finish_reason).toBe('stop');
+
+    const usageChunks = chunks.filter((c) => c !== '[DONE]' && c.usage);
+    expect(usageChunks).toHaveLength(1);
+    expect(usageChunks[0].choices).toEqual([]);
+    expect(usageChunks[0].usage.total_tokens).toBe(15);
+
+    expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
+    expect(chunks.filter((c) => c === '[DONE]')).toHaveLength(1);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('propagates usage on a recognizable finish (error-channel, e.g. Responses incomplete/content_filter)', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_cf',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_cf',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'content_filter',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+          reasoning_tokens: 0,
+          cached_tokens: 0,
+          cache_creation_tokens: 0,
+        },
+        error: {
+          statusCode: 500,
+          code: 'content_filter',
+          message: 'Response ended incomplete: content_filter',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const finishChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'content_filter'
+    );
+    expect(finishChunk).toBeDefined();
+    expect(finishChunk.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+      prompt_tokens_details: null,
+      reasoning_tokens: 0,
+    });
+  });
+
+  test('propagates usage on a hard error chunk (e.g. Responses response.failed)', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_failusage',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_failusage',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        usage: {
+          input_tokens: 20,
+          output_tokens: 8,
+          total_tokens: 28,
+          reasoning_tokens: 0,
+          cached_tokens: 0,
+          cache_creation_tokens: 0,
+        },
+        error: {
+          statusCode: 500,
+          code: 'response_failed',
+          message: 'The model response failed.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage.total_tokens).toBe(28);
+  });
+
+  test('does not add a usage field to a hard error chunk when the unified chunk carries none', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_nousage',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: { statusCode: 500, code: 'response_failed', message: 'The model response failed.' },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage).toBeUndefined();
+  });
+
+  test('a Gemini trailing done-marker chunk after a normal finish is dropped harmlessly (no crash, no extra terminal payload)', async () => {
+    // Gemini's transformStream always emits a `{event: 'done', delta: {}}`
+    // marker chunk when it sees the raw `[DONE]` sentinel, even after a
+    // normal finish. It carries no usage, so it must NOT hit the new
+    // trailing-usage-passthrough lane — it should simply be dropped, exactly
+    // as it already was.
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_7',
+        model: 'gemini-3.1-flash',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'Hi' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_7',
+        model: 'gemini-3.1-flash',
+        created: 1234567890,
+        delta: {},
+        finish_reason: 'stop',
+      },
+      {
+        id: '',
+        model: '',
+        created: 1234567890,
+        event: 'done',
+        delta: {},
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const finishChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason);
+    expect(finishChunks).toHaveLength(1);
+    expect(chunks.some((c) => c !== '[DONE]' && c.usage)).toBe(false);
+    expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
+    expect(chunks.filter((c) => c === '[DONE]')).toHaveLength(1);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+});

--- a/packages/backend/src/transformers/__tests__/openai-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/openai-stream.test.ts
@@ -57,6 +57,29 @@ describe('OpenAITransformer.formatStream robustness', () => {
     expect(finishChunks).toHaveLength(1);
     expect(finishChunks[0].choices[0].finish_reason).toBe('stop');
     expect(finishChunks[0].choices[0].delta).toEqual({});
+    // The flushed stop chunk echoes the id/model seen on the stream.
+    expect(finishChunks[0].id).toBe('chatcmpl_1');
+    expect(finishChunks[0].model).toBe('gpt-4o');
+  });
+
+  test('synthesizes an id on the flushed stop chunk when ZERO chunks arrived', async () => {
+    const formatted = new OpenAITransformer().formatStream(unifiedStreamFromChunks([]));
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    expect(chunks.at(-1)).toBe('[DONE]');
+    const payloadChunks = chunks.filter((c) => c !== '[DONE]');
+    expect(payloadChunks).toHaveLength(1);
+
+    const stopChunk = payloadChunks[0];
+    expect(stopChunk.object).toBe('chat.completion.chunk');
+    expect(stopChunk.choices).toEqual([{ index: 0, delta: {}, finish_reason: 'stop' }]);
+    // No upstream id ever arrived — one must be synthesized so the stop
+    // chunk is still a well-formed chat.completion.chunk.
+    expect(stopChunk.id).toMatch(/^chatcmpl_/);
+    // formatStream's only input is the unified chunk stream itself (the
+    // formatter has no request context); with zero chunks no model is
+    // reachable, so none is fabricated.
+    expect(stopChunk).not.toHaveProperty('model');
   });
 
   test('does not synthesize an extra finish chunk when one already arrived', async () => {
@@ -476,5 +499,42 @@ describe('OpenAITransformer.formatStream robustness', () => {
     expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
     expect(chunks.filter((c) => c === '[DONE]')).toHaveLength(1);
     expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('a unified chunk carrying typed image_generation_calls renders ONLY the markdown content into chat SSE', async () => {
+    // responses.ts transformStream pairs each completed image item's typed
+    // carry (chunk-level `image_generation_calls`, full base64) with its
+    // chat-format markdown rendering on `delta.content`. A chat-format
+    // client must receive exactly the markdown — the typed field (which can
+    // hold multi-megabyte, uncapped base64) must never leak into the chat
+    // wire chunk.
+    const markdown = '![generated image](data:image/png;base64,aGVsbG8=)';
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_img',
+        model: 'gpt-image-model',
+        created: 1234567890,
+        delta: { content: markdown },
+        image_generation_calls: [{ id: 'ig_1', status: 'completed', result: 'aGVsbG8=' }],
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_img',
+        model: 'gpt-image-model',
+        created: 1234567890,
+        delta: {},
+        finish_reason: 'stop',
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const contentChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.delta?.content);
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].choices[0].delta.content).toBe(markdown);
+    expect(
+      chunks.some((c) => c !== '[DONE]' && JSON.stringify(c).includes('image_generation_calls'))
+    ).toBe(false);
   });
 });

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -206,6 +206,37 @@ describe('Responses responses -> responses round-trip preserves native fields', 
     expect(built.safety_identifier).toBe('si-1');
   });
 
+  it('does not inject a default temperature when the client omits it', async () => {
+    const transformer = new ResponsesTransformer();
+    const { temperature, ...requestWithoutTemperature } = RESPONSES_REQUEST;
+
+    const unified = await transformer.parseRequest(requestWithoutTemperature);
+    expect(unified.temperature).toBeUndefined();
+
+    const built = await transformer.transformRequest({
+      ...unified,
+      incomingApiType: 'responses',
+      originalBody: requestWithoutTemperature,
+    });
+
+    expect(built.temperature).toBeUndefined();
+    expect(built).not.toHaveProperty('temperature');
+  });
+
+  it('still forwards an explicit temperature the client sent', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+    expect(unified.temperature).toBe(0.7);
+
+    const built = await transformer.transformRequest({
+      ...unified,
+      incomingApiType: 'responses',
+      originalBody: RESPONSES_REQUEST,
+    });
+
+    expect(built.temperature).toBe(0.7);
+  });
+
   it('preserves sampling params top_p, top_logprobs, max_tool_calls', async () => {
     const transformer = new ResponsesTransformer();
     const unified = await transformer.parseRequest(RESPONSES_REQUEST);

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeCompositeResponsesCallIds,
   normalizeResponsesReasoningContent,
 } from '../responses';
+import { OpenAITransformer } from '../openai';
 
 /**
  * Round-trip tests for the Responses API transformer.
@@ -212,6 +213,11 @@ describe('Responses responses -> responses round-trip preserves native fields', 
 
     const unified = await transformer.parseRequest(requestWithoutTemperature);
     expect(unified.temperature).toBeUndefined();
+    // Stronger than undefined: the unified request must carry NO own
+    // `temperature` property at all. A phantom `temperature: undefined` own
+    // property survives object spreads and flips `'temperature' in x` /
+    // hasOwnProperty checks downstream even though JSON would drop it.
+    expect('temperature' in unified).toBe(false);
 
     const built = await transformer.transformRequest({
       ...unified,
@@ -280,5 +286,232 @@ describe('Responses responses -> responses round-trip preserves native fields', 
     expect(built.store).toBeUndefined();
     expect(built.service_tier).toBeUndefined();
     expect(built.stream_options).toBeUndefined();
+  });
+});
+
+describe('parseRequest conditional-spread hygiene (omitted fields leave no own property)', () => {
+  // Same rationale as the temperature test above: a phantom
+  // `field: undefined` own property survives object spreads and flips
+  // `'field' in x` / hasOwnProperty checks downstream even though JSON
+  // serialization would drop it.
+  const MINIMAL_REQUEST = {
+    model: 'gpt-4o',
+    input: [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Hello' }],
+      },
+    ],
+  };
+
+  it('omitted optional client fields leave NO own property on the unified request', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(MINIMAL_REQUEST);
+
+    for (const field of [
+      'requestId',
+      'max_tokens',
+      'temperature',
+      'stream',
+      'reasoning',
+      'include',
+      'prompt_cache_key',
+      'text',
+      'parallel_tool_calls',
+      'metadata',
+      'tools',
+      'response_format',
+    ]) {
+      expect(field in unified, `'${field}' in unified must be false when omitted`).toBe(false);
+    }
+  });
+
+  it('present tools still forward through the computed conversion (lock one example)', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({
+      ...MINIMAL_REQUEST,
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the weather',
+          parameters: { type: 'object', properties: { city: { type: 'string' } } },
+        },
+      ],
+    });
+
+    expect('tools' in unified).toBe(true);
+    expect(unified.tools).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'get_weather',
+          description: 'Get the weather',
+          parameters: { type: 'object', properties: { city: { type: 'string' } } },
+        },
+      },
+    ]);
+  });
+
+  it('a present text.format still forwards as response_format (lock one example)', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({
+      ...MINIMAL_REQUEST,
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'result',
+          schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+        },
+      },
+    });
+
+    expect('response_format' in unified).toBe(true);
+    expect(unified.response_format).toEqual({
+      type: 'json_schema',
+      json_schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+      name: 'result',
+    });
+  });
+
+  it('an explicit stream:false still forwards as a real own property', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({ ...MINIMAL_REQUEST, stream: false });
+
+    expect('stream' in unified).toBe(true);
+    expect(unified.stream).toBe(false);
+  });
+
+  describe('structured-output descriptor carry (text.format name/description/strict)', () => {
+    // The Responses `text.format` structured-output descriptor is more than
+    // the schema: clients also send `name`, `description`, and `strict`.
+    // Discarding them forces the responses -> chat emission to fabricate
+    // `name: "response_schema"` / `strict: true`, silently overriding what
+    // the client asked for (e.g. strict: false).
+    const DESCRIPTOR_REQUEST = {
+      ...MINIMAL_REQUEST,
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'weather_report',
+          description: 'A structured weather report',
+          strict: false,
+          schema: { type: 'object', properties: { temp: { type: 'number' } } },
+        },
+      },
+    };
+
+    it('parseRequest carries name/description/strict on the unified response_format', async () => {
+      const unified = await new ResponsesTransformer().parseRequest(DESCRIPTOR_REQUEST);
+
+      expect(unified.response_format).toEqual({
+        type: 'json_schema',
+        json_schema: { type: 'object', properties: { temp: { type: 'number' } } },
+        name: 'weather_report',
+        description: 'A structured weather report',
+        strict: false,
+      });
+    });
+
+    it('the outbound Chat payload emits the client-supplied descriptor values (responses -> chat)', async () => {
+      const unified = await new ResponsesTransformer().parseRequest(DESCRIPTOR_REQUEST);
+      const chatPayload = await new OpenAITransformer().transformRequest(unified);
+
+      expect(chatPayload.response_format).toEqual({
+        type: 'json_schema',
+        json_schema: {
+          name: 'weather_report',
+          description: 'A structured weather report',
+          schema: { type: 'object', properties: { temp: { type: 'number' } } },
+          strict: false,
+        },
+      });
+    });
+
+    it('fallbacks apply ONLY when the client omitted the descriptor fields', async () => {
+      const unified = await new ResponsesTransformer().parseRequest({
+        ...MINIMAL_REQUEST,
+        text: {
+          format: {
+            type: 'json_schema',
+            schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+          },
+        },
+      });
+      const chatPayload = await new OpenAITransformer().transformRequest(unified);
+
+      expect(chatPayload.response_format).toEqual({
+        type: 'json_schema',
+        json_schema: {
+          name: 'response_schema',
+          schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+          strict: true,
+        },
+      });
+    });
+
+    it('strict: false survives to the outbound chat payload (must not be clobbered to true)', async () => {
+      const unified = await new ResponsesTransformer().parseRequest(DESCRIPTOR_REQUEST);
+      const chatPayload = await new OpenAITransformer().transformRequest(unified);
+
+      expect(chatPayload.response_format.json_schema.strict).toBe(false);
+    });
+  });
+
+  it('explicit values still forward (spot-check stream, max_output_tokens, metadata)', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+
+    expect(unified.stream).toBe(true);
+    expect(unified.max_tokens).toBe(1024);
+    expect(unified.metadata).toEqual({ session: 's1' });
+    expect(unified.reasoning).toEqual({ effort: 'medium' });
+    expect(unified.include).toEqual(['reasoning.encrypted_content']);
+    expect(unified.prompt_cache_key).toBe('cache-1');
+    expect(unified.parallel_tool_calls).toBe(true);
+    expect(unified.text).toEqual({ format: { type: 'text' } });
+  });
+});
+
+describe('transformRequest stream-field hygiene (no phantom `stream: undefined`)', () => {
+  // parseRequest already keeps an omitted client `stream` off the unified
+  // request (see the conditional-spread tests above) — transformRequest must
+  // not recreate it as a `stream: undefined` own property on the outbound
+  // payload, which survives object spreads and flips `'stream' in x` checks
+  // downstream even though JSON would drop it.
+  const MINIMAL_REQUEST = {
+    model: 'gpt-4o',
+    input: [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Hello' }],
+      },
+    ],
+  };
+
+  it('an omitted client stream leaves NO own `stream` property on the outbound payload', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(MINIMAL_REQUEST);
+    expect('stream' in unified).toBe(false);
+
+    const built = await transformer.transformRequest(unified);
+    expect('stream' in built).toBe(false);
+  });
+
+  it('an explicit stream:true still forwards', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({ ...MINIMAL_REQUEST, stream: true });
+    const built = await transformer.transformRequest(unified);
+    expect(built.stream).toBe(true);
+  });
+
+  it('an explicit stream:false still forwards as a real own property', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({ ...MINIMAL_REQUEST, stream: false });
+    const built = await transformer.transformRequest(unified);
+    expect('stream' in built).toBe(true);
+    expect(built.stream).toBe(false);
   });
 });

--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { ResponsesTransformer } from '../responses';
+import { OpenAITransformer } from '../openai';
 
 async function transformEvents(events: Record<string, unknown>[]): Promise<any[]> {
   const encoder = new TextEncoder();
@@ -179,5 +180,443 @@ describe('ResponsesTransformer stream transformation', () => {
     ]);
 
     expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('tool_calls');
+  });
+});
+
+describe('ResponsesTransformer stream transformation - error handling', () => {
+  test('maps response.failed to a unified error chunk instead of dropping it', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_1', model: 'gpt-5', created_at: 1234567890 },
+      },
+      {
+        type: 'response.failed',
+        response: {
+          id: 'resp_1',
+          status: 'failed',
+          error: { code: 'server_error', message: 'The model encountered an error.' },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.message).toBe('The model encountered an error.');
+    // No phantom success finish should accompany a failure.
+    expect(chunks.some((chunk) => chunk.finish_reason === 'stop')).toBe(false);
+  });
+
+  test('maps response.incomplete (max_output_tokens) to a unified error chunk carrying a length finish hint and incomplete_details', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_2', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Partial output' },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_2',
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.finish_reason).toBe('length');
+    expect(errorChunk.error.code).toBe('max_output_tokens');
+    expect(errorChunk.incomplete_details).toEqual({ reason: 'max_output_tokens' });
+  });
+
+  test('maps response.incomplete (content_filter) to a unified error chunk carrying a content_filter finish hint and incomplete_details', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_cf', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Partial' },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_cf',
+          status: 'incomplete',
+          incomplete_details: { reason: 'content_filter' },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.finish_reason).toBe('content_filter');
+    expect(errorChunk.error.code).toBe('content_filter');
+    expect(errorChunk.incomplete_details).toEqual({ reason: 'content_filter' });
+  });
+
+  test('propagates response.usage on response.failed into the unified error chunk', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_failusage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      {
+        type: 'response.failed',
+        response: {
+          id: 'resp_failusage',
+          status: 'failed',
+          error: { code: 'server_error', message: 'boom' },
+          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage).toEqual(
+      expect.objectContaining({ input_tokens: 10, output_tokens: 5, total_tokens: 15 })
+    );
+  });
+
+  test('propagates response.usage on response.incomplete into the unified error chunk', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_incompleteusage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_incompleteusage',
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+          usage: { input_tokens: 20, output_tokens: 8, total_tokens: 28 },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage).toEqual(
+      expect.objectContaining({ input_tokens: 20, output_tokens: 8, total_tokens: 28 })
+    );
+  });
+
+  test('does not attach a usage field when response.failed/response.incomplete carry none', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_nousage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      {
+        type: 'response.failed',
+        response: { id: 'resp_nousage', status: 'failed', error: { message: 'boom' } },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage).toBeUndefined();
+  });
+
+  test('maps a generic top-level error event to a unified error chunk', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_3', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'error', code: 'server_error', message: 'boom' },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.message).toBe('boom');
+  });
+});
+
+describe('ResponsesTransformer formatStream - error handling (client-facing)', () => {
+  function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
+    return new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+  }
+
+  async function collectFormatStreamEvents(chunks: any[]): Promise<any[]> {
+    const reader = new ResponsesTransformer()
+      .formatStream(unifiedStreamFromChunks(chunks))
+      .getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+    return output
+      .split('\n\n')
+      .filter((block) => block.trim().length > 0)
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        return JSON.parse((dataLine as string).replace(/^data:\s*/, ''));
+      });
+  }
+
+  test('emits response.failed (not response.completed) when a unified error chunk arrives', async () => {
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_err_1',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_err_1',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 500,
+          code: 'server_error',
+          message: 'The model encountered an error.',
+        },
+      },
+    ]);
+
+    expect(events.some((e) => e.type === 'response.completed')).toBe(false);
+    const failedEvent = events.find((e) => e.type === 'response.failed');
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.response.status).toBe('failed');
+    expect(failedEvent.response.error.message).toBe('The model encountered an error.');
+  });
+
+  test('surfaces response.incomplete (not response.failed) when the unified chunk carries incomplete_details', async () => {
+    // A hard failure (no incomplete_details) still becomes response.failed —
+    // see the test above. When transformStream marked this as an "ended
+    // incomplete" outcome (incomplete_details present), the Responses-facing
+    // client must see the more specific response.incomplete event, not a
+    // generic hard failure.
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_err_2',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial output' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_err_2',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'length',
+        incomplete_details: { reason: 'max_output_tokens' },
+        error: {
+          statusCode: 500,
+          code: 'max_output_tokens',
+          message: 'Response ended incomplete: max_output_tokens',
+        },
+      },
+    ]);
+
+    expect(events.some((e) => e.type === 'response.completed')).toBe(false);
+    expect(events.some((e) => e.type === 'response.failed')).toBe(false);
+    const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
+    expect(incompleteEvent).toBeDefined();
+    expect(incompleteEvent.response.status).toBe('incomplete');
+    expect(incompleteEvent.response.incomplete_details).toEqual({ reason: 'max_output_tokens' });
+    expect(incompleteEvent.response.output?.[0]?.content?.[0]?.text).toBe('partial output');
+  });
+
+  test('emits response.incomplete (content_filter) with incomplete_details and usage for a Responses-format client', async () => {
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_err_cf',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_err_cf',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'content_filter',
+        incomplete_details: { reason: 'content_filter' },
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+          reasoning_tokens: 0,
+          cached_tokens: 0,
+          cache_creation_tokens: 0,
+        },
+        error: {
+          statusCode: 500,
+          code: 'content_filter',
+          message: 'Response ended incomplete: content_filter',
+        },
+      },
+    ]);
+
+    expect(events.some((e) => e.type === 'response.failed')).toBe(false);
+    const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
+    expect(incompleteEvent).toBeDefined();
+    expect(incompleteEvent.response.status).toBe('incomplete');
+    expect(incompleteEvent.response.incomplete_details).toEqual({ reason: 'content_filter' });
+    expect(incompleteEvent.response.usage.total_tokens).toBe(15);
+  });
+
+  test('keeps emitting response.failed exactly as before for a genuine hard error (no incomplete_details)', async () => {
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_hard_err',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_hard_err',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: { statusCode: 500, code: 'server_error', message: 'The model response failed.' },
+      },
+    ]);
+
+    expect(events.some((e) => e.type === 'response.incomplete')).toBe(false);
+    const failedEvent = events.find((e) => e.type === 'response.failed');
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.response.status).toBe('failed');
+  });
+});
+
+describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream (cross-format)', () => {
+  // Proves the fix cross-format, not just within ResponsesTransformer: a
+  // Responses-API UPSTREAM feeding a CHAT-format client (e.g. the client
+  // sent Chat Completions but got routed to a Responses-API provider) must
+  // still see the mapped finish reason and the propagated usage.
+  async function transformAndFormatAsChat(events: Record<string, unknown>[]): Promise<any[]> {
+    const encoder = new TextEncoder();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(
+            encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+          );
+        }
+        controller.close();
+      },
+    });
+
+    const unifiedStream = new ResponsesTransformer().transformStream(source);
+    const chatStream = new OpenAITransformer().formatStream(unifiedStream);
+
+    const reader = chatStream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    return buffer
+      .split('\n\n')
+      .map((block) => block.trim())
+      .filter(Boolean)
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        const data = (dataLine as string).replace(/^data:\s*/, '');
+        return data === '[DONE]' ? '[DONE]' : JSON.parse(data);
+      });
+  }
+
+  test('response.incomplete (content_filter) surfaces as a chat finish_reason "content_filter"', async () => {
+    const chunks = await transformAndFormatAsChat([
+      {
+        type: 'response.created',
+        response: { id: 'resp_cf_chat', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Partial' },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_cf_chat',
+          status: 'incomplete',
+          incomplete_details: { reason: 'content_filter' },
+        },
+      },
+    ]);
+
+    const finishChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'content_filter'
+    );
+    expect(finishChunk).toBeDefined();
+    // A recognized non-fatal finish must NOT be rendered as an error payload.
+    expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('response.failed carrying usage propagates that usage to the chat client', async () => {
+    const chunks = await transformAndFormatAsChat([
+      {
+        type: 'response.created',
+        response: { id: 'resp_fail_usage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'partial' },
+      {
+        type: 'response.failed',
+        response: {
+          id: 'resp_fail_usage',
+          status: 'failed',
+          error: { code: 'server_error', message: 'boom' },
+          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        },
+      },
+    ]);
+
+    const usageChunk = chunks.find((c) => c !== '[DONE]' && c.usage);
+    expect(usageChunk).toBeDefined();
+    expect(usageChunk.usage.prompt_tokens).toBe(10);
+    expect(usageChunk.usage.completion_tokens).toBe(5);
+    expect(usageChunk.usage.total_tokens).toBe(15);
+    // Still rendered as an error (this was a hard failure, not an incomplete).
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+  });
+
+  test('response.incomplete carrying usage propagates that usage to the chat client alongside the finish_reason', async () => {
+    const chunks = await transformAndFormatAsChat([
+      {
+        type: 'response.created',
+        response: { id: 'resp_incomplete_usage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'partial' },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_incomplete_usage',
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+          usage: { input_tokens: 7, output_tokens: 3, total_tokens: 10 },
+        },
+      },
+    ]);
+
+    const finishChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'length'
+    );
+    expect(finishChunk).toBeDefined();
+    expect(finishChunk.usage.total_tokens).toBe(10);
   });
 });

--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -335,6 +335,791 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 });
 
+// Tiny fake base64 payload — content is irrelevant, only the data-URI
+// plumbing matters.
+const TINY_IMAGE_B64 = 'aGVsbG8=';
+const TINY_IMAGE_MARKDOWN = `![generated image](data:image/png;base64,${TINY_IMAGE_B64})`;
+
+describe('ResponsesTransformer transformResponse - image_generation_call rendering', () => {
+  test('an image_generation_call with a base64 result becomes markdown data-URI unified content', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      ],
+      usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+    });
+
+    expect(unified.content).toBe(TINY_IMAGE_MARKDOWN);
+  });
+
+  test('image markdown respects output-item order relative to the message item', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_order',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          id: 'msg_1',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Here is your image:' }],
+        },
+        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      ],
+    });
+
+    expect(unified.content).toBe(`Here is your image:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  // `output_format` is a REQUEST-side image tool field — it is not present
+  // on image_generation_call output items, so the mime subtype is sniffed
+  // from the decoded base64 head's magic bytes instead (PNG/JPEG/WebP/GIF,
+  // defaulting to png).
+  describe('mime subtype sniffing from the base64 signature', () => {
+    const b64 = (bytes: number[]) => Buffer.from(bytes).toString('base64');
+
+    const renderImage = async (result: string) => {
+      const unified = await new ResponsesTransformer().transformResponse({
+        id: 'resp_img_sniff',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result }],
+      });
+      return unified.content;
+    };
+
+    test('PNG signature (\\x89PNG) renders image/png', async () => {
+      const png = b64([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
+      expect(await renderImage(png)).toBe(`![generated image](data:image/png;base64,${png})`);
+    });
+
+    test('JPEG signature (\\xFF\\xD8) renders image/jpeg', async () => {
+      const jpeg = b64([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01]);
+      expect(await renderImage(jpeg)).toBe(`![generated image](data:image/jpeg;base64,${jpeg})`);
+    });
+
+    test('WebP signature (RIFF....WEBP) renders image/webp', async () => {
+      const webp = b64([
+        0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+        0x20,
+      ]);
+      expect(await renderImage(webp)).toBe(`![generated image](data:image/webp;base64,${webp})`);
+    });
+
+    test('GIF signature (GIF8) renders image/gif', async () => {
+      const gif = b64([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00]);
+      expect(await renderImage(gif)).toBe(`![generated image](data:image/gif;base64,${gif})`);
+    });
+
+    test('an unrecognized signature defaults to image/png', async () => {
+      // TINY_IMAGE_B64 decodes to "hello" — no known magic bytes.
+      expect(await renderImage(TINY_IMAGE_B64)).toBe(TINY_IMAGE_MARKDOWN);
+    });
+
+    test('a request-style output_format field on the item is IGNORED (not a response field)', async () => {
+      const unified = await new ResponsesTransformer().transformResponse({
+        id: 'resp_img_webp',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+            output_format: 'webp',
+          },
+        ],
+      });
+
+      // The payload's actual bytes ("hello" — no signature) decide: png.
+      expect(unified.content).toBe(TINY_IMAGE_MARKDOWN);
+    });
+
+    test('RIFF head WITHOUT the WEBP tag does not sniff as webp', async () => {
+      const riffOnly = b64([
+        0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x41, 0x56, 0x49, 0x20,
+      ]);
+      expect(await renderImage(riffOnly)).toBe(
+        `![generated image](data:image/png;base64,${riffOnly})`
+      );
+    });
+  });
+
+  test('an image_generation_call without a base64 result contributes nothing', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_noresult',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
+    });
+
+    expect(unified.content).toBeNull();
+  });
+
+  test('a text-only response keeps its existing unified content shape (happy path unchanged)', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_text_only',
+      object: 'response',
+      model: 'gpt-4o',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          id: 'msg_1',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Full answer' }],
+        },
+      ],
+    });
+
+    expect(unified.content).toBe('Full answer');
+  });
+
+  test('a base64 result over the inline limit renders the omission placeholder, not a data URI', async () => {
+    // One char past MAX_INLINE_IMAGE_BASE64_CHARS (8 * 1024 * 1024).
+    // Approximate decoded size = 8388609 * 3/4 bytes ≈ 6.0 MB.
+    const oversized = 'A'.repeat(8 * 1024 * 1024 + 1);
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_oversized',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: oversized },
+      ],
+    });
+
+    expect(unified.content).toBe('[generated image omitted: 6.0 MB exceeds inline limit]');
+  });
+
+  test('a base64 result exactly at the inline limit still renders as a data URI (boundary)', async () => {
+    const atLimit = 'A'.repeat(8 * 1024 * 1024);
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_at_limit',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result: atLimit }],
+    });
+
+    expect(unified.content).toBe(`![generated image](data:image/png;base64,${atLimit})`);
+  });
+});
+
+describe('ResponsesTransformer transformStream - image_generation_call rendering', () => {
+  test('a completed image_generation_call output item becomes a unified content delta (markdown data URI)', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s1', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      },
+      { type: 'response.completed', response: {} },
+    ]);
+
+    const contentChunks = chunks.filter(
+      (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
+    );
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].delta.content).toBe(TINY_IMAGE_MARKDOWN);
+  });
+
+  test('an image_generation_call present only in response.completed still renders, before the final chunk', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s2', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'resp_img_s2',
+          status: 'completed',
+          output: [
+            {
+              id: 'ig_1',
+              type: 'image_generation_call',
+              status: 'completed',
+              result: TINY_IMAGE_B64,
+            },
+          ],
+          usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+        },
+      },
+    ]);
+
+    const contentIndex = chunks.findIndex((chunk) => chunk.delta?.content === TINY_IMAGE_MARKDOWN);
+    const finishIndex = chunks.findIndex((chunk) => chunk.finish_reason);
+    expect(contentIndex).toBeGreaterThan(-1);
+    expect(finishIndex).toBeGreaterThan(contentIndex);
+  });
+
+  test('does not double-render an item that streamed via output_item.done AND appears in response.completed', async () => {
+    const imageItem = {
+      id: 'ig_1',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    };
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s3', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      { type: 'response.output_item.done', output_index: 0, item: imageItem },
+      { type: 'response.completed', response: { id: 'resp_img_s3', output: [imageItem] } },
+    ]);
+
+    const contentChunks = chunks.filter((chunk) => chunk.delta?.content === TINY_IMAGE_MARKDOWN);
+    expect(contentChunks).toHaveLength(1);
+  });
+
+  test('partial-image delta events are skipped (explicitly out of scope) — only the completed item renders', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s4', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.image_generation_call.partial_image',
+        output_index: 0,
+        item_id: 'ig_1',
+        partial_image_index: 0,
+        partial_image_b64: 'UEFSVElBTA==',
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      },
+      { type: 'response.completed', response: {} },
+    ]);
+
+    const contentChunks = chunks.filter(
+      (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
+    );
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].delta.content).toBe(TINY_IMAGE_MARKDOWN);
+    expect(chunks.some((chunk) => JSON.stringify(chunk).includes('UEFSVElBTA=='))).toBe(false);
+  });
+
+  test('a base64 result over the inline limit streams the omission placeholder instead of the data URI', async () => {
+    // Twice MAX_INLINE_IMAGE_BASE64_CHARS (8 * 1024 * 1024).
+    // Approximate decoded size = 16777216 * 3/4 bytes = 12.0 MB.
+    const oversized = 'B'.repeat(2 * 8 * 1024 * 1024);
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s5', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: oversized,
+        },
+      },
+      { type: 'response.completed', response: {} },
+    ]);
+
+    const contentChunks = chunks.filter(
+      (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
+    );
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].delta.content).toBe(
+      '[generated image omitted: 12.0 MB exceeds inline limit]'
+    );
+    // The oversized base64 payload must never reach a CONTENT delta (chat/
+    // messages clients render content strings — that's what the inline size
+    // guard protects). The chunk-level `image_generation_calls` typed carry
+    // deliberately DOES hold the full base64 so responses-facing clients can
+    // receive the native item byte-intact — see the typed-carry describe
+    // below.
+    expect(
+      chunks.some(
+        (chunk) =>
+          typeof chunk.delta?.content === 'string' && chunk.delta.content.includes('BBBBBBBB')
+      )
+    ).toBe(false);
+    expect(contentChunks[0].image_generation_calls?.[0]?.result).toBe(oversized);
+  });
+});
+
+// The markdown collapse alone is lossy for SAME-format clients: a non-bypass
+// responses -> responses route (e.g. a responses:lite subtype, adapter
+// active, vision fallthrough) would receive `message`/`output_text` markdown
+// instead of the native `image_generation_call` item — and the oversized
+// placeholder would destroy the base64 for clients that take it natively.
+// The typed chunk-level carry (UnifiedImageGenerationCall) keeps the item
+// intact through the unified layer; the responses-facing formatStream /
+// formatResponse re-emit it natively.
+describe('ResponsesTransformer typed image_generation_call carry (responses -> responses)', () => {
+  function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
+    return new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+  }
+
+  async function collectFormatStreamEvents(
+    chunks: any[],
+    transformer = new ResponsesTransformer()
+  ): Promise<any[]> {
+    const reader = transformer.formatStream(unifiedStreamFromChunks(chunks)).getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+    return output
+      .split('\n\n')
+      .filter((block) => block.trim().length > 0)
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        return JSON.parse((dataLine as string).replace(/^data:\s*/, ''));
+      });
+  }
+
+  describe('transformStream carries the typed item alongside the markdown', () => {
+    test('a completed image item carries a typed entry on the SAME chunk as its markdown delta', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_typed_1', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: {
+            id: 'ig_1',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        },
+        { type: 'response.completed', response: {} },
+      ]);
+
+      const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
+      expect(imageChunks).toHaveLength(1);
+      expect(imageChunks[0].image_generation_calls).toEqual([
+        { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      ]);
+      // The chat-format markdown rendering rides the same chunk's content.
+      expect(imageChunks[0].delta.content).toBe(TINY_IMAGE_MARKDOWN);
+    });
+
+    test('the typed entry is chunk-level, NOT inside delta (chat formatters forward delta by reference)', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_typed_2', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: {
+            id: 'ig_1',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        },
+        { type: 'response.completed', response: {} },
+      ]);
+
+      const imageChunk = chunks.find((chunk) => chunk.image_generation_calls);
+      expect(imageChunk).toBeDefined();
+      expect(imageChunk.delta.image_generation_calls).toBeUndefined();
+    });
+
+    test('the completed-fallback also carries the typed entry, without double-carrying deduped items', async () => {
+      const imageItem = {
+        id: 'ig_1',
+        type: 'image_generation_call',
+        status: 'completed',
+        result: TINY_IMAGE_B64,
+      };
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_typed_3', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        { type: 'response.output_item.done', output_index: 0, item: imageItem },
+        { type: 'response.completed', response: { id: 'resp_typed_3', output: [imageItem] } },
+      ]);
+
+      const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
+      expect(imageChunks).toHaveLength(1);
+    });
+
+    test('a completed-only item (never streamed via output_item.done) still gets the typed carry', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_typed_4', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_typed_4',
+            status: 'completed',
+            output: [
+              {
+                id: 'ig_9',
+                type: 'image_generation_call',
+                status: 'completed',
+                result: TINY_IMAGE_B64,
+              },
+            ],
+          },
+        },
+      ]);
+
+      const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
+      expect(imageChunks).toHaveLength(1);
+      expect(imageChunks[0].image_generation_calls[0]).toEqual({
+        id: 'ig_9',
+        status: 'completed',
+        result: TINY_IMAGE_B64,
+      });
+    });
+  });
+
+  describe('formatStream re-emits typed items as native output items', () => {
+    const imageChunkFor = (result: string) => ({
+      id: 'resp_native_1',
+      model: 'gpt-image-model',
+      created: 1234567890,
+      delta: { content: `![generated image](data:image/png;base64,${result})` },
+      image_generation_calls: [{ id: 'ig_1', status: 'completed', result }],
+      finish_reason: null,
+    });
+
+    const finishChunk = () => ({
+      id: 'resp_native_1',
+      model: 'gpt-image-model',
+      created: 1234567890,
+      finish_reason: 'stop',
+      usage: {
+        input_tokens: 5,
+        output_tokens: 1,
+        total_tokens: 6,
+        reasoning_tokens: 0,
+        cached_tokens: 0,
+        cache_creation_tokens: 0,
+      },
+    });
+
+    test('emits a native image_generation_call output item (byte-intact) instead of markdown text', async () => {
+      const events = await collectFormatStreamEvents([
+        imageChunkFor(TINY_IMAGE_B64),
+        finishChunk(),
+      ]);
+
+      const doneEvents = events.filter(
+        (e) => e.type === 'response.output_item.done' && e.item?.type === 'image_generation_call'
+      );
+      expect(doneEvents).toHaveLength(1);
+      expect(doneEvents[0].item).toEqual({
+        id: 'ig_1',
+        type: 'image_generation_call',
+        status: 'completed',
+        result: TINY_IMAGE_B64,
+      });
+
+      // The paired markdown must NOT also stream as output_text — the native
+      // item is the only carrier for a Responses-format client.
+      expect(events.some((e) => e.type === 'response.output_text.delta')).toBe(false);
+      expect(JSON.stringify(events).includes('![generated image]')).toBe(false);
+    });
+
+    test('the final response.completed output array includes the native image item', async () => {
+      const events = await collectFormatStreamEvents([
+        imageChunkFor(TINY_IMAGE_B64),
+        finishChunk(),
+      ]);
+
+      const completed = events.find((e) => e.type === 'response.completed');
+      expect(completed).toBeDefined();
+      const imageItems = completed.response.output.filter(
+        (item: any) => item.type === 'image_generation_call'
+      );
+      expect(imageItems).toHaveLength(1);
+      expect(imageItems[0].result).toBe(TINY_IMAGE_B64);
+    });
+
+    test('an OVERSIZED result re-emits with the FULL base64 — the native format has no inline cap', async () => {
+      const oversized = 'C'.repeat(2 * 8 * 1024 * 1024);
+      // transformStream renders the placeholder on content for oversized
+      // items — mirror that pairing here.
+      const events = await collectFormatStreamEvents([
+        {
+          id: 'resp_native_2',
+          model: 'gpt-image-model',
+          created: 1234567890,
+          delta: { content: '[generated image omitted: 12.0 MB exceeds inline limit]' },
+          image_generation_calls: [{ id: 'ig_big', status: 'completed', result: oversized }],
+          finish_reason: null,
+        },
+        finishChunk(),
+      ]);
+
+      const doneEvent = events.find(
+        (e) => e.type === 'response.output_item.done' && e.item?.type === 'image_generation_call'
+      );
+      expect(doneEvent).toBeDefined();
+      expect(doneEvent.item.result).toBe(oversized);
+      // The placeholder must not leak into any text.
+      expect(JSON.stringify(events).includes('exceeds inline limit')).toBe(false);
+    });
+
+    test('message text on OTHER chunks still streams normally alongside a native image item', async () => {
+      const events = await collectFormatStreamEvents([
+        {
+          id: 'resp_native_3',
+          model: 'gpt-image-model',
+          created: 1234567890,
+          delta: { content: 'Here is your image:' },
+          finish_reason: null,
+        },
+        imageChunkFor(TINY_IMAGE_B64),
+        finishChunk(),
+      ]);
+
+      const textDeltas = events.filter((e) => e.type === 'response.output_text.delta');
+      expect(textDeltas).toHaveLength(1);
+      expect(textDeltas[0].delta).toBe('Here is your image:');
+
+      const completed = events.find((e) => e.type === 'response.completed');
+      const types = completed.response.output.map((item: any) => item.type);
+      expect(types).toContain('message');
+      expect(types).toContain('image_generation_call');
+      const messageItem = completed.response.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe('Here is your image:');
+    });
+
+    test('full streaming round-trip (provider SSE -> unified -> client SSE) keeps the item byte-intact', async () => {
+      const unifiedChunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_rt_1', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: {
+            id: 'ig_rt',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        },
+        {
+          type: 'response.completed',
+          response: { usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 } },
+        },
+      ]);
+
+      const events = await collectFormatStreamEvents(unifiedChunks);
+      const doneEvent = events.find(
+        (e) => e.type === 'response.output_item.done' && e.item?.type === 'image_generation_call'
+      );
+      expect(doneEvent).toBeDefined();
+      expect(doneEvent.item.result).toBe(TINY_IMAGE_B64);
+      expect(events.some((e) => e.type === 'response.output_text.delta')).toBe(false);
+    });
+  });
+
+  describe('formatResponse (unary) re-emits typed items as native output items', () => {
+    test('transformResponse attaches the typed items alongside the markdown content', async () => {
+      const unified = await new ResponsesTransformer().transformResponse({
+        id: 'resp_unary_typed',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            id: 'msg_1',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Here is your image:' }],
+          },
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        ],
+      });
+
+      expect(unified.image_generation_calls).toEqual([
+        { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      ]);
+      // The chat-facing rendering is unchanged.
+      expect(unified.content).toBe(`Here is your image:\n${TINY_IMAGE_MARKDOWN}`);
+    });
+
+    test('a result-less image item still contributes no typed entry', async () => {
+      const unified = await new ResponsesTransformer().transformResponse({
+        id: 'resp_unary_noresult',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
+      });
+
+      expect(unified.image_generation_calls).toBeUndefined();
+    });
+
+    test('formatResponse emits the native item and strips the paired markdown from the message text', async () => {
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_unary_rt',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            id: 'msg_1',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Here is your image:' }],
+          },
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        ],
+      });
+
+      const formatted = await transformer.formatResponse(unified as any);
+
+      const imageItems = formatted.output.filter(
+        (item: any) => item.type === 'image_generation_call'
+      );
+      expect(imageItems).toHaveLength(1);
+      expect(imageItems[0]).toMatchObject({
+        type: 'image_generation_call',
+        id: 'ig_1',
+        status: 'completed',
+        result: TINY_IMAGE_B64,
+      });
+
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe('Here is your image:');
+      expect(JSON.stringify(formatted).includes('![generated image]')).toBe(false);
+    });
+
+    test('an image-only unary response round-trips as a native item (no markdown text)', async () => {
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_unary_imgonly',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        ],
+      });
+
+      // The unified content still carries the markdown, so the
+      // empty-completion detector keeps seeing visible output.
+      expect(unified.content).toBe(TINY_IMAGE_MARKDOWN);
+
+      const formatted = await transformer.formatResponse(unified as any);
+      const imageItems = formatted.output.filter(
+        (item: any) => item.type === 'image_generation_call'
+      );
+      expect(imageItems).toHaveLength(1);
+      expect(imageItems[0].result).toBe(TINY_IMAGE_B64);
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe('');
+    });
+
+    test('an OVERSIZED unary result re-emits byte-intact natively — the placeholder never reaches the client', async () => {
+      const oversized = 'D'.repeat(8 * 1024 * 1024 + 1);
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_unary_big',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          { type: 'image_generation_call', id: 'ig_big', status: 'completed', result: oversized },
+        ],
+      });
+
+      // Chat-facing content keeps the guarded placeholder...
+      expect(unified.content).toBe('[generated image omitted: 6.0 MB exceeds inline limit]');
+      // ...while the typed carry keeps the full payload.
+      expect(unified.image_generation_calls?.[0]?.result).toBe(oversized);
+
+      const formatted = await transformer.formatResponse(unified as any);
+      const imageItem = formatted.output.find((item: any) => item.type === 'image_generation_call');
+      expect(imageItem.result).toBe(oversized);
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe('');
+      expect(JSON.stringify(formatted).includes('exceeds inline limit')).toBe(false);
+    });
+  });
+});
+
 describe('ResponsesTransformer formatStream - error handling (client-facing)', () => {
   function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
     return new ReadableStream({
@@ -475,6 +1260,104 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
     expect(incompleteEvent.response.usage.total_tokens).toBe(15);
   });
 
+  test('marks still-in-progress output items status "incomplete" when emitting response.incomplete', async () => {
+    // Everything that was mid-stream when the upstream ended incomplete —
+    // the reasoning item, the message item, and the tool call — was never
+    // finished, so the finalized items must carry status 'incomplete', not a
+    // fabricated 'completed'.
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_inc_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', reasoning_content: 'thinking...' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_inc_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { content: 'partial output' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_inc_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'lookup', arguments: '{"q":' },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_inc_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'length',
+        incomplete_details: { reason: 'max_output_tokens' },
+        error: {
+          statusCode: 500,
+          code: 'max_output_tokens',
+          message: 'Response ended incomplete: max_output_tokens',
+        },
+      },
+    ]);
+
+    const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
+    expect(incompleteEvent).toBeDefined();
+    const outputItems = incompleteEvent.response.output;
+    expect(outputItems.map((item: any) => item.type).sort()).toEqual([
+      'function_call',
+      'message',
+      'reasoning',
+    ]);
+    for (const item of outputItems) {
+      expect(item.status).toBe('incomplete');
+    }
+
+    // The finalization output_item.done events on this path carry the same
+    // item-level status as the final response.incomplete output array.
+    const doneEvents = events.filter((e) => e.type === 'response.output_item.done');
+    expect(doneEvents.length).toBe(3);
+    for (const done of doneEvents) {
+      expect(done.item.status).toBe('incomplete');
+    }
+  });
+
+  test('response.failed finalization keeps item statuses unchanged (completed)', async () => {
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_failed_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_failed_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: { statusCode: 500, code: 'server_error', message: 'boom' },
+      },
+    ]);
+
+    const failedEvent = events.find((e) => e.type === 'response.failed');
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.response.output).toHaveLength(1);
+    expect(failedEvent.response.output[0].status).toBe('completed');
+  });
+
   test('keeps emitting response.failed exactly as before for a genuine hard error (no incomplete_details)', async () => {
     const events = await collectFormatStreamEvents([
       {
@@ -593,6 +1476,54 @@ describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream
     // Still rendered as an error (this was a hard failure, not an incomplete).
     const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
     expect(errorChunk).toBeDefined();
+  });
+
+  test('a streamed completed image_generation_call reaches a chat client as a markdown data-URI content delta', async () => {
+    const chunks = await transformAndFormatAsChat([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_chat', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'resp_img_chat',
+          status: 'completed',
+          output: [
+            {
+              id: 'ig_1',
+              type: 'image_generation_call',
+              status: 'completed',
+              result: TINY_IMAGE_B64,
+            },
+          ],
+          usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+        },
+      },
+    ]);
+
+    const contentChunks = chunks.filter(
+      (c) =>
+        c !== '[DONE]' &&
+        typeof c.choices?.[0]?.delta?.content === 'string' &&
+        c.choices[0].delta.content.length > 0
+    );
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].choices[0].delta.content).toBe(TINY_IMAGE_MARKDOWN);
+    expect(chunks.some((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'stop')).toBe(
+      true
+    );
+    expect(chunks.at(-1)).toBe('[DONE]');
   });
 
   test('response.incomplete carrying usage propagates that usage to the chat client alongside the finish_reason', async () => {

--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -255,6 +255,34 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
     expect(errorChunk.incomplete_details).toEqual({ reason: 'content_filter' });
   });
 
+  test('defaults incomplete_details to reason "unknown" (finish hint "length") when upstream response.incomplete carries none', async () => {
+    // Some upstreams emit response.incomplete with no incomplete_details at
+    // all. The unified chunk must still carry BOTH markers of an "ended
+    // incomplete" outcome — incomplete_details (what the responses-facing
+    // formatStream keys response.incomplete emission on) and an
+    // OpenAI-compatible finish hint ('length': the same
+    // everything-but-content_filter default as usage-logging's raw-mode
+    // incomplete mapping) — otherwise downstream renders the event as a
+    // hard failure.
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_nodetails', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Partial' },
+      {
+        type: 'response.incomplete',
+        response: { id: 'resp_nodetails', status: 'incomplete' },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.incomplete_details).toEqual({ reason: 'unknown' });
+    expect(errorChunk.finish_reason).toBe('length');
+    expect(errorChunk.error.code).toBe('unknown');
+  });
+
   test('propagates response.usage on response.failed into the unified error chunk', async () => {
     const chunks = await transformEvents([
       {
@@ -1391,6 +1419,79 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
     expect(incompleteEvent.response.status).toBe('incomplete');
     expect(incompleteEvent.response.incomplete_details).toEqual({ reason: 'content_filter' });
     expect(incompleteEvent.response.usage.total_tokens).toBe(15);
+  });
+
+  test('a detail-less upstream response.incomplete still reaches a Responses client as response.incomplete (reason "unknown"), not response.failed', async () => {
+    // Full pipeline (transformStream -> formatStream): when the upstream
+    // omits incomplete_details entirely, the defaulted { reason: 'unknown' }
+    // must keep the event on the incomplete path — without the default, the
+    // missing field made formatStream downgrade the outcome to a hard
+    // response.failed.
+    const unified = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_nodetails_rt', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'partial output' },
+      {
+        type: 'response.incomplete',
+        response: { id: 'resp_nodetails_rt', status: 'incomplete' },
+      },
+    ]);
+    const events = await collectFormatStreamEvents(unified);
+
+    expect(events.some((e) => e.type === 'response.failed')).toBe(false);
+    const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
+    expect(incompleteEvent).toBeDefined();
+    expect(incompleteEvent.response.status).toBe('incomplete');
+    expect(incompleteEvent.response.incomplete_details).toEqual({ reason: 'unknown' });
+    expect(incompleteEvent.response.output?.[0]?.content?.[0]?.text).toBe('partial output');
+  });
+
+  test('a detail-less upstream response.incomplete reaches a CHAT client as a normal "length" finish, not an error payload', async () => {
+    // Full pipeline (transformStream -> OpenAI formatStream): the defaulted
+    // finish hint ('length') must make the chat-facing formatter render the
+    // detail-less incomplete as an ordinary finish — the same rendering
+    // known-reason (max_output_tokens) incompletes already get — instead of
+    // the hard-error payload it produced when finish_reason was absent.
+    const unified = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_nodetails_chat', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'partial output' },
+      {
+        type: 'response.incomplete',
+        response: { id: 'resp_nodetails_chat', status: 'incomplete' },
+      },
+    ]);
+
+    const reader = new OpenAITransformer()
+      .formatStream(unifiedStreamFromChunks(unified))
+      .getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+    const chunks = output
+      .split('\n\n')
+      .filter((block) => block.trim().length > 0)
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        const payload = (dataLine as string).replace(/^data:\s*/, '');
+        return payload === '[DONE]' ? '[DONE]' : JSON.parse(payload);
+      });
+
+    expect(chunks.some((chunk) => chunk !== '[DONE]' && chunk.error)).toBe(false);
+    const finishChunk = chunks.find(
+      (chunk) => chunk !== '[DONE]' && chunk.choices?.[0]?.finish_reason
+    );
+    expect(finishChunk).toBeDefined();
+    expect(finishChunk.choices[0].finish_reason).toBe('length');
+    expect(chunks.at(-1)).toBe('[DONE]');
   });
 
   test('marks still-in-progress output items status "incomplete" when emitting response.incomplete', async () => {

--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -340,8 +340,19 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
 const TINY_IMAGE_B64 = 'aGVsbG8=';
 const TINY_IMAGE_MARKDOWN = `![generated image](data:image/png;base64,${TINY_IMAGE_B64})`;
 
-describe('ResponsesTransformer transformResponse - image_generation_call rendering', () => {
-  test('an image_generation_call with a base64 result becomes markdown data-URI unified content', async () => {
+describe('ResponsesTransformer image_generation_call rendering (pure unified content + chat composition)', () => {
+  // The chat-visible text for a unified response, exactly as a CHAT-format
+  // client receives it: OpenAITransformer.formatResponse composes the
+  // authored text + rendered image markdown from the typed carry
+  // (transformers/image-rendering.ts). The expected strings in this describe
+  // are the pre-split baked-content bytes — chat clients must keep receiving
+  // them byte-identically.
+  const chatVisibleContent = async (unified: any): Promise<string | null> => {
+    const chat = await new OpenAITransformer().formatResponse(unified);
+    return chat.choices[0].message.content;
+  };
+
+  test('an image_generation_call with a base64 result renders markdown data-URI content for chat clients', async () => {
     const unified = await new ResponsesTransformer().transformResponse({
       id: 'resp_img',
       object: 'response',
@@ -354,10 +365,16 @@ describe('ResponsesTransformer transformResponse - image_generation_call renderi
       usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
     });
 
-    expect(unified.content).toBe(TINY_IMAGE_MARKDOWN);
+    // Unified content stays PURE — no message item, no text. The image
+    // travels typed; the markdown exists only in the chat projection.
+    expect(unified.content).toBeNull();
+    expect(unified.image_generation_calls).toEqual([
+      { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+    ]);
+    expect(await chatVisibleContent(unified)).toBe(TINY_IMAGE_MARKDOWN);
   });
 
-  test('image markdown respects output-item order relative to the message item', async () => {
+  test('chat composition appends image markdown after the authored message text', async () => {
     const unified = await new ResponsesTransformer().transformResponse({
       id: 'resp_img_order',
       object: 'response',
@@ -376,7 +393,8 @@ describe('ResponsesTransformer transformResponse - image_generation_call renderi
       ],
     });
 
-    expect(unified.content).toBe(`Here is your image:\n${TINY_IMAGE_MARKDOWN}`);
+    expect(unified.content).toBe('Here is your image:');
+    expect(await chatVisibleContent(unified)).toBe(`Here is your image:\n${TINY_IMAGE_MARKDOWN}`);
   });
 
   // `output_format` is a REQUEST-side image tool field — it is not present
@@ -395,7 +413,7 @@ describe('ResponsesTransformer transformResponse - image_generation_call renderi
         status: 'completed',
         output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result }],
       });
-      return unified.content;
+      return chatVisibleContent(unified);
     };
 
     test('PNG signature (\\x89PNG) renders image/png', async () => {
@@ -445,7 +463,7 @@ describe('ResponsesTransformer transformResponse - image_generation_call renderi
       });
 
       // The payload's actual bytes ("hello" — no signature) decide: png.
-      expect(unified.content).toBe(TINY_IMAGE_MARKDOWN);
+      expect(await chatVisibleContent(unified)).toBe(TINY_IMAGE_MARKDOWN);
     });
 
     test('RIFF head WITHOUT the WEBP tag does not sniff as webp', async () => {
@@ -469,6 +487,8 @@ describe('ResponsesTransformer transformResponse - image_generation_call renderi
     });
 
     expect(unified.content).toBeNull();
+    expect(unified.image_generation_calls).toBeUndefined();
+    expect(await chatVisibleContent(unified)).toBeNull();
   });
 
   test('a text-only response keeps its existing unified content shape (happy path unchanged)', async () => {
@@ -492,7 +512,7 @@ describe('ResponsesTransformer transformResponse - image_generation_call renderi
     expect(unified.content).toBe('Full answer');
   });
 
-  test('a base64 result over the inline limit renders the omission placeholder, not a data URI', async () => {
+  test('a base64 result over the inline limit renders the omission placeholder for chat clients, not a data URI', async () => {
     // One char past MAX_INLINE_IMAGE_BASE64_CHARS (8 * 1024 * 1024).
     // Approximate decoded size = 8388609 * 3/4 bytes ≈ 6.0 MB.
     const oversized = 'A'.repeat(8 * 1024 * 1024 + 1);
@@ -507,7 +527,13 @@ describe('ResponsesTransformer transformResponse - image_generation_call renderi
       ],
     });
 
-    expect(unified.content).toBe('[generated image omitted: 6.0 MB exceeds inline limit]');
+    // Pure unified content; the size guard applies only to the chat
+    // projection — the typed carry keeps the full payload.
+    expect(unified.content).toBeNull();
+    expect(unified.image_generation_calls?.[0]?.result).toBe(oversized);
+    expect(await chatVisibleContent(unified)).toBe(
+      '[generated image omitted: 6.0 MB exceeds inline limit]'
+    );
   });
 
   test('a base64 result exactly at the inline limit still renders as a data URI (boundary)', async () => {
@@ -521,7 +547,9 @@ describe('ResponsesTransformer transformResponse - image_generation_call renderi
       output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result: atLimit }],
     });
 
-    expect(unified.content).toBe(`![generated image](data:image/png;base64,${atLimit})`);
+    expect(await chatVisibleContent(unified)).toBe(
+      `![generated image](data:image/png;base64,${atLimit})`
+    );
   });
 });
 
@@ -681,14 +709,17 @@ describe('ResponsesTransformer transformStream - image_generation_call rendering
   });
 });
 
-// The markdown collapse alone is lossy for SAME-format clients: a non-bypass
-// responses -> responses route (e.g. a responses:lite subtype, adapter
-// active, vision fallthrough) would receive `message`/`output_text` markdown
-// instead of the native `image_generation_call` item — and the oversized
-// placeholder would destroy the base64 for clients that take it natively.
-// The typed chunk-level carry (UnifiedImageGenerationCall) keeps the item
+// A markdown-only collapse would be lossy for SAME-format clients: a
+// non-bypass responses -> responses route (e.g. a responses:lite subtype,
+// adapter active, vision fallthrough) would receive `message`/`output_text`
+// markdown instead of the native `image_generation_call` item — and the
+// oversized placeholder would destroy the base64 for clients that take it
+// natively. The typed carry (UnifiedImageGenerationCall) keeps the item
 // intact through the unified layer; the responses-facing formatStream /
-// formatResponse re-emit it natively.
+// formatResponse re-emit it natively. On the unary path the typed carry is
+// the ONLY image carrier (unified content stays pure); on the streaming path
+// it rides chunk-level, paired with the chat markdown delta on the same
+// chunk, which the responses-facing formatStream structurally skips.
 describe('ResponsesTransformer typed image_generation_call carry (responses -> responses)', () => {
   function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
     return new ReadableStream({
@@ -972,7 +1003,7 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
   });
 
   describe('formatResponse (unary) re-emits typed items as native output items', () => {
-    test('transformResponse attaches the typed items alongside the markdown content', async () => {
+    test('transformResponse attaches the typed items and keeps unified content PURE', async () => {
       const unified = await new ResponsesTransformer().transformResponse({
         id: 'resp_unary_typed',
         object: 'response',
@@ -999,8 +1030,9 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
       expect(unified.image_generation_calls).toEqual([
         { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
       ]);
-      // The chat-facing rendering is unchanged.
-      expect(unified.content).toBe(`Here is your image:\n${TINY_IMAGE_MARKDOWN}`);
+      // PURE authored text — the chat-format markdown projection is composed
+      // by the client-facing renderers, never baked in here.
+      expect(unified.content).toBe('Here is your image:');
     });
 
     test('a result-less image item still contributes no typed entry', async () => {
@@ -1077,9 +1109,11 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
         ],
       });
 
-      // The unified content still carries the markdown, so the
-      // empty-completion detector keeps seeing visible output.
-      expect(unified.content).toBe(TINY_IMAGE_MARKDOWN);
+      // Pure unified content: nothing authored, nothing baked. The typed
+      // carry is what keeps the empty-completion detector seeing visible
+      // output (see empty-completion.ts countTypedImageGenerationCalls).
+      expect(unified.content).toBeNull();
+      expect(unified.image_generation_calls?.[0]?.result).toBe(TINY_IMAGE_B64);
 
       const formatted = await transformer.formatResponse(unified as any);
       const imageItems = formatted.output.filter(
@@ -1105,8 +1139,9 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
         ],
       });
 
-      // Chat-facing content keeps the guarded placeholder...
-      expect(unified.content).toBe('[generated image omitted: 6.0 MB exceeds inline limit]');
+      // Pure unified content (the guarded placeholder exists only in the
+      // chat projection)...
+      expect(unified.content).toBeNull();
       // ...while the typed carry keeps the full payload.
       expect(unified.image_generation_calls?.[0]?.result).toBe(oversized);
 
@@ -1116,6 +1151,104 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
       const messageItem = formatted.output.find((item: any) => item.type === 'message');
       expect(messageItem.content[0].text).toBe('');
       expect(JSON.stringify(formatted).includes('exceeds inline limit')).toBe(false);
+    });
+  });
+
+  describe('unary content-corruption probe — authored text colliding with rendered image segments', () => {
+    // The model can legitimately AUTHOR text containing the exact string of a
+    // rendered image segment (echoing a small image's markdown, or quoting
+    // the oversized-omission placeholder). The authored copy is genuine
+    // message content and must reach every client byte-intact; the rendered
+    // segment is a chat-format projection a responses client never sees (it
+    // gets the native item instead). Any indexOf-based "remove the rendered
+    // segment" surgery removes the FIRST occurrence — the authored copy —
+    // and leaks the appended rendering: content corruption.
+
+    const authoredWithMarkdown = `Check this markdown I wrote myself:\n${TINY_IMAGE_MARKDOWN}\nNeat, right?`;
+
+    const collisionResponseBody = () => ({
+      id: 'resp_probe_md',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          id: 'msg_1',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: authoredWithMarkdown }],
+        },
+        {
+          type: 'image_generation_call',
+          id: 'ig_1',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      ],
+    });
+
+    test('authored text containing an exact copy of the image markdown reaches a responses client byte-intact', async () => {
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse(collisionResponseBody());
+      const formatted = await transformer.formatResponse(unified as any);
+
+      // The native item is the image's only carrier...
+      const imageItems = formatted.output.filter(
+        (item: any) => item.type === 'image_generation_call'
+      );
+      expect(imageItems).toHaveLength(1);
+      expect(imageItems[0].result).toBe(TINY_IMAGE_B64);
+
+      // ...and the AUTHORED text — including its own copy of the markdown —
+      // survives byte-intact: nothing removed, no appended rendering leaked.
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe(authoredWithMarkdown);
+    });
+
+    test('authored text quoting the oversized-omission placeholder reaches a responses client byte-intact', async () => {
+      const oversized = 'B'.repeat(2 * 8 * 1024 * 1024); // placeholder reads "12.0 MB"
+      const placeholder = '[generated image omitted: 12.0 MB exceeds inline limit]';
+      const authored = `If a file is too large you may see "${placeholder}" instead of the image.`;
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_probe_ph',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            id: 'msg_1',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: authored }],
+          },
+          { type: 'image_generation_call', id: 'ig_big', status: 'completed', result: oversized },
+        ],
+      });
+
+      const formatted = await transformer.formatResponse(unified as any);
+
+      const imageItem = formatted.output.find((item: any) => item.type === 'image_generation_call');
+      expect(imageItem.result).toBe(oversized);
+
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe(authored);
+      // Exactly ONE occurrence — the authored quote. The rendered
+      // placeholder itself must never leak into the responses payload.
+      expect(messageItem.content[0].text.split(placeholder).length - 1).toBe(1);
+    });
+
+    test('the same authored-collision response renders authored text + appended markdown for a CHAT client (duplication is genuine content)', async () => {
+      const unified = await new ResponsesTransformer().transformResponse(collisionResponseBody());
+      const chat = await new OpenAITransformer().formatResponse(unified as any);
+
+      expect(chat.choices[0].message.content).toBe(
+        `${authoredWithMarkdown}\n${TINY_IMAGE_MARKDOWN}`
+      );
     });
   });
 });

--- a/packages/backend/src/transformers/adapters/__tests__/suppress-unsupported-gpt5-options.adapter.test.ts
+++ b/packages/backend/src/transformers/adapters/__tests__/suppress-unsupported-gpt5-options.adapter.test.ts
@@ -20,4 +20,37 @@ describe('suppressUnsupportedGpt5OptionsAdapter', () => {
 
     expect(payload).toEqual({ model: 'gpt-5.2', input: 'hello' });
   });
+
+  // Updated LobeHub sends safety_identifier on gpt-5.5 traffic; some
+  // configured upstreams 400 with "Unsupported parameter: safety_identifier".
+  it('removes safety_identifier and preserves other fields', () => {
+    const payload = suppressUnsupportedGpt5OptionsAdapter.preDispatch({
+      model: 'gpt-5.5',
+      input: 'hello',
+      safety_identifier: 'user-hash-abc',
+    });
+
+    expect(payload).toEqual({ model: 'gpt-5.5', input: 'hello' });
+  });
+
+  // prompt_cache_key is intentionally NOT statically stripped: the
+  // Codex-OAuth native path (oauth-native-request.ts) legitimately derives
+  // its session-id/x-client-request-id headers from this field, and no
+  // upstream has been observed rejecting it. A provider that does reject it
+  // is handled by the reactive strip-and-retry in dispatcher-auto-compat.ts
+  // instead (see planUnsupportedParamStrip / dispatcher-auto-compat.test.ts).
+  it('preserves prompt_cache_key (not statically stripped)', () => {
+    const payload = suppressUnsupportedGpt5OptionsAdapter.preDispatch({
+      model: 'gpt-5.5',
+      input: 'hello',
+      safety_identifier: 'user-hash-abc',
+      prompt_cache_key: 'cache-key-123',
+    });
+
+    expect(payload).toEqual({
+      model: 'gpt-5.5',
+      input: 'hello',
+      prompt_cache_key: 'cache-key-123',
+    });
+  });
 });

--- a/packages/backend/src/transformers/adapters/suppress-unsupported-gpt5-options.adapter.ts
+++ b/packages/backend/src/transformers/adapters/suppress-unsupported-gpt5-options.adapter.ts
@@ -11,6 +11,19 @@ const GPT5_UNSUPPORTED_OPTIONS = [
   'truncation',
   'max_output_tokens',
   'max_completion_tokens',
+  // Client-only Responses API field some upstreams reject outright (e.g.
+  // updated LobeHub sends this on gpt-5.5 traffic; ChatGPT/Codex-OAuth and
+  // some aggregators 400 with "Unsupported parameter: safety_identifier").
+  //
+  // NOTE: prompt_cache_key is intentionally NOT in this static list.
+  // oauth-native-request.ts's Codex-OAuth native path legitimately derives
+  // its session-id/x-client-request-id headers from prompt_cache_key (it's
+  // a real Codex CLI session/cache-correlation id), and no upstream has been
+  // observed rejecting it. If one ever does, the reactive strip-and-retry in
+  // dispatcher-auto-compat.ts (planUnsupportedParamStrip, wired in
+  // standard-attempt-request.ts) strips it on that specific 400 instead of
+  // unconditionally removing it from every GPT-5 request up front.
+  'safety_identifier',
 ] as const;
 
 export function stripUnsupportedGpt5Options(payload: Record<string, any>): Record<string, any> {

--- a/packages/backend/src/transformers/anthropic/response-formatter.ts
+++ b/packages/backend/src/transformers/anthropic/response-formatter.ts
@@ -1,4 +1,5 @@
 import { UnifiedChatResponse } from '../../types/unified';
+import { composeContentWithImageMarkdown } from '../image-rendering';
 
 /**
  * Formats a unified response back to Anthropic's format for returning to clients.
@@ -40,8 +41,15 @@ export async function formatAnthropicResponse(response: UnifiedChatResponse): Pr
     });
   }
 
-  if (response.content) {
-    content.push({ type: 'text', text: response.content });
+  // Messages-format clients see image_generation_call output as size-guarded
+  // markdown composed after the authored text (see
+  // transformers/image-rendering.ts) — unified `content` itself stays pure.
+  const textContent = composeContentWithImageMarkdown(
+    response.content,
+    response.image_generation_calls
+  );
+  if (textContent) {
+    content.push({ type: 'text', text: textContent });
   }
 
   if (response.tool_calls) {

--- a/packages/backend/src/transformers/anthropic/stream-transformer.ts
+++ b/packages/backend/src/transformers/anthropic/stream-transformer.ts
@@ -166,6 +166,25 @@ export function transformAnthropicStream(stream: ReadableStream): ReadableStream
                     : undefined,
                 };
                 break;
+
+              case 'error':
+                // Anthropic mid-stream error event: `{"type":"error","error":{"type":"...","message":"..."}}`.
+                // Surface it as a unified error chunk (same shape
+                // OpenAITransformer.formatStream already renders) instead of
+                // silently dropping it and truncating the client stream.
+                unifiedChunk = {
+                  id: messageId,
+                  model: model,
+                  created: Math.floor(Date.now() / 1000),
+                  event: 'error',
+                  delta: {},
+                  error: {
+                    statusCode: 500,
+                    code: data.error?.type || 'error',
+                    message: data.error?.message || 'Upstream error',
+                  },
+                };
+                break;
             }
 
             if (unifiedChunk) {

--- a/packages/backend/src/transformers/completions.ts
+++ b/packages/backend/src/transformers/completions.ts
@@ -4,6 +4,7 @@ import { createParser, EventSourceMessage } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { normalizeOpenAIChatUsage } from '../utils/usage-normalizer';
 import { getApiBaseType } from '../utils/api-format';
+import { composeContentWithImageMarkdown } from './image-rendering';
 
 const FIM_PREFIX_TOKEN = '<|fim_prefix|>';
 const FIM_SUFFIX_TOKEN = '<|fim_suffix|>';
@@ -196,7 +197,13 @@ export class OpenAICompletionTransformer implements Transformer {
   }
 
   async formatResponse(response: UnifiedChatResponse): Promise<any> {
-    const content = response.content || '';
+    // Image output renders as size-guarded markdown composed after the
+    // authored text (see transformers/image-rendering.ts) — unified
+    // `content` itself stays pure. Composed BEFORE FIM normalization so the
+    // combined text flows through the same pipeline the baked content
+    // previously did.
+    const content =
+      composeContentWithImageMarkdown(response.content, response.image_generation_calls) || '';
     const normalizedContent =
       this.fimUserPrompt === null ? content : normalizeFimResponse(content, this.fimUserPrompt);
 

--- a/packages/backend/src/transformers/gemini/response-formatter.ts
+++ b/packages/backend/src/transformers/gemini/response-formatter.ts
@@ -1,5 +1,6 @@
 import { Part } from '@google/genai';
 import { UnifiedChatResponse } from '../../types/unified';
+import { composeContentWithImageMarkdown } from '../image-rendering';
 
 /**
  * Formats a unified response back to Gemini's format for returning to clients.
@@ -19,7 +20,14 @@ export async function formatGeminiResponse(response: UnifiedChatResponse): Promi
     parts.push(part);
   }
 
-  if (response.content) parts.push({ text: response.content });
+  // Gemini-format clients see image_generation_call output as size-guarded
+  // markdown composed after the authored text (see
+  // transformers/image-rendering.ts) — unified `content` itself stays pure.
+  const textContent = composeContentWithImageMarkdown(
+    response.content,
+    response.image_generation_calls
+  );
+  if (textContent) parts.push({ text: textContent });
 
   if (response.tool_calls) {
     response.tool_calls.forEach((tc, index) => {

--- a/packages/backend/src/transformers/image-rendering.ts
+++ b/packages/backend/src/transformers/image-rendering.ts
@@ -1,0 +1,123 @@
+import { UnifiedImageGenerationCall } from '../types/unified';
+
+/**
+ * Chat-format rendering of Responses API `image_generation_call` output.
+ *
+ * The unified layer carries completed image items TYPED ONLY
+ * (`image_generation_calls`, full base64, never size-capped — see
+ * types/unified.ts). Unified `content` stays PURE authored message text.
+ * Client-facing renderers that want a text projection of the image (chat,
+ * anthropic/messages, gemini, ollama, legacy completions) compose it HERE,
+ * from the typed items; the responses-facing formatters re-emit the native
+ * item instead and never perform string surgery on the text. That split is
+ * what makes authored text that happens to contain the same characters as a
+ * rendered image segment (the markdown of a small image, or the oversized
+ * placeholder) impossible to corrupt.
+ */
+
+// Largest image_generation_call base64 `result` (in characters) that
+// renderImageResultMarkdown will inline as a data URI. Anything larger is
+// rendered as an omission placeholder instead: the markdown lands in a single
+// composed content string / SSE content delta, and a multi-megabyte data URI
+// there can blow past client/proxy message-size limits.
+export const MAX_INLINE_IMAGE_BASE64_CHARS = 8 * 1024 * 1024;
+
+/**
+ * Sniffs the image mime SUBTYPE from the magic bytes at the head of a base64
+ * payload. `output_format` is a REQUEST-side image tool field — it is not
+ * present on image_generation_call output items — so the payload's own
+ * signature is the only reliable source:
+ *   - PNG:  \x89 P N G
+ *   - JPEG: \xFF \xD8
+ *   - WebP: R I F F ...(4 size bytes)... W E B P
+ *   - GIF:  G I F 8
+ * Anything unrecognized defaults to png. Only the markdown data-URI rendering
+ * needs a mime — the native typed re-emit carries raw base64 with no URI.
+ */
+function sniffImageMimeSubtype(base64Result: string): string {
+  // 24 base64 chars decode to 18 bytes — enough for every signature above
+  // (WebP needs 12).
+  const head = Buffer.from(base64Result.slice(0, 24), 'base64');
+  if (
+    head.length >= 4 &&
+    head[0] === 0x89 &&
+    head[1] === 0x50 &&
+    head[2] === 0x4e &&
+    head[3] === 0x47
+  ) {
+    return 'png';
+  }
+  if (head.length >= 2 && head[0] === 0xff && head[1] === 0xd8) {
+    return 'jpeg';
+  }
+  if (
+    head.length >= 12 &&
+    head.toString('latin1', 0, 4) === 'RIFF' &&
+    head.toString('latin1', 8, 12) === 'WEBP'
+  ) {
+    return 'webp';
+  }
+  if (head.length >= 4 && head.toString('latin1', 0, 4) === 'GIF8') {
+    return 'gif';
+  }
+  return 'png';
+}
+
+/**
+ * Renders one base64 image `result` as a markdown data-URI image for
+ * chat-format text surfaces. Returns null for a missing/empty payload.
+ * Results larger than MAX_INLINE_IMAGE_BASE64_CHARS are NOT inlined: a short
+ * placeholder text segment (naming the approximate decoded size) is rendered
+ * instead, so a huge image can't flood a single content string/SSE delta.
+ * The mime subtype is sniffed from the payload's magic bytes (see
+ * sniffImageMimeSubtype).
+ */
+function renderImageResultMarkdown(result: unknown): string | null {
+  if (typeof result !== 'string' || result.length === 0) return null;
+  if (result.length > MAX_INLINE_IMAGE_BASE64_CHARS) {
+    // Base64 decodes to ~3/4 of its character count; report the
+    // approximate decoded size with one decimal.
+    const approxDecodedMb = ((result.length * 3) / 4 / (1024 * 1024)).toFixed(1);
+    return `[generated image omitted: ${approxDecodedMb} MB exceeds inline limit]`;
+  }
+  const format = sniffImageMimeSubtype(result);
+  return `![generated image](data:image/${format};base64,${result})`;
+}
+
+/**
+ * Renders a COMPLETED image_generation_call output item's base64 `result`
+ * as chat-format markdown (minimal-scope rendering: completed items only —
+ * partial-image preview deltas are explicitly out of scope, see
+ * responses.ts transformStream). Returns null when the item is not an
+ * image_generation_call or carries no base64 `result` payload. Size guard
+ * and mime sniff per renderImageResultMarkdown.
+ */
+export function imageGenerationCallMarkdown(item: any): string | null {
+  if (!item || item.type !== 'image_generation_call') return null;
+  return renderImageResultMarkdown(item.result);
+}
+
+/**
+ * Composes the client-visible text for a CHAT-FORMAT unary response: the
+ * pure authored `content`, followed by one rendered markdown segment per
+ * typed image item (data URI, or the oversized placeholder), joined with
+ * single `\n`s — the same client-visible bytes the pre-split design baked
+ * into unified content.
+ *
+ * When no image renders (the overwhelmingly common path), the original
+ * `content` value is returned UNCHANGED — no coercion, no copy — so
+ * image-less responses stay byte-identical through every chat-format
+ * formatter that previously passed `content` straight through.
+ */
+export function composeContentWithImageMarkdown(
+  content: string | null | undefined,
+  imageGenerationCalls: UnifiedImageGenerationCall[] | undefined
+): string | null | undefined {
+  const markdownSegments: string[] = [];
+  for (const imageCall of imageGenerationCalls ?? []) {
+    const markdown = renderImageResultMarkdown(imageCall?.result);
+    if (markdown) markdownSegments.push(markdown);
+  }
+  if (markdownSegments.length === 0) return content;
+  return (content ? [content, ...markdownSegments] : markdownSegments).join('\n');
+}

--- a/packages/backend/src/transformers/ollama.ts
+++ b/packages/backend/src/transformers/ollama.ts
@@ -1,5 +1,6 @@
 import { Transformer } from '../types/transformer';
 import { UnifiedChatRequest, UnifiedChatResponse, UnifiedChatStreamChunk } from '../types/unified';
+import { composeContentWithImageMarkdown } from './image-rendering';
 
 /**
  * OllamaTransformer
@@ -154,7 +155,13 @@ export class OllamaTransformer implements Transformer {
           index: 0,
           message: {
             role: 'assistant',
-            content: response.content,
+            // Image output renders as size-guarded markdown composed after
+            // the authored text (see transformers/image-rendering.ts) —
+            // unified `content` itself stays pure.
+            content: composeContentWithImageMarkdown(
+              response.content,
+              response.image_generation_calls
+            ),
             tool_calls: response.tool_calls,
           },
           finish_reason: response.tool_calls ? 'tool_calls' : response.finishReason || 'stop',

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -4,6 +4,7 @@ import { createParser, EventSourceMessage } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { normalizeOpenAIChatUsage } from '../utils/usage-normalizer';
 import { GEMINI_MALFORMED_FUNCTION_CALL_CODE } from '../utils/gemini-malformed-function-call';
+import { composeContentWithImageMarkdown } from './image-rendering';
 
 /**
  * OpenAITransformer
@@ -165,7 +166,12 @@ export class OpenAITransformer implements Transformer {
     // which normalizes incoming assistant messages into pi-ai's array format.
     const message: any = {
       role: 'assistant',
-      content: response.content,
+      // Chat-format clients receive image_generation_call output as
+      // size-guarded markdown (data URI or omission placeholder) appended
+      // after the authored text — composed HERE from the typed unified
+      // carry, never baked into unified `content` (which stays pure). See
+      // transformers/image-rendering.ts.
+      content: composeContentWithImageMarkdown(response.content, response.image_generation_calls),
       reasoning_content: response.reasoning_content,
       tool_calls: response.tool_calls,
       ...(response.annotations && response.annotations.length > 0

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -3,6 +3,7 @@ import { UnifiedChatRequest, UnifiedChatResponse } from '../types/unified';
 import { createParser, EventSourceMessage } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { normalizeOpenAIChatUsage } from '../utils/usage-normalizer';
+import { GEMINI_MALFORMED_FUNCTION_CALL_CODE } from '../utils/gemini-malformed-function-call';
 
 /**
  * OpenAITransformer
@@ -247,6 +248,47 @@ export class OpenAITransformer implements Transformer {
     const encoder = new TextEncoder();
     const reader = stream.getReader();
     let hasSentError = false;
+    // Only the legacy Gemini MALFORMED_FUNCTION_CALL defect (a transient,
+    // retry-worthy signal — see utils/gemini-malformed-function-call.ts)
+    // intentionally ends the stream WITHOUT `[DONE]`, so it reads as an
+    // aborted stream rather than a clean finish. Any other upstream error
+    // (Anthropic mid-stream error, Responses response.failed/error) is a
+    // genuine terminal condition and should still close cleanly with
+    // `[DONE]` so OpenAI-compatible clients don't hang waiting for one.
+    let suppressDone = false;
+    // Tracks whether any terminal signal (a real finish_reason chunk, an
+    // error chunk rendered as a normal finish, or the hard-error JSON
+    // payload) has already reached the client, so the end-of-stream flush
+    // below never synthesizes a redundant one.
+    let hasSentFinish = false;
+    // Some OpenAI-compatible upstreams (and Plexus itself, for Copilot-native
+    // streaming — see services/oauth/oauth-native-request.ts) request
+    // `stream_options.include_usage`, which sends a trailing
+    // `{choices: [], usage: {...}}` frame AFTER the real finish chunk.
+    // transformStream has no real choice to read there, so it can't tell
+    // that frame apart from a genuinely empty/terminal chunk — this flag lets
+    // exactly one such trailing usage frame still reach the client even
+    // though a terminal signal was already sent, without reopening the door
+    // for a second finish_reason or error chunk.
+    let hasForwardedTrailingUsage = false;
+    let lastChunkId: string | undefined;
+    let lastChunkModel: string | undefined;
+
+    const isEmptyDelta = (delta: any): boolean =>
+      !delta || (!delta.role && !delta.content && !delta.reasoning_content && !delta.tool_calls);
+
+    const buildChatUsagePayload = (usage: any) =>
+      usage
+        ? {
+            prompt_tokens: usage.input_tokens + (usage.cached_tokens || 0),
+            completion_tokens: usage.output_tokens,
+            total_tokens: usage.total_tokens,
+            prompt_tokens_details: usage.cached_tokens
+              ? { cached_tokens: usage.cached_tokens }
+              : null,
+            reasoning_tokens: usage.reasoning_tokens,
+          }
+        : undefined;
 
     return new ReadableStream({
       async start(controller) {
@@ -254,7 +296,26 @@ export class OpenAITransformer implements Transformer {
           while (true) {
             const { done, value: unifiedChunk } = await reader.read();
             if (done) {
-              if (!hasSentError) {
+              if (!hasSentFinish) {
+                // Source ended without ever emitting a finish_reason
+                // (upstream aborted, error dropped upstream of us, or zero
+                // parsable events): synthesize one so OpenAI-compatible
+                // clients never see a stream with no stop chunk.
+                controller.enqueue(
+                  encoder.encode(
+                    encode({
+                      data: JSON.stringify({
+                        id: lastChunkId,
+                        object: 'chat.completion.chunk',
+                        created: Math.floor(Date.now() / 1000),
+                        model: lastChunkModel,
+                        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+                      }),
+                    })
+                  )
+                );
+              }
+              if (!suppressDone) {
                 controller.enqueue(encoder.encode(encode({ data: '[DONE]' })));
               }
               break;
@@ -262,7 +323,95 @@ export class OpenAITransformer implements Transformer {
 
             if (hasSentError) continue;
 
+            lastChunkId = unifiedChunk.id ?? lastChunkId;
+            lastChunkModel = unifiedChunk.model ?? lastChunkModel;
+
+            // Once any terminal signal has been rendered — a hard-error
+            // payload OR an error-channel chunk rendered as a normal finish
+            // (e.g. the `length` case below) — close the door on everything
+            // else so a stray/duplicate chunk can never produce a second
+            // terminal payload. Mirrors the unconditional single-latch
+            // pattern used by the sibling formatters (formatAnthropicStream's
+            // `hasSentFinish` guard, formatGeminiStream's `hasSentError`
+            // guard). The one carved-out exception is a single trailing
+            // usage-only frame (see `hasForwardedTrailingUsage` above):
+            // rendered without a finish_reason (whatever transformStream put
+            // there, fabricated or not, is ignored) since it is metadata, not
+            // a second finish.
+            if (hasSentFinish) {
+              const isTrailingUsageOnly =
+                !hasForwardedTrailingUsage &&
+                unifiedChunk.event !== 'error' &&
+                !!unifiedChunk.usage &&
+                isEmptyDelta(unifiedChunk.delta);
+
+              if (!isTrailingUsageOnly) continue;
+
+              hasForwardedTrailingUsage = true;
+              const usagePayload = buildChatUsagePayload(unifiedChunk.usage);
+              controller.enqueue(
+                encoder.encode(
+                  encode({
+                    data: JSON.stringify({
+                      id: unifiedChunk.id,
+                      object: 'chat.completion.chunk',
+                      created: unifiedChunk.created || Math.floor(Date.now() / 1000),
+                      model: unifiedChunk.model,
+                      choices: [],
+                      ...(usagePayload ? { usage: usagePayload } : {}),
+                    }),
+                  })
+                )
+              );
+              continue;
+            }
+
             if (unifiedChunk.event === 'error') {
+              if (unifiedChunk.finish_reason) {
+                // A recognizable, non-fatal finish (e.g. Responses
+                // `response.incomplete` with reason `max_output_tokens` or
+                // `content_filter`) was carried through the error-chunk
+                // channel; render it as a normal finish instead of an error
+                // payload. Forward any final usage the upstream attached to
+                // this same chunk (see responses.ts transformStream) using
+                // the same usage-shaping helper as everywhere else in this
+                // file, so chat-format clients still receive it.
+                const usagePayload = buildChatUsagePayload(unifiedChunk.usage);
+                controller.enqueue(
+                  encoder.encode(
+                    encode({
+                      data: JSON.stringify({
+                        id: unifiedChunk.id,
+                        object: 'chat.completion.chunk',
+                        created: unifiedChunk.created || Math.floor(Date.now() / 1000),
+                        model: unifiedChunk.model,
+                        choices: [
+                          { index: 0, delta: {}, finish_reason: unifiedChunk.finish_reason },
+                        ],
+                        ...(usagePayload ? { usage: usagePayload } : {}),
+                      }),
+                    })
+                  )
+                );
+                hasSentFinish = true;
+                continue;
+              }
+
+              // The legacy Gemini MALFORMED_FUNCTION_CALL defect keeps its
+              // existing, specific rendering (downstream/clients may already
+              // key off this exact code) and its [DONE]-suppression. Any
+              // other hard error (Anthropic mid-stream error, Responses
+              // response.failed/error, or anything else routed through this
+              // channel) propagates its own upstream code instead of being
+              // mislabeled with Gemini's — falling back to a neutral generic
+              // only when the upstream genuinely didn't supply one.
+              const isLegacyGeminiMalformedCall =
+                unifiedChunk.error?.code === GEMINI_MALFORMED_FUNCTION_CALL_CODE;
+              // Same final-usage forwarding as the recognizable-finish
+              // branch above — a hard failure (e.g. Responses
+              // response.failed) can still carry final usage.
+              const usagePayload = buildChatUsagePayload(unifiedChunk.usage);
+
               controller.enqueue(
                 encoder.encode(
                   encode({
@@ -270,14 +419,25 @@ export class OpenAITransformer implements Transformer {
                       error: {
                         message: unifiedChunk.error?.message,
                         type: 'server_error',
-                        code: 'upstream_malformed_function_call',
+                        code: isLegacyGeminiMalformedCall
+                          ? 'upstream_malformed_function_call'
+                          : unifiedChunk.error?.code || 'upstream_error',
                       },
+                      ...(usagePayload ? { usage: usagePayload } : {}),
                     }),
                   })
                 )
               );
               hasSentError = true;
+              hasSentFinish = true;
+              if (isLegacyGeminiMalformedCall) {
+                suppressDone = true;
+              }
               continue;
+            }
+
+            if (unifiedChunk.finish_reason) {
+              hasSentFinish = true;
             }
 
             const choice: any = {

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -107,13 +107,21 @@ export class OpenAITransformer implements Transformer {
 
     if (request.response_format) {
       if (request.response_format.type === 'json_schema' && request.response_format.json_schema) {
-        // OpenAI json_schema mode requires {name, schema, strict} wrapping
+        // OpenAI json_schema mode requires {name, schema, strict} wrapping.
+        // The client-supplied descriptor (carried on the unified
+        // response_format — see types/unified.ts) wins; the fabricated
+        // `response_schema` / `strict: true` values are fallbacks ONLY for
+        // clients that omitted them (`?? `— an explicit strict: false must
+        // survive).
         out.response_format = {
           type: 'json_schema',
           json_schema: {
-            name: 'response_schema',
+            name: request.response_format.name ?? 'response_schema',
+            ...(request.response_format.description !== undefined
+              ? { description: request.response_format.description }
+              : {}),
             schema: request.response_format.json_schema,
-            strict: true,
+            strict: request.response_format.strict ?? true,
           },
         };
       } else {
@@ -301,11 +309,21 @@ export class OpenAITransformer implements Transformer {
                 // (upstream aborted, error dropped upstream of us, or zero
                 // parsable events): synthesize one so OpenAI-compatible
                 // clients never see a stream with no stop chunk.
+                //
+                // With ZERO parsable chunks there is no upstream id to echo,
+                // so synthesize one (this file has no id-generation
+                // convention of its own; `chatcmpl_` matches the OpenAI wire
+                // prefix). No `model` is synthesized in that case: this
+                // formatter's only input is the unified chunk stream itself
+                // — it has no request context — so when no chunk ever
+                // arrived the model is genuinely unknowable here, and the
+                // field is omitted (JSON drops the undefined) rather than
+                // fabricated.
                 controller.enqueue(
                   encoder.encode(
                     encode({
                       data: JSON.stringify({
-                        id: lastChunkId,
+                        id: lastChunkId ?? `chatcmpl_${crypto.randomUUID()}`,
                         object: 'chat.completion.chunk',
                         created: Math.floor(Date.now() / 1000),
                         model: lastChunkModel,

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -156,7 +156,11 @@ export class ResponsesTransformer implements Transformer {
       model: input.model,
       messages,
       max_tokens: input.max_output_tokens,
-      temperature: input.temperature ?? 1.0,
+      // Forward temperature only when the client actually sent it. GPT-5
+      // reasoning models (and others) reject sampling params outright, so
+      // injecting a fabricated default here would send `temperature: 1.0`
+      // upstream on every request that omitted it.
+      temperature: input.temperature,
       stream: input.stream ?? false,
       tools: tools.length > 0 ? tools : undefined,
       tool_choice: this.convertToolChoiceForChatCompletions(input.tool_choice),
@@ -1074,6 +1078,80 @@ export class ResponsesTransformer implements Transformer {
                     hasFunctionCall || completedResponseHasFunctionCall ? 'tool_calls' : 'stop',
                   usage: normalizedUsage,
                 });
+              } else if (data.type === 'response.failed') {
+                // Upstream reported a hard failure mid-stream. Surface it as
+                // a unified error chunk (same shape OpenAITransformer.formatStream
+                // already renders) instead of silently ending the stream.
+                // Propagate final usage (when the upstream included it
+                // alongside the failure) so chat-format clients still
+                // receive an accurate token count for the turn instead of
+                // silently losing it.
+                const err = data.response?.error || {};
+                const usage = data.response?.usage;
+                const normalizedUsage = usage ? normalizeOpenAIResponsesUsage(usage) : undefined;
+                controller.enqueue({
+                  id: responseId || data.response?.id || '',
+                  model: responseModel || data.response?.model || '',
+                  created: Math.floor(Date.now() / 1000),
+                  event: 'error',
+                  delta: {},
+                  error: {
+                    statusCode: 500,
+                    code: err.code || 'response_failed',
+                    message: err.message || 'The model response failed to complete.',
+                  },
+                  ...(normalizedUsage ? { usage: normalizedUsage } : {}),
+                });
+              } else if (data.type === 'response.incomplete') {
+                // Upstream ended the response early (e.g. hitting
+                // max_output_tokens, or a content_filter cutoff) rather than
+                // failing outright. Carry both the OpenAI-compatible finish
+                // reason AND the raw incomplete_details on the unified chunk
+                // — formatStream (both chat- and responses-facing) needs
+                // incomplete_details to tell an "ended incomplete" chunk
+                // apart from a genuine response.failed hard error. Also
+                // propagate final usage, same as response.failed above.
+                const incompleteDetails = data.response?.incomplete_details;
+                const reason = incompleteDetails?.reason || 'unknown';
+                const usage = data.response?.usage;
+                const normalizedUsage = usage ? normalizeOpenAIResponsesUsage(usage) : undefined;
+                controller.enqueue({
+                  id: responseId || data.response?.id || '',
+                  model: responseModel || data.response?.model || '',
+                  created: Math.floor(Date.now() / 1000),
+                  event: 'error',
+                  delta: {},
+                  finish_reason:
+                    reason === 'max_output_tokens'
+                      ? 'length'
+                      : reason === 'content_filter'
+                        ? 'content_filter'
+                        : undefined,
+                  incomplete_details: incompleteDetails,
+                  error: {
+                    statusCode: 500,
+                    code: reason,
+                    message: `Response ended incomplete: ${reason}`,
+                  },
+                  ...(normalizedUsage ? { usage: normalizedUsage } : {}),
+                });
+              } else if (data.type === 'error') {
+                // Generic Responses API stream error event (top-level, not
+                // nested under `response`) — no incomplete_details, since
+                // this is a hard stream-level error, not an "ended
+                // incomplete" signal.
+                controller.enqueue({
+                  id: responseId,
+                  model: responseModel,
+                  created: Math.floor(Date.now() / 1000),
+                  event: 'error',
+                  delta: {},
+                  error: {
+                    statusCode: 500,
+                    code: data.code || 'error',
+                    message: data.message || 'Upstream error',
+                  },
+                });
               }
             } catch (e) {
               logger.error('Error parsing Responses API streaming chunk', e);
@@ -1457,6 +1535,24 @@ export class ResponsesTransformer implements Transformer {
         .map(([, item]) => item);
     };
 
+    const buildUsagePayload = (usage: any) =>
+      usage
+        ? {
+            input_tokens:
+              (usage.input_tokens || 0) +
+              (usage.cached_tokens || 0) +
+              (usage.cache_creation_tokens || 0),
+            output_tokens: usage.output_tokens,
+            total_tokens: usage.total_tokens,
+            input_tokens_details: {
+              cached_tokens: usage.cached_tokens || 0,
+            },
+            output_tokens_details: {
+              reasoning_tokens: usage.reasoning_tokens || 0,
+            },
+          }
+        : undefined;
+
     return new ReadableStream({
       async start(controller) {
         try {
@@ -1502,6 +1598,58 @@ export class ResponsesTransformer implements Transformer {
 
             ensureCreated(controller, unifiedChunk);
             ensureInProgress(controller);
+
+            if (unifiedChunk.event === 'error') {
+              // Upstream failed, ended incomplete, or reported a stream-level
+              // error (surfaced as a unified error chunk by transformStream).
+              // Emit the matching Responses-API terminal event instead of
+              // unconditionally completing, so the client sees the actual
+              // outcome rather than a phantom success:
+              //   - incomplete_details present -> response.incomplete (the
+              //     upstream ended the turn early — max_output_tokens /
+              //     content_filter — not a hard failure).
+              //   - otherwise -> response.failed (a genuine hard error),
+              //     exactly as before.
+              if (unifiedChunk.usage) {
+                lastUsage = unifiedChunk.usage;
+              }
+              const outputItems = finalizeOutputItems(controller);
+              const err = unifiedChunk.error || {};
+
+              if (unifiedChunk.incomplete_details) {
+                sendEvent(controller, {
+                  type: 'response.incomplete',
+                  response: {
+                    id: responseId || undefined,
+                    object: 'response',
+                    created_at: responseCreatedAt || Math.floor(Date.now() / 1000),
+                    status: 'incomplete',
+                    model: responseModel,
+                    output: outputItems,
+                    incomplete_details: unifiedChunk.incomplete_details,
+                    usage: buildUsagePayload(lastUsage),
+                  },
+                });
+              } else {
+                sendEvent(controller, {
+                  type: 'response.failed',
+                  response: {
+                    id: responseId || undefined,
+                    object: 'response',
+                    created_at: responseCreatedAt || Math.floor(Date.now() / 1000),
+                    status: 'failed',
+                    model: responseModel,
+                    output: outputItems,
+                    error: {
+                      code: err.code || 'server_error',
+                      message: err.message || 'The model response failed to complete.',
+                    },
+                    usage: buildUsagePayload(lastUsage),
+                  },
+                });
+              }
+              break;
+            }
 
             if (unifiedChunk.usage) {
               lastUsage = unifiedChunk.usage;

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -11,7 +11,12 @@ import {
   ResponsesReasoningTextPart,
   ResponsesSummaryTextPart,
 } from '../types/responses';
-import { UnifiedChatRequest, UnifiedChatResponse, UnifiedMessage } from '../types/unified';
+import {
+  UnifiedChatRequest,
+  UnifiedChatResponse,
+  UnifiedImageGenerationCall,
+  UnifiedMessage,
+} from '../types/unified';
 import { createParser } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { logger } from '../utils/logger';
@@ -19,6 +24,89 @@ import { normalizeOpenAIChatUsage, normalizeOpenAIResponsesUsage } from '../util
 
 const OPENAI_RESPONSES_CALL_ID_MAX_LENGTH = 64;
 const OPENAI_RESPONSES_REASONING_CONTENT_MAX_ITEMS = 0;
+
+// Largest image_generation_call base64 `result` (in characters) that
+// imageGenerationCallMarkdown will inline as a data URI. Anything larger is
+// rendered as an omission placeholder instead: the markdown lands in a single
+// unified content string / SSE content delta, and a multi-megabyte data URI
+// there can blow past client/proxy message-size limits.
+const MAX_INLINE_IMAGE_BASE64_CHARS = 8 * 1024 * 1024;
+
+/**
+ * Projects a completed image_generation_call output item (with a non-empty
+ * base64 `result`) onto the typed unified carry — see
+ * UnifiedImageGenerationCall in types/unified.ts. The `result` is carried
+ * byte-intact: the inline size cap applies only to the paired markdown
+ * rendering, never to the typed item.
+ */
+function toUnifiedImageGenerationCall(item: any): UnifiedImageGenerationCall {
+  return {
+    ...(typeof item.id === 'string' ? { id: item.id } : {}),
+    ...(typeof item.status === 'string' ? { status: item.status } : {}),
+    result: item.result,
+  };
+}
+
+/**
+ * Sniffs the image mime SUBTYPE from the magic bytes at the head of a base64
+ * payload. `output_format` is a REQUEST-side image tool field — it is not
+ * present on image_generation_call output items — so the payload's own
+ * signature is the only reliable source:
+ *   - PNG:  \x89 P N G
+ *   - JPEG: \xFF \xD8
+ *   - WebP: R I F F ...(4 size bytes)... W E B P
+ *   - GIF:  G I F 8
+ * Anything unrecognized defaults to png. Only the markdown data-URI rendering
+ * needs a mime — the native typed re-emit carries raw base64 with no URI.
+ */
+function sniffImageMimeSubtype(base64Result: string): string {
+  // 24 base64 chars decode to 18 bytes — enough for every signature above
+  // (WebP needs 12).
+  const head = Buffer.from(base64Result.slice(0, 24), 'base64');
+  if (
+    head.length >= 4 &&
+    head[0] === 0x89 &&
+    head[1] === 0x50 &&
+    head[2] === 0x4e &&
+    head[3] === 0x47
+  ) {
+    return 'png';
+  }
+  if (head.length >= 2 && head[0] === 0xff && head[1] === 0xd8) {
+    return 'jpeg';
+  }
+  if (
+    head.length >= 12 &&
+    head.toString('latin1', 0, 4) === 'RIFF' &&
+    head.toString('latin1', 8, 12) === 'WEBP'
+  ) {
+    return 'webp';
+  }
+  if (head.length >= 4 && head.toString('latin1', 0, 4) === 'GIF8') {
+    return 'gif';
+  }
+  return 'png';
+}
+
+/**
+ * Removes one rendered image segment (a markdown data-URI or the oversized
+ * placeholder) from a combined unified content string, consuming the single
+ * `\n` join that transformResponse inserted between segments. Used by the
+ * responses-facing formatResponse so the native image_generation_call item is
+ * the ONLY carrier — the message text keeps just the real message segments.
+ */
+function removeRenderedImageSegment(content: string, segment: string): string {
+  const index = content.indexOf(segment);
+  if (index === -1) return content;
+  const end = index + segment.length;
+  if (end < content.length && content[end] === '\n') {
+    return content.slice(0, index) + content.slice(end + 1);
+  }
+  if (index > 0 && content[index - 1] === '\n') {
+    return content.slice(0, index - 1) + content.slice(end);
+  }
+  return content.slice(0, index) + content.slice(end);
+}
 
 // Some Responses clients have been observed replaying tool calls with composite
 // IDs like "call_...|fc_...". OpenAI-compatible providers validate call_id
@@ -151,31 +239,51 @@ export class ResponsesTransformer implements Transformer {
       });
     }
 
+    // Maybe-undefined client fields use conditional spread (not
+    // `key: input.maybeUndefined`) so an omitted client field leaves NO own
+    // property on the unified request — a phantom `key: undefined` own
+    // property survives object spreads and flips `'key' in x` /
+    // hasOwnProperty checks downstream even though JSON would drop it.
     return {
-      requestId: input.requestId,
+      ...(input.requestId !== undefined ? { requestId: input.requestId } : {}),
       model: input.model,
       messages,
-      max_tokens: input.max_output_tokens,
+      ...(input.max_output_tokens !== undefined ? { max_tokens: input.max_output_tokens } : {}),
       // Forward temperature only when the client actually sent it. GPT-5
       // reasoning models (and others) reject sampling params outright, so
       // injecting a fabricated default here would send `temperature: 1.0`
       // upstream on every request that omitted it.
-      temperature: input.temperature,
-      stream: input.stream ?? false,
-      tools: tools.length > 0 ? tools : undefined,
+      ...(input.temperature !== undefined ? { temperature: input.temperature } : {}),
+      ...(input.stream !== undefined ? { stream: input.stream } : {}),
+      ...(tools.length > 0 ? { tools } : {}),
       tool_choice: this.convertToolChoiceForChatCompletions(input.tool_choice),
-      reasoning: input.reasoning,
-      include: input.include,
-      prompt_cache_key: input.prompt_cache_key,
-      text: input.text,
-      parallel_tool_calls: input.parallel_tool_calls,
-      response_format: input.text?.format
+      ...(input.reasoning !== undefined ? { reasoning: input.reasoning } : {}),
+      ...(input.include !== undefined ? { include: input.include } : {}),
+      ...(input.prompt_cache_key !== undefined ? { prompt_cache_key: input.prompt_cache_key } : {}),
+      ...(input.text !== undefined ? { text: input.text } : {}),
+      ...(input.parallel_tool_calls !== undefined
+        ? { parallel_tool_calls: input.parallel_tool_calls }
+        : {}),
+      ...(input.text?.format
         ? {
-            type: input.text.format.type,
-            json_schema: input.text.format.schema,
+            response_format: {
+              type: input.text.format.type,
+              json_schema: input.text.format.schema,
+              // Carry the full structured-output descriptor: dropping
+              // name/description/strict would force the responses -> chat
+              // emission to fabricate `name: "response_schema"` /
+              // `strict: true` over the client-supplied values.
+              ...(input.text.format.name !== undefined ? { name: input.text.format.name } : {}),
+              ...(input.text.format.description !== undefined
+                ? { description: input.text.format.description }
+                : {}),
+              ...(input.text.format.strict !== undefined
+                ? { strict: input.text.format.strict }
+                : {}),
+            },
           }
-        : undefined,
-      metadata: input.metadata,
+        : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
       incomingApiType: 'responses',
       originalBody: input,
     };
@@ -268,10 +376,15 @@ export class ResponsesTransformer implements Transformer {
       };
     });
 
+    // `stream` uses conditional spread for the same reason parseRequest does:
+    // when the client omitted it, the outbound payload must carry NO own
+    // `stream` property — a phantom `stream: undefined` survives object
+    // spreads and flips `'stream' in x` / hasOwnProperty checks downstream
+    // even though JSON serialization would drop it.
     const payload: any = {
       model: request.model,
       input: inputItems,
-      stream: request.stream,
+      ...(request.stream !== undefined ? { stream: request.stream } : {}),
     };
 
     if (instructions) {
@@ -367,7 +480,33 @@ export class ResponsesTransformer implements Transformer {
 
       // Find the first message output item for content
       const messageItem = response.output?.find((item: any) => item.type === 'message');
-      const content = messageItem?.content?.map((part: any) => part.text).join('\n') || null;
+      const messageText = messageItem?.content?.map((part: any) => part.text).join('\n') || null;
+
+      // Minimal image_generation_call rendering for chat-format clients:
+      // a completed item with a base64 `result` becomes a markdown data-URI
+      // image appended to the unified content, in output-item order relative
+      // to the (first) message item. Without this, an image-only Responses
+      // completion yields no content at all once transformed. When no image
+      // items are present the content is exactly the message text, as before.
+      //
+      // The same completed items are ALSO carried typed (byte-intact, no
+      // inline size cap) on `image_generation_calls` so a responses-facing
+      // formatResponse can re-emit the native item instead of the lossy
+      // markdown — see UnifiedImageGenerationCall in types/unified.ts.
+      const contentSegments: string[] = [];
+      const imageGenerationCalls: UnifiedImageGenerationCall[] = [];
+      for (const item of response.output ?? []) {
+        if (item === messageItem && messageText) {
+          contentSegments.push(messageText);
+          continue;
+        }
+        const imageMarkdown = this.imageGenerationCallMarkdown(item);
+        if (imageMarkdown) {
+          contentSegments.push(imageMarkdown);
+          imageGenerationCalls.push(toUnifiedImageGenerationCall(item));
+        }
+      }
+      const content = contentSegments.length > 0 ? contentSegments.join('\n') : messageText;
 
       // Collect url_citation annotations from all output_text content parts
       const annotations: any[] = [];
@@ -433,6 +572,9 @@ export class ResponsesTransformer implements Transformer {
         reasoning_content,
         annotations: annotations.length > 0 ? annotations : undefined,
         tool_calls: toolCalls && toolCalls.length > 0 ? toolCalls : undefined,
+        ...(imageGenerationCalls.length > 0
+          ? { image_generation_calls: imageGenerationCalls }
+          : {}),
         usage,
       };
     } else {
@@ -844,6 +986,35 @@ export class ResponsesTransformer implements Transformer {
   }
 
   /**
+   * Renders a COMPLETED image_generation_call output item's base64 `result`
+   * as a markdown data-URI image for chat-format clients (minimal-scope
+   * rendering: completed items only — partial-image preview deltas are
+   * explicitly out of scope, see transformStream). Returns null when the
+   * item carries no base64 `result` payload. The mime subtype is sniffed
+   * from the decoded payload's magic bytes (see sniffImageMimeSubtype) —
+   * `output_format` is a request-tool field that never appears on output
+   * items, so it is deliberately not consulted.
+   *
+   * Results larger than MAX_INLINE_IMAGE_BASE64_CHARS are NOT inlined:
+   * a short placeholder text segment (naming the approximate decoded size)
+   * is rendered instead, so a huge image can't flood a single content
+   * string/SSE delta. Both call sites (transformResponse segments and
+   * transformStream's done/completed rendering) share this guard.
+   */
+  private imageGenerationCallMarkdown(item: any): string | null {
+    if (!item || item.type !== 'image_generation_call') return null;
+    if (typeof item.result !== 'string' || item.result.length === 0) return null;
+    if (item.result.length > MAX_INLINE_IMAGE_BASE64_CHARS) {
+      // Base64 decodes to ~3/4 of its character count; report the
+      // approximate decoded size with one decimal.
+      const approxDecodedMb = ((item.result.length * 3) / 4 / (1024 * 1024)).toFixed(1);
+      return `[generated image omitted: ${approxDecodedMb} MB exceeds inline limit]`;
+    }
+    const format = sniffImageMimeSubtype(item.result);
+    return `![generated image](data:image/${format};base64,${item.result})`;
+  }
+
+  /**
    * Converts Chat Completions response to output items array
    */
   private convertChatResponseToOutputItems(response: UnifiedChatResponse): ResponsesOutputItem[] {
@@ -875,6 +1046,31 @@ export class ResponsesTransformer implements Transformer {
       }
     }
 
+    // Re-emit typed image_generation_call items natively (full base64 — the
+    // native format has no inline-markdown size concern), and strip each
+    // item's paired chat-format rendering (recomputed via the same pure
+    // imageGenerationCallMarkdown helper: data URI, or the oversized
+    // placeholder) out of the combined content so the message text below
+    // carries only the real message segments — never the image twice, never
+    // the placeholder.
+    let messageText = response.content || '';
+    for (const imageCall of response.image_generation_calls ?? []) {
+      if (typeof imageCall.result !== 'string' || imageCall.result.length === 0) continue;
+      const markdown = this.imageGenerationCallMarkdown({
+        type: 'image_generation_call',
+        result: imageCall.result,
+      });
+      if (markdown) {
+        messageText = removeRenderedImageSegment(messageText, markdown);
+      }
+      items.push({
+        type: 'image_generation_call',
+        id: imageCall.id ?? this.generateItemId('ig'),
+        status: (imageCall.status as 'in_progress' | 'completed' | 'failed') ?? 'completed',
+        result: imageCall.result,
+      });
+    }
+
     // Add main message
     items.push({
       type: 'message',
@@ -884,7 +1080,7 @@ export class ResponsesTransformer implements Transformer {
       content: [
         {
           type: 'output_text',
-          text: response.content || '',
+          text: messageText,
           annotations: response.annotations || [],
         },
       ],
@@ -953,6 +1149,14 @@ export class ResponsesTransformer implements Transformer {
     const toolCallIndexByItemId = new Map<string, number>();
     let nextToolCallIndex = 0;
     let hasFunctionCall = false;
+    // image_generation_call items already rendered as a content delta from
+    // their response.output_item.done event, so the response.completed
+    // fallback below doesn't render them a second time.
+    const renderedImageItemIds = new Set<string>();
+    // `start(controller)` below uses method shorthand, so `this` inside it is
+    // the stream's underlying source, not this transformer instance — capture
+    // the helper as a local for use in that scope.
+    const imageGenerationCallMarkdown = (item: any) => this.imageGenerationCallMarkdown(item);
 
     const getToolCallIndex = (data: any): number => {
       const outputIndex =
@@ -1060,6 +1264,38 @@ export class ResponsesTransformer implements Transformer {
                   },
                   finish_reason: null,
                 });
+              } else if (
+                data.type === 'response.output_item.done' &&
+                data.item?.type === 'image_generation_call'
+              ) {
+                // Minimal image rendering, COMPLETED items only: a finished
+                // image_generation_call with a base64 result becomes a
+                // markdown data-URI content delta for chat-format clients,
+                // PAIRED with the chunk-level typed carry
+                // (`image_generation_calls`, full base64 — see
+                // types/unified.ts) that responses-facing formatters re-emit
+                // natively instead of the markdown. Partial-image preview
+                // events (response.image_generation_call.partial_image) are
+                // deliberately NOT handled — rendering progressive previews
+                // as chat content deltas has no sensible mapping, so they
+                // are explicitly skipped as out of scope; only the final
+                // completed image renders.
+                const imageMarkdown = imageGenerationCallMarkdown(data.item);
+                if (imageMarkdown) {
+                  if (typeof data.item.id === 'string') {
+                    renderedImageItemIds.add(data.item.id);
+                  }
+                  controller.enqueue({
+                    id: responseId,
+                    model: responseModel,
+                    created: Math.floor(Date.now() / 1000),
+                    delta: {
+                      content: imageMarkdown,
+                    },
+                    image_generation_calls: [toUnifiedImageGenerationCall(data.item)],
+                    finish_reason: null,
+                  });
+                }
               } else if (data.type === 'response.completed') {
                 // Final chunk with usage data and an OpenAI-compatible finish reason.
                 // `response.completed` includes the full output as a fallback because some
@@ -1069,6 +1305,28 @@ export class ResponsesTransformer implements Transformer {
                 const completedResponseHasFunctionCall = data.response?.output?.some(
                   (item: any) => item?.type === 'function_call'
                 );
+                // Same fallback as function calls above: render any completed
+                // image_generation_call items that only appear in the final
+                // response (skipping ones already rendered from their own
+                // response.output_item.done event) BEFORE the terminal chunk,
+                // so the content delta still reaches the client — with the
+                // same paired typed carry as the output_item.done path.
+                for (const item of data.response?.output ?? []) {
+                  if (item?.type !== 'image_generation_call') continue;
+                  if (typeof item.id === 'string' && renderedImageItemIds.has(item.id)) continue;
+                  const imageMarkdown = imageGenerationCallMarkdown(item);
+                  if (!imageMarkdown) continue;
+                  controller.enqueue({
+                    id: responseId,
+                    model: responseModel,
+                    created: Math.floor(Date.now() / 1000),
+                    delta: {
+                      content: imageMarkdown,
+                    },
+                    image_generation_calls: [toUnifiedImageGenerationCall(item)],
+                    finish_reason: null,
+                  });
+                }
                 controller.enqueue({
                   id: responseId,
                   model: responseModel,
@@ -1390,12 +1648,52 @@ export class ResponsesTransformer implements Transformer {
       });
     };
 
-    const finalizeOutputItems = (controller: ReadableStreamDefaultController): any[] => {
+    // Re-emits typed image_generation_call carries (see types/unified.ts) as
+    // native Responses output items — full base64 `result`, no inline size
+    // cap (the markdown guard exists for content strings; the native format
+    // has no such concern). Each item is registered in outputItemsByIndex so
+    // the terminal response.completed's output array includes it.
+    const emitImageGenerationCallItems = (
+      controller: ReadableStreamDefaultController,
+      imageCalls: Array<{ id?: string; status?: string; result: string }>
+    ) => {
+      for (const imageCall of imageCalls) {
+        const outputIndex = reserveOutputIndex();
+        const itemId = imageCall.id || this.generateItemId('ig');
+        const doneItem = {
+          id: itemId,
+          type: 'image_generation_call',
+          status: imageCall.status || 'completed',
+          result: imageCall.result,
+        };
+        sendEvent(controller, {
+          type: 'response.output_item.added',
+          output_index: outputIndex,
+          item: { ...doneItem, status: 'in_progress', result: null },
+        });
+        sendEvent(controller, {
+          type: 'response.output_item.done',
+          output_index: outputIndex,
+          item: doneItem,
+        });
+        outputItemsByIndex.set(outputIndex, doneItem);
+      }
+    };
+
+    // `itemStatus` is the terminal status stamped on items that were still
+    // in progress when the stream ended. The completed and failed paths keep
+    // the pre-existing 'completed' stamp; only the response.incomplete path
+    // passes 'incomplete' (matching the real Responses API, where items cut
+    // off mid-generation surface as status 'incomplete').
+    const finalizeOutputItems = (
+      controller: ReadableStreamDefaultController,
+      itemStatus: 'completed' | 'incomplete' = 'completed'
+    ): any[] => {
       if (reasoningItemSent && reasoningOutputIndex !== null) {
         const reasoningItem = {
           id: reasoningItemId,
           type: 'reasoning',
-          status: 'completed',
+          status: itemStatus,
           content: reasoningText
             ? [
                 {
@@ -1455,7 +1753,7 @@ export class ResponsesTransformer implements Transformer {
         const messageItem = {
           id: messageItemId,
           type: 'message',
-          status: 'completed',
+          status: itemStatus,
           role: 'assistant',
           content: [
             {
@@ -1505,7 +1803,7 @@ export class ResponsesTransformer implements Transformer {
           toolItem = {
             id: itemId,
             type: 'custom_tool_call',
-            status: 'completed',
+            status: itemStatus,
             call_id: callId,
             name: flatName,
             input: this.customToolInput(args),
@@ -1515,7 +1813,7 @@ export class ResponsesTransformer implements Transformer {
           toolItem = {
             id: itemId,
             type: 'function_call',
-            status: 'completed',
+            status: itemStatus,
             call_id: callId,
             name: namespaced ? namespaced.name : flatName,
             ...(namespaced ? { namespace: namespaced.namespace } : {}),
@@ -1613,7 +1911,13 @@ export class ResponsesTransformer implements Transformer {
               if (unifiedChunk.usage) {
                 lastUsage = unifiedChunk.usage;
               }
-              const outputItems = finalizeOutputItems(controller);
+              // Items still in progress on the incomplete path finalize with
+              // status 'incomplete'; the failed path keeps the pre-existing
+              // 'completed' stamp (see finalizeOutputItems).
+              const outputItems = finalizeOutputItems(
+                controller,
+                unifiedChunk.incomplete_details ? 'incomplete' : 'completed'
+              );
               const err = unifiedChunk.error || {};
 
               if (unifiedChunk.incomplete_details) {
@@ -1661,6 +1965,22 @@ export class ResponsesTransformer implements Transformer {
             const reasoningSummaryDelta =
               typeof delta.thinking?.content === 'string' ? delta.thinking.content : null;
 
+            // Typed image_generation_call carries re-emit as NATIVE output
+            // items for this Responses-format client. The same chunk's
+            // `delta.content` is the chat-format markdown rendering of these
+            // exact items (transformStream pairs them 1:1), so the content
+            // delta is skipped below — the native item is the only carrier
+            // here (a chat client would render the markdown instead).
+            const typedImageCalls = Array.isArray(unifiedChunk.image_generation_calls)
+              ? unifiedChunk.image_generation_calls.filter(
+                  (imageCall: any) =>
+                    imageCall && typeof imageCall.result === 'string' && imageCall.result.length > 0
+                )
+              : [];
+            if (typedImageCalls.length > 0) {
+              emitImageGenerationCallItems(controller, typedImageCalls);
+            }
+
             if (reasoningDelta && reasoningDelta.length > 0) {
               ensureReasoningItem(controller);
               reasoningText += reasoningDelta;
@@ -1698,7 +2018,11 @@ export class ResponsesTransformer implements Transformer {
               });
             }
 
-            if (typeof delta.content === 'string' && delta.content.length > 0) {
+            if (
+              typeof delta.content === 'string' &&
+              delta.content.length > 0 &&
+              typedImageCalls.length === 0
+            ) {
               ensureMessageItem(controller);
               messageText += delta.content;
               sendEvent(controller, {

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -1255,10 +1255,15 @@ export class ResponsesTransformer implements Transformer {
                 // reason AND the raw incomplete_details on the unified chunk
                 // — formatStream (both chat- and responses-facing) needs
                 // incomplete_details to tell an "ended incomplete" chunk
-                // apart from a genuine response.failed hard error. Also
-                // propagate final usage, same as response.failed above.
-                const incompleteDetails = data.response?.incomplete_details;
-                const reason = incompleteDetails?.reason || 'unknown';
+                // apart from a genuine response.failed hard error. When the
+                // upstream omits incomplete_details entirely, default to
+                // { reason: 'unknown' } so the chunk still reads as an
+                // incomplete (not a hard failure) downstream. Also propagate
+                // final usage, same as response.failed above.
+                const incompleteDetails = data.response?.incomplete_details ?? {
+                  reason: 'unknown',
+                };
+                const reason = incompleteDetails.reason || 'unknown';
                 const usage = data.response?.usage;
                 const normalizedUsage = usage ? normalizeOpenAIResponsesUsage(usage) : undefined;
                 controller.enqueue({
@@ -1267,12 +1272,13 @@ export class ResponsesTransformer implements Transformer {
                   created: Math.floor(Date.now() / 1000),
                   event: 'error',
                   delta: {},
-                  finish_reason:
-                    reason === 'max_output_tokens'
-                      ? 'length'
-                      : reason === 'content_filter'
-                        ? 'content_filter'
-                        : undefined,
+                  // 'content_filter' keeps its own finish reason; everything
+                  // else (max_output_tokens, unknown/absent reasons) maps to
+                  // 'length' — the same OpenAI-compatible default as
+                  // usage-logging's raw-mode incomplete mapping — so every
+                  // incomplete chunk carries a recognizable non-fatal finish
+                  // for the chat-facing formatters.
+                  finish_reason: reason === 'content_filter' ? 'content_filter' : 'length',
                   incomplete_details: incompleteDetails,
                   error: {
                     statusCode: 500,

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -21,23 +21,17 @@ import { createParser } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { logger } from '../utils/logger';
 import { normalizeOpenAIChatUsage, normalizeOpenAIResponsesUsage } from '../utils/usage-normalizer';
+import { imageGenerationCallMarkdown } from './image-rendering';
 
 const OPENAI_RESPONSES_CALL_ID_MAX_LENGTH = 64;
 const OPENAI_RESPONSES_REASONING_CONTENT_MAX_ITEMS = 0;
-
-// Largest image_generation_call base64 `result` (in characters) that
-// imageGenerationCallMarkdown will inline as a data URI. Anything larger is
-// rendered as an omission placeholder instead: the markdown lands in a single
-// unified content string / SSE content delta, and a multi-megabyte data URI
-// there can blow past client/proxy message-size limits.
-const MAX_INLINE_IMAGE_BASE64_CHARS = 8 * 1024 * 1024;
 
 /**
  * Projects a completed image_generation_call output item (with a non-empty
  * base64 `result`) onto the typed unified carry — see
  * UnifiedImageGenerationCall in types/unified.ts. The `result` is carried
- * byte-intact: the inline size cap applies only to the paired markdown
- * rendering, never to the typed item.
+ * byte-intact: the inline size cap applies only to the chat-format markdown
+ * rendering (see transformers/image-rendering.ts), never to the typed item.
  */
 function toUnifiedImageGenerationCall(item: any): UnifiedImageGenerationCall {
   return {
@@ -45,67 +39,6 @@ function toUnifiedImageGenerationCall(item: any): UnifiedImageGenerationCall {
     ...(typeof item.status === 'string' ? { status: item.status } : {}),
     result: item.result,
   };
-}
-
-/**
- * Sniffs the image mime SUBTYPE from the magic bytes at the head of a base64
- * payload. `output_format` is a REQUEST-side image tool field — it is not
- * present on image_generation_call output items — so the payload's own
- * signature is the only reliable source:
- *   - PNG:  \x89 P N G
- *   - JPEG: \xFF \xD8
- *   - WebP: R I F F ...(4 size bytes)... W E B P
- *   - GIF:  G I F 8
- * Anything unrecognized defaults to png. Only the markdown data-URI rendering
- * needs a mime — the native typed re-emit carries raw base64 with no URI.
- */
-function sniffImageMimeSubtype(base64Result: string): string {
-  // 24 base64 chars decode to 18 bytes — enough for every signature above
-  // (WebP needs 12).
-  const head = Buffer.from(base64Result.slice(0, 24), 'base64');
-  if (
-    head.length >= 4 &&
-    head[0] === 0x89 &&
-    head[1] === 0x50 &&
-    head[2] === 0x4e &&
-    head[3] === 0x47
-  ) {
-    return 'png';
-  }
-  if (head.length >= 2 && head[0] === 0xff && head[1] === 0xd8) {
-    return 'jpeg';
-  }
-  if (
-    head.length >= 12 &&
-    head.toString('latin1', 0, 4) === 'RIFF' &&
-    head.toString('latin1', 8, 12) === 'WEBP'
-  ) {
-    return 'webp';
-  }
-  if (head.length >= 4 && head.toString('latin1', 0, 4) === 'GIF8') {
-    return 'gif';
-  }
-  return 'png';
-}
-
-/**
- * Removes one rendered image segment (a markdown data-URI or the oversized
- * placeholder) from a combined unified content string, consuming the single
- * `\n` join that transformResponse inserted between segments. Used by the
- * responses-facing formatResponse so the native image_generation_call item is
- * the ONLY carrier — the message text keeps just the real message segments.
- */
-function removeRenderedImageSegment(content: string, segment: string): string {
-  const index = content.indexOf(segment);
-  if (index === -1) return content;
-  const end = index + segment.length;
-  if (end < content.length && content[end] === '\n') {
-    return content.slice(0, index) + content.slice(end + 1);
-  }
-  if (index > 0 && content[index - 1] === '\n') {
-    return content.slice(0, index - 1) + content.slice(end);
-  }
-  return content.slice(0, index) + content.slice(end);
 }
 
 // Some Responses clients have been observed replaying tool calls with composite
@@ -482,31 +415,27 @@ export class ResponsesTransformer implements Transformer {
       const messageItem = response.output?.find((item: any) => item.type === 'message');
       const messageText = messageItem?.content?.map((part: any) => part.text).join('\n') || null;
 
-      // Minimal image_generation_call rendering for chat-format clients:
-      // a completed item with a base64 `result` becomes a markdown data-URI
-      // image appended to the unified content, in output-item order relative
-      // to the (first) message item. Without this, an image-only Responses
-      // completion yields no content at all once transformed. When no image
-      // items are present the content is exactly the message text, as before.
-      //
-      // The same completed items are ALSO carried typed (byte-intact, no
-      // inline size cap) on `image_generation_calls` so a responses-facing
-      // formatResponse can re-emit the native item instead of the lossy
-      // markdown — see UnifiedImageGenerationCall in types/unified.ts.
-      const contentSegments: string[] = [];
+      // Completed image_generation_call items (non-empty base64 `result`)
+      // are carried TYPED ONLY, byte-intact and never size-capped, on
+      // `image_generation_calls` — see UnifiedImageGenerationCall in
+      // types/unified.ts. The unified `content` stays PURE authored message
+      // text: chat-format client renderers compose their own markdown
+      // projection from the typed items (composeContentWithImageMarkdown in
+      // transformers/image-rendering.ts), and the responses-facing
+      // formatResponse re-emits the native item with NO string surgery on
+      // the text — so authored text that happens to contain the same
+      // characters as a rendered image segment can never be corrupted.
       const imageGenerationCalls: UnifiedImageGenerationCall[] = [];
       for (const item of response.output ?? []) {
-        if (item === messageItem && messageText) {
-          contentSegments.push(messageText);
-          continue;
-        }
-        const imageMarkdown = this.imageGenerationCallMarkdown(item);
-        if (imageMarkdown) {
-          contentSegments.push(imageMarkdown);
+        if (
+          item?.type === 'image_generation_call' &&
+          typeof item.result === 'string' &&
+          item.result.length > 0
+        ) {
           imageGenerationCalls.push(toUnifiedImageGenerationCall(item));
         }
       }
-      const content = contentSegments.length > 0 ? contentSegments.join('\n') : messageText;
+      const content = messageText;
 
       // Collect url_citation annotations from all output_text content parts
       const annotations: any[] = [];
@@ -986,35 +915,6 @@ export class ResponsesTransformer implements Transformer {
   }
 
   /**
-   * Renders a COMPLETED image_generation_call output item's base64 `result`
-   * as a markdown data-URI image for chat-format clients (minimal-scope
-   * rendering: completed items only — partial-image preview deltas are
-   * explicitly out of scope, see transformStream). Returns null when the
-   * item carries no base64 `result` payload. The mime subtype is sniffed
-   * from the decoded payload's magic bytes (see sniffImageMimeSubtype) —
-   * `output_format` is a request-tool field that never appears on output
-   * items, so it is deliberately not consulted.
-   *
-   * Results larger than MAX_INLINE_IMAGE_BASE64_CHARS are NOT inlined:
-   * a short placeholder text segment (naming the approximate decoded size)
-   * is rendered instead, so a huge image can't flood a single content
-   * string/SSE delta. Both call sites (transformResponse segments and
-   * transformStream's done/completed rendering) share this guard.
-   */
-  private imageGenerationCallMarkdown(item: any): string | null {
-    if (!item || item.type !== 'image_generation_call') return null;
-    if (typeof item.result !== 'string' || item.result.length === 0) return null;
-    if (item.result.length > MAX_INLINE_IMAGE_BASE64_CHARS) {
-      // Base64 decodes to ~3/4 of its character count; report the
-      // approximate decoded size with one decimal.
-      const approxDecodedMb = ((item.result.length * 3) / 4 / (1024 * 1024)).toFixed(1);
-      return `[generated image omitted: ${approxDecodedMb} MB exceeds inline limit]`;
-    }
-    const format = sniffImageMimeSubtype(item.result);
-    return `![generated image](data:image/${format};base64,${item.result})`;
-  }
-
-  /**
    * Converts Chat Completions response to output items array
    */
   private convertChatResponseToOutputItems(response: UnifiedChatResponse): ResponsesOutputItem[] {
@@ -1047,22 +947,15 @@ export class ResponsesTransformer implements Transformer {
     }
 
     // Re-emit typed image_generation_call items natively (full base64 — the
-    // native format has no inline-markdown size concern), and strip each
-    // item's paired chat-format rendering (recomputed via the same pure
-    // imageGenerationCallMarkdown helper: data URI, or the oversized
-    // placeholder) out of the combined content so the message text below
-    // carries only the real message segments — never the image twice, never
-    // the placeholder.
-    let messageText = response.content || '';
+    // native format has no inline-markdown size concern). Unified `content`
+    // is PURE authored text (transformResponse never bakes a rendered image
+    // segment into it — see transformers/image-rendering.ts), so the message
+    // text below needs NO string surgery: it reaches the client byte-intact
+    // even when the authored text happens to contain the same characters as
+    // a rendered image segment (markdown or oversized placeholder).
+    const messageText = response.content || '';
     for (const imageCall of response.image_generation_calls ?? []) {
       if (typeof imageCall.result !== 'string' || imageCall.result.length === 0) continue;
-      const markdown = this.imageGenerationCallMarkdown({
-        type: 'image_generation_call',
-        result: imageCall.result,
-      });
-      if (markdown) {
-        messageText = removeRenderedImageSegment(messageText, markdown);
-      }
       items.push({
         type: 'image_generation_call',
         id: imageCall.id ?? this.generateItemId('ig'),
@@ -1153,11 +1046,6 @@ export class ResponsesTransformer implements Transformer {
     // their response.output_item.done event, so the response.completed
     // fallback below doesn't render them a second time.
     const renderedImageItemIds = new Set<string>();
-    // `start(controller)` below uses method shorthand, so `this` inside it is
-    // the stream's underlying source, not this transformer instance — capture
-    // the helper as a local for use in that scope.
-    const imageGenerationCallMarkdown = (item: any) => this.imageGenerationCallMarkdown(item);
-
     const getToolCallIndex = (data: any): number => {
       const outputIndex =
         typeof data.output_index === 'number' ? (data.output_index as number) : undefined;

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -293,6 +293,15 @@ export interface UnifiedChatStreamChunk {
   finish_reason?: string | null;
   usage?: UnifiedUsage;
   error?: UnifiedClientError;
+  /**
+   * Present only on an `event: 'error'` chunk that represents a Responses
+   * API "ended incomplete" outcome (`response.incomplete` — e.g.
+   * max_output_tokens or content_filter cutoff) rather than a hard failure
+   * (`response.failed`). Lets a client-facing `formatStream` render the more
+   * specific incomplete semantics (e.g. Responses' own `response.incomplete`
+   * event, status 'incomplete') instead of a generic failure.
+   */
+  incomplete_details?: { reason: string };
 }
 
 // Unified Embeddings Request

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -142,6 +142,15 @@ export interface UnifiedChatRequest {
   response_format?: {
     type: 'text' | 'json_object' | 'json_schema';
     json_schema?: any;
+    /**
+     * Structured-output descriptor fields carried from the client (Responses
+     * `text.format.name` / `description` / `strict`) so cross-format
+     * emission preserves the client-supplied values — fabricated fallbacks
+     * (`response_schema`, `strict: true`) apply only when these are absent.
+     */
+    name?: string;
+    description?: string;
+    strict?: boolean;
   };
   prompt?: string | string[];
   suffix?: string | null;
@@ -191,6 +200,24 @@ export interface UnifiedUsage {
   cache_creation_tokens: number;
 }
 
+/**
+ * A COMPLETED Responses-API `image_generation_call` output item carried typed
+ * through the unified layer (mirroring how tool_calls are carried) so
+ * same-format (responses -> responses) non-bypass routes can re-emit the
+ * native item instead of a lossy markdown rendering. The responses -> unified
+ * transforms emit BOTH this typed item (full base64 `result`, never
+ * size-capped) and the chat-format markdown rendering on the content string
+ * (size-guarded): responses-facing formatters re-emit the native item and
+ * skip the paired markdown; chat/messages-facing formatters render the
+ * content string and never read this field.
+ */
+export interface UnifiedImageGenerationCall {
+  id?: string;
+  status?: string;
+  /** Base64 image payload, byte-intact (no inline-size cap at this layer). */
+  result: string;
+}
+
 export interface UnifiedChatResponse {
   id: string;
   model: string;
@@ -229,6 +256,13 @@ export interface UnifiedChatResponse {
       arguments: string;
     };
   }>;
+  /**
+   * Completed image_generation_call output items, typed (see
+   * UnifiedImageGenerationCall). Populated alongside the markdown rendering
+   * already appended to `content` — responses-facing formatters re-emit these
+   * natively and subtract the paired markdown from the message text.
+   */
+  image_generation_calls?: UnifiedImageGenerationCall[];
   annotations?: Annotation[];
   stream?: ReadableStream | any;
   bypassTransformation?: boolean;
@@ -302,6 +336,19 @@ export interface UnifiedChatStreamChunk {
    * event, status 'incomplete') instead of a generic failure.
    */
   incomplete_details?: { reason: string };
+  /**
+   * Completed image_generation_call items carried typed (see
+   * UnifiedImageGenerationCall), paired with their chat-format markdown
+   * rendering on `delta.content` in the SAME chunk. Deliberately a CHUNK-level
+   * field (not inside `delta`, where tool_calls live): the chat-facing
+   * formatters (openai.ts, ollama.ts) forward `delta` BY REFERENCE into the
+   * client SSE chunk, so a delta-level field would leak the (possibly
+   * multi-megabyte, uncapped) base64 into chat-format wire chunks — top-level
+   * unified-chunk fields are never copied by those formatters. The
+   * responses-facing formatStream re-emits these as native output items and
+   * skips the paired markdown content delta.
+   */
+  image_generation_calls?: UnifiedImageGenerationCall[];
 }
 
 // Unified Embeddings Request

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -204,12 +204,20 @@ export interface UnifiedUsage {
  * A COMPLETED Responses-API `image_generation_call` output item carried typed
  * through the unified layer (mirroring how tool_calls are carried) so
  * same-format (responses -> responses) non-bypass routes can re-emit the
- * native item instead of a lossy markdown rendering. The responses -> unified
- * transforms emit BOTH this typed item (full base64 `result`, never
- * size-capped) and the chat-format markdown rendering on the content string
- * (size-guarded): responses-facing formatters re-emit the native item and
- * skip the paired markdown; chat/messages-facing formatters render the
- * content string and never read this field.
+ * native item instead of a lossy markdown rendering. The typed item always
+ * carries the full base64 `result`, never size-capped.
+ *
+ * UNARY: transformResponse carries images typed ONLY — unified `content`
+ * stays pure authored text, and chat/messages-facing formatters compose the
+ * size-guarded markdown projection themselves from this field (see
+ * transformers/image-rendering.ts) while responses-facing formatters re-emit
+ * the native item with no string surgery.
+ *
+ * STREAMING: transformStream pairs the typed chunk-level carry with the
+ * chat-format markdown rendering on the SAME chunk's `delta.content`;
+ * responses-facing formatStream re-emits the native item and structurally
+ * skips that paired content delta (keyed on the typed items being present on
+ * the chunk — never on string matching).
  */
 export interface UnifiedImageGenerationCall {
   id?: string;
@@ -258,9 +266,12 @@ export interface UnifiedChatResponse {
   }>;
   /**
    * Completed image_generation_call output items, typed (see
-   * UnifiedImageGenerationCall). Populated alongside the markdown rendering
-   * already appended to `content` — responses-facing formatters re-emit these
-   * natively and subtract the paired markdown from the message text.
+   * UnifiedImageGenerationCall). The ONLY carrier of unary image output:
+   * `content` stays pure authored text. Chat/messages-facing formatters
+   * compose their markdown projection from these (see
+   * transformers/image-rendering.ts); responses-facing formatters re-emit
+   * them natively with no string surgery on the text; empty-completion
+   * detection counts entries with a non-empty `result` as visible output.
    */
   image_generation_calls?: UnifiedImageGenerationCall[];
   annotations?: Annotation[];

--- a/packages/backend/src/utils/__tests__/response-handler.test.ts
+++ b/packages/backend/src/utils/__tests__/response-handler.test.ts
@@ -2,9 +2,12 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { handleResponse } from '../../services/responses/response-handler';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { UsageStorageService } from '../../services/observability/usage-storage';
+import { TransformerFactory } from '../../services/dispatch/transformer-factory';
 import { Transformer } from '../../types/transformer';
 import { UnifiedChatResponse } from '../../types/unified';
 import { UsageRecord } from '../../types/usage';
+import { registerSpy } from '../../../test/test-utils';
+import { logger } from '../../utils/logger';
 
 describe('handleResponse', () => {
   const originalAdminKey = process.env.ADMIN_KEY;
@@ -369,6 +372,273 @@ describe('handleResponse', () => {
       expect(usageRecord.tokensCached).toBe(55);
       expect(usageRecord.tokensCacheWrite).toBe(66);
       expect(mockStorage.saveRequest).toHaveBeenCalled();
+    });
+  });
+
+  describe('streaming empty-completion detection (T5)', () => {
+    // Fake transformer whose "provider" wire format is newline-delimited
+    // JSON — each line IS already a UnifiedChatStreamChunk object. This
+    // sidesteps any specific real provider SSE format so the test exercises
+    // exactly the response-handler.ts seam under test (the tap inserted
+    // between transformStream's output and formatStream's input), independent
+    // of any one real transformer's implementation.
+    function makeFakeStreamingTransformer(): Transformer {
+      return {
+        name: 'fake-stream-transformer',
+        defaultEndpoint: '/test',
+        parseRequest: vi.fn(),
+        transformRequest: vi.fn(),
+        transformResponse: vi.fn(),
+        extractUsage: vi.fn(),
+        formatResponse: vi.fn(),
+        transformStream(stream: ReadableStream): ReadableStream {
+          const decoder = new TextDecoder();
+          return new ReadableStream({
+            async start(controller) {
+              const reader = stream.getReader();
+              let buffer = '';
+              try {
+                while (true) {
+                  const { done, value } = await reader.read();
+                  if (done) break;
+                  buffer += decoder.decode(value, { stream: true });
+                }
+              } finally {
+                reader.releaseLock();
+              }
+              for (const line of buffer.split('\n')) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                controller.enqueue(JSON.parse(trimmed));
+              }
+              controller.close();
+            },
+          });
+        },
+        formatStream(stream: ReadableStream): ReadableStream {
+          const encoder = new TextEncoder();
+          return new ReadableStream({
+            async start(controller) {
+              const reader = stream.getReader();
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                controller.enqueue(encoder.encode(`${JSON.stringify(value)}\n`));
+              }
+              controller.close();
+            },
+          });
+        },
+      };
+    }
+
+    function makeRawChunkStream(chunks: unknown[]): ReadableStream<Uint8Array> {
+      const encoder = new TextEncoder();
+      return new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(encoder.encode(`${JSON.stringify(chunk)}\n`));
+          }
+          controller.close();
+        },
+      });
+    }
+
+    /** Drains a Node Readable to completion, the way reply.send(pipeline) would in production. */
+    function drainNodeStream(stream: any): Promise<void> {
+      return new Promise((resolve, reject) => {
+        stream.on('data', () => {});
+        stream.once('end', () => resolve());
+        stream.once('error', reject);
+      });
+    }
+
+    test('stream with zero visible deltas marks responseStatus="empty" and logs a warn', async () => {
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-empty-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          { id: 'c1', model: 'model-1', delta: {}, finish_reason: null },
+          { id: 'c1', model: 'model-1', delta: {}, finish_reason: 'stop' },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-empty-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      // Let any pending microtasks (e.g. fire-and-forget saveRequest) settle.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('empty');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Empty completion (no visible output)')
+      );
+    });
+
+    test('stream with visible content keeps responseStatus="success"', async () => {
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-content-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          { id: 'c1', model: 'model-1', delta: { content: 'Hello' }, finish_reason: null },
+          { id: 'c1', model: 'model-1', delta: {}, finish_reason: 'stop' },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-content-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('success');
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('Empty completion (no visible output)')
+      );
+    });
+
+    test('stream with an error chunk (no content) marks responseStatus="error", not "empty"/"success"', async () => {
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-error-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          {
+            id: 'c1',
+            model: 'model-1',
+            event: 'error',
+            delta: {},
+            error: { statusCode: 500, code: 'response_failed', message: 'boom' },
+          },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-error-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Not 'empty' (would silently hide the failure) and not the initial
+      // 'success' default — the error chunk must win over both.
+      expect(usageRecord.responseStatus).toBe('error');
+    });
+
+    test('stream with visible content THEN an error chunk still marks responseStatus="error"', async () => {
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-content-then-error-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          { id: 'c1', model: 'model-1', delta: { content: 'Partial' }, finish_reason: null },
+          {
+            id: 'c1',
+            model: 'model-1',
+            event: 'error',
+            delta: {},
+            error: { statusCode: 500, code: 'response_failed', message: 'boom mid-stream' },
+          },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-content-then-error-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('error');
     });
   });
 });

--- a/packages/backend/src/utils/__tests__/response-handler.test.ts
+++ b/packages/backend/src/utils/__tests__/response-handler.test.ts
@@ -640,5 +640,133 @@ describe('handleResponse', () => {
 
       expect(usageRecord.responseStatus).toBe('error');
     });
+
+    test('stream with content then an incomplete-as-length error chunk (finish_reason present) keeps responseStatus="success"', async () => {
+      // "Ended incomplete" outcomes (Responses response.incomplete →
+      // max_output_tokens/content_filter) deliberately travel the unified
+      // error channel WITH a finish_reason and are rendered as a normal
+      // finish for chat clients — a successful-if-truncated turn, not an
+      // error. Only finish_reason-less error chunks (hard failures) may
+      // stamp the usage record 'error'.
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-incomplete-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          { id: 'c1', model: 'model-1', delta: { content: 'Partial' }, finish_reason: null },
+          {
+            id: 'c1',
+            model: 'model-1',
+            event: 'error',
+            delta: {},
+            finish_reason: 'length',
+            incomplete_details: { reason: 'max_output_tokens' },
+            error: {
+              statusCode: 500,
+              code: 'max_output_tokens',
+              message: 'Response ended incomplete: max_output_tokens',
+            },
+          },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-incomplete-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('success');
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('Empty completion (no visible output)')
+      );
+    });
+
+    test('incomplete stream with ZERO visible output is downgraded to "empty" at flush, not recorded as "error"', async () => {
+      // Locked deliberately: an incomplete-as-length chunk no longer stamps
+      // 'error' (it is a finish, not a failure), so the record still holds
+      // the baseline 'success' when the flush runs — and a stream that
+      // delivered zero visible output to the client is exactly what the
+      // flush's empty-downgrade exists to flag, regardless of WHY it ended.
+      // The truncation detail is not lost: the record's finishReason
+      // ('length'/'content_filter', via usage-logging's raw-mode incomplete
+      // mapping) still says the turn was cut off — 'empty' + that
+      // finishReason together read "truncated before any visible output".
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-incomplete-empty-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          {
+            id: 'c1',
+            model: 'model-1',
+            event: 'error',
+            delta: {},
+            finish_reason: 'length',
+            incomplete_details: { reason: 'max_output_tokens' },
+            error: {
+              statusCode: 500,
+              code: 'max_output_tokens',
+              message: 'Response ended incomplete: max_output_tokens',
+            },
+          },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-incomplete-empty-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('empty');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Empty completion (no visible output)')
+      );
+    });
   });
 });


### PR DESCRIPTION
…ization, stream and empty-completion hardening

- scope native Anthropic OAuth response passthrough to messages-format clients; chat/responses clients get transformed output (mirrors the Codex cross-format fix from #727)
- match provider-prefixed gpt-5 ids in the adapter resolver, stop injecting a temperature default on responses->responses transforms, and statically strip safety_identifier for gpt-5 targets
- reactively strip upstream-named unsupported params and retry the same target once per param (prototype-safe, copy-on-write dotted-path delete with bounded retries)
- strip stale thinking blocks and retry once on Anthropic invalid-signature 400s during cross-model failover
- surface response.failed/response.incomplete/error stream events, guarantee a finish chunk, and forward exactly one trailing usage frame on OpenAI-facing streams
- fail over on terminal-empty non-streaming completions (finish-reason gated, clientError-safe) and flag empty streams in usage records
- include per-attempt status codes in "All targets failed" messages
- record usage and finish state for failed/incomplete Responses streams in debug and usage snapshots