### PR TITLE
fix(dispatch): reactive unsupported-param and thinking-signature strips with GPT-5 param sanitization

### DIFF
--- a/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
+++ b/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
@@ -45,6 +45,32 @@ describe('resolveAdapters', () => {
     ]);
   });
 
+  it('auto-injects unsupported-option suppression for a provider-prefixed GPT-5 target model', () => {
+    // Target models routed through the pi-ai registry carry a provider prefix
+    // (e.g. an OpenLimits aggregator target for gpt-5.5), which the anchored
+    // legacy regex missed entirely.
+    const route: RouteResult = { ...makeRoute(), model: 'openai/gpt-5.5' };
+    expect(resolveAdapters(route).map((r) => r.adapter.name)).toEqual([
+      'suppress_unsupported_gpt5_options',
+    ]);
+  });
+
+  it('auto-injects unsupported-option suppression for gpt-5 and gpt-5-mini', () => {
+    for (const model of ['gpt-5', 'gpt-5-mini']) {
+      const route: RouteResult = { ...makeRoute(), model };
+      expect(resolveAdapters(route).map((r) => r.adapter.name)).toEqual([
+        'suppress_unsupported_gpt5_options',
+      ]);
+    }
+  });
+
+  it('does not auto-inject GPT-5 suppression for lookalike model ids', () => {
+    for (const model of ['gpt-55', 'chatgpt-5', 'my-gpt-5x']) {
+      const route: RouteResult = { ...makeRoute(), model };
+      expect(resolveAdapters(route)).toHaveLength(0);
+    }
+  });
+
   it('does not auto-inject GPT-5 suppression for other model families', () => {
     const route: RouteResult = { ...makeRoute(), model: 'gpt-4.1' };
     expect(resolveAdapters(route)).toHaveLength(0);

--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -4,6 +4,20 @@ import { Dispatcher } from '../dispatch/dispatcher';
 import * as piAiRegistry from '../pi-ai/registry';
 import type { RouteResult } from '../routing/router';
 import type { UnifiedChatRequest } from '../../types/unified';
+import {
+  createUnsupportedParamStripState,
+  deleteDottedPath,
+  matchUnsupportedParameter,
+  planUnsupportedParamStrip,
+  MAX_UNSUPPORTED_PARAM_STRIP_RETRIES,
+  createThinkingSignatureStripState,
+  isAnthropicMessagesPayload,
+  matchThinkingSignatureError,
+  planThinkingSignatureStrip,
+  refundThinkingSignatureStrip,
+  stripThinkingSignatureBlocks,
+  MAX_THINKING_SIGNATURE_STRIP_RETRIES,
+} from '../dispatch/dispatcher-auto-compat';
 
 function route(overrides: Partial<RouteResult> = {}): RouteResult {
   return {
@@ -197,5 +211,1054 @@ describe('Dispatcher registry auto-compat', () => {
     );
 
     expect(result.payload.reasoning_effort).toBe('low');
+  });
+});
+
+describe('matchUnsupportedParameter', () => {
+  test('extracts the param name from a {"detail": "..."} body', () => {
+    expect(matchUnsupportedParameter('{"detail":"Unsupported parameter: safety_identifier"}')).toBe(
+      'safety_identifier'
+    );
+  });
+
+  test('extracts the param name from a {"error":{"message": "..."}} body with quotes', () => {
+    expect(
+      matchUnsupportedParameter(
+        '{"error":{"message":"Unsupported parameter: \'prompt_cache_key\'"}}'
+      )
+    ).toBe('prompt_cache_key');
+  });
+
+  test('extracts dotted-path param names', () => {
+    expect(
+      matchUnsupportedParameter(
+        '{"error":{"message":"Unsupported parameter: \'reasoning.summary\'"}}'
+      )
+    ).toBe('reasoning.summary');
+  });
+
+  test('extracts a bracket-notation param name, normalized to canonical dotted form', () => {
+    // The old `[\w.]+` capture stopped at the `[`, truncating
+    // `messages[0].name` to `messages` — and the paired deleteDottedPath call
+    // then deleted the ENTIRE conversation from the retry payload.
+    expect(
+      matchUnsupportedParameter(
+        '{"error":{"message":"Unsupported parameter: \'messages[0].name\'"}}'
+      )
+    ).toBe('messages.0.name');
+  });
+
+  test('returns undefined when the body does not name an unsupported parameter', () => {
+    expect(matchUnsupportedParameter('{"error":{"message":"Invalid request"}}')).toBeUndefined();
+  });
+
+  test('returns undefined for an empty body', () => {
+    expect(matchUnsupportedParameter('')).toBeUndefined();
+  });
+});
+
+describe('deleteDottedPath', () => {
+  test('deletes a top-level field and returns deleted:true with a new payload object', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5', safety_identifier: 'abc' };
+    const result = deleteDottedPath(payload, 'safety_identifier');
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({ model: 'gpt-5.5' });
+    // Copy-on-write: the ORIGINAL argument object is never mutated.
+    expect(payload).toEqual({ model: 'gpt-5.5', safety_identifier: 'abc' });
+    expect(result.payload).not.toBe(payload);
+  });
+
+  test('deletes a nested field via a dotted path, preserving siblings', () => {
+    const payload: Record<string, any> = {
+      reasoning: { effort: 'high', summary: 'auto' },
+    };
+    const result = deleteDottedPath(payload, 'reasoning.summary');
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({ reasoning: { effort: 'high' } });
+    // Original untouched.
+    expect(payload).toEqual({ reasoning: { effort: 'high', summary: 'auto' } });
+  });
+
+  test('returns deleted:false and leaves the payload untouched when the field is absent', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5' };
+    const result = deleteDottedPath(payload, 'safety_identifier');
+    expect(result.deleted).toBe(false);
+    expect(result.payload).toEqual({ model: 'gpt-5.5' });
+    expect(payload).toEqual({ model: 'gpt-5.5' });
+  });
+
+  test('returns deleted:false without throwing when an intermediate segment does not exist', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5' };
+    const result = deleteDottedPath(payload, 'reasoning.summary');
+    expect(result.deleted).toBe(false);
+    expect(result.payload).toEqual({ model: 'gpt-5.5' });
+  });
+
+  test('returns deleted:false without throwing when an intermediate segment is not an object', () => {
+    const payload: Record<string, any> = { reasoning: 'not-an-object' };
+    const result = deleteDottedPath(payload, 'reasoning.summary');
+    expect(result.deleted).toBe(false);
+    expect(result.payload).toEqual({ reasoning: 'not-an-object' });
+  });
+
+  // --- SECURITY: prototype-pollution hardening -------------------------------
+  //
+  // `path` is attacker-influenced: it comes from parsing an UPSTREAM PROVIDER's
+  // error message (matchUnsupportedParameter's `[\w.]+` capture group matches
+  // dots AND underscores, so a malicious/compromised upstream can name
+  // `__proto__.toString` as the "unsupported parameter"). The OLD
+  // implementation traversed with `segment in target` (true for INHERITED
+  // properties too) and mutated in place — `payload.__proto__` resolves via
+  // the inherited accessor to the REAL `Object.prototype`, so
+  // `deleteDottedPath({}, '__proto__.toString')` would delete the global
+  // `Object.prototype.toString` for the entire process, permanently, for
+  // every subsequent request.
+  describe('prototype-pollution hardening', () => {
+    test('rejects a `__proto__.<leaf>` path and leaves Object.prototype.toString intact', () => {
+      const originalToString = Object.prototype.toString;
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+
+      const result = deleteDottedPath(payload, '__proto__.toString');
+
+      expect(result.deleted).toBe(false);
+      expect(result.payload).toEqual({ model: 'gpt-5.5' });
+      // The actual attack: prove global state survived, not just that the
+      // function returned a particular value.
+      expect(Object.prototype.toString).toBe(originalToString);
+      expect(typeof Object.prototype.toString).toBe('function');
+      expect({}.toString()).toBe('[object Object]');
+    });
+
+    test('rejects a bare top-level `__proto__` path', () => {
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+      const result = deleteDottedPath(payload, '__proto__');
+      expect(result.deleted).toBe(false);
+      expect(Object.getPrototypeOf(payload)).toBe(Object.prototype);
+    });
+
+    test('rejects `constructor.prototype.<leaf>` (classic gadget path)', () => {
+      const originalToString = Object.prototype.toString;
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+
+      const result = deleteDottedPath(payload, 'constructor.prototype.toString');
+
+      expect(result.deleted).toBe(false);
+      expect(Object.prototype.toString).toBe(originalToString);
+      expect(typeof Object.prototype.toString).toBe('function');
+    });
+
+    test('rejects a dangerous segment appearing in the middle of the path, not just at the edges', () => {
+      const payload: Record<string, any> = { a: { __proto__: { b: 'x' } } };
+      const result = deleteDottedPath(payload, 'a.__proto__.b');
+      expect(result.deleted).toBe(false);
+    });
+
+    test('rejects `prototype` as a segment name', () => {
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+      const result = deleteDottedPath(payload, 'prototype.polluted');
+      expect(result.deleted).toBe(false);
+    });
+
+    test('traverses only OWN enumerable properties — inherited properties are never walked', () => {
+      // `toString` is never an OWN property of a plain object literal; it's
+      // inherited from Object.prototype. `in` (the old check) would say
+      // true; hasOwnProperty must say false.
+      const payload: Record<string, any> = { model: 'gpt-5.5' };
+      const result = deleteDottedPath(payload, 'toString');
+      expect(result.deleted).toBe(false);
+      expect(typeof payload.toString).toBe('function');
+    });
+  });
+
+  // --- Copy-on-write: shared nested objects must never be mutated ------------
+  //
+  // `providerPayload.reasoning` can be the SAME object reference as the
+  // long-lived `UnifiedChatRequest.reasoning` (see
+  // `payload.reasoning = request.reasoning` in transformers/responses.ts).
+  // Mutating it in place would corrupt that shared object for every OTHER
+  // failover target built from the same request afterward.
+  describe('copy-on-write (shared nested object references)', () => {
+    test('does not mutate a nested object shared by reference with another source object', () => {
+      const sharedReasoning = { effort: 'high', summary: 'auto' };
+      const request = { reasoning: sharedReasoning };
+      // Mirrors `payload.reasoning = request.reasoning` — same reference, not a clone.
+      const payload: Record<string, any> = { model: 'gpt-5.5', reasoning: request.reasoning };
+      expect(payload.reasoning).toBe(sharedReasoning);
+
+      const result = deleteDottedPath(payload, 'reasoning.summary');
+
+      expect(result.deleted).toBe(true);
+      expect(result.payload).toEqual({ model: 'gpt-5.5', reasoning: { effort: 'high' } });
+
+      // Assert BY REFERENCE: the source object binding is untouched...
+      expect(request.reasoning).toBe(sharedReasoning);
+      // ...AND by deep equality: its CONTENT was never mutated in place.
+      expect(request.reasoning).toEqual({ effort: 'high', summary: 'auto' });
+      expect(sharedReasoning).toEqual({ effort: 'high', summary: 'auto' });
+
+      // The original `payload` argument itself is also untouched.
+      expect(payload).toEqual({ model: 'gpt-5.5', reasoning: sharedReasoning });
+      expect(payload.reasoning).toBe(sharedReasoning);
+
+      // The returned payload's reasoning object is a NEW object, not the shared one.
+      expect(result.payload.reasoning).not.toBe(sharedReasoning);
+    });
+
+    test('sibling nested objects on the payload are shared (not cloned) since they are never touched', () => {
+      const untouchedSibling = { foo: 'bar' };
+      const payload: Record<string, any> = {
+        reasoning: { effort: 'high', summary: 'auto' },
+        metadata: untouchedSibling,
+      };
+
+      const result = deleteDottedPath(payload, 'reasoning.summary');
+
+      expect(result.deleted).toBe(true);
+      // Untouched branch of the object tree is the SAME reference (only the
+      // path actually being modified gets cloned).
+      expect(result.payload.metadata).toBe(untouchedSibling);
+    });
+  });
+
+  // --- Array containers: numeric path segments must preserve Array-ness ------
+  //
+  // matchUnsupportedParameter's `[\w.]+` capture CAN name a path through an
+  // array (an upstream 400 like "Unsupported parameter: messages.0.some_field").
+  // The copy-on-write rebuild must keep every array on the path an ARRAY —
+  // an unconditional `{ ...target }` would turn `messages` into an
+  // object-shaped `{"0": {...}, "1": {...}}` and produce a malformed retry
+  // payload that every upstream rejects.
+  describe('array container preservation', () => {
+    test('deleting a field inside an array element keeps the array an array', () => {
+      const payload: Record<string, any> = {
+        model: 'gpt-5.5',
+        messages: [
+          { role: 'user', content: 'hi', some_field: 'x' },
+          { role: 'assistant', content: 'yo' },
+        ],
+      };
+      const snapshot = structuredClone(payload);
+
+      const result = deleteDottedPath(payload, 'messages.0.some_field');
+
+      expect(result.deleted).toBe(true);
+      expect(Array.isArray(result.payload.messages)).toBe(true);
+      expect(result.payload.messages).toEqual([
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'yo' },
+      ]);
+      // Copy-on-write extends to array levels: original untouched...
+      expect(payload).toEqual(snapshot);
+      expect(result.payload.messages).not.toBe(payload.messages);
+      // ...and the untouched sibling element is shared, not cloned.
+      expect(result.payload.messages[1]).toBe(payload.messages[1]);
+    });
+
+    test('an array-index leaf removes the element splice-style (no hole, no null)', () => {
+      const t0 = { type: 'function', name: 'a' };
+      const t1 = { type: 'function', name: 'b' };
+      const t2 = { type: 'function', name: 'c' };
+      const payload: Record<string, any> = { model: 'gpt-5.5', tools: [t0, t1, t2] };
+
+      const result = deleteDottedPath(payload, 'tools.2');
+
+      expect(result.deleted).toBe(true);
+      expect(Array.isArray(result.payload.tools)).toBe(true);
+      expect(result.payload.tools).toEqual([t0, t1]);
+      expect(result.payload.tools).toHaveLength(2);
+      // No hole left behind: `delete arr[2]` would keep length 3 and
+      // serialize the gap as null — every index must be an own property.
+      expect(Object.keys(result.payload.tools)).toEqual(['0', '1']);
+      // Original untouched.
+      expect(payload.tools).toHaveLength(3);
+      expect(payload.tools[2]).toBe(t2);
+    });
+
+    test('removing a MIDDLE array element shifts later elements left (no hole)', () => {
+      const payload: Record<string, any> = { tools: ['a', 'b', 'c'] };
+
+      const result = deleteDottedPath(payload, 'tools.1');
+
+      expect(result.deleted).toBe(true);
+      expect(result.payload.tools).toEqual(['a', 'c']);
+      expect(Object.keys(result.payload.tools)).toEqual(['0', '1']);
+      expect(payload.tools).toEqual(['a', 'b', 'c']);
+    });
+
+    test('preserves arrays at intermediate depths of a longer path', () => {
+      const payload: Record<string, any> = {
+        messages: [{ role: 'user', meta: { keep: 1, drop: 2 } }],
+      };
+
+      const result = deleteDottedPath(payload, 'messages.0.meta.drop');
+
+      expect(result.deleted).toBe(true);
+      expect(Array.isArray(result.payload.messages)).toBe(true);
+      expect(result.payload.messages[0].meta).toEqual({ keep: 1 });
+      expect(payload.messages[0].meta).toEqual({ keep: 1, drop: 2 });
+    });
+
+    test('does not mutate an array shared by reference with another holder', () => {
+      const sharedMessages = [{ role: 'user', content: 'hi', bad_field: 1 }];
+      const request = { messages: sharedMessages };
+      // Mirrors payload.messages = request.messages — same reference.
+      const payload: Record<string, any> = { model: 'claude-x', messages: request.messages };
+
+      const result = deleteDottedPath(payload, 'messages.0.bad_field');
+
+      expect(result.deleted).toBe(true);
+      expect(request.messages).toBe(sharedMessages);
+      expect(sharedMessages).toEqual([{ role: 'user', content: 'hi', bad_field: 1 }]);
+      expect(result.payload.messages).not.toBe(sharedMessages);
+      expect(result.payload.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    });
+
+    test('returns deleted:false for an out-of-bounds array index', () => {
+      const payload: Record<string, any> = { tools: ['a'] };
+
+      const result = deleteDottedPath(payload, 'tools.5');
+
+      expect(result.deleted).toBe(false);
+      expect(result.payload).toBe(payload);
+    });
+
+    test('returns deleted:false for a non-index own property on an array (e.g. length) instead of corrupting the array', () => {
+      // Arrays have `length` as an OWN property, so hasOwnProperty alone
+      // would let "messages.length" through — and the rebuild would turn the
+      // array into an object. Only canonical in-bounds indices are valid
+      // array segments; anything else is refused untouched.
+      const payload: Record<string, any> = { messages: [{ role: 'user', content: 'hi' }] };
+
+      const result = deleteDottedPath(payload, 'messages.length');
+
+      expect(result.deleted).toBe(false);
+      expect(result.payload).toBe(payload);
+      expect(Array.isArray(payload.messages)).toBe(true);
+      expect(payload.messages).toHaveLength(1);
+    });
+
+    test('rejects a non-canonical numeric segment ("01") on an array', () => {
+      const payload: Record<string, any> = { tools: ['a', 'b'] };
+
+      const result = deleteDottedPath(payload, 'tools.01');
+
+      expect(result.deleted).toBe(false);
+      expect(result.payload).toBe(payload);
+    });
+  });
+});
+
+describe('planUnsupportedParamStrip', () => {
+  test('strips a newly-named param and records the attempt', () => {
+    const state = createUnsupportedParamStripState();
+    const result = planUnsupportedParamStrip(
+      '{"detail":"Unsupported parameter: safety_identifier"}',
+      state
+    );
+    expect(result).toBe('safety_identifier');
+    expect(state.attempts).toBe(1);
+    expect(state.strippedParams.has('safety_identifier')).toBe(true);
+  });
+
+  test('allows up to MAX_UNSUPPORTED_PARAM_STRIP_RETRIES distinct params, then stops', () => {
+    expect(MAX_UNSUPPORTED_PARAM_STRIP_RETRIES).toBe(2);
+    const state = createUnsupportedParamStripState();
+
+    expect(
+      planUnsupportedParamStrip('{"detail":"Unsupported parameter: safety_identifier"}', state)
+    ).toBe('safety_identifier');
+    expect(
+      planUnsupportedParamStrip('{"detail":"Unsupported parameter: prompt_cache_key"}', state)
+    ).toBe('prompt_cache_key');
+
+    // Bound reached — a THIRD distinct param must not trigger another retry.
+    expect(
+      planUnsupportedParamStrip('{"detail":"Unsupported parameter: reasoning.summary"}', state)
+    ).toBeUndefined();
+    expect(state.attempts).toBe(2);
+  });
+
+  test('stops immediately (no infinite loop) when upstream keeps naming the same param', () => {
+    const state = createUnsupportedParamStripState();
+    const body = '{"detail":"Unsupported parameter: safety_identifier"}';
+
+    expect(planUnsupportedParamStrip(body, state)).toBe('safety_identifier');
+    // Upstream 400s again naming the SAME param even after it was stripped —
+    // stop rather than burning through the retry bound on a no-op.
+    expect(planUnsupportedParamStrip(body, state)).toBeUndefined();
+    expect(planUnsupportedParamStrip(body, state)).toBeUndefined();
+    expect(state.attempts).toBe(1);
+  });
+
+  test('returns undefined when the body does not name an unsupported parameter', () => {
+    const state = createUnsupportedParamStripState();
+    expect(
+      planUnsupportedParamStrip('{"error":{"message":"Invalid request"}}', state)
+    ).toBeUndefined();
+    expect(state.attempts).toBe(0);
+  });
+
+  test('structural guard: refuses to strip the whole messages/input/model field, consuming no budget', () => {
+    // Deleting any of these wholesale guarantees a malformed request — every
+    // retry would 400 on a missing-conversation/missing-model error instead,
+    // so the plan must refuse outright (normal failover proceeds) and must
+    // NOT burn a strip attempt doing so.
+    const state = createUnsupportedParamStripState();
+    for (const field of ['messages', 'input', 'model']) {
+      expect(
+        planUnsupportedParamStrip(`{"detail":"Unsupported parameter: ${field}"}`, state)
+      ).toBeUndefined();
+    }
+    expect(state.attempts).toBe(0);
+    expect(state.strippedParams.size).toBe(0);
+  });
+
+  test('structural guard is exact-match only: sub-paths inside messages stay strippable', () => {
+    const state = createUnsupportedParamStripState();
+    expect(
+      planUnsupportedParamStrip('{"detail":"Unsupported parameter: messages.0.name"}', state)
+    ).toBe('messages.0.name');
+    expect(state.attempts).toBe(1);
+  });
+
+  describe('structural array elements (messages[N] / input[N]) are refused budget-free', () => {
+    // `Unsupported parameter: messages[0]` normalizes to `messages.0`, which
+    // dodges the exact-name guard — and the paired deleteDottedPath would
+    // splice an ENTIRE message out of the conversation. A numeric leaf
+    // directly under a structural root deletes a whole conversation item,
+    // so it gets the same budget-free refusal as the whole-field guard:
+    // normal failover proceeds, no strip attempt is consumed.
+    test('a 400 naming messages[0] (bracket form) is refused, consuming no budget', () => {
+      const state = createUnsupportedParamStripState();
+      expect(
+        planUnsupportedParamStrip(
+          '{"error":{"message":"Unsupported parameter: \'messages[0]\'"}}',
+          state
+        )
+      ).toBeUndefined();
+      expect(state.attempts).toBe(0);
+      expect(state.strippedParams.size).toBe(0);
+    });
+
+    test('a 400 naming input[2] (bracket form) is refused, consuming no budget', () => {
+      const state = createUnsupportedParamStripState();
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: input[2]"}', state)
+      ).toBeUndefined();
+      expect(state.attempts).toBe(0);
+      expect(state.strippedParams.size).toBe(0);
+    });
+
+    test('the already-dotted spelling (messages.0) is refused identically', () => {
+      const state = createUnsupportedParamStripState();
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: messages.0"}', state)
+      ).toBeUndefined();
+      expect(state.attempts).toBe(0);
+    });
+
+    test('a refusal leaves the full budget for later legitimately-strippable params', () => {
+      const state = createUnsupportedParamStripState();
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: messages[0]"}', state)
+      ).toBeUndefined();
+      // Both retry slots must still be available afterwards.
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: safety_identifier"}', state)
+      ).toBe('safety_identifier');
+      expect(
+        planUnsupportedParamStrip('{"detail":"Unsupported parameter: prompt_cache_key"}', state)
+      ).toBe('prompt_cache_key');
+      expect(state.attempts).toBe(2);
+    });
+
+    test('deeper paths under a structural element (messages.0.name) remain strippable', () => {
+      const state = createUnsupportedParamStripState();
+      const payload: Record<string, any> = {
+        model: 'gpt-4o',
+        messages: [
+          { role: 'user', content: 'hi', name: 'bob!' },
+          { role: 'assistant', content: 'yo' },
+        ],
+      };
+
+      const paramToStrip = planUnsupportedParamStrip(
+        '{"error":{"message":"Unsupported parameter: \'messages[0].name\'"}}',
+        state
+      );
+      expect(paramToStrip).toBe('messages.0.name');
+
+      const result = deleteDottedPath(payload, paramToStrip!);
+      expect(result.deleted).toBe(true);
+      expect(result.payload.messages).toEqual([
+        { role: 'user', content: 'hi' },
+        { role: 'assistant', content: 'yo' },
+      ]);
+    });
+
+    test('numeric leaves under NON-structural arrays (tools[2]) stay splice-deletable', () => {
+      const state = createUnsupportedParamStripState();
+      const payload: Record<string, any> = {
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+      };
+
+      const paramToStrip = planUnsupportedParamStrip(
+        '{"detail":"Unsupported parameter: tools[2]"}',
+        state
+      );
+      expect(paramToStrip).toBe('tools.2');
+      expect(state.attempts).toBe(1);
+
+      const result = deleteDottedPath(payload, paramToStrip!);
+      expect(result.deleted).toBe(true);
+      expect(result.payload.tools).toEqual([{ name: 'a' }, { name: 'b' }]);
+      expect(Array.isArray(result.payload.tools)).toBe(true);
+    });
+  });
+});
+
+// The production bug this pipeline guards against: an upstream 400 naming
+// `messages[0].name` was truncated by the old `[\w.]+` matcher to `messages`,
+// so the strip-and-retry deleted the WHOLE conversation and retried a
+// guaranteed-malformed payload. Bracket segments must be captured, normalized
+// to canonical dotted form, and land on the array ELEMENT's field.
+describe('bracket-notation unsupported params (match -> plan -> delete pipeline)', () => {
+  test('a 400 naming messages[0].name deletes only that element field — the conversation array survives', () => {
+    const state = createUnsupportedParamStripState();
+    const payload: Record<string, any> = {
+      model: 'gpt-4o',
+      messages: [
+        { role: 'user', content: 'hi', name: 'bob!' },
+        { role: 'assistant', content: 'yo' },
+      ],
+    };
+
+    const paramToStrip = planUnsupportedParamStrip(
+      '{"error":{"message":"Unsupported parameter: \'messages[0].name\'"}}',
+      state
+    );
+
+    expect(paramToStrip).toBe('messages.0.name');
+
+    const result = deleteDottedPath(payload, paramToStrip!);
+    expect(result.deleted).toBe(true);
+    expect(Array.isArray(result.payload.messages)).toBe(true);
+    expect(result.payload.messages).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'yo' },
+    ]);
+  });
+
+  test('other whole top-level fields (tools) are still strippable', () => {
+    // The structural guard is a narrow deny-list (messages/input/model), not
+    // a blanket "no whole fields" rule: stripping a whole `tools` (or
+    // `safety_identifier`, etc.) leaves a well-formed request.
+    const state = createUnsupportedParamStripState();
+    const payload: Record<string, any> = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [{ type: 'function', function: { name: 'f' } }],
+    };
+
+    const paramToStrip = planUnsupportedParamStrip(
+      '{"detail":"Unsupported parameter: tools"}',
+      state
+    );
+
+    expect(paramToStrip).toBe('tools');
+    const result = deleteDottedPath(payload, paramToStrip!);
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+  });
+});
+
+// prompt_cache_key is intentionally NOT in the static
+// suppress_unsupported_gpt5_options strip list (the Codex-OAuth native path
+// derives session-id/x-client-request-id headers from it, and no upstream
+// has been observed rejecting it) — so the reactive path is the ONLY
+// mechanism that removes it, and only when an upstream actually 400s naming
+// it. These tests exercise the full match -> plan -> delete pipeline on a
+// realistic provider payload, for both a plain and a dotted-path occurrence
+// of the field.
+describe('reactive strip-and-retry handles prompt_cache_key (not statically stripped)', () => {
+  test('strips a plain top-level prompt_cache_key named in a 400', () => {
+    const state = createUnsupportedParamStripState();
+    const payload: Record<string, any> = {
+      model: 'openai/gpt-5.5',
+      input: 'hello',
+      prompt_cache_key: 'cache-key-123',
+    };
+
+    const paramToStrip = planUnsupportedParamStrip(
+      '{"detail":"Unsupported parameter: prompt_cache_key"}',
+      state
+    );
+
+    expect(paramToStrip).toBe('prompt_cache_key');
+    const result = deleteDottedPath(payload, paramToStrip!);
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({ model: 'openai/gpt-5.5', input: 'hello' });
+  });
+
+  test('strips a dotted-path prompt_cache_key named in a 400', () => {
+    const state = createUnsupportedParamStripState();
+    const payload: Record<string, any> = {
+      model: 'openai/gpt-5.5',
+      input: 'hello',
+      metadata: { prompt_cache_key: 'cache-key-123', session: 's1' },
+    };
+
+    const paramToStrip = planUnsupportedParamStrip(
+      '{"error":{"message":"Unsupported parameter: \'metadata.prompt_cache_key\'"}}',
+      state
+    );
+
+    expect(paramToStrip).toBe('metadata.prompt_cache_key');
+    const result = deleteDottedPath(payload, paramToStrip!);
+    expect(result.deleted).toBe(true);
+    expect(result.payload).toEqual({
+      model: 'openai/gpt-5.5',
+      input: 'hello',
+      metadata: { session: 's1' },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3: thinking-signature failover recovery
+// ---------------------------------------------------------------------------
+//
+// Alias-level failover can replay a conversation containing `thinking` /
+// `redacted_thinking` blocks signed by one Claude model against a different
+// Claude model (e.g. cc/claude-opus-5 -> cc/claude-opus-4-8). Anthropic
+// rejects the stale signature with a 400 naming it specifically; every
+// remaining target would reject the same replayed signature the same way, so
+// failing over doesn't help — strip the thinking blocks and retry the SAME
+// target instead.
+
+describe('matchThinkingSignatureError', () => {
+  test('matches the exact production error body', () => {
+    const body = JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'messages.3.content.0: Invalid `signature` in `thinking` block',
+      },
+      request_id: 'req_test123',
+    });
+    expect(matchThinkingSignatureError(body)).toBe(true);
+  });
+
+  test('matches without backtick quoting around signature/thinking', () => {
+    expect(
+      matchThinkingSignatureError('{"error":{"message":"Invalid signature in thinking block"}}')
+    ).toBe(true);
+  });
+
+  test('matches regardless of case', () => {
+    expect(matchThinkingSignatureError('INVALID SIGNATURE IN THINKING BLOCK')).toBe(true);
+  });
+
+  test('returns false for an unrelated 400 body', () => {
+    expect(
+      matchThinkingSignatureError('{"error":{"message":"Invalid request: missing model"}}')
+    ).toBe(false);
+  });
+
+  test('returns false for a thinking-adjacent but unrelated error', () => {
+    expect(
+      matchThinkingSignatureError('{"error":{"message":"thinking.budget_tokens must be positive"}}')
+    ).toBe(false);
+  });
+
+  test('returns false for an empty body', () => {
+    expect(matchThinkingSignatureError('')).toBe(false);
+  });
+});
+
+describe('isAnthropicMessagesPayload', () => {
+  test('true when the payload has a messages array', () => {
+    expect(isAnthropicMessagesPayload({ model: 'claude-x', messages: [] })).toBe(true);
+  });
+
+  test('false when messages is missing (e.g. a Responses API payload)', () => {
+    expect(isAnthropicMessagesPayload({ model: 'gpt-5.5', input: 'hi' })).toBe(false);
+  });
+
+  test('false when messages is present but not an array', () => {
+    expect(isAnthropicMessagesPayload({ messages: 'not-an-array' })).toBe(false);
+  });
+
+  test('false for null, undefined, and non-object payloads', () => {
+    expect(isAnthropicMessagesPayload(null)).toBe(false);
+    expect(isAnthropicMessagesPayload(undefined)).toBe(false);
+    expect(isAnthropicMessagesPayload('a string')).toBe(false);
+  });
+});
+
+describe('stripThinkingSignatureBlocks', () => {
+  test('removes a thinking block preceding text, preserving ordering', () => {
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
+            { type: 'text', text: 'the answer' },
+          ],
+        },
+      ],
+    };
+    const snapshot = structuredClone(payload);
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'the answer' }] },
+    ]);
+    // Copy-on-write: the ORIGINAL payload argument is never mutated.
+    expect(payload).toEqual(snapshot);
+  });
+
+  test('removes a thinking block preceding a tool_use, preserving ordering', () => {
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'do the thing' }] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
+            { type: 'tool_use', id: 'tool-1', name: 'search', input: { q: 'x' } },
+          ],
+        },
+      ],
+    };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages[1].content).toEqual([
+      { type: 'tool_use', id: 'tool-1', name: 'search', input: { q: 'x' } },
+    ]);
+    // Ordering/other messages untouched.
+    expect(result.payload.messages[0]).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: 'do the thing' }],
+    });
+  });
+
+  test('removes a redacted_thinking block, preserving sibling content', () => {
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'redacted_thinking', data: 'opaque-encrypted-payload' },
+            { type: 'text', text: 'the answer' },
+          ],
+        },
+      ],
+    };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'the answer' }] },
+    ]);
+  });
+
+  test('removes both thinking and redacted_thinking blocks in the same message', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'a', signature: 'sig-a' },
+            { type: 'redacted_thinking', data: 'b' },
+            { type: 'text', text: 'the answer' },
+          ],
+        },
+      ],
+    };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(2);
+    expect(result.payload.messages[0].content).toEqual([{ type: 'text', text: 'the answer' }]);
+  });
+
+  test('leaves non-array content (plain string messages) untouched and returns the SAME payload reference', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi there' },
+      ],
+    };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
+    expect(payload.messages).toEqual([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi there' },
+    ]);
+  });
+
+  test('is a no-op (same payload reference) when the payload has no messages array', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5', input: 'hi' };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
+    expect(payload).toEqual({ model: 'gpt-5.5', input: 'hi' });
+  });
+
+  test('no-op contract: an Anthropic-shaped payload with array content but no thinking blocks returns strippedCount 0 and the SAME reference', () => {
+    // The structural isAnthropicMessagesPayload check also matches OpenAI
+    // chat-completions payloads (they have a `messages` array too). This is
+    // the known false-positive shape the dispatch loop must NOT retry on:
+    // strippedCount 0 + identical payload reference is the signal.
+    const payload: Record<string, any> = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    };
+    const snapshot = structuredClone(payload);
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
+    expect(payload).toEqual(snapshot);
+  });
+
+  test('copy-on-write: never mutates the input payload, its messages array, or untouched message objects', () => {
+    const untouchedMessage = { role: 'user', content: [{ type: 'text', text: 'hi' }] };
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        untouchedMessage,
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'stale', signature: 'sig-a' },
+            { type: 'text', text: 'answer' },
+          ],
+        },
+      ],
+    };
+    const originalMessages = payload.messages;
+    const snapshot = structuredClone(payload);
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    // A NEW root object with a NEW messages array is returned...
+    expect(result.payload).not.toBe(payload);
+    expect(result.payload.messages).not.toBe(originalMessages);
+    // ...while the input payload keeps its original array and full content.
+    expect(payload.messages).toBe(originalMessages);
+    expect(payload).toEqual(snapshot);
+    // Untouched messages are shared (not cloned), mirroring deleteDottedPath's
+    // "untouched sibling branches are shared" copy-on-write behavior.
+    expect(result.payload.messages[0]).toBe(untouchedMessage);
+  });
+
+  test('drops a thinking-only assistant message at the end of the conversation (no alternation break, nothing to orphan)', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+        },
+      ],
+    };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    ]);
+  });
+
+  test('replaces a thinking-only assistant message with a placeholder when dropping it would break user/assistant alternation', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'first' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'second' }] },
+      ],
+    };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'first' }] },
+      { role: 'assistant', content: [{ type: 'text', text: '[reasoning elided]' }] },
+      { role: 'user', content: [{ type: 'text', text: 'second' }] },
+    ]);
+  });
+
+  test('replaces a thinking-only message with a placeholder when dropping it would orphan a tool_result (no matching tool_use adjacent)', () => {
+    // Deliberately constructed so the alternation check alone would NOT catch
+    // this (prev='assistant', next='user' — different roles) — isolating the
+    // tool_result-orphan guard: `next` carries a tool_result but `prev` does
+    // NOT carry the tool_use it would need to correspond to, so dropping the
+    // thinking-only message would leave that tool_result dangling.
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'q' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'partial answer, no tool call' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+        },
+      ],
+    };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages[2]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: '[reasoning elided]' }],
+    });
+    // Everything else is untouched.
+    expect(result.payload.messages[0]).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: 'q' }],
+    });
+    expect(result.payload.messages[1]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'partial answer, no tool call' }],
+    });
+    expect(result.payload.messages[3]).toEqual({
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+    });
+  });
+
+  test('drops a thinking-only message when the next tool_result correctly pairs with a preceding tool_use', () => {
+    // Here dropping the empty message actually restores correct adjacency
+    // between the tool_use and its tool_result, so it is safe to drop.
+    const payload: Record<string, any> = {
+      messages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tool-1', name: 'search', input: {} }],
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+        },
+      ],
+    };
+
+    const result = stripThinkingSignatureBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'search', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+      },
+    ]);
+  });
+});
+
+describe('planThinkingSignatureStrip', () => {
+  const signatureBody = JSON.stringify({
+    error: { message: 'messages.3.content.0: Invalid `signature` in `thinking` block' },
+  });
+  const anthropicPayload = { model: 'claude-x', messages: [] };
+
+  test('MAX_THINKING_SIGNATURE_STRIP_RETRIES is exactly 1 (one strip-retry per target)', () => {
+    expect(MAX_THINKING_SIGNATURE_STRIP_RETRIES).toBe(1);
+  });
+
+  test('plans a strip-retry on the first matching 400 for an Anthropic messages payload', () => {
+    const state = createThinkingSignatureStripState();
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('does not plan a retry when the body does not name a signature error', () => {
+    const state = createThinkingSignatureStripState();
+    expect(
+      planThinkingSignatureStrip('{"error":{"message":"Invalid request"}}', anthropicPayload, state)
+    ).toBe(false);
+    expect(state.attempts).toBe(0);
+  });
+
+  test('does not plan a retry when the outbound payload is not Anthropic-messages-shaped', () => {
+    const state = createThinkingSignatureStripState();
+    const responsesPayload = { model: 'gpt-5.5', input: 'hi' };
+    expect(planThinkingSignatureStrip(signatureBody, responsesPayload, state)).toBe(false);
+    expect(state.attempts).toBe(0);
+  });
+
+  test('retry bound: a second signature 400 on the same target does not plan a second strip-retry', () => {
+    const state = createThinkingSignatureStripState();
+
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(true);
+    // Upstream 400s again with the SAME (or another) signature error — the
+    // one-per-target bound is already used up, so normal failover must
+    // proceed instead of stripping again.
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(false);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('refundThinkingSignatureStrip returns the budget after a 0-strip plan, so a later genuine signature 400 can still strip-retry', () => {
+    // Sequence mirrors the dispatch loop's false-positive path: the plan
+    // fires (structural check matched an OpenAI-shaped payload), the strip
+    // turns out to be a no-op (0 blocks), NO retry happens — so the attempt
+    // is refunded and the one-per-target budget stays available.
+    const state = createThinkingSignatureStripState();
+
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+
+    refundThinkingSignatureStrip(state);
+    expect(state.attempts).toBe(0);
+
+    // The budget is intact: a later signature 400 on the same target still
+    // gets its strip-and-retry.
+    expect(planThinkingSignatureStrip(signatureBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('refundThinkingSignatureStrip never drives attempts below zero', () => {
+    const state = createThinkingSignatureStripState();
+    refundThinkingSignatureStrip(state);
+    expect(state.attempts).toBe(0);
   });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
@@ -3,6 +3,9 @@ import { Dispatcher } from '../dispatch/dispatcher';
 import { setConfigForTesting } from '../../config';
 import type { UnifiedChatRequest } from '../../types/unified';
 import { CooldownManager } from '../runtime/cooldown-manager';
+// Globally mocked in test/vitest.setup.ts — imported here only to assert on
+// the warn calls the strip-and-retry paths emit.
+import { logger } from '../../utils/logger';
 
 const fetchMock: any = vi.fn(async (): Promise<any> => {
   throw new Error('fetch mock not configured for test');
@@ -68,6 +71,32 @@ function makeChatRequest(stream = false): UnifiedChatRequest {
   };
 }
 
+/**
+ * A chat request whose outbound provider payload actually CONTAINS the
+ * fields the same-target strip-and-retry tests below name as "unsupported"
+ * (`safety_identifier`, `prompt_cache_key`) — via `originalBody`, since
+ * OpenAITransformer.transformRequest only carries unmapped fields through
+ * when `incomingApiType === 'chat'` (same-format) AND `originalBody` is set.
+ * Needed so `deleteDottedPath` actually finds and removes something
+ * (`deleted: true`); the call site now correctly refuses to retry a strip
+ * that didn't remove anything, so a fixture that never put the field in the
+ * payload in the first place would no longer exercise the retry at all.
+ */
+function makeChatRequestWithUnsupportedParams(): UnifiedChatRequest {
+  return {
+    model: 'test-alias',
+    messages: [{ role: 'user', content: 'hello' }],
+    incomingApiType: 'chat',
+    stream: false,
+    originalBody: {
+      model: 'test-alias',
+      messages: [{ role: 'user', content: 'hello' }],
+      safety_identifier: 'safety-abc',
+      prompt_cache_key: 'cache-key-123',
+    },
+  } as any;
+}
+
 function successChatResponse(model: string) {
   return new Response(
     JSON.stringify({
@@ -93,6 +122,112 @@ function errorResponse(status: number, message: string) {
     status,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+// --- T3: thinking-signature failover recovery helpers -----------------------
+
+function makeAnthropicMessagesConfig(options?: { targetCount?: number }) {
+  const targetCount = options?.targetCount ?? 1;
+  // api_base_url uses the record/map form ({ messages: <url> }) rather than a
+  // bare string so getProviderTypes()/resolveProviderBaseUrl() resolve the
+  // 'messages' API type explicitly (the string-URL inference path only
+  // recognizes 'messages' for URLs containing "anthropic.com" — see
+  // config.ts's getProviderTypes()).
+  const providers: Record<string, any> = {
+    p1: {
+      api_base_url: { messages: 'https://p1.example.com' },
+      api_key: 'test-key-p1',
+      useClaudeMasking: false,
+      models: { 'model-1': {} },
+    },
+    p2: {
+      api_base_url: { messages: 'https://p2.example.com' },
+      api_key: 'test-key-p2',
+      useClaudeMasking: false,
+      models: { 'model-2': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'claude-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+function makeMessagesRequest(messages: any[]): UnifiedChatRequest {
+  return {
+    model: 'claude-alias',
+    // Unified `messages` is required by the type but unused on the
+    // pass-through path — the bypass path clones `originalBody` verbatim.
+    messages: [{ role: 'user', content: 'hello' }],
+    incomingApiType: 'messages',
+    originalBody: {
+      model: 'claude-alias',
+      max_tokens: 1024,
+      messages,
+    },
+  } as any;
+}
+
+function thinkingSignatureErrorResponse() {
+  // Verbatim production body from the task brief.
+  return new Response(
+    JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'messages.3.content.0: Invalid `signature` in `thinking` block',
+      },
+      request_id: 'req_test123',
+    }),
+    { status: 400, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function successMessagesResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: 'msg-1',
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'ok' }],
+      model,
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function messagesWithStaleThinking() {
+  return [
+    { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
+        { type: 'text', text: 'answer' },
+      ],
+    },
+    { role: 'user', content: [{ type: 'text', text: 'follow up' }] },
+  ];
 }
 
 describe('Dispatcher Failover', () => {
@@ -425,6 +560,258 @@ describe('Dispatcher Failover', () => {
       expect(error.routingContext?.attemptCount).toBe(1);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     }
+  });
+
+  test('same-target retry: strips a named unsupported parameter and retries instead of failing over', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () =>
+        errorResponse(400, 'Unsupported parameter: safety_identifier')
+      )
+      .mockImplementationOnce(async () => successChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequestWithUnsupportedParams());
+    const meta = (response as any).plexus;
+
+    // Single configured target — a second fetch call can only mean the
+    // SAME target was retried after stripping the offending field, not a
+    // failover to a different provider (there isn't one).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+
+    // The field was ACTUALLY removed from the retried payload, not just a
+    // retry regardless of outcome.
+    const retriedBody = JSON.parse((fetchMock.mock.calls[1] as any[])[1].body as string);
+    expect(retriedBody.safety_identifier).toBeUndefined();
+
+    // The strip warn is the only operator-visible trace that the outbound
+    // payload was modified mid-request — it must name both the target
+    // (provider/model) and the exact param that was removed.
+    const paramStripWarn = vi
+      .mocked(logger.warn)
+      .mock.calls.map((call) => String(call[0]))
+      .find((message) => message.includes('rejected unsupported parameter'));
+    expect(paramStripWarn).toBeDefined();
+    expect(paramStripWarn).toContain('p1/model-1');
+    expect(paramStripWarn).toContain("'safety_identifier'");
+  });
+
+  test('same-target retry: gives up after the retry bound and fails normally when the upstream keeps naming a NEW unsupported param', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () =>
+        errorResponse(400, 'Unsupported parameter: safety_identifier')
+      )
+      .mockImplementationOnce(async () =>
+        errorResponse(400, "Unsupported parameter: 'prompt_cache_key'")
+      )
+      .mockImplementationOnce(async () =>
+        errorResponse(400, "Unsupported parameter: 'reasoning.summary'")
+      );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequestWithUnsupportedParams());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    // 1 initial attempt + 2 bounded strip-retries = 3 fetch calls, then give
+    // up rather than stripping a 3rd distinct param.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('same-target retry: a prototype-pollution attempt (__proto__.toString) is rejected — no retry, global state intact', async () => {
+    // A malicious/compromised upstream can name ANY dotted string via the
+    // "Unsupported parameter: X" 400 body (matchUnsupportedParameter's regex
+    // captures dots and underscores). This proves the reactive strip-and-retry
+    // path cannot be turned into a prototype-pollution gadget: the attempt
+    // must be rejected (no field actually removed), so the call site must NOT
+    // resend the identical payload — single target, single fetch call.
+    const originalToString = Object.prototype.toString;
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () =>
+      errorResponse(400, "Unsupported parameter: '__proto__.toString'")
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    // No retry happened: deleteDottedPath rejected the dangerous path, so
+    // nothing was actually stripped, so the call site must not resend an
+    // identical payload to the same target. A single configured target with
+    // failover on but a non-retryable 400 means exactly one fetch call.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The actual attack: prove global state survived, not just that dispatch
+    // failed for some other reason.
+    expect(Object.prototype.toString).toBe(originalToString);
+    expect(typeof Object.prototype.toString).toBe('function');
+    expect({}.toString()).toBe('[object Object]');
+  });
+
+  test('same-target retry: refuses to strip the whole `messages` field — no strip, no retry', async () => {
+    // Deleting the entire conversation wholesale guarantees a malformed
+    // request, so the structural guard must refuse: exactly one fetch (no
+    // same-target retry with a messages-less payload), then normal failure.
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () => errorResponse(400, 'Unsupported parameter: messages'));
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('same-target retry: bracket notation (messages[0].name) strips only that element field and retries with the conversation intact', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () =>
+        errorResponse(400, "Unsupported parameter: 'messages[0].name'")
+      )
+      .mockImplementationOnce(async () => successChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch({
+      model: 'test-alias',
+      messages: [{ role: 'user', content: 'hello' }],
+      incomingApiType: 'chat',
+      stream: false,
+      originalBody: {
+        model: 'test-alias',
+        messages: [{ role: 'user', content: 'hello', name: 'bob!' }],
+      },
+    } as any);
+    const meta = (response as any).plexus;
+
+    // Single configured target — the second fetch is a same-target retry.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+
+    const retriedBody = JSON.parse((fetchMock.mock.calls[1] as any[])[1].body as string);
+    // The delete landed on the array ELEMENT's field (bracket segments
+    // normalized to canonical indices) — the old truncating matcher instead
+    // deleted `messages` wholesale from the retry payload.
+    expect(Array.isArray(retriedBody.messages)).toBe(true);
+    expect(retriedBody.messages).toEqual([{ role: 'user', content: 'hello' }]);
+  });
+
+  test('same-target retry: a no-op strip (named field not actually present) does not retry', async () => {
+    // The upstream names a field that plainly isn't in the outbound payload
+    // at all — deleteDottedPath finds nothing to remove. Retrying here would
+    // just resend the exact same payload and get the exact same 400 again;
+    // the call site must respect the `deleted` return value and skip the retry.
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () =>
+      errorResponse(400, 'Unsupported parameter: totally_fake_field_xyz')
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('same-target retry: stops immediately (no infinite loop) when the upstream keeps naming the SAME unsupported param', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () =>
+      errorResponse(400, 'Unsupported parameter: safety_identifier')
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequestWithUnsupportedParams());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    // First 400 strips safety_identifier and retries; the second 400 names
+    // the SAME already-stripped param, so the loop stops there instead of
+    // spinning until the retry bound is exhausted.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('same-target retry: strips stale thinking-block signatures and retries instead of failing over', async () => {
+    setConfigForTesting(makeAnthropicMessagesConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () => thinkingSignatureErrorResponse())
+      .mockImplementationOnce(async () => successMessagesResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeMessagesRequest(messagesWithStaleThinking()));
+    const meta = (response as any).plexus;
+
+    // Single configured target — a second fetch call can only mean the SAME
+    // target was retried after stripping the stale thinking blocks, not a
+    // failover to a different provider (there isn't one).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+
+    const retriedBody = JSON.parse((fetchMock.mock.calls[1] as any[])[1].body as string);
+    expect(Array.isArray(retriedBody.messages)).toBe(true);
+    for (const message of retriedBody.messages) {
+      const content = Array.isArray(message.content) ? message.content : [];
+      expect(
+        content.some(
+          (block: any) => block.type === 'thinking' || block.type === 'redacted_thinking'
+        )
+      ).toBe(false);
+    }
+    // Non-thinking content survives the strip.
+    expect(retriedBody.messages[1].content).toEqual([{ type: 'text', text: 'answer' }]);
+
+    // The strip warn is the only operator-visible trace that conversation
+    // content was modified mid-request — it must name the target
+    // (provider/model) and how many thinking blocks were stripped (the
+    // fixture carries exactly one).
+    const signatureStripWarn = vi
+      .mocked(logger.warn)
+      .mock.calls.map((call) => String(call[0]))
+      .find((message) => message.includes('stale thinking-block'));
+    expect(signatureStripWarn).toBeDefined();
+    expect(signatureStripWarn).toContain('p1/model-1');
+    expect(signatureStripWarn).toContain('stripped 1 thinking block(s)');
+  });
+
+  test('same-target retry: gives up after the one-shot thinking-signature retry bound and fails normally when the signature error persists', async () => {
+    setConfigForTesting(makeAnthropicMessagesConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () => thinkingSignatureErrorResponse());
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeMessagesRequest(messagesWithStaleThinking()));
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    // 1 initial attempt + exactly 1 bounded signature strip-retry = 2 fetch
+    // calls, then give up rather than looping forever on a persistent error.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test('embeddings failover', async () => {

--- a/packages/backend/src/services/__tests__/dispatcher-oauth-passthrough.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-oauth-passthrough.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import type { FastifyReply, FastifyRequest } from 'fastify';
 import { setConfigForTesting } from '../../config';
 import { OAuthAuthManager } from '../oauth/oauth-auth-manager';
 import { registerSpy } from '../../../test/test-utils';
-import type { UnifiedChatRequest } from '../../types/unified';
+import { TransformerFactory } from '../dispatch/transformer-factory';
+import { handleResponse } from '../responses/response-handler';
+import type { UsageStorageService } from '../observability/usage-storage';
+import type { UnifiedChatRequest, UnifiedChatResponse } from '../../types/unified';
+import type { UsageRecord } from '../../types/usage';
 
 // Regression test for issue #162 (dispatcher-level):
 //   a multi-turn conversation routed to Claude Code OAuth must succeed, not
@@ -123,5 +128,377 @@ describe('Dispatcher OAuth pass-through regression (issue #162)', () => {
     expect(headers.Authorization).toBe('Bearer sk-ant-oat-fake-token-for-test');
     expect(headers['anthropic-beta']).toBeTruthy();
     expect(headers['x-app']).toBe('cli');
+  });
+});
+
+// Regression coverage for the production defect where OpenAI-format clients
+// (chat/responses) routed to an OAuth-Anthropic native target received RAW
+// Anthropic SSE back (empty completions — no `choices`, no `data: [DONE]`).
+// Root cause: the native-OAuth response bypass in request-payload-builder.ts
+// was unconditional (`true`) for the Anthropic branch, regardless of the
+// incoming client's API format. Fix mirrors the identical Codex defect fixed
+// in commit 4f74c1c6 ("fix(oauth): translate cross-format Codex responses"):
+// scope the bypass to same-format (`messages`) clients only; chat/responses
+// clients must flow through the standard transform pipeline.
+
+function oauthAnthropicCrossFormatConfig() {
+  return {
+    providers: {
+      Claude: {
+        type: 'oauth',
+        api_base_url: 'oauth://anthropic',
+        oauth_provider: 'anthropic',
+        oauth_account: 'test-account',
+        models: {
+          'claude-test': {
+            pricing: { source: 'simple', input: 0, output: 0 },
+            access_via: ['chat', 'messages', 'responses'],
+          },
+        },
+      },
+    },
+    models: {
+      'test-alias': {
+        targets: [{ provider: 'Claude', model: 'claude-test' }],
+      },
+    },
+    keys: {},
+  } as any;
+}
+
+// A realistic upstream Anthropic Messages SSE stream: message_start ->
+// content_block_start/delta (text) -> content_block_stop -> message_delta
+// (stop_reason: end_turn) -> message_stop. Whitespace/shape kept exactly as
+// a real Anthropic response would send it — the messages-inbound regression
+// guard asserts byte-for-byte equality against this constant.
+const UPSTREAM_ANTHROPIC_SSE = [
+  'event: message_start',
+  'data: {"type":"message_start","message":{"id":"msg_test123","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}',
+  '',
+  'event: content_block_start',
+  'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+  '',
+  'event: content_block_delta',
+  'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from Claude"}}',
+  '',
+  'event: content_block_stop',
+  'data: {"type":"content_block_stop","index":0}',
+  '',
+  'event: message_delta',
+  'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":4}}',
+  '',
+  'event: message_stop',
+  'data: {"type":"message_stop"}',
+  '',
+  '',
+].join('\n');
+
+function chatStreamingRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'test-alias',
+    stream: true,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'test-alias',
+    messages: body.messages,
+    stream: true,
+    incomingApiType: 'chat',
+    originalBody: body,
+  } as any;
+}
+
+function responsesStreamingRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'test-alias',
+    stream: true,
+    input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+  };
+  return {
+    model: 'test-alias',
+    messages: [{ role: 'user', content: 'hi' }],
+    stream: true,
+    incomingApiType: 'responses',
+    originalBody: body,
+  } as any;
+}
+
+function messagesStreamingRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'test-alias',
+    max_tokens: 256,
+    stream: true,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'test-alias',
+    messages: body.messages,
+    max_tokens: 256,
+    stream: true,
+    incomingApiType: 'messages',
+    originalBody: body,
+  } as any;
+}
+
+function nonStreamingChatRequest(): UnifiedChatRequest {
+  const body = {
+    model: 'test-alias',
+    stream: false,
+    messages: [{ role: 'user', content: 'hi' }],
+  };
+  return {
+    model: 'test-alias',
+    messages: body.messages,
+    stream: false,
+    incomingApiType: 'chat',
+    originalBody: body,
+  } as any;
+}
+
+async function drainBytes(stream: ReadableStream): Promise<string> {
+  const reader = stream.getReader();
+  const dec = new TextDecoder();
+  let out = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out += typeof value === 'string' ? value : dec.decode(value);
+  }
+  return out;
+}
+
+/** Extracts every SSE frame's JSON `data:` payload, dropping the `[DONE]` sentinel. */
+function parseSseDataPayloads(text: string): any[] {
+  return text
+    .split('\n\n')
+    .map((block) => block.split('\n').find((line) => line.startsWith('data:')))
+    .filter((line): line is string => !!line)
+    .map((line) => line.replace(/^data:\s*/, ''))
+    .filter((data) => data !== '[DONE]')
+    .map((data) => JSON.parse(data));
+}
+
+describe('Dispatcher OAuth pass-through — cross-format Anthropic response translation (regression)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    OAuthAuthManager.resetForTesting();
+    registerSpy(OAuthAuthManager.getInstance(), 'getApiKey').mockResolvedValue(
+      'sk-ant-oat-fake-token-for-test'
+    );
+    fetchSpy = registerSpy(global, 'fetch').mockResolvedValue(
+      new Response(UPSTREAM_ANTHROPIC_SSE, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    OAuthAuthManager.resetForTesting();
+  });
+
+  /**
+   * Mirrors the standard dispatch pipeline in response-handler.ts (~lines
+   * 274-284): raw provider SSE -> providerTransformer.transformStream ->
+   * unified chunks -> clientTransformer.formatStream -> client SSE bytes.
+   * The dispatcher itself never runs this pipeline (it only decides, via
+   * `bypassTransformation`, whether response-handler.ts should) so the test
+   * replicates it to prove cross-format clients actually get a well-formed,
+   * translated stream rather than just checking the boolean flag.
+   */
+  async function translatedClientBytes(
+    response: UnifiedChatResponse,
+    incomingApiType: string
+  ): Promise<string> {
+    const providerTransformer = TransformerFactory.getTransformer('messages');
+    const clientTransformer = TransformerFactory.getTransformer(incomingApiType);
+    const unifiedStream = providerTransformer.transformStream!(response.stream!);
+    const clientStream = clientTransformer.formatStream!(unifiedStream);
+    return drainBytes(clientStream);
+  }
+
+  test('chat-inbound + oauth-anthropic target, streaming: translates to OpenAI chunks, no raw Anthropic frames', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    const response = await new Dispatcher().dispatch(chatStreamingRequest());
+
+    // Sanity: the upstream leg always speaks native Anthropic Messages.
+    expect(response.plexus?.apiType).toBe('messages');
+    // The actual fix: response leg must NOT bypass for a chat-inbound client.
+    expect(response.bypassTransformation).toBe(false);
+    expect(response.stream).toBeDefined();
+
+    const clientBytes = await translatedClientBytes(response, 'chat');
+    const payloads = parseSseDataPayloads(clientBytes);
+
+    const contentChunk = payloads.find((p) => p.choices?.[0]?.delta?.content);
+    expect(contentChunk?.choices[0].delta.content).toBe('Hello from Claude');
+
+    const finishChunk = payloads.find((p) => p.choices?.[0]?.finish_reason);
+    expect(finishChunk?.choices[0].finish_reason).toBe('stop');
+
+    expect(clientBytes.trim().endsWith('data: [DONE]')).toBe(true);
+    // No raw Anthropic SSE frames leaked to the client (OpenAI chunks never
+    // use a named `event:` line).
+    expect(clientBytes).not.toMatch(/^event:/m);
+    expect(clientBytes).not.toContain('message_start');
+    expect(clientBytes).not.toContain('content_block_delta');
+  });
+
+  test('responses-inbound + oauth-anthropic target, streaming: translates to Responses events, no raw Anthropic frames', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    const response = await new Dispatcher().dispatch(responsesStreamingRequest());
+
+    expect(response.plexus?.apiType).toBe('messages');
+    expect(response.bypassTransformation).toBe(false);
+    expect(response.stream).toBeDefined();
+
+    const clientBytes = await translatedClientBytes(response, 'responses');
+    const payloads = parseSseDataPayloads(clientBytes);
+
+    const deltaEvent = payloads.find((p) => p.type === 'response.output_text.delta');
+    expect(deltaEvent?.delta).toBe('Hello from Claude');
+    expect(payloads.some((p) => p.type === 'response.completed')).toBe(true);
+
+    expect(clientBytes).toContain('event: response.output_text.delta');
+    expect(clientBytes).not.toContain('event: message_start');
+    expect(clientBytes).not.toContain('event: content_block_delta');
+    expect(clientBytes).not.toContain('event: message_delta');
+    expect(clientBytes).not.toContain('event: message_stop');
+  });
+
+  test('messages-inbound + oauth-anthropic target, streaming: raw Anthropic SSE passthrough unchanged (regression guard)', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    const response = await new Dispatcher().dispatch(messagesStreamingRequest());
+
+    expect(response.bypassTransformation).toBe(true);
+    expect(response.stream).toBeDefined();
+
+    const clientBytes = await drainBytes(response.stream!);
+    // Byte-for-byte: Claude Code traffic depends on zero re-serialization.
+    expect(clientBytes).toBe(UPSTREAM_ANTHROPIC_SSE);
+  });
+
+  test('chat-inbound + oauth-anthropic target, non-streaming: same scoping applies (bypass disabled, JSON translated)', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'msg_test123',
+          type: 'message',
+          role: 'assistant',
+          model: 'claude-test',
+          content: [{ type: 'text', text: 'Hello from Claude' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 4 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+
+    const response = await new Dispatcher().dispatch(nonStreamingChatRequest());
+
+    // Non-streaming's non-bypass branch (dispatcher.ts handleNonStreamingResponse)
+    // returns transformer.transformResponse(...) as-is without stamping an
+    // explicit `bypassTransformation: false` (only the bypass=true branch stamps
+    // it). response-handler.ts only ever does a truthy check on this flag, so
+    // `undefined` and `false` are behaviorally identical — assert falsy rather
+    // than a stricter equality the surrounding code doesn't actually guarantee.
+    expect(response.bypassTransformation).toBeFalsy();
+
+    const formatted = await TransformerFactory.getTransformer('chat').formatResponse(response);
+    expect(formatted.choices[0].message.content).toBe('Hello from Claude');
+  });
+
+  // End-to-end lock for the scenario the manual `translatedClientBytes` tests
+  // above only approximate: drive `handleResponse` ITSELF (the code that runs
+  // in production) with the dispatcher's real cross-format result and let it
+  // resolve the REAL provider transformer (AnthropicTransformer, via the
+  // un-mocked TransformerFactory) and the REAL client transformer
+  // (OpenAITransformer). Asserts the exact bytes a chat client receives.
+  test('chat-inbound + oauth-anthropic target, streaming: END-TO-END through handleResponse yields OpenAI chunks', async () => {
+    setConfigForTesting(oauthAnthropicCrossFormatConfig());
+    const response = await new Dispatcher().dispatch(chatStreamingRequest());
+
+    // Preconditions (same dispatcher decisions the manual tests assert).
+    expect(response.plexus?.apiType).toBe('messages');
+    expect(response.bypassTransformation).toBe(false);
+    expect(response.stream).toBeDefined();
+
+    const clientTransformer = TransformerFactory.getTransformer('chat');
+    const usageRecord: Partial<UsageRecord> = { requestId: 'req-e2e-cross-format' };
+    const usageStorage = {
+      saveRequest: vi.fn(),
+      saveError: vi.fn(),
+      updatePerformanceMetrics: vi.fn(),
+    } as unknown as UsageStorageService;
+    const sentBodies: any[] = [];
+    const reply = {
+      header: vi.fn(function (this: any) {
+        return this;
+      }),
+      code: vi.fn(function (this: any) {
+        return this;
+      }),
+      send: vi.fn(function (this: any, body: any) {
+        sentBodies.push(body);
+        return this;
+      }),
+    } as unknown as FastifyReply;
+    const fastifyRequest = { id: 'req-e2e-cross-format', headers: {} } as unknown as FastifyRequest;
+
+    await handleResponse(
+      fastifyRequest,
+      reply,
+      response,
+      clientTransformer,
+      usageRecord,
+      usageStorage,
+      Date.now(),
+      'chat'
+    );
+
+    expect(reply.header).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+
+    // handleResponse sends a Node Readable pipeline — collect the exact bytes
+    // a client would receive over the wire.
+    const pipeline = sentBodies.at(-1);
+    expect(pipeline).toBeDefined();
+    const clientBytes: string = await new Promise((resolve, reject) => {
+      let out = '';
+      pipeline.on('data', (chunk: any) => {
+        out += chunk.toString();
+      });
+      pipeline.once('end', () => resolve(out));
+      pipeline.once('error', reject);
+    });
+    // Let fire-and-forget completion work (UsageInspector flush) settle.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Structured SSE parsing: every data frame must be an OpenAI chat chunk.
+    const payloads = parseSseDataPayloads(clientBytes);
+    expect(payloads.length).toBeGreaterThan(0);
+    for (const payload of payloads) {
+      expect(payload.object).toBe('chat.completion.chunk');
+    }
+
+    const contentChunk = payloads.find((p) => p.choices?.[0]?.delta?.content);
+    expect(contentChunk?.choices[0].delta.content).toBe('Hello from Claude');
+
+    const finishChunk = payloads.find((p) => p.choices?.[0]?.finish_reason);
+    expect(finishChunk?.choices[0].finish_reason).toBe('stop');
+
+    expect(clientBytes.trim().endsWith('data: [DONE]')).toBe(true);
+
+    // No raw Anthropic SSE frames may leak through the real pipeline.
+    expect(clientBytes).not.toMatch(/^event:/m);
+    expect(clientBytes).not.toContain('message_start');
+    expect(clientBytes).not.toContain('content_block_delta');
+
+    // Pipeline bookkeeping: the stream had visible output and was transformed.
+    expect(usageRecord.responseStatus).toBe('success');
+    expect(usageRecord.isPassthrough).toBe(false);
+    expect(usageStorage.saveRequest).toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerSpy } from '../../../../test/test-utils';
+import {
+  deriveProbeStallConfig,
+  executeStandardAttempt,
+  type StandardAttemptContext,
+} from '../standard-attempt-request';
+import type { RequestManagerHost } from '../request-manager';
+import type { RouteResult } from '../../routing/router';
+import type { UnifiedChatRequest } from '../../../types/unified';
+import type { StallConfig } from '../../inspectors/stall-inspector';
+
+function makeStallConfig(overrides: Partial<StallConfig> = {}): StallConfig {
+  return {
+    ttfbMs: 5000,
+    ttfbBytes: 1024,
+    minBytesPerSecond: null,
+    windowMs: 1000,
+    gracePeriodMs: 0,
+    ...overrides,
+  };
+}
+
+describe('deriveProbeStallConfig', () => {
+  it('returns the pristine config unchanged when no fetch time has elapsed', () => {
+    const pristine = makeStallConfig({ ttfbMs: 5000 });
+    expect(deriveProbeStallConfig(pristine, 0)).toEqual(pristine);
+  });
+
+  it('nulls out ttfbMs once elapsed time meets or exceeds the full budget', () => {
+    const pristine = makeStallConfig({ ttfbMs: 5000 });
+    expect(deriveProbeStallConfig(pristine, 5000)).toEqual({ ...pristine, ttfbMs: null });
+    expect(deriveProbeStallConfig(pristine, 6000)).toEqual({ ...pristine, ttfbMs: null });
+  });
+
+  it('reduces ttfbMs by the elapsed time for a partial budget', () => {
+    const pristine = makeStallConfig({ ttfbMs: 5000 });
+    expect(deriveProbeStallConfig(pristine, 4900)).toEqual({ ...pristine, ttfbMs: 100 });
+  });
+
+  it('passes a null/undefined pristine config through unchanged', () => {
+    expect(deriveProbeStallConfig(null, 1000)).toBeNull();
+    expect(deriveProbeStallConfig(undefined, 1000)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch-level seam: `host.probeStreamingStart` is the injected "probe
+// config receiver" — executeStandardAttempt calls it exactly once, after the
+// same-target strip-and-retry while(true) loop breaks, with whatever
+// `effectiveStallConfig` the FINAL iteration computed. That makes it the
+// only clean spy-able point to prove which ttfbMs budget a given iteration
+// actually derived from (there is no host method that observes the *armed*
+// per-iteration TTFB timer directly — it's a local `setTimeout`, not passed
+// through the host).
+// ---------------------------------------------------------------------------
+
+function makeRoute(): RouteResult {
+  return { provider: 'p1', model: 'model-1', config: {} as any } as RouteResult;
+}
+
+function makeStreamingRequest(): UnifiedChatRequest {
+  return {
+    requestId: 'req-1',
+    model: 'model-1',
+    messages: [{ role: 'user', content: 'hi' } as any],
+    stream: true,
+    incomingApiType: 'chat',
+  };
+}
+
+function makeHost(overrides: Partial<RequestManagerHost> = {}): RequestManagerHost {
+  return {
+    appendFailureAttempt: vi.fn(),
+    appendSkippedAttempt: vi.fn(),
+    appendSuccessAttempt: vi.fn(),
+    attachAttemptMetadata: vi.fn(),
+    buildAllTargetsFailedError: vi.fn(() => new Error('all targets failed')),
+    buildCancelledError: vi.fn(() => new Error('cancelled')),
+    buildRequestUrl: vi.fn(() => 'https://example.test/v1/chat/completions'),
+    buildTimeoutError: vi.fn(() => new Error('timeout')),
+    createAttemptTimeout: vi.fn(),
+    emitRoutingUpdate: vi.fn(),
+    executeProviderRequest: vi.fn(),
+    formatFailureReason: vi.fn((error: any) => error?.message ?? 'error'),
+    getUsageStorage: vi.fn(() => undefined),
+    handleNonStreamingResponse: vi.fn(async () => ({}) as any),
+    handleProviderError: vi.fn(),
+    handleStreamingResponse: vi.fn(() => ({}) as any),
+    isPiAiRoute: vi.fn(() => false),
+    isRetryableNetworkError: vi.fn(() => false),
+    isRetryableStatus: vi.fn(() => false),
+    probeStreamingStart: vi.fn(),
+    recordAttemptMetric: vi.fn(async () => {}),
+    recordStickySession: vi.fn(),
+    saveIntermediateError: vi.fn(),
+    selectTargetApiType: vi.fn(() => ({ selectionReason: 'test' })),
+    setupHeaders: vi.fn(() => ({})),
+    transformRequestPayload: vi.fn(async () => ({ payload: {}, bypassTransformation: false })),
+    ...overrides,
+  };
+}
+
+describe('executeStandardAttempt — per-fetch TTFB budget reset', () => {
+  it("gives a same-target strip-and-retry attempt the full pristine TTFB budget instead of the previous attempt's reduced one", async () => {
+    const dateSpy = registerSpy(Date, 'now');
+    // Sequence matches the exact Date.now() read sites for this scenario:
+    // iter1 dispatchStartTime, iter1 post-fetch (fetchElapsed calc), iter2
+    // dispatchStartTime, iter2 post-fetch (fetchElapsed calc). The strip
+    // path taken between iter1 and iter2 doesn't call Date.now() itself, and
+    // the synthetic probeStreamingStart failure below short-circuits the
+    // function before any later (CooldownManager-driven) Date.now() calls.
+    dateSpy
+      .mockReturnValueOnce(1_000_000) // iter1 dispatchStartTime
+      .mockReturnValueOnce(1_004_900) // iter1 post-fetch => fetchElapsed 4900ms (near the 5000ms budget)
+      .mockReturnValueOnce(2_000_000) // iter2 dispatchStartTime
+      .mockReturnValueOnce(2_000_050); // iter2 post-fetch => fetchElapsed 50ms
+
+    const badRequestResponse = new Response(
+      JSON.stringify({ error: { message: "Unsupported parameter: 'safety_identifier'" } }),
+      { status: 400 }
+    );
+    const okResponse = new Response(null, { status: 200 });
+
+    const executeProviderRequest = vi
+      .fn()
+      .mockResolvedValueOnce(badRequestResponse)
+      .mockResolvedValueOnce(okResponse);
+
+    const probeStopError = new Error('test-stop-after-probe');
+    const probeStreamingStart = vi.fn().mockResolvedValue({
+      ok: false,
+      streamStarted: true,
+      error: probeStopError,
+    });
+
+    const host = makeHost({ executeProviderRequest, probeStreamingStart });
+    const route = makeRoute();
+    const request = makeStreamingRequest();
+
+    // originalBody-less payload carrying the exact field the synthetic 400
+    // names, so planUnsupportedParamStrip's paired deleteDottedPath actually
+    // removes something (`deleted: true`) — otherwise the strip is refused
+    // and the loop falls through to normal failover instead of retrying the
+    // same target, which is the scenario this test needs.
+    const providerPayload = { model: 'model-1', safety_identifier: 'abc' };
+
+    const context: StandardAttemptContext = {
+      host,
+      providerPayload,
+      request,
+      requestWithTargetModel: request,
+      route,
+      targetApiType: 'chat',
+      transformer: { name: 'test-transformer' },
+      bypassTransformation: false,
+      adapters: [],
+      stallConfig: makeStallConfig({ ttfbMs: 5000 }),
+      attemptTimeout: {
+        signal: new AbortController().signal,
+        isTimedOut: () => false,
+        cleanup: vi.fn(),
+      },
+      failoverEnabled: true,
+      hasNextTarget: true,
+      retryableStatusCodes: [500, 502, 503],
+      retryableErrors: [],
+      retryHistory: [],
+      attemptedProviders: [],
+      sessionKey: null,
+      release: vi.fn(),
+    };
+
+    await expect(executeStandardAttempt(context)).rejects.toThrow('test-stop-after-probe');
+
+    // Same target dispatched twice: the initial attempt, then the
+    // strip-and-retry after the 400.
+    expect(executeProviderRequest).toHaveBeenCalledTimes(2);
+    expect(probeStreamingStart).toHaveBeenCalledTimes(1);
+
+    const [, receivedStallConfig] = probeStreamingStart.mock.calls[0]!;
+    // Pristine ttfbMs is 5000ms. Iteration 2's own fetch took 50ms (per the
+    // Date.now() sequence above), so a correctly-reset budget leaves
+    // 4950ms for the probe. Before the fix, iteration 2 inherited
+    // iteration 1's already-reduced ttfbMs (100ms, left over from a
+    // 4900ms first fetch against the same 5000ms budget) and derived only
+    // 50ms from THAT — starving the probe of nearly its whole budget.
+    expect(receivedStallConfig.ttfbMs).toBe(4950);
+  });
+});
+
+describe('executeStandardAttempt — thinking-signature strip-and-retry', () => {
+  const signature400Body = JSON.stringify({
+    type: 'error',
+    error: {
+      type: 'invalid_request_error',
+      message: 'messages.3.content.0: Invalid `signature` in `thinking` block',
+    },
+  });
+
+  function makeNonStreamingRequest(): UnifiedChatRequest {
+    return {
+      requestId: 'req-1',
+      model: 'model-1',
+      messages: [{ role: 'user', content: 'hi' } as any],
+      stream: false,
+      incomingApiType: 'chat',
+    };
+  }
+
+  function makeContext(
+    host: RequestManagerHost,
+    providerPayload: any,
+    overrides: Partial<StandardAttemptContext> = {}
+  ): StandardAttemptContext {
+    const request = makeNonStreamingRequest();
+    return {
+      host,
+      providerPayload,
+      request,
+      requestWithTargetModel: request,
+      route: makeRoute(),
+      targetApiType: 'messages',
+      transformer: { name: 'test-transformer' },
+      bypassTransformation: false,
+      adapters: [],
+      stallConfig: null,
+      attemptTimeout: {
+        signal: new AbortController().signal,
+        isTimedOut: () => false,
+        cleanup: vi.fn(),
+      },
+      failoverEnabled: true,
+      hasNextTarget: true,
+      retryableStatusCodes: [500, 502, 503],
+      retryableErrors: [],
+      retryHistory: [],
+      attemptedProviders: [],
+      sessionKey: null,
+      release: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it('does not retry the same target when a signature-matching 400 hits a payload with no thinking blocks (single fetch, normal failover)', async () => {
+    // Fresh Response per call: a Response body is single-read, so a shared
+    // instance would throw on a second (buggy) fetch's .text() and mask the
+    // real assertion failure.
+    const executeProviderRequest = vi.fn(
+      async () => new Response(signature400Body, { status: 400 })
+    );
+    const handleProviderError = vi.fn(async () => {
+      throw new Error('HTTP 400: invalid signature');
+    });
+    const isRetryableStatus = vi.fn(() => true);
+    const host = makeHost({ executeProviderRequest, handleProviderError, isRetryableStatus });
+
+    // The known false-positive shape: an OpenAI-chat-format payload also has
+    // a `messages` array (so the structural Anthropic-payload check matches)
+    // but carries NO thinking blocks — a strip would remove zero blocks and
+    // a retry would resend a byte-identical request.
+    const providerPayload = {
+      model: 'model-1',
+      messages: [{ role: 'user', content: 'hi' }],
+    };
+    const snapshot = structuredClone(providerPayload);
+
+    const result = await executeStandardAttempt(makeContext(host, providerPayload));
+
+    // Normal failover proceeds (retry outcome hands control back to the
+    // caller's next-target loop)...
+    expect(result.outcome).toBe('retry');
+    // ...but the SAME target was fetched exactly once: the zero-block strip
+    // must not burn a same-target retry on an identical payload.
+    expect(executeProviderRequest).toHaveBeenCalledTimes(1);
+    // Nothing was stripped, so the payload is untouched.
+    expect(providerPayload).toEqual(snapshot);
+  });
+
+  it('strips thinking blocks copy-on-write on a genuine signature 400: original payload object never mutated, retried payload stripped', async () => {
+    const executeProviderRequest = vi
+      .fn()
+      .mockImplementationOnce(async () => new Response(signature400Body, { status: 400 }))
+      .mockImplementationOnce(async () => new Response('{"id":"msg_1"}', { status: 200 }));
+    const handleNonStreamingResponse = vi.fn(async () => ({ content: 'ok' }) as any);
+    const host = makeHost({ executeProviderRequest, handleNonStreamingResponse });
+
+    const providerPayload = {
+      model: 'model-1',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'stale', signature: 'sig-a' },
+            { type: 'text', text: 'answer' },
+          ],
+        },
+      ],
+    };
+    const snapshot = structuredClone(providerPayload);
+
+    const result = await executeStandardAttempt(makeContext(host, providerPayload));
+
+    expect(result.outcome).toBe('success');
+    expect(executeProviderRequest).toHaveBeenCalledTimes(2);
+
+    // First fetch sent the original payload object...
+    expect(executeProviderRequest.mock.calls[0]![2]).toBe(providerPayload);
+    // ...the same-target retry sent a NEW payload with the blocks stripped...
+    const retriedPayload = executeProviderRequest.mock.calls[1]![2];
+    expect(retriedPayload).not.toBe(providerPayload);
+    expect(retriedPayload.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'answer' }] },
+    ]);
+    // ...and the ORIGINAL payload (which can share `messages` with the
+    // long-lived request) was never mutated in place.
+    expect(providerPayload).toEqual(snapshot);
+  });
+});

--- a/packages/backend/src/services/dispatch/adapter-resolver.ts
+++ b/packages/backend/src/services/dispatch/adapter-resolver.ts
@@ -82,5 +82,9 @@ function resolveImplicitAdapters(route: RouteResult): AdapterEntry[] {
 }
 
 function isGpt5Model(model: string): boolean {
-  return /^gpt-5(?:[.-]|$)/i.test(model);
+  // Matches bare ids ("gpt-5", "gpt-5.2", "gpt-5-mini") AND provider-prefixed
+  // target ids ("openai/gpt-5.5") used by pi-ai-registry-backed targets (e.g.
+  // an OpenLimits aggregator route). Must not match lookalikes like "gpt-55",
+  // "chatgpt-5", or "my-gpt-5x".
+  return /(?:^|\/)gpt-5(?:[.-]|$)/i.test(model);
 }

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -412,3 +412,519 @@ export function applyRegistryAutoCompat(
 
   return nextPayload;
 }
+
+// ---------------------------------------------------------------------------
+// Reactive auto-compat: strip-and-retry on named unsupported params
+// ---------------------------------------------------------------------------
+//
+// Some upstreams 400 naming one *specific* parameter rather than rejecting the
+// whole request (e.g. OpenAI-compatible Responses API providers reject a
+// client-sent `safety_identifier` or `prompt_cache_key` with
+// `{"detail":"Unsupported parameter: safety_identifier"}` or
+// `{"error":{"message":"Unsupported parameter: 'foo'"}}`). Failing over to the
+// next configured target doesn't help when the *client* sent the offending
+// field — every target would reject it the same way. Instead, the dispatch
+// loop (see standard-attempt-request.ts) strips the named field from the
+// outbound payload and retries the SAME target.
+
+/**
+ * Matches both `{"detail":"Unsupported parameter: X"}` and
+ * `{"error":{"message":"Unsupported parameter: 'X'"}}` shapes. The captured
+ * group also matches dotted paths (e.g. `reasoning.summary`) and
+ * bracket-notation paths (e.g. `messages[0].name`), since providers name
+ * nested fields both ways. A capture that stopped at `[` would truncate
+ * `messages[0].name` to `messages` — and the paired delete would then remove
+ * the ENTIRE conversation from the retry payload.
+ */
+const UNSUPPORTED_PARAMETER_PATTERN = /unsupported parameter[:\s]+['"]?([\w.[\]]+)['"]?/i;
+
+/**
+ * Canonicalizes bracket-notation segments to dotted form
+ * (`messages[0].name` → `messages.0.name`) so `deleteDottedPath` — which
+ * only understands dot-separated segments — receives the path in the form
+ * its array handling expects, and so the same field can't dodge
+ * already-stripped dedup by being spelled two ways across retries.
+ */
+function normalizeBracketSegments(path: string): string {
+  return path.replace(/\[(\w+)\]/g, '.$1');
+}
+
+/**
+ * Extracts the offending parameter name from an upstream error response body
+ * (normalized to canonical dotted form — see `normalizeBracketSegments`), or
+ * `undefined` when the body doesn't name an unsupported parameter.
+ */
+export function matchUnsupportedParameter(responseBody: string): string | undefined {
+  if (!responseBody) return undefined;
+  const paramName = UNSUPPORTED_PARAMETER_PATTERN.exec(responseBody)?.[1];
+  return paramName === undefined ? undefined : normalizeBracketSegments(paramName);
+}
+
+/** Segment names that must never be traversed — see `deleteDottedPath`. */
+const DANGEROUS_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** Canonical decimal index: "0", "7", "12" — never "01", "length", "-1". */
+const CANONICAL_ARRAY_INDEX_PATTERN = /^(0|[1-9]\d*)$/;
+
+/**
+ * True when `segment` addresses an in-bounds element of `array` in canonical
+ * decimal form. Arrays participate in `deleteDottedPath` ONLY through such
+ * segments: `hasOwnProperty` alone would also admit `length` (an OWN
+ * property of every array) and expando keys, and rebuilding around those
+ * would corrupt the array into an object. Anything non-canonical is refused
+ * (deleted:false) rather than guessed at.
+ */
+function isCanonicalArrayIndex(segment: string, array: readonly unknown[]): boolean {
+  return CANONICAL_ARRAY_INDEX_PATTERN.test(segment) && Number(segment) < array.length;
+}
+
+export interface DeleteDottedPathResult {
+  /**
+   * The payload with the field removed. A NEW object (copy-on-write) when
+   * `deleted` is true: every object on the affected path, from the root down
+   * to the leaf's immediate parent, is shallow-cloned before the leaf is
+   * deleted, so nothing shared with another reference is ever mutated.
+   * Identical to the input `payload` reference when `deleted` is false
+   * (rejected path or no-op — nothing to rebuild).
+   */
+  payload: Record<string, any>;
+  /**
+   * Whether a field was actually removed. `false` for a rejected dangerous
+   * segment, an absent field, or a non-object intermediate segment — callers
+   * MUST treat `false` as "nothing changed" and skip any retry that assumes
+   * the payload is now different.
+   */
+  deleted: boolean;
+}
+
+/**
+ * Deletes a (possibly dotted, e.g. "reasoning.summary") field path from a
+ * payload object. Returns the (possibly new) payload plus whether a field
+ * was actually removed.
+ *
+ * SECURITY: `path` is attacker-influenced — it is parsed out of an upstream
+ * provider's error message (see `matchUnsupportedParameter`, whose
+ * `[\w.[\]]+` capture matches dots, underscores, AND bracket segments,
+ * normalized to dotted form), and the upstream is not a trusted party. Two
+ * independent defenses prevent prototype pollution:
+ *   1. Any segment named `__proto__`, `constructor`, or `prototype` is
+ *      rejected outright, before any traversal. Without this, a path like
+ *      `__proto__.toString` would resolve `payload.__proto__` via the
+ *      INHERITED accessor to the real `Object.prototype` (typical payload
+ *      objects have no OWN property by that name), and the previous
+ *      in-place `delete target[leaf]` would then delete the global
+ *      `Object.prototype.toString` for the entire process, permanently,
+ *      across every subsequent request.
+ *   2. Traversal only ever follows OWN enumerable properties
+ *      (`hasOwnProperty`), never inherited ones (the previous `segment in
+ *      target` check matched inherited properties too), so even a segment
+ *      not on the deny-list can't walk onto something inherited from the
+ *      prototype chain.
+ *
+ * COPY-ON-WRITE: the input `payload`, and every nested container on the
+ * traversed path, is never mutated in place. `providerPayload` can share a
+ * nested object BY REFERENCE with the long-lived `UnifiedChatRequest` (e.g.
+ * `payload.reasoning = request.reasoning` in transformers/responses.ts) —
+ * mutating that object in place would corrupt it for every OTHER failover
+ * target built from the same request afterward. Instead, every container
+ * from the root down to the leaf's immediate parent is shallow-cloned and a
+ * NEW payload is returned; untouched sibling branches are shared, not
+ * cloned.
+ *
+ * ARRAYS: numeric segments CAN traverse arrays (an upstream 400 naming e.g.
+ * `messages.0.some_field` is capturable by `matchUnsupportedParameter`), and
+ * every array on the path is rebuilt AS an array — never spread into an
+ * object-shaped `{"0": ...}` payload. Arrays only participate via canonical
+ * in-bounds indices (see `isCanonicalArrayIndex`; `length`/expando segments
+ * are refused untouched). When the LEAF itself is an array index, the
+ * element is removed splice-style — later elements shift left — because
+ * `delete arr[i]` would leave a hole that serializes as `null`, which is
+ * just as malformed as the object-shaped payload.
+ */
+export function deleteDottedPath(
+  payload: Record<string, any>,
+  path: string
+): DeleteDottedPathResult {
+  const segments = path.split('.');
+
+  if (segments.some((segment) => DANGEROUS_PATH_SEGMENTS.has(segment))) {
+    return { payload, deleted: false };
+  }
+
+  // Walk the path, recording the (container, key) pair at each level so the
+  // chain can be rebuilt with clones afterward. Bail out — no traversal
+  // beyond this point, no mutation, no clone — the instant a segment isn't
+  // an own enumerable property (or, for arrays, a canonical in-bounds
+  // index): an absent field or non-object intermediate means there's
+  // nothing to strip.
+  const chain: Array<{ obj: Record<string, any>; key: string }> = [];
+  let target: any = payload;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i]!;
+    if (
+      target == null ||
+      typeof target !== 'object' ||
+      !Object.prototype.hasOwnProperty.call(target, segment) ||
+      (Array.isArray(target) && !isCanonicalArrayIndex(segment, target))
+    ) {
+      return { payload, deleted: false };
+    }
+    chain.push({ obj: target, key: segment });
+    target = target[segment];
+  }
+
+  const leaf = segments[segments.length - 1]!;
+  if (
+    target == null ||
+    typeof target !== 'object' ||
+    !Object.prototype.hasOwnProperty.call(target, leaf) ||
+    (Array.isArray(target) && !isCanonicalArrayIndex(leaf, target))
+  ) {
+    return { payload, deleted: false };
+  }
+
+  // Rebuild the chain bottom-up with shallow clones so nothing shared with
+  // another reference is mutated, preserving each level's container kind.
+  let rebuilt: any;
+  if (Array.isArray(target)) {
+    // Array-index leaf: splice-style removal (no hole — see doc comment).
+    const index = Number(leaf);
+    rebuilt = [...target.slice(0, index), ...target.slice(index + 1)];
+  } else {
+    rebuilt = { ...target };
+    delete rebuilt[leaf];
+  }
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const { obj, key } = chain[i]!;
+    if (Array.isArray(obj)) {
+      const clone = [...obj];
+      clone[Number(key)] = rebuilt;
+      rebuilt = clone;
+    } else {
+      rebuilt = { ...obj, [key]: rebuilt };
+    }
+  }
+
+  return { payload: rebuilt, deleted: true };
+}
+
+/** Per-target, per-request bound: at most this many strip-and-retry cycles. */
+export const MAX_UNSUPPORTED_PARAM_STRIP_RETRIES = 2;
+
+/**
+ * Top-level fields the strip-and-retry mechanism must never delete
+ * WHOLESALE: removing the entire conversation (`messages` / `input`) or the
+ * `model` guarantees a malformed request that every upstream rejects, so an
+ * upstream 400 naming one of these EXACTLY (full normalized path, no
+ * sub-path) gets normal failover instead of a doomed strip-retry. Sub-paths
+ * within them (e.g. `messages.0.name`) and other whole fields (`tools`,
+ * `safety_identifier`, ...) remain strippable.
+ */
+const UNSTRIPPABLE_STRUCTURAL_FIELDS = new Set(['messages', 'input', 'model']);
+
+/**
+ * Structural roots whose DIRECT numeric elements are entire conversation
+ * items. `Unsupported parameter: messages[0]` normalizes to `messages.0`,
+ * which dodges the exact-name guard above — but the paired deleteDottedPath
+ * would splice a whole message/input item out of the conversation, mutilating
+ * the request as surely as deleting the whole field. `model` is a string, so
+ * it has no element paths to guard.
+ */
+const STRUCTURAL_ARRAY_ROOTS = new Set(['messages', 'input']);
+
+/**
+ * True when the normalized path is exactly `<structural root>.<number>` — a
+ * numeric leaf DIRECTLY under a structural array (`messages.0`, `input.12`).
+ * Deeper paths (`messages.0.name`) address a field WITHIN the item and stay
+ * strippable; numeric leaves under non-structural arrays (`tools.2`) stay
+ * splice-deletable.
+ */
+function isStructuralArrayElementPath(path: string): boolean {
+  const segments = path.split('.');
+  return (
+    segments.length === 2 && STRUCTURAL_ARRAY_ROOTS.has(segments[0]!) && /^\d+$/.test(segments[1]!)
+  );
+}
+
+/** Tracks strip-and-retry progress for a single target within one request. */
+export interface UnsupportedParamStripState {
+  attempts: number;
+  strippedParams: Set<string>;
+}
+
+export function createUnsupportedParamStripState(): UnsupportedParamStripState {
+  return { attempts: 0, strippedParams: new Set() };
+}
+
+/**
+ * Decides whether an upstream 400 body naming an unsupported parameter should
+ * trigger another strip-and-retry cycle against the same target, recording
+ * the attempt in `state` when it does.
+ *
+ * Returns the parameter name to strip (in canonical dotted form), or
+ * `undefined` when the retry should NOT happen because:
+ *   - the body doesn't name an unsupported parameter, OR
+ *   - the named parameter is a protected structural field
+ *     (UNSTRIPPABLE_STRUCTURAL_FIELDS) whose wholesale deletion guarantees a
+ *     malformed request — refused before any budget is consumed, OR
+ *   - the named parameter is a numeric element directly under a structural
+ *     array (`messages.0` / `input[2]` — see isStructuralArrayElementPath):
+ *     splice-deleting an entire conversation item is as destructive as
+ *     deleting the whole field, so it gets the same budget-free refusal, OR
+ *   - the MAX_UNSUPPORTED_PARAM_STRIP_RETRIES bound has been reached, OR
+ *   - the named parameter was already stripped on an earlier attempt for this
+ *     target — an upstream that keeps rejecting the same field after it's
+ *     been removed can't be fixed by retrying, so stop immediately rather
+ *     than burning through the retry bound on a no-op loop.
+ */
+export function planUnsupportedParamStrip(
+  responseBody: string,
+  state: UnsupportedParamStripState
+): string | undefined {
+  if (state.attempts >= MAX_UNSUPPORTED_PARAM_STRIP_RETRIES) return undefined;
+
+  const paramName = matchUnsupportedParameter(responseBody);
+  if (!paramName || UNSTRIPPABLE_STRUCTURAL_FIELDS.has(paramName)) return undefined;
+  if (isStructuralArrayElementPath(paramName)) return undefined;
+  if (state.strippedParams.has(paramName)) return undefined;
+
+  state.attempts++;
+  state.strippedParams.add(paramName);
+  return paramName;
+}
+
+// ---------------------------------------------------------------------------
+// Reactive auto-compat: strip-and-retry on stale Anthropic thinking-block
+// signatures
+// ---------------------------------------------------------------------------
+//
+// Alias-level failover can replay a conversation containing `thinking` /
+// `redacted_thinking` blocks signed by one Claude model against a DIFFERENT
+// Claude model (e.g. cc/claude-opus-5 -> cc/claude-opus-4-8 -> cc/claude-opus-4-7).
+// Anthropic rejects a thinking-block signature produced by another
+// model/session with a 400 naming the signature specifically, e.g.:
+//   {"type":"error","error":{"type":"invalid_request_error",
+//    "message":"messages.3.content.0: Invalid `signature` in `thinking` block"}}
+// Failing over to the next target doesn't help — every remaining Claude
+// target rejects the same stale signature the same way. Instead strip the
+// thinking/redacted_thinking blocks from the outbound Anthropic Messages
+// payload and retry the SAME target once.
+
+/**
+ * Matches Anthropic's stale/invalid thinking-block-signature 400, e.g.
+ * `messages.3.content.0: Invalid \`signature\` in \`thinking\` block`.
+ * Backtick-quoting of "signature"/"thinking" is optional since not every
+ * upstream quotes them identically.
+ */
+const THINKING_SIGNATURE_ERROR_PATTERN = /invalid\s+`?signature`?\s+in\s+`?thinking`?\s+block/i;
+
+/**
+ * True when an upstream error response body names an invalid/stale
+ * thinking-block signature.
+ */
+export function matchThinkingSignatureError(responseBody: string): boolean {
+  if (!responseBody) return false;
+  return THINKING_SIGNATURE_ERROR_PATTERN.test(responseBody);
+}
+
+/**
+ * True when the outbound payload is Anthropic-Messages-API-shaped (has a
+ * `messages` array) — the only shape that can carry `thinking` /
+ * `redacted_thinking` blocks in the first place. Note this is a structural
+ * check only: an OpenAI chat-completions payload also has a `messages`
+ * array, so this alone doesn't prove the target is Anthropic. In practice
+ * that's harmless here — the paired body match
+ * (`matchThinkingSignatureError`) only fires on Anthropic's specific
+ * signature-rejection wording, which a non-Anthropic upstream won't emit.
+ */
+export function isAnthropicMessagesPayload(payload: any): boolean {
+  return !!payload && typeof payload === 'object' && Array.isArray(payload.messages);
+}
+
+function isThinkingBlock(block: any): boolean {
+  return (
+    !!block &&
+    typeof block === 'object' &&
+    (block.type === 'thinking' || block.type === 'redacted_thinking')
+  );
+}
+
+function contentHasBlockType(content: any, type: string): boolean {
+  return (
+    Array.isArray(content) &&
+    content.some((block: any) => block && typeof block === 'object' && block.type === type)
+  );
+}
+
+// A fresh array/object is allocated per call (not a shared module-level
+// constant) so multiple placeholder messages in the same payload never end
+// up aliasing the same mutable content array.
+function reasoningElidedPlaceholder(): Array<{ type: 'text'; text: string }> {
+  return [{ type: 'text', text: '[reasoning elided]' }];
+}
+
+export interface ThinkingSignatureStripResult {
+  /**
+   * The payload with every `thinking` / `redacted_thinking` block removed.
+   * A NEW object (copy-on-write) when `strippedCount` > 0: the root is
+   * shallow-cloned with a NEW `messages` array, and each message whose
+   * content changed is shallow-cloned — the input payload, its `messages`
+   * array, and every original message object are never mutated (the payload
+   * can share `messages`/message objects by reference with the long-lived
+   * `UnifiedChatRequest`; see `deleteDottedPath`'s copy-on-write rationale).
+   * Untouched messages are shared, not cloned. Identical to the input
+   * `payload` reference when `strippedCount` is 0 — nothing to rebuild.
+   */
+  payload: Record<string, any>;
+  /**
+   * Number of thinking/redacted_thinking blocks actually removed (0 when
+   * the payload isn't Anthropic-messages-shaped, or had none to strip).
+   * Callers MUST treat 0 as "nothing changed" and skip any retry that
+   * assumes the payload is now different — the structural
+   * `isAnthropicMessagesPayload` gate also matches OpenAI chat-completions
+   * payloads (they have a `messages` array too), which never carry thinking
+   * blocks, so a 0-strip retry would resend a byte-identical request.
+   */
+  strippedCount: number;
+}
+
+/**
+ * Removes every `thinking` / `redacted_thinking` block from every message's
+ * `content` array, copy-on-write (see `ThinkingSignatureStripResult` — the
+ * input payload is never mutated). When a message's `content` becomes empty
+ * as a result of the strip, the message is dropped entirely UNLESS doing so
+ * would:
+ *   - break strict user/assistant role alternation — the nearest retained
+ *     message before it and the message right after it would end up with
+ *     the same role, or
+ *   - orphan a `tool_result` — the next message carries a `tool_result` but
+ *     the nearest retained message before the drop does NOT carry the
+ *     matching `tool_use`, so removing the bridge would leave that
+ *     `tool_result` without its paired call.
+ * In either case the emptied content is replaced with a
+ * `[{"type":"text","text":"[reasoning elided]"}]` placeholder instead of
+ * dropping the message, so the conversation shape stays valid.
+ *
+ * Non-array `content` (e.g. plain-string messages) is left untouched.
+ */
+export function stripThinkingSignatureBlocks(
+  payload: Record<string, any>
+): ThinkingSignatureStripResult {
+  if (!isAnthropicMessagesPayload(payload)) return { payload, strippedCount: 0 };
+
+  let strippedCount = 0;
+  const perMessage: Array<{
+    message: any;
+    content: any;
+    isArrayContent: boolean;
+    changed: boolean;
+  }> = payload.messages.map((message: any) => {
+    if (!message || !Array.isArray(message.content)) {
+      return { message, content: message?.content, isArrayContent: false, changed: false };
+    }
+    const kept = message.content.filter((block: any) => {
+      if (isThinkingBlock(block)) {
+        strippedCount++;
+        return false;
+      }
+      return true;
+    });
+    return {
+      message,
+      content: kept,
+      isArrayContent: true,
+      changed: kept.length !== message.content.length,
+    };
+  });
+
+  if (strippedCount === 0) return { payload, strippedCount: 0 };
+
+  const result: any[] = [];
+  for (let i = 0; i < perMessage.length; i++) {
+    const { message, content, isArrayContent, changed } = perMessage[i]!;
+
+    if (!isArrayContent || content.length > 0) {
+      // Only messages that actually lost a block are cloned; untouched
+      // messages are shared by reference (copy-on-write).
+      result.push(changed ? { ...message, content } : message);
+      continue;
+    }
+
+    // Content became empty after stripping — decide drop vs. placeholder.
+    const prevMessage = result[result.length - 1];
+    const nextMessage = perMessage[i + 1]?.message;
+
+    const wouldBreakAlternation =
+      !!prevMessage && !!nextMessage && prevMessage.role === nextMessage.role;
+    const nextHasToolResult = contentHasBlockType(nextMessage?.content, 'tool_result');
+    const prevHasToolUse = contentHasBlockType(prevMessage?.content, 'tool_use');
+    const wouldOrphanToolResult = nextHasToolResult && !prevHasToolUse;
+
+    if (wouldBreakAlternation || wouldOrphanToolResult) {
+      result.push({ ...message, content: reasoningElidedPlaceholder() });
+    }
+    // else: drop — push nothing for this message.
+  }
+
+  return { payload: { ...payload, messages: result }, strippedCount };
+}
+
+/** Per-target, per-request bound: at most one signature-strip-and-retry cycle. */
+export const MAX_THINKING_SIGNATURE_STRIP_RETRIES = 1;
+
+/** Tracks signature-strip-and-retry progress for a single target within one request. */
+export interface ThinkingSignatureStripState {
+  attempts: number;
+}
+
+export function createThinkingSignatureStripState(): ThinkingSignatureStripState {
+  return { attempts: 0 };
+}
+
+/**
+ * Decides whether an upstream 400 body naming an invalid thinking-block
+ * signature should trigger a strip-and-retry cycle against the same target,
+ * recording the attempt in `state` when it does. Returns `false` when the
+ * retry should NOT happen because:
+ *   - the body doesn't name a thinking-signature error, OR
+ *   - the outbound payload isn't Anthropic-messages-shaped (no `messages`
+ *     array to strip thinking blocks from), OR
+ *   - MAX_THINKING_SIGNATURE_STRIP_RETRIES has already been used for this
+ *     target (bounded to exactly one retry — unlike the unsupported-param
+ *     strip, there's no "new param" escape hatch here: once the thinking
+ *     blocks are gone, a repeat 400 means stripping them didn't fix it, so
+ *     normal failover should proceed rather than retrying again).
+ */
+export function planThinkingSignatureStrip(
+  responseBody: string,
+  payload: any,
+  state: ThinkingSignatureStripState
+): boolean {
+  if (state.attempts >= MAX_THINKING_SIGNATURE_STRIP_RETRIES) return false;
+  if (!matchThinkingSignatureError(responseBody)) return false;
+  if (!isAnthropicMessagesPayload(payload)) return false;
+
+  state.attempts++;
+  return true;
+}
+
+/**
+ * Refunds the attempt recorded by the most recent `planThinkingSignatureStrip`
+ * when the paired `stripThinkingSignatureBlocks` turned out to be a no-op
+ * (`strippedCount` 0 — the structural `messages`-array check matched an
+ * OpenAI-format payload that carries no thinking blocks). No retry happened,
+ * so the budget must not be consumed: a LATER genuine signature 400 on the
+ * same target must still get its one strip-and-retry.
+ *
+ * Loop safety: the refund is issued only on the signature branch's no-strip
+ * path, which itself never `continue`s — so a refund can never re-arm the
+ * signature retry it was issued for. The refunding ITERATION may still
+ * `continue` via the unsupported-param handling in the latter half of the
+ * same `response.status === 400` guard, but that retry consumes an attempt
+ * from the param-strip budget, so the combined fetch bound in
+ * standard-attempt-request.ts holds: every extra fetch consumes an
+ * un-refunded attempt from one of the two strip budgets.
+ */
+export function refundThinkingSignatureStrip(state: ThinkingSignatureStripState): void {
+  if (state.attempts > 0) state.attempts--;
+}

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -201,15 +201,18 @@ export async function buildRequestPayload(
     );
     // Codex CLI and Responses clients receive the native Responses stream.
     // Cross-format Codex requests must translate the response back to the
-    // incoming client format. Anthropic remains raw pass-through, while
-    // Copilot honors its computed same-format decision.
-    const incomingIsResponses =
-      getApiBaseType(request.incomingApiType?.toLowerCase() ?? '') === 'responses';
+    // incoming client format. Anthropic bypasses only for same-format
+    // (Messages) clients — chat/responses clients get the response
+    // translated by the standard pipeline (mirrors the identical Codex fix,
+    // commit 4f74c1c6). Copilot honors its computed same-format decision.
+    const incomingBaseType = getApiBaseType(request.incomingApiType?.toLowerCase() ?? '');
+    const incomingIsResponses = incomingBaseType === 'responses';
+    const incomingIsMessages = incomingBaseType === 'messages';
     const nativeBypass = codexNative
       ? codexCliPassthrough || incomingIsResponses
       : copilotNative
         ? bypassTransformation
-        : true;
+        : incomingIsMessages;
     return { payload: prepared.body, bypassTransformation: nativeBypass };
   }
 

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -6,10 +6,48 @@ import type { RetryAttemptRecord } from './dispatcher-types';
 import type { StallConfig } from '../inspectors/stall-inspector';
 import { CooldownManager } from '../runtime/cooldown-manager';
 import type { RequestManagerHost } from './request-manager';
