### PR TITLE
fix(debug): persist ephemeral traces when a debug dimension matches

### DIFF
--- a/packages/backend/src/services/__tests__/debug-manager-ephemeral.test.ts
+++ b/packages/backend/src/services/__tests__/debug-manager-ephemeral.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { DebugManager } from '../observability/debug-manager';
+import { runInRequestContext } from '../observability/request-context';
+import type { UsageStorageService } from '../observability/usage-storage';
+
+describe('DebugManager ephemeral capture', () => {
+  let debugManager: DebugManager;
+  let saveDebugLog: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    debugManager = DebugManager.getInstance();
+    debugManager.resetForTesting();
+    debugManager.setEnabled(false);
+    saveDebugLog = vi.fn();
+    debugManager.setStorage({ saveDebugLog } as unknown as UsageStorageService);
+  });
+
+  test('discards the ephemeral trace when no debug dimension is enabled', () => {
+    debugManager.startLog('req-none', { model: 'untracked-alias' });
+    debugManager.markEphemeral('req-none');
+    debugManager.flush('req-none');
+
+    expect(saveDebugLog).not.toHaveBeenCalled();
+    expect(debugManager.getPendingLog('req-none')).toBeUndefined();
+  });
+
+  test('discards the ephemeral trace when discardEphemeral runs and no dimension is enabled', () => {
+    debugManager.setEnabled(true);
+    debugManager.startLog('req-discard', { model: 'untracked-alias' });
+    debugManager.setEnabled(false);
+    debugManager.markEphemeral('req-discard');
+
+    debugManager.discardEphemeral('req-discard');
+    debugManager.flush('req-discard');
+
+    expect(saveDebugLog).not.toHaveBeenCalled();
+    expect(debugManager.getPendingLog('req-discard')).toBeUndefined();
+  });
+
+  test('persists the ephemeral trace when global debug capture is enabled', () => {
+    debugManager.setEnabled(true);
+
+    debugManager.startLog('req-global', { model: 'untracked-alias' });
+    debugManager.markEphemeral('req-global');
+    debugManager.flush('req-global');
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+    expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
+      requestId: 'req-global',
+      modelAlias: 'untracked-alias',
+    });
+  });
+
+  test('persists the ephemeral trace when the usage inspector discards before flush', () => {
+    // Mirrors the token-estimation flow: the usage inspector calls
+    // discardEphemeral once estimation completes, and the normal flush runs
+    // afterwards — the trace must survive both.
+    debugManager.setEnabled(true);
+    debugManager.startLog('req-estimation', { model: 'untracked-alias' });
+    debugManager.markEphemeral('req-estimation');
+
+    debugManager.discardEphemeral('req-estimation');
+    debugManager.flush('req-estimation');
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+  });
+
+  test('persists the ephemeral trace when the request key is enabled', () => {
+    debugManager.enableForKey('test-key');
+
+    runInRequestContext({ keyName: 'test-key' }, () => {
+      debugManager.startLog('req-key', { model: 'untracked-alias' });
+      debugManager.markEphemeral('req-key');
+      debugManager.flush('req-key');
+    });
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+    expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
+      requestId: 'req-key',
+      apiKey: 'test-key',
+    });
+  });
+
+  test('persists the ephemeral trace when capture-on-error forces persistence', () => {
+    debugManager.setCaptureOnError(true);
+
+    debugManager.startLog('req-error', { model: 'untracked-alias' });
+    debugManager.markEphemeral('req-error');
+    debugManager.markForcePersist('req-error');
+    debugManager.flush('req-error');
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+    expect(saveDebugLog.mock.calls[0]?.[0]).toMatchObject({
+      requestId: 'req-error',
+      forcePersist: true,
+    });
+  });
+
+  test('keeps the trace when discardEphemeral runs under capture-on-error with an error', () => {
+    debugManager.setCaptureOnError(true);
+
+    debugManager.startLog('req-error-discard', { model: 'untracked-alias' });
+    debugManager.markEphemeral('req-error-discard');
+    debugManager.markForcePersist('req-error-discard');
+
+    // The usage inspector discards after estimating tokens; the trace must
+    // survive so a later flush still persists the error.
+    debugManager.discardEphemeral('req-error-discard');
+    debugManager.flush('req-error-discard');
+
+    expect(saveDebugLog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/services/observability/debug-manager.ts
+++ b/packages/backend/src/services/observability/debug-manager.ts
@@ -320,35 +320,44 @@ export class DebugManager {
     log.responseHeaders = headers;
   }
 
-  flush(requestId: string) {
-    // Skip flushing ephemeral requests
-    if (this.ephemeralRequests.has(requestId)) {
-      logger.debug(`Skipping flush for ephemeral request ${requestId}`);
-      this.pendingLogs.delete(requestId);
-      return;
-    }
+  /**
+   * True when any debug dimension (global, key, alias, or provider) matches
+   * this request, or when the request was flagged for forced persistence
+   * (capture-on-error mode). Ephemeral traces captured for token estimation
+   * are only kept when this returns true.
+   */
+  private shouldPersistLog(log: DebugLogRecord): boolean {
+    return (
+      this.enabledGlobal ||
+      this.isKeyDimensionEnabled(log.apiKey ?? null) ||
+      this.isAliasDimensionEnabled(log.modelAlias ?? null) ||
+      this.isProviderDimensionEnabled(log.provider ?? null) ||
+      !!log.forcePersist
+    );
+  }
 
+  flush(requestId: string) {
     const log = this.pendingLogs.get(requestId);
     if (!log) return;
 
-    const enabledByGlobal = this.enabledGlobal;
-    const enabledByKey = this.isKeyDimensionEnabled(log.apiKey ?? null);
-    const enabledByAlias = this.isAliasDimensionEnabled(log.modelAlias ?? null);
-    const enabledByProvider = this.isProviderDimensionEnabled(log.provider ?? null);
+    // Skip flushing ephemeral requests, unless a debug dimension also wants
+    // the trace — ephemeral capture exists for token estimation, but an
+    // enabled dimension (or a forced persist) takes precedence.
+    if (this.ephemeralRequests.has(requestId) && !this.shouldPersistLog(log)) {
+      logger.debug(`Skipping flush for ephemeral request ${requestId}`);
+      this.pendingLogs.delete(requestId);
+      this.ephemeralRequests.delete(requestId);
+      return;
+    }
 
     // Persist when any debug dimension matches this request, or when the
     // request was flagged for forced persistence (capture-on-error mode).
-    if (
-      !enabledByGlobal &&
-      !enabledByKey &&
-      !enabledByAlias &&
-      !enabledByProvider &&
-      !log.forcePersist
-    ) {
+    if (!this.shouldPersistLog(log)) {
       logger.debug(
         `Skipping flush for ${requestId} - debug mode not enabled for key '${log.apiKey ?? '(none)'}', alias '${log.modelAlias ?? '(none)'}', provider '${log.provider ?? '(none)'}'`
       );
       this.pendingLogs.delete(requestId);
+      this.ephemeralRequests.delete(requestId);
       return;
     }
 
@@ -359,6 +368,7 @@ export class DebugManager {
       this.storage.saveDebugLog(log);
     }
     this.pendingLogs.delete(requestId);
+    this.ephemeralRequests.delete(requestId);
   }
 
   /**
@@ -374,7 +384,8 @@ export class DebugManager {
   }
 
   /**
-   * Mark a request as ephemeral (debug data won't be persisted)
+   * Mark a request as ephemeral (debug data won't be persisted unless a
+   * debug dimension matches it — see shouldPersistLog)
    */
   markEphemeral(requestId: string): void {
     this.ephemeralRequests.add(requestId);
@@ -397,10 +408,19 @@ export class DebugManager {
   }
 
   /**
-   * Discard ephemeral debug data without saving to database
+   * Discard ephemeral debug data without saving to database.
+   *
+   * The trace is kept (and persisted on the next flush) when a debug
+   * dimension matches the request — an enabled dimension takes precedence
+   * over the ephemeral marker.
    */
   discardEphemeral(requestId: string): void {
     if (this.ephemeralRequests.has(requestId)) {
+      const log = this.pendingLogs.get(requestId);
+      if (log && this.shouldPersistLog(log)) {
+        logger.debug(`Keeping ephemeral data for ${requestId} - debug mode wants it persisted`);
+        return;
+      }
       this.pendingLogs.delete(requestId);
       this.ephemeralRequests.delete(requestId);
       logger.debug(`Discarded ephemeral data for ${requestId}`);

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -593,6 +593,15 @@ export async function handleResponse(
     DebugManager.getInstance().addTransformedResponse(usageRecord.requestId!, responseBody);
     DebugManager.getInstance().flush(usageRecord.requestId!);
 
+    // Restore debug mode after a non-streaming response. Mirrors the restore
+    // in the streaming path's pipeline 'error'/'end' handlers above — without
+    // this, the temporary global enable for token estimation (above) would
+    // never be turned back off for unary responses, leaving debug capture
+    // stuck on for every subsequent request.
+    if (shouldEstimateTokens && !wasDebugEnabled) {
+      debugManager.setEnabled(false);
+    }
+
     // Record the usage.
     finalizeUsage(
       usageRecord,

--- a/packages/backend/src/utils/__tests__/response-handler.test.ts
+++ b/packages/backend/src/utils/__tests__/response-handler.test.ts
@@ -5,6 +5,7 @@ import { UsageStorageService } from '../../services/observability/usage-storage'
 import { Transformer } from '../../types/transformer';
 import { UnifiedChatResponse } from '../../types/unified';
 import { UsageRecord } from '../../types/usage';
+import { DebugManager } from '../../services/observability/debug-manager';
 
 describe('handleResponse', () => {
   const originalAdminKey = process.env.ADMIN_KEY;
@@ -333,6 +334,46 @@ describe('handleResponse', () => {
       }),
       'test-key'
     );
+  });
+
+  test('restores global debug mode after a non-streaming response that needed token estimation', async () => {
+    const debugManager = DebugManager.getInstance();
+    debugManager.resetForTesting();
+    debugManager.setEnabled(false);
+    expect(debugManager.isEnabled()).toBe(false);
+
+    const unifiedResponse: UnifiedChatResponse = {
+      id: 'resp-estimate',
+      model: 'model-1',
+      content: 'Hello',
+      plexus: {
+        provider: 'provider-1',
+        model: 'model-orig',
+        apiType: 'chat',
+      },
+      // No usage block — this is what triggers estimateTokens upstream.
+    };
+
+    const usageRecord: Partial<UsageRecord> = {
+      requestId: 'req-estimate',
+    };
+
+    await handleResponse(
+      mockRequest,
+      mockReply,
+      unifiedResponse,
+      mockTransformer,
+      usageRecord,
+      mockStorage,
+      Date.now(),
+      'chat',
+      /* shouldEstimateTokens */ true
+    );
+
+    // Global debug mode must be restored to its prior (disabled) state once
+    // the unary response has been handled — otherwise it stays stuck on for
+    // every subsequent request until the process restarts.
+    expect(debugManager.isEnabled()).toBe(false);
   });
 
   describe('Usage Mapping Regression Tests', () => {


### PR DESCRIPTION
## Problem

Requests whose provider doesn't return token usage need token estimation. Those requests are marked **ephemeral** (`response-handler.ts`) so their debug trace is captured in memory for estimation and never stored.

The bug: the ephemeral marker suppressed persistence **even when an operator-enabled debug dimension matched the request** — global debug mode, a targeted key/alias/provider, or a capture-on-error `forcePersist`. Traces the operator explicitly asked for were silently dropped:

- `DebugManager.flush()` skipped ephemeral requests unconditionally, before checking any enable dimension
- `discardEphemeral()` (called by the usage inspector right after estimation) deleted the pending trace outright

Verified against a production database (24h window):

```
tokens_estimated = 0:  4676 usage rows → 3888 have debug logs
tokens_estimated = 1:  1501 usage rows →    0 have debug logs
```

Every request needing token estimation was missing from the debug_logs view, and in capture-on-error mode even *error* traces were lost when the request also needed estimation.

## Fix

The persistence decision for both `flush()` and `discardEphemeral()` now goes through one shared predicate, `shouldPersistLog()`:

- any debug dimension matches (global / key / alias / provider), **or**
- the request was flagged for forced persistence (capture-on-error)

The ephemeral marker only wins when nothing wants the trace persisted. Behavior is unchanged when debug capture is fully off (ephemeral traces are still dropped, payloads still aren't persisted).

As a side effect, both paths now also remove the request id from `ephemeralRequests` on the persist and not-enabled paths, so the set doesn't accumulate ids.

## Tests

New suite `debug-manager-ephemeral.test.ts` (7 tests) covering: discard when nothing is enabled, persist under global capture, persist under key targeting, the usage-inspector ordering (`discardEphemeral` → `flush`), and both capture-on-error cases (with and without `forcePersist`).

Related existing suites pass: debug-manager-targets/startup/metadata, debug-logging-error/reconstruction, usage-logging(+metadata), speech-debug, transcriptions-debug — 44/44.