### PR TITLE
fix(responses): preserve streamed tool argument fragments

### DIFF
--- a/packages/backend/src/transformers/__tests__/responses-codex-tools.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-codex-tools.test.ts
@@ -37,6 +37,85 @@ async function collectFormatStreamEvents(
 }
 
 describe('Codex CLI namespace tool flattening', () => {
+  test('preserves JSON-looking text inside streamed tool arguments', async () => {
+    const transformer = new ResponsesTransformer();
+    const events = await collectFormatStreamEvents(transformer, [
+      {
+        id: 'resp_1',
+        model: 'gpt-5.6',
+        created: 1,
+        delta: {
+          tool_calls: [{ index: 0, id: 'call_1', function: { name: 'run', arguments: '' } }],
+        },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_1',
+        model: 'gpt-5.6',
+        created: 1,
+        delta: { tool_calls: [{ index: 0, function: { arguments: '{"command":"before ' } }] },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_1',
+        model: 'gpt-5.6',
+        created: 1,
+        delta: { tool_calls: [{ index: 0, function: { arguments: '{' + '}' } }] },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_1',
+        model: 'gpt-5.6',
+        created: 1,
+        delta: { tool_calls: [{ index: 0, function: { arguments: ' after"}' } }] },
+        finish_reason: null,
+      },
+      { id: 'resp_1', model: 'gpt-5.6', created: 1, delta: null, finish_reason: 'tool_calls' },
+    ]);
+
+    const doneEvent = events.find(
+      (event) => event.type === 'response.output_item.done' && event.item?.type === 'function_call'
+    );
+    expect(JSON.parse(doneEvent.item.arguments)).toEqual({
+      command: 'before ' + '{' + '}' + ' after',
+    });
+  });
+
+  test('accepts a complete argument snapshot after leading whitespace', async () => {
+    const transformer = new ResponsesTransformer();
+    const events = await collectFormatStreamEvents(transformer, [
+      {
+        id: 'resp_1',
+        model: 'gpt-5.6',
+        created: 1,
+        delta: {
+          tool_calls: [{ index: 0, id: 'call_1', function: { name: 'run', arguments: '' } }],
+        },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_1',
+        model: 'gpt-5.6',
+        created: 1,
+        delta: { tool_calls: [{ index: 0, function: { arguments: ' {"command":"fu' } }] },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_1',
+        model: 'gpt-5.6',
+        created: 1,
+        delta: { tool_calls: [{ index: 0, function: { arguments: '{"command":"full"}' } }] },
+        finish_reason: null,
+      },
+      { id: 'resp_1', model: 'gpt-5.6', created: 1, delta: null, finish_reason: 'tool_calls' },
+    ]);
+
+    const doneEvent = events.find(
+      (event) => event.type === 'response.output_item.done' && event.item?.type === 'function_call'
+    );
+    expect(JSON.parse(doneEvent.item.arguments)).toEqual({ command: 'full' });
+  });
+
   test('parseRequest flattens namespace tools to flat function tools', async () => {
     const transformer = new ResponsesTransformer();
     const unified = await transformer.parseRequest({

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -1140,9 +1140,9 @@ export class ResponsesTransformer implements Transformer {
       if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
         try {
           JSON.parse(trimmed);
-          return trimmed;
+          if (!previous || trimmed.startsWith(previous.trimStart())) return trimmed;
         } catch {
-          return previous + delta;
+          // Argument deltas may contain incomplete JSON.
         }
       }
       return previous + delta;


### PR DESCRIPTION
## Summary

Preserve streamed tool argument fragments when one chunk is independently valid JSON. This prevents Responses API tool calls from losing their accumulated prefix before finalization.

## Problem

`ResponsesTransformer.formatStream()` supports both incremental argument deltas and providers that repeat a complete argument snapshot. Its snapshot heuristic currently replaces the accumulator whenever one chunk parses as a complete JSON object.

Stream boundaries are arbitrary. A shell command or patch can contain an empty object literal that arrives as its own chunk. Plexus then mistakes that content fragment for a complete snapshot, discards every preceding argument fragment, and emits a truncated suffix in `response.output_item.done` and `response.completed`.

Clients receive malformed finalized arguments even though the preceding `response.function_call_arguments.delta` events reconstruct correctly. Defensive clients may reduce the malformed value to an empty object, causing required tool parameters such as `command` or `input` to disappear.

## Simplified example

Suppose a model streams one tool argument in these chunks:

```text
1. {"command":"before 
2. {}
3.  after"}
```

Concatenating them should produce:

```json
{"command":"before {} after"}
```

The previous heuristic parsed chunk 2 independently as valid JSON and replaced the accumulated prefix with it. Plexus then finalized this malformed suffix:

```text
{} after"}
```

A client could fail to parse that value and fall back to empty arguments, so required fields such as `command` or `input` disappeared even though the streamed preview looked complete.

## Changes

- Replace accumulated arguments only when a valid complete JSON candidate extends the accumulated prefix.
- Ignore leading whitespace when comparing a partial prefix with a complete snapshot.
- Add regression coverage for object-looking content inside a streamed string argument.
- Preserve coverage for complete snapshots following whitespace-prefixed partial data.

## Testing

- `bun run format:check`
- `bun run typecheck`
- `bun run test` (51 test files, 348 tests passed)