+import {
+  createThinkingSignatureStripState,
+  createUnsupportedParamStripState,
+  deleteDottedPath,
+  planThinkingSignatureStrip,
+  planUnsupportedParamStrip,
+  refundThinkingSignatureStrip,
+  stripThinkingSignatureBlocks,
+  MAX_THINKING_SIGNATURE_STRIP_RETRIES,
+  MAX_UNSUPPORTED_PARAM_STRIP_RETRIES,
+} from './dispatcher-auto-compat';
 
 export type StandardAttemptResult =
   | { outcome: 'success'; response: UnifiedChatResponse }
   | { outcome: 'retry'; error: any };
+
+/**
+ * Derives the stall config to hand the post-fetch streaming probe: the
+ * pristine (full, per-request-configured) TTFB budget minus however long
+ * fetch() itself already took to return headers. Pure function of the
+ * PRISTINE config — never of a previously-derived one — so calling it again
+ * for a later retry iteration can't compound an earlier iteration's
+ * reduction (see the reset in `executeStandardAttempt`'s retry loop).
+ *
+ * `null`/`undefined` pass through unchanged (TTFB stall detection disabled
+ * for this request). When `pristineConfig.ttfbMs` is itself `null`, the
+ * config is returned as-is too — there's no budget to subtract from.
+ */
+export function deriveProbeStallConfig(
+  pristineConfig: StallConfig | null | undefined,
+  fetchElapsedMs: number
+): StallConfig | null | undefined {
+  if (!pristineConfig || pristineConfig.ttfbMs == null) return pristineConfig;
+
+  const remainingTtfbMs = Math.max(0, pristineConfig.ttfbMs - fetchElapsedMs);
+  // Fetch returned just barely within (or beyond) the TTFB window — no time
+  // left for the probe. Signal "skip the probe" via null and let the
+  // pipeline handle it, rather than arming a probe with ~0ms to work with.
+  return remainingTtfbMs <= 0
+    ? { ...pristineConfig, ttfbMs: null }
+    : { ...pristineConfig, ttfbMs: remainingTtfbMs };
+}
 
 export interface StandardAttemptContext {
   host: RequestManagerHost;
@@ -40,7 +78,6 @@ export async function executeStandardAttempt(
 ): Promise<StandardAttemptResult> {
   const {
     host,
-    providerPayload,
     request: currentRequest,
     requestWithTargetModel,
     route,
@@ -60,7 +97,18 @@ export async function executeStandardAttempt(
     sessionKey,
     release: doRelease,
   } = context;
-  let effectiveStallConfig = initialStallConfig;
+  // Mutable (not const): the unsupported-param strip-and-retry path below
+  // rebuilds this via copy-on-write (deleteDottedPath) rather than mutating
+  // in place, so a successful strip must reassign this binding.
+  let providerPayload = context.providerPayload;
+  // Pristine snapshot taken once, outside the loop. Every retry iteration
+  // below resets `effectiveStallConfig` from THIS rather than carrying
+  // forward whatever the previous iteration's post-fetch adjustment left it
+  // as — otherwise a same-target strip-and-retry (thinking-signature or
+  // unsupported-param, below) would inherit a reduced or null ttfbMs from
+  // the failed attempt instead of the full configured budget.
+  const pristineStallConfig = initialStallConfig;
+  let effectiveStallConfig = pristineStallConfig;
 
   const incomingApi = currentRequest.incomingApiType || 'unknown';
   const url = host.buildRequestUrl(route, transformer, requestWithTargetModel, targetApiType);
@@ -70,161 +118,248 @@ export async function executeStandardAttempt(
     `Dispatching ${currentRequest.model} to ${route.provider}:${route.model} ${incomingApi} <-> ${transformer.name}`
   );
 
-  logger.silly('Upstream Request Payload', providerPayload);
+  // Reactive auto-compat: bounded per-target state so a strip-and-retry
+  // cycle (see the 400 handling below) can't loop forever (see
+  // dispatcher-auto-compat.ts for the matching/bound logic). Two independent
+  // mechanisms, two independent budgets — neither resets the other's
+  // counter, so the combined worst case for this target is bounded at
+  // exactly 1 (initial attempt) + MAX_THINKING_SIGNATURE_STRIP_RETRIES +
+  // MAX_UNSUPPORTED_PARAM_STRIP_RETRIES fetches, however the two mechanisms
+  // interleave — they can't ping-pong into an unbounded loop.
+  const paramStripState = createUnsupportedParamStripState();
+  const thinkingStripState = createThinkingSignatureStripState();
 
-  // When TTFB stall detection is configured for streaming requests, wrap
-  // the fetch + probe in a single timeout that covers the entire TTFB
-  // window (from request dispatch to receiving ttfbBytes of body data).
-  // This handles the case where fetch() itself blocks for a long time
-  // waiting for HTTP response headers from a slow provider.
+  // Looped so a strip-and-retry can redo the fetch against the SAME target
+  // without returning to the caller's failover loop — failing over would
+  // just hit the same "client sent an unsupported param" problem on the
+  // next provider too. Logging the payload inside the loop means a
+  // strip-retry's silly-level log reflects the field that was actually
+  // removed, not just the original request.
   let response: Response;
-  let stallAbortController: AbortController | undefined;
-  let ttfbTimerId: ReturnType<typeof setTimeout> | undefined;
-  const dispatchStartTime = Date.now();
+  while (true) {
+    // Reset to the pristine, full TTFB budget at the start of every
+    // iteration — see the comment on `pristineStallConfig` above.
+    effectiveStallConfig = pristineStallConfig;
 
-  if (currentRequest.stream && effectiveStallConfig?.ttfbMs != null) {
-    // Create a separate AbortController for the TTFB stall timeout.
-    // We don't use the route's abortController because an abort there
-    // means the client disconnected — we need a distinct signal for
-    // "provider is too slow to start responding".
-    stallAbortController = new AbortController();
-    const combinedSignal = AbortSignal.any([attemptTimeout.signal, stallAbortController.signal]);
+    logger.silly('Upstream Request Payload', providerPayload);
 
-    const ttfbMs = effectiveStallConfig.ttfbMs!;
-    ttfbTimerId = setTimeout(() => {
-      stallAbortController!.abort(
-        new DOMException(
-          `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`,
-          'TimeoutError'
-        )
-      );
-    }, ttfbMs);
-    ttfbTimerId.unref?.();
+    let stallAbortController: AbortController | undefined;
+    let ttfbTimerId: ReturnType<typeof setTimeout> | undefined;
+    const dispatchStartTime = Date.now();
 
-    try {
-      response = await host.executeProviderRequest(url, headers, providerPayload, combinedSignal);
-    } catch (fetchError: any) {
-      // Client disconnected takes priority over stall detection —
-      // if the client is gone, no point retrying.
-      if (signal?.aborted) {
-        clearTimeout(ttfbTimerId);
-        throw host.buildCancelledError(signal);
+    // When TTFB stall detection is configured for streaming requests, wrap
+    // the fetch + probe in a single timeout that covers the entire TTFB
+    // window (from request dispatch to receiving ttfbBytes of body data).
+    // This handles the case where fetch() itself blocks for a long time
+    // waiting for HTTP response headers from a slow provider.
+    if (currentRequest.stream && effectiveStallConfig?.ttfbMs != null) {
+      // Create a separate AbortController for the TTFB stall timeout.
+      // We don't use the route's abortController because an abort there
+      // means the client disconnected — we need a distinct signal for
+      // "provider is too slow to start responding".
+      stallAbortController = new AbortController();
+      const combinedSignal = AbortSignal.any([attemptTimeout.signal, stallAbortController.signal]);
+
+      const ttfbMs = effectiveStallConfig.ttfbMs!;
+      ttfbTimerId = setTimeout(() => {
+        stallAbortController!.abort(
+          new DOMException(
+            `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`,
+            'TimeoutError'
+          )
+        );
+      }, ttfbMs);
+      ttfbTimerId.unref?.();
+
+      try {
+        response = await host.executeProviderRequest(url, headers, providerPayload, combinedSignal);
+      } catch (fetchError: any) {
+        // Client disconnected takes priority over stall detection —
+        // if the client is gone, no point retrying.
+        if (signal?.aborted) {
+          clearTimeout(ttfbTimerId);
+          throw host.buildCancelledError(signal);
+        }
+
+        // If the error was caused by our TTFB stall timeout, synthesize
+        // a stall result instead of treating it as a generic network error.
+        if (stallAbortController.signal.aborted) {
+          clearTimeout(ttfbTimerId);
+          const stallError = new Error(
+            `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`
+          );
+
+          const canRetryStall =
+            failoverEnabled &&
+            hasNextTarget &&
+            (host.isRetryableNetworkError(stallError, retryableErrors) ||
+              stallError.message?.includes('stalled'));
+
+          if (canRetryStall) {
+            attemptTimeout.cleanup();
+            await host.recordAttemptMetric(route, currentRequest.requestId, false, {
+              isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+              isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+              visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
+            });
+            host.appendFailureAttempt(retryHistory, route, stallError, targetApiType, true);
+            CooldownManager.getInstance().markProviderStallFailure(
+              route.provider,
+              route.model,
+              host.formatFailureReason(stallError)
+            );
+            host.saveIntermediateError(
+              currentRequest.requestId,
+              targetApiType || 'chat',
+              stallError
+            );
+            logger.info(
+              `TTFB stall: fetch timed out after ${ttfbMs}ms for ${route.provider}/${route.model}, retrying with next provider`
+            );
+            doRelease();
+            return { outcome: 'retry', error: stallError };
+          }
+          doRelease();
+          throw stallError;
+        }
+        throw fetchError;
       }
 
-      // If the error was caused by our TTFB stall timeout, synthesize
-      // a stall result instead of treating it as a generic network error.
-      if (stallAbortController.signal.aborted) {
-        clearTimeout(ttfbTimerId);
-        const stallError = new Error(
-          `Stream stalled: TTFB timeout — no response within ${ttfbMs}ms`
+      // Fetch returned — clear the TTFB timer (we beat the timeout)
+      clearTimeout(ttfbTimerId);
+      ttfbTimerId = undefined;
+
+      // Adjust the stall config's ttfbMs for the probe — subtract the time
+      // already spent waiting for fetch() to return. The probe only needs
+      // to cover the remaining time until the byte threshold is met. Always
+      // derived from the PRISTINE snapshot (never from the possibly
+      // already-reduced `effectiveStallConfig`), so a value computed on a
+      // previous retry iteration can never compound into this one.
+      const fetchElapsed = Date.now() - dispatchStartTime;
+      effectiveStallConfig = deriveProbeStallConfig(pristineStallConfig, fetchElapsed);
+    } else {
+      response = await host.executeProviderRequest(
+        url,
+        headers,
+        providerPayload,
+        attemptTimeout.signal
+      );
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text();
+
+      // Reactive auto-compat: a 400 can name a problem that failing over
+      // won't fix — every remaining target would reject the same request
+      // the same way — so both mechanisms below strip the offending content
+      // and retry the SAME target instead. Checked in order:
+      //
+      //   1. Stale thinking-block signatures: alias-level failover can
+      //      replay a conversation whose `thinking`/`redacted_thinking`
+      //      blocks were signed by a DIFFERENT Claude model/session than
+      //      the one we're now targeting, and Anthropic 400s naming the
+      //      stale signature specifically.
+      //   2. Unsupported parameters: some upstreams 400 naming one specific
+      //      client-sent field (e.g. LobeHub's gpt-5.5 traffic sending
+      //      safety_identifier / prompt_cache_key that a provider rejects).
+      if (response.status === 400) {
+        if (planThinkingSignatureStrip(errorText, providerPayload, thinkingStripState)) {
+          const stripResult = stripThinkingSignatureBlocks(providerPayload);
+          if (stripResult.strippedCount > 0) {
+            // Copy-on-write, like the unsupported-param strip below: the
+            // strip returns a NEW payload and never mutates the original
+            // (whose `messages` can be shared by reference with the
+            // long-lived request), so a successful strip reassigns the
+            // binding.
+            providerPayload = stripResult.payload;
+            logger.warn(
+              `Auto-compat: ${route.provider}/${route.model} rejected a stale thinking-block ` +
+                `signature — stripped ${stripResult.strippedCount} thinking block(s) and retrying the ` +
+                `same target (attempt ${thinkingStripState.attempts}/${MAX_THINKING_SIGNATURE_STRIP_RETRIES})`
+            );
+            continue;
+          }
+          // Zero blocks stripped — planThinkingSignatureStrip's structural
+          // `messages`-array check also matches OpenAI-format payloads,
+          // which never carry thinking blocks. Retrying would resend a
+          // byte-identical request, so fall through to the unsupported-param
+          // check / normal failover handling below instead of retrying this
+          // target — and refund the planned attempt: no retry happened, so
+          // the one-per-target budget stays available for a later genuine
+          // signature 400. Loop-safe because this branch never `continue`s.
+          refundThinkingSignatureStrip(thinkingStripState);
+        }
+
+        const paramToStrip = planUnsupportedParamStrip(errorText, paramStripState);
+        if (paramToStrip) {
+          const stripResult = deleteDottedPath(providerPayload, paramToStrip);
+          if (stripResult.deleted) {
+            providerPayload = stripResult.payload;
+            logger.warn(
+              `Auto-compat: ${route.provider}/${route.model} rejected unsupported parameter ` +
+                `'${paramToStrip}' — stripping it and retrying the same target ` +
+                `(attempt ${paramStripState.attempts}/${MAX_UNSUPPORTED_PARAM_STRIP_RETRIES})`
+            );
+            continue;
+          }
+          // Nothing was actually removed (a rejected __proto__/constructor/
+          // prototype segment, or the named field wasn't present) —
+          // resending the SAME payload would just repeat the identical
+          // upstream rejection, so fall through to normal failover/error
+          // handling below instead of retrying this target again.
+        }
+      }
+
+      const canRetry =
+        failoverEnabled &&
+        hasNextTarget &&
+        host.isRetryableStatus(response.status, retryableStatusCodes);
+
+      try {
+        await host.handleProviderError(
+          response,
+          route,
+          errorText,
+          url,
+          headers,
+          targetApiType,
+          currentRequest.requestId
         );
+      } catch (e: any) {
+        if (signal?.aborted) throw host.buildCancelledError(signal);
+        host.appendFailureAttempt(retryHistory, route, e, targetApiType, canRetry);
 
-        const canRetryStall =
-          failoverEnabled &&
-          hasNextTarget &&
-          (host.isRetryableNetworkError(stallError, retryableErrors) ||
-            stallError.message?.includes('stalled'));
-
-        if (canRetryStall) {
+        if (canRetry) {
           attemptTimeout.cleanup();
+          doRelease();
           await host.recordAttemptMetric(route, currentRequest.requestId, false, {
             isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
             isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
             visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
           });
-          host.appendFailureAttempt(retryHistory, route, stallError, targetApiType, true);
-          CooldownManager.getInstance().markProviderStallFailure(
-            route.provider,
-            route.model,
-            host.formatFailureReason(stallError)
+          // Only mark as failed if the error actually triggered a cooldown (i.e., it's not a caller error like validation)
+          // Caller errors (400 validation errors, 413, 422) should not cause cooldown
+          if (e?.routingContext?.cooldownTriggered) {
+            CooldownManager.getInstance().markProviderFailure(
+              route.provider,
+              route.model,
+              undefined,
+              host.formatFailureReason(e, true)
+            );
+          }
+          host.saveIntermediateError(currentRequest.requestId, targetApiType || 'chat', e);
+          logger.warn(
+            `Failover: retrying after HTTP ${response.status} from ${route.provider}/${route.model}`
           );
-          host.saveIntermediateError(currentRequest.requestId, targetApiType || 'chat', stallError);
-          logger.info(
-            `TTFB stall: fetch timed out after ${ttfbMs}ms for ${route.provider}/${route.model}, retrying with next provider`
-          );
-          doRelease();
-          return { outcome: 'retry', error: stallError };
+          return { outcome: 'retry', error: e };
         }
+
         doRelease();
-        throw stallError;
+        throw e;
       }
-      throw fetchError;
     }
 
-    // Fetch returned — clear the TTFB timer (we beat the timeout)
-    clearTimeout(ttfbTimerId);
-    ttfbTimerId = undefined;
-
-    // Adjust the stall config's ttfbMs for the probe — subtract the time
-    // already spent waiting for fetch() to return. The probe only needs
-    // to cover the remaining time until the byte threshold is met.
-    const fetchElapsed = Date.now() - dispatchStartTime;
-    const remainingTtfbMs = Math.max(0, ttfbMs - fetchElapsed);
-    if (remainingTtfbMs <= 0 && effectiveStallConfig) {
-      // Fetch returned just barely within the TTFB window — no time left
-      // for the probe. Skip the probe and let the pipeline handle it.
-      effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: null };
-    } else if (effectiveStallConfig) {
-      effectiveStallConfig = { ...effectiveStallConfig, ttfbMs: remainingTtfbMs };
-    }
-  } else {
-    response = await host.executeProviderRequest(
-      url,
-      headers,
-      providerPayload,
-      attemptTimeout.signal
-    );
-  }
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    const canRetry =
-      failoverEnabled &&
-      hasNextTarget &&
-      host.isRetryableStatus(response.status, retryableStatusCodes);
-
-    try {
-      await host.handleProviderError(
-        response,
-        route,
-        errorText,
-        url,
-        headers,
-        targetApiType,
-        currentRequest.requestId
-      );
-    } catch (e: any) {
-      if (signal?.aborted) throw host.buildCancelledError(signal);
-      host.appendFailureAttempt(retryHistory, route, e, targetApiType, canRetry);
-
-      if (canRetry) {
-        attemptTimeout.cleanup();
-        doRelease();
-        await host.recordAttemptMetric(route, currentRequest.requestId, false, {
-          isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
-          isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
-          visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
-        });
-        // Only mark as failed if the error actually triggered a cooldown (i.e., it's not a caller error like validation)
-        // Caller errors (400 validation errors, 413, 422) should not cause cooldown
-        if (e?.routingContext?.cooldownTriggered) {
-          CooldownManager.getInstance().markProviderFailure(
-            route.provider,
-            route.model,
-            undefined,
-            host.formatFailureReason(e, true)
-          );
-        }
-        host.saveIntermediateError(currentRequest.requestId, targetApiType || 'chat', e);
-        logger.warn(
-          `Failover: retrying after HTTP ${response.status} from ${route.provider}/${route.model}`
-        );
-        return { outcome: 'retry', error: e };
-      }
-
-      doRelease();
-      throw e;
-    }
+    break;
   }
 
   // 5. Handle Response
@@ -351,6 +486,7 @@ export async function executeStandardAttempt(
     bypassTransformation,
     adapters
   );
+
   await host.recordAttemptMetric(route, currentRequest.requestId, true, {
     isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
     isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -206,6 +206,42 @@ describe('Responses responses -> responses round-trip preserves native fields', 
     expect(built.safety_identifier).toBe('si-1');
   });
 
+  it('does not inject a default temperature when the client omits it', async () => {
+    const transformer = new ResponsesTransformer();
+    const { temperature, ...requestWithoutTemperature } = RESPONSES_REQUEST;
+
+    const unified = await transformer.parseRequest(requestWithoutTemperature);
+    expect(unified.temperature).toBeUndefined();
+    // Stronger than undefined: the unified request must carry NO own
+    // `temperature` property at all. A phantom `temperature: undefined` own
+    // property survives object spreads and flips `'temperature' in x` /
+    // hasOwnProperty checks downstream even though JSON would drop it.
+    expect('temperature' in unified).toBe(false);
+
+    const built = await transformer.transformRequest({
+      ...unified,
+      incomingApiType: 'responses',
+      originalBody: requestWithoutTemperature,
+    });
+
+    expect(built.temperature).toBeUndefined();
+    expect(built).not.toHaveProperty('temperature');
+  });
+
+  it('still forwards an explicit temperature the client sent', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+    expect(unified.temperature).toBe(0.7);
+
+    const built = await transformer.transformRequest({
+      ...unified,
+      incomingApiType: 'responses',
+      originalBody: RESPONSES_REQUEST,
+    });
+
+    expect(built.temperature).toBe(0.7);
+  });
+
   it('preserves sampling params top_p, top_logprobs, max_tool_calls', async () => {
     const transformer = new ResponsesTransformer();
     const unified = await transformer.parseRequest(RESPONSES_REQUEST);
@@ -249,5 +285,135 @@ describe('Responses responses -> responses round-trip preserves native fields', 
     expect(built.store).toBeUndefined();
     expect(built.service_tier).toBeUndefined();
     expect(built.stream_options).toBeUndefined();
+  });
+});
+
+describe('parseRequest conditional-spread hygiene (omitted fields leave no own property)', () => {
+  // Same rationale as the temperature test above: a phantom
+  // `field: undefined` own property survives object spreads and flips
+  // `'field' in x` / hasOwnProperty checks downstream even though JSON
+  // serialization would drop it.
+  const MINIMAL_REQUEST = {
+    model: 'gpt-4o',
+    input: [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Hello' }],
+      },
+    ],
+  };
+
+  it('omitted optional client fields leave NO own property on the unified request', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(MINIMAL_REQUEST);
+
+    for (const field of [
+      'requestId',
+      'max_tokens',
+      'temperature',
+      'stream',
+      'reasoning',
+      'include',
+      'prompt_cache_key',
+      'text',
+      'parallel_tool_calls',
+      'metadata',
+      'tools',
+      'response_format',
+    ]) {
+      expect(field in unified, `'${field}' in unified must be false when omitted`).toBe(false);
+    }
+  });
+
+  it('present tools still forward through the computed conversion (lock one example)', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({
+      ...MINIMAL_REQUEST,
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the weather',
+          parameters: { type: 'object', properties: { city: { type: 'string' } } },
+        },
+      ],
+    });
+
+    expect('tools' in unified).toBe(true);
+    expect(unified.tools).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'get_weather',
+          description: 'Get the weather',
+          parameters: { type: 'object', properties: { city: { type: 'string' } } },
+        },
+      },
+    ]);
+  });
+
+  it('an explicit stream:false still forwards as a real own property', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({ ...MINIMAL_REQUEST, stream: false });
+
+    expect('stream' in unified).toBe(true);
+    expect(unified.stream).toBe(false);
+  });
+
+  it('explicit values still forward (spot-check stream, max_output_tokens, metadata)', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(RESPONSES_REQUEST);
+
+    expect(unified.stream).toBe(true);
+    expect(unified.max_tokens).toBe(1024);
+    expect(unified.metadata).toEqual({ session: 's1' });
+    expect(unified.reasoning).toEqual({ effort: 'medium' });
+    expect(unified.include).toEqual(['reasoning.encrypted_content']);
+    expect(unified.prompt_cache_key).toBe('cache-1');
+    expect(unified.parallel_tool_calls).toBe(true);
+    expect(unified.text).toEqual({ format: { type: 'text' } });
+  });
+});
+
+describe('transformRequest stream-field hygiene (no phantom `stream: undefined`)', () => {
+  // parseRequest already keeps an omitted client `stream` off the unified
+  // request (see the conditional-spread tests above) — transformRequest must
+  // not recreate it as a `stream: undefined` own property on the outbound
+  // payload, which survives object spreads and flips `'stream' in x` checks
+  // downstream even though JSON would drop it.
+  const MINIMAL_REQUEST = {
+    model: 'gpt-4o',
+    input: [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Hello' }],
+      },
+    ],
+  };
+
+  it('an omitted client stream leaves NO own `stream` property on the outbound payload', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest(MINIMAL_REQUEST);
+    expect('stream' in unified).toBe(false);
+
+    const built = await transformer.transformRequest(unified);
+    expect('stream' in built).toBe(false);
+  });
+
+  it('an explicit stream:true still forwards', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({ ...MINIMAL_REQUEST, stream: true });
+    const built = await transformer.transformRequest(unified);
+    expect(built.stream).toBe(true);
+  });
+
+  it('an explicit stream:false still forwards as a real own property', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({ ...MINIMAL_REQUEST, stream: false });
+    const built = await transformer.transformRequest(unified);
+    expect('stream' in built).toBe(true);
+    expect(built.stream).toBe(false);
   });
 });

--- a/packages/backend/src/transformers/adapters/__tests__/suppress-unsupported-gpt5-options.adapter.test.ts
+++ b/packages/backend/src/transformers/adapters/__tests__/suppress-unsupported-gpt5-options.adapter.test.ts
@@ -20,4 +20,37 @@ describe('suppressUnsupportedGpt5OptionsAdapter', () => {
 
     expect(payload).toEqual({ model: 'gpt-5.2', input: 'hello' });
   });
+
+  // Updated LobeHub sends safety_identifier on gpt-5.5 traffic; some
+  // configured upstreams 400 with "Unsupported parameter: safety_identifier".
+  it('removes safety_identifier and preserves other fields', () => {
+    const payload = suppressUnsupportedGpt5OptionsAdapter.preDispatch({
+      model: 'gpt-5.5',
+      input: 'hello',
+      safety_identifier: 'user-hash-abc',
+    });
+
+    expect(payload).toEqual({ model: 'gpt-5.5', input: 'hello' });
+  });
+
+  // prompt_cache_key is intentionally NOT statically stripped: the
+  // Codex-OAuth native path (oauth-native-request.ts) legitimately derives
+  // its session-id/x-client-request-id headers from this field, and no
+  // upstream has been observed rejecting it. A provider that does reject it
+  // is handled by the reactive strip-and-retry in dispatcher-auto-compat.ts
+  // instead (see planUnsupportedParamStrip / dispatcher-auto-compat.test.ts).
+  it('preserves prompt_cache_key (not statically stripped)', () => {
+    const payload = suppressUnsupportedGpt5OptionsAdapter.preDispatch({
+      model: 'gpt-5.5',
+      input: 'hello',
+      safety_identifier: 'user-hash-abc',
+      prompt_cache_key: 'cache-key-123',
+    });
+
+    expect(payload).toEqual({
+      model: 'gpt-5.5',
+      input: 'hello',
+      prompt_cache_key: 'cache-key-123',
+    });
+  });
 });

--- a/packages/backend/src/transformers/adapters/suppress-unsupported-gpt5-options.adapter.ts
+++ b/packages/backend/src/transformers/adapters/suppress-unsupported-gpt5-options.adapter.ts
@@ -11,6 +11,19 @@ const GPT5_UNSUPPORTED_OPTIONS = [
   'truncation',
   'max_output_tokens',
   'max_completion_tokens',
+  // Client-only Responses API field some upstreams reject outright (e.g.
+  // updated LobeHub sends this on gpt-5.5 traffic; ChatGPT/Codex-OAuth and
+  // some aggregators 400 with "Unsupported parameter: safety_identifier").
+  //
+  // NOTE: prompt_cache_key is intentionally NOT in this static list.
+  // oauth-native-request.ts's Codex-OAuth native path legitimately derives
+  // its session-id/x-client-request-id headers from prompt_cache_key (it's
+  // a real Codex CLI session/cache-correlation id), and no upstream has been
+  // observed rejecting it. If one ever does, the reactive strip-and-retry in
+  // dispatcher-auto-compat.ts (planUnsupportedParamStrip, wired in
+  // standard-attempt-request.ts) strips it on that specific 400 instead of
+  // unconditionally removing it from every GPT-5 request up front.
+  'safety_identifier',
 ] as const;
 
 export function stripUnsupportedGpt5Options(payload: Record<string, any>): Record<string, any> {

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -151,27 +151,40 @@ export class ResponsesTransformer implements Transformer {
       });
     }
 
+    // Maybe-undefined client fields use conditional spread (not
+    // `key: input.maybeUndefined`) so an omitted client field leaves NO own
+    // property on the unified request — a phantom `key: undefined` own
+    // property survives object spreads and flips `'key' in x` /
+    // hasOwnProperty checks downstream even though JSON would drop it.
     return {
-      requestId: input.requestId,
+      ...(input.requestId !== undefined ? { requestId: input.requestId } : {}),
       model: input.model,
       messages,
-      max_tokens: input.max_output_tokens,
-      temperature: input.temperature ?? 1.0,
-      stream: input.stream ?? false,
-      tools: tools.length > 0 ? tools : undefined,
+      ...(input.max_output_tokens !== undefined ? { max_tokens: input.max_output_tokens } : {}),
+      // Forward temperature only when the client actually sent it. GPT-5
+      // reasoning models (and others) reject sampling params outright, so
+      // injecting a fabricated default here would send `temperature: 1.0`
+      // upstream on every request that omitted it.
+      ...(input.temperature !== undefined ? { temperature: input.temperature } : {}),
+      ...(input.stream !== undefined ? { stream: input.stream } : {}),
+      ...(tools.length > 0 ? { tools } : {}),
       tool_choice: this.convertToolChoiceForChatCompletions(input.tool_choice),
-      reasoning: input.reasoning,
-      include: input.include,
-      prompt_cache_key: input.prompt_cache_key,
-      text: input.text,
-      parallel_tool_calls: input.parallel_tool_calls,
-      response_format: input.text?.format
+      ...(input.reasoning !== undefined ? { reasoning: input.reasoning } : {}),
+      ...(input.include !== undefined ? { include: input.include } : {}),
+      ...(input.prompt_cache_key !== undefined ? { prompt_cache_key: input.prompt_cache_key } : {}),
+      ...(input.text !== undefined ? { text: input.text } : {}),
+      ...(input.parallel_tool_calls !== undefined
+        ? { parallel_tool_calls: input.parallel_tool_calls }
+        : {}),
+      ...(input.text?.format
         ? {
-            type: input.text.format.type,
-            json_schema: input.text.format.schema,
+            response_format: {
+              type: input.text.format.type,
+              json_schema: input.text.format.schema,
+            },
           }
-        : undefined,
-      metadata: input.metadata,
+        : {}),
+      ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
       incomingApiType: 'responses',
       originalBody: input,
     };
@@ -264,10 +277,15 @@ export class ResponsesTransformer implements Transformer {
       };
     });
 
+    // `stream` uses conditional spread for the same reason parseRequest does:
+    // when the client omitted it, the outbound payload must carry NO own
+    // `stream` property — a phantom `stream: undefined` survives object
+    // spreads and flips `'stream' in x` / hasOwnProperty checks downstream
+    // even though JSON serialization would drop it.
     const payload: any = {
       model: request.model,
       input: inputItems,
-      stream: request.stream,
+      ...(request.stream !== undefined ? { stream: request.stream } : {}),
     };
 
     if (instructions) {


### PR DESCRIPTION
## Summary

Part 2/5 of the split of #757 — **stacked on #760** (the GitHub diff shows cumulative changes until #760 merges; review scope below).

Stops client-only/unsupported params from killing requests upstream. Production trigger: updated LobeChat sends Responses API calls with `safety_identifier`, which both a ChatGPT-OAuth target (`400 Unsupported parameter: safety_identifier`) and an aggregator rejected — every gpt-5.5 request failed on all targets.

## What changed

- GPT-5 adapter matching now covers provider-prefixed ids (`openai/gpt-5.5`); `safety_identifier` added to the suppression list; no more injected `temperature: 1.0` default; omitted client params leave no phantom own properties (conditional spreads in the Responses parse/transform paths).
- **Reactive strip-and-retry**: on a 400 naming an unsupported parameter (`{"detail": ...}` and `{"error":{"message": ...}}` shapes, dotted and bracket notation normalized), the named field is removed and the same target retried — bounded per target, budget-refunded on no-ops. Prototype-safe, copy-on-write, array-preserving dotted-path deletion with structural guards (`messages`/`input`/`model` whole-field and `messages.N`/`input.N` element deletion refused).
- Same mechanism for Anthropic `Invalid signature in thinking block` 400s (stale thinking blocks stripped copy-on-write, one retry, budget refunded when nothing strippable).
- TTFB stall budget derived fresh per retry iteration instead of carrying the prior attempt's reduced budget.

## Review scope

`adapter-resolver.ts`, `suppress-unsupported-gpt5-options.adapter.ts`, `dispatcher-auto-compat.ts`, `standard-attempt-request.ts`, Responses conditional-spread hunks in `transformers/responses.ts`, + their tests.

## Tests

Full suite green on this branch: 228 files / 2388 tests, typecheck and biome clean. Includes an end-to-end prototype-pollution attack test through the real dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
