### PR TITLE
fix(transformers,inspectors): surface stream errors and incompletes, capture usage on cancellation

### DIFF
--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -112,4 +112,303 @@ describe('DebugLoggingInspector Reconstruction', () => {
     expect(snapshot).not.toBeNull();
     expect(snapshot.candidates[0].finishReason).toBe('STOP');
   });
+
+  describe('reconstructResponses streaming (Responses API)', () => {
+    const writeEvents = (stream: any, events: any[]) => {
+      for (const event of events) {
+        stream.write(Buffer.from(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      stream.end();
+    };
+
+    test('response.failed captures status, error, and usage (mid-stream failure)', async () => {
+      const failedRequestId = 'test-responses-failed';
+      const inspector = new DebugLoggingInspector(failedRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_test123',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'in_progress',
+            model: 'gpt-4o',
+            output: [],
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: '' }],
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          output_index: 0,
+          content_index: 0,
+          delta: 'Partial answer before it broke',
+        },
+        {
+          type: 'response.failed',
+          response: {
+            id: 'resp_test123',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'failed',
+            model: 'gpt-4o',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Partial answer before it broke' }],
+              },
+            ],
+            error: { code: 'server_error', message: 'The model response failed to complete.' },
+            usage: {
+              input_tokens: 42,
+              output_tokens: 8,
+              total_tokens: 50,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens_details: { reasoning_tokens: 0 },
+            },
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const dm = DebugManager.getInstance();
+      const snapshot = dm.getReconstructedRawResponse(failedRequestId);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.status).toBe('failed');
+      expect(snapshot.error).toEqual({
+        code: 'server_error',
+        message: 'The model response failed to complete.',
+      });
+      expect(snapshot.usage).toEqual({
+        input_tokens: 42,
+        output_tokens: 8,
+        total_tokens: 50,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      });
+    });
+
+    test('response.failed with NO usage captures status and error, and absent usage stays absent', async () => {
+      const failedNoUsageRequestId = 'test-responses-failed-no-usage';
+      const inspector = new DebugLoggingInspector(failedNoUsageRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_nousage_1',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'in_progress',
+            model: 'gpt-4o',
+            output: [],
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: '' }],
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          output_index: 0,
+          content_index: 0,
+          delta: 'Partial answer before it broke',
+        },
+        {
+          type: 'response.failed',
+          response: {
+            id: 'resp_nousage_1',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'failed',
+            model: 'gpt-4o',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Partial answer before it broke' }],
+              },
+            ],
+            error: { code: 'server_error', message: 'The model response failed to complete.' },
+            // No usage at all — the upstream failed before reporting any.
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const dm = DebugManager.getInstance();
+      const snapshot = dm.getReconstructedRawResponse(failedNoUsageRequestId);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.status).toBe('failed');
+      expect(snapshot.error).toEqual({
+        code: 'server_error',
+        message: 'The model response failed to complete.',
+      });
+      // Usage was never reported anywhere in the stream: it must stay
+      // ABSENT on the snapshot (no phantom `usage` own property either),
+      // locking in the optional-usage contract downstream consumers
+      // (usage-logging) rely on.
+      expect(snapshot.usage).toBeUndefined();
+      expect(snapshot).not.toHaveProperty('usage');
+    });
+
+    test('response.incomplete captures status, incomplete_details, and usage (max_output_tokens truncation)', async () => {
+      const incompleteRequestId = 'test-responses-incomplete';
+      const inspector = new DebugLoggingInspector(incompleteRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_test789',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'in_progress',
+            model: 'gpt-4o',
+            output: [],
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: '' }],
+          },
+        },
+        {
+          type: 'response.output_text.delta',
+          output_index: 0,
+          content_index: 0,
+          delta: 'Truncated answer that ran out of ',
+        },
+        {
+          type: 'response.incomplete',
+          response: {
+            id: 'resp_test789',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'incomplete',
+            model: 'gpt-4o',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Truncated answer that ran out of ' }],
+              },
+            ],
+            incomplete_details: { reason: 'max_output_tokens' },
+            usage: {
+              input_tokens: 30,
+              output_tokens: 16,
+              total_tokens: 46,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens_details: { reasoning_tokens: 0 },
+            },
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const dm = DebugManager.getInstance();
+      const snapshot = dm.getReconstructedRawResponse(incompleteRequestId);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.status).toBe('incomplete');
+      expect(snapshot.incomplete_details).toEqual({ reason: 'max_output_tokens' });
+      expect(snapshot.usage).toEqual({
+        input_tokens: 30,
+        output_tokens: 16,
+        total_tokens: 46,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      });
+    });
+
+    test('response.completed still captures status and usage (regression)', async () => {
+      const completedRequestId = 'test-responses-completed';
+      const inspector = new DebugLoggingInspector(completedRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_test456',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'in_progress',
+            model: 'gpt-4o',
+            output: [],
+          },
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_test456',
+            object: 'response',
+            created_at: 1700000000,
+            status: 'completed',
+            model: 'gpt-4o',
+            output: [
+              {
+                id: 'msg_1',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Full answer' }],
+              },
+            ],
+            usage: {
+              input_tokens: 42,
+              output_tokens: 20,
+              total_tokens: 62,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens_details: { reasoning_tokens: 0 },
+            },
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const dm = DebugManager.getInstance();
+      const snapshot = dm.getReconstructedRawResponse(completedRequestId);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot.status).toBe('completed');
+      expect(snapshot.error).toBeUndefined();
+      expect(snapshot.usage).toEqual({
+        input_tokens: 42,
+        output_tokens: 20,
+        total_tokens: 62,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      });
+    });
+  });
 });

--- a/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
+++ b/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
@@ -16,9 +16,14 @@
  * See packages/backend/src/__tests__/disconnect-detection/ for the exploratory
  * test scripts that established these findings.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Readable } from 'node:stream';
 import { PassThrough } from 'node:stream';
+import { handleResponse } from '../responses/response-handler';
+import { OpenAITransformer } from '../../transformers/openai';
+import { DebugManager } from '../observability/debug-manager';
+import type { UnifiedChatResponse } from '../../types/unified';
+import type { UsageRecord } from '../../types/usage';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -269,5 +274,124 @@ describe('nodeStream destruction state', () => {
 
     expect(wasCancelled()).toBe(true);
     expect(nodeStream.destroyed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: cancellation mid-stream still records usage
+// ---------------------------------------------------------------------------
+//
+// The debug taps' snapshots (which UsageInspector's _destroy fallback reads)
+// used to be written ONLY by the taps' flush/'end' handlers — and a client
+// disconnect/timeout cancels the web TransformStreams WITHOUT running flush,
+// so production cancellations finalized with no usage at all (the earlier
+// tests pre-seeded the snapshots and never noticed). This exercises the REAL
+// path end-to-end through handleResponse: provider SSE with usage-bearing
+// chunks -> abort mid-stream (no flush anywhere) -> the saved record must
+// still carry the observed usage, via the teardown's explicit finalize.
+describe('handleResponse cancellation records usage from live captures (no pre-seeding)', () => {
+  beforeEach(() => {
+    DebugManager.getInstance().resetForTesting();
+  });
+
+  it('a client disconnect after usage-bearing chunks finalizes the record WITH usage and costs', async () => {
+    const encoder = new TextEncoder();
+    // Chat-format provider SSE: role/content chunk, then the usage-bearing
+    // final chunk — and then the stream stays OPEN (no [DONE], no close):
+    // the client disconnects first, so no flush ever runs anywhere. (In
+    // production the upstream fetch is killed by the abort signal +
+    // nodeStream.destroy(); this test asserts the usage RECORD, which is
+    // what cancellations used to lose.)
+    const providerStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl_e2e","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}\n\n'
+          )
+        );
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl_e2e","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":50,"completion_tokens":9,"total_tokens":59}}\n\n'
+          )
+        );
+        // Deliberately NOT closed.
+      },
+    });
+
+    const unifiedResponse: UnifiedChatResponse = {
+      id: 'resp-cancel-e2e',
+      model: 'gpt-4o',
+      content: null,
+      stream: providerStream,
+      plexus: {
+        provider: 'test-provider',
+        model: 'gpt-4o',
+        apiType: 'chat',
+        pricing: { source: 'simple', input: 1000, output: 2000 },
+      },
+    };
+
+    const usageRecord: Partial<UsageRecord> = { requestId: 'req-cancel-e2e' };
+    const savedRecords: UsageRecord[] = [];
+    const mockStorage = {
+      saveRequest: vi.fn(async (record: UsageRecord) => {
+        savedRecords.push(record);
+      }),
+      updatePerformanceMetrics: vi.fn(async () => {}),
+      saveError: vi.fn(),
+    };
+    const reply = {
+      header: vi.fn(function (this: any) {
+        return this;
+      }),
+      send: vi.fn((pipeline: any) => pipeline),
+      code: vi.fn(function (this: any) {
+        return this;
+      }),
+    };
+    const request = { headers: {}, raw: {} };
+    const abortController = new AbortController();
+
+    await handleResponse(
+      request as any,
+      reply as any,
+      unifiedResponse,
+      new OpenAITransformer(),
+      usageRecord,
+      mockStorage as any,
+      Date.now(),
+      'chat',
+      false,
+      undefined,
+      undefined,
+      undefined,
+      abortController,
+      null
+    );
+
+    const pipeline = (reply.send as any).mock.calls.at(-1)[0];
+    pipeline.on('data', () => {});
+    pipeline.on('error', () => {});
+
+    // Let the chunks flow through the full production pipeline (provider SSE
+    // -> raw tap -> unified -> client SSE -> transformed tap), then
+    // disconnect the client mid-stream.
+    await wait(80);
+    abortController.abort();
+    // Long enough for the teardown to finish AND for the disconnect poll to
+    // observe the destroyed pipeline and clear itself.
+    await wait(300);
+
+    expect(savedRecords).toHaveLength(1);
+    const record = savedRecords[0]!;
+    expect(record.responseStatus).toBe('cancelled');
+    // The usage the provider streamed BEFORE the disconnect must be on the
+    // record — this is exactly what production cancellations lost when the
+    // snapshots were only written on flush.
+    expect(record.tokensInput).toBe(50);
+    expect(record.tokensOutput).toBe(9);
+    // 50/1M * $1000 + 9/1M * $2000 = $0.068.
+    expect(record.costSource).toBe('simple');
+    expect(record.costTotal).toBeCloseTo(0.068, 10);
   });
 });

--- a/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { registerSpy } from '../../../test/test-utils';
 import { PassThrough } from 'stream';
 import { UsageInspector } from '../inspectors/usage-logging';
+import { DebugLoggingInspector } from '../inspectors/debug-logging';
 import { DebugManager } from '../observability/debug-manager';
 import type { UsageRecord } from '../../types/usage';
 import { DEFAULT_GPU_PARAMS, DEFAULT_MODEL } from '@plexus/shared';
@@ -20,6 +21,7 @@ describe('UsageInspector Metadata Robustness', () => {
       outputCostPerToken: 0,
     };
     const dm = DebugManager.getInstance();
+    dm.resetForTesting();
     dm.setEnabled(true);
   });
 
@@ -193,5 +195,695 @@ describe('UsageInspector Metadata Robustness', () => {
     const record = await runInspector(requestId, 'unknown-api', snapshot);
     expect(record?.toolCallsCount).toBe(2);
     expect(record?.finishReason).toBe('something_else');
+  });
+
+  describe('Responses API status → finishReason mapping', () => {
+    // Mirrors the reconstructed snapshot shape produced by
+    // DebugLoggingInspector.updateResponsesSnapshot for the same
+    // response.created -> response.output_text.delta -> response.failed
+    // stream exercised in debug-logging-reconstruction.test.ts.
+    it('should map a failed Responses API stream to finishReason "error" with non-zero usage', async () => {
+      const requestId = 'responses-failed-stream';
+      const snapshot = {
+        id: 'resp_test123',
+        object: 'response',
+        status: 'failed',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Partial answer before it broke' }],
+          },
+        ],
+        error: { code: 'server_error', message: 'The model response failed to complete.' },
+        usage: {
+          input_tokens: 42,
+          output_tokens: 8,
+          total_tokens: 50,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('error');
+      expect(record?.tokensInput).toBe(42);
+      expect(record?.tokensOutput).toBe(8);
+    });
+
+    // Mirrors the reconstructed snapshot shape produced by
+    // DebugLoggingInspector.updateResponsesSnapshot for the same
+    // response.created -> response.output_text.delta -> response.incomplete
+    // stream exercised in debug-logging-reconstruction.test.ts.
+    it('should map an incomplete Responses API stream (max_output_tokens) to finishReason "length" with non-zero usage', async () => {
+      const requestId = 'responses-incomplete-max-tokens-stream';
+      const snapshot = {
+        id: 'resp_test789',
+        object: 'response',
+        status: 'incomplete',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Truncated answer that ran out of ' }],
+          },
+        ],
+        incomplete_details: { reason: 'max_output_tokens' },
+        usage: {
+          input_tokens: 30,
+          output_tokens: 16,
+          total_tokens: 46,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('length');
+      expect(record?.tokensInput).toBe(30);
+      expect(record?.tokensOutput).toBe(16);
+    });
+
+    it('should map an incomplete Responses API stream (content_filter) to finishReason "content_filter"', async () => {
+      const requestId = 'responses-incomplete-content-filter-stream';
+      const snapshot = {
+        id: 'resp_test999',
+        object: 'response',
+        status: 'incomplete',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Cut off by the content filter' }],
+          },
+        ],
+        incomplete_details: { reason: 'content_filter' },
+        usage: {
+          input_tokens: 25,
+          output_tokens: 4,
+          total_tokens: 29,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('content_filter');
+      expect(record?.tokensInput).toBe(25);
+      expect(record?.tokensOutput).toBe(4);
+    });
+
+    it('should default an incomplete Responses API stream with an unknown/absent reason to finishReason "length"', async () => {
+      const requestId = 'responses-incomplete-unknown-reason-stream';
+      const snapshot = {
+        id: 'resp_test000',
+        object: 'response',
+        status: 'incomplete',
+        model: 'gpt-4o',
+        output: [],
+        // No incomplete_details at all — must still default sensibly instead
+        // of leaking 'incomplete' or throwing on the optional chain.
+        usage: {
+          input_tokens: 12,
+          output_tokens: 1,
+          total_tokens: 13,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('length');
+    });
+
+    it('should record a failed Responses API stream carrying NO usage with finishReason "error" and zero tokens (optional-usage behavior locked in)', async () => {
+      // Mirrors the response.failed-without-usage stream exercised in
+      // debug-logging-reconstruction.test.ts: the reconstruction keeps usage
+      // absent, so usage-logging must record no tokens (and must not throw).
+      const requestId = 'responses-failed-no-usage-stream';
+      const snapshot = {
+        id: 'resp_nousage_1',
+        object: 'response',
+        status: 'failed',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Partial answer before it broke' }],
+          },
+        ],
+        error: { code: 'server_error', message: 'The model response failed to complete.' },
+        // No usage at all — the upstream failed before reporting any.
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('error');
+      expect(record?.tokensInput).toBe(0);
+      expect(record?.tokensOutput).toBe(0);
+      expect(record?.tokensReasoning).toBe(0);
+    });
+
+    it('should still map a completed Responses API stream to finishReason "stop" (regression)', async () => {
+      const requestId = 'responses-completed-stream';
+      const snapshot = {
+        id: 'resp_test456',
+        object: 'response',
+        status: 'completed',
+        model: 'gpt-4o',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Full answer' }],
+          },
+        ],
+        usage: {
+          input_tokens: 42,
+          output_tokens: 20,
+          total_tokens: 62,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.finishReason).toBe('stop');
+      expect(record?.tokensInput).toBe(42);
+      expect(record?.tokensOutput).toBe(20);
+    });
+  });
+
+  describe('usage fallback to the transformed-mode snapshot', () => {
+    // The raw-mode reconstruction stays authoritative; the transformed-mode
+    // snapshot (written by the client-facing DebugLoggingInspector, keyed by
+    // the CLIENT api type) is only consulted when raw yields no usage at all.
+    const runInspectorWithSnapshots = async (
+      requestId: string,
+      options: {
+        providerApiType: string;
+        incomingApiType?: string;
+        rawSnapshot?: any;
+        transformedSnapshot?: any;
+      }
+    ): Promise<UsageRecord | null> => {
+      const inspector = new UsageInspector(
+        requestId,
+        mockStorage,
+        { requestId } as Partial<UsageRecord>,
+        mockPricing,
+        undefined,
+        Date.now(),
+        false,
+        options.providerApiType,
+        options.incomingApiType,
+        undefined,
+        DEFAULT_GPU_PARAMS,
+        DEFAULT_MODEL
+      );
+
+      const dm = DebugManager.getInstance();
+      dm.startLog(requestId, {});
+      if (options.rawSnapshot !== undefined) {
+        dm.addReconstructedRawResponse(requestId, options.rawSnapshot);
+      }
+      if (options.transformedSnapshot !== undefined) {
+        dm.addTransformedResponseSnapshot(requestId, options.transformedSnapshot);
+      }
+
+      let capturedRecord: UsageRecord | null = null;
+      registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+        capturedRecord = record;
+        return Promise.resolve();
+      });
+
+      const mockStream = new PassThrough();
+      mockStream.pipe(inspector);
+      mockStream.end();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return capturedRecord;
+    };
+
+    const responsesRawSnapshotWithUsage = () => ({
+      id: 'resp_raw_1',
+      object: 'response',
+      status: 'completed',
+      model: 'gpt-4o',
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Full answer' }],
+        },
+      ],
+      usage: {
+        input_tokens: 42,
+        output_tokens: 8,
+        total_tokens: 50,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      },
+    });
+
+    // Transformed snapshot as reconstructed for a CHAT-format client.
+    const chatTransformedSnapshotWithUsage = () => ({
+      id: 'chatcmpl_t1',
+      object: 'chat.completion.chunk',
+      model: 'gpt-4o',
+      choices: [{ index: 0, delta: { role: 'assistant', content: 'Full answer' } }],
+      usage: { prompt_tokens: 21, completion_tokens: 7, total_tokens: 28 },
+    });
+
+    it('raw reconstruction with usage stays authoritative — the transformed snapshot is ignored', async () => {
+      const record = await runInspectorWithSnapshots('fallback-raw-authoritative', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        rawSnapshot: responsesRawSnapshotWithUsage(),
+        transformedSnapshot: chatTransformedSnapshotWithUsage(),
+      });
+
+      expect(record?.tokensInput).toBe(42);
+      expect(record?.tokensOutput).toBe(8);
+    });
+
+    it('falls back to the transformed-mode snapshot when NO raw reconstruction exists', async () => {
+      const record = await runInspectorWithSnapshots('fallback-raw-absent', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        transformedSnapshot: chatTransformedSnapshotWithUsage(),
+      });
+
+      expect(record?.tokensInput).toBe(21);
+      expect(record?.tokensOutput).toBe(7);
+    });
+
+    it('falls back when the raw reconstruction exists but carries no usage (metadata still from raw)', async () => {
+      const record = await runInspectorWithSnapshots('fallback-raw-usageless', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'resp_raw_2',
+          object: 'response',
+          status: 'failed',
+          model: 'gpt-4o',
+          output: [],
+          error: { code: 'server_error', message: 'boom' },
+          // No usage block at all.
+        },
+        transformedSnapshot: chatTransformedSnapshotWithUsage(),
+      });
+
+      // Tokens from the transformed snapshot...
+      expect(record?.tokensInput).toBe(21);
+      expect(record?.tokensOutput).toBe(7);
+      // ...while response metadata still comes from the raw reconstruction.
+      expect(record?.finishReason).toBe('error');
+    });
+
+    it('records no tokens when both snapshots are absent (current behavior unchanged)', async () => {
+      const record = await runInspectorWithSnapshots('fallback-both-absent', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+      });
+
+      expect(record).not.toBeNull();
+      expect(record?.tokensInput).toBeUndefined();
+      expect(record?.tokensOutput).toBeUndefined();
+    });
+
+    it('records no tokens when the raw reconstruction is usage-less and no transformed snapshot exists (current behavior unchanged)', async () => {
+      const record = await runInspectorWithSnapshots('fallback-raw-usageless-no-transformed', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'resp_raw_3',
+          object: 'response',
+          status: 'failed',
+          model: 'gpt-4o',
+          output: [],
+          error: { code: 'server_error', message: 'boom' },
+        },
+      });
+
+      expect(record?.tokensInput).toBe(0);
+      expect(record?.tokensOutput).toBe(0);
+      expect(record?.finishReason).toBe('error');
+    });
+
+    describe('destroyed/cancelled streams (_destroy) use the same raw-then-transformed read', () => {
+      // Same scenarios as runInspectorWithSnapshots, but the stream is
+      // DESTROYED (client disconnect/cancel) instead of ending normally, so
+      // finalization goes through _destroy rather than _flush — and the
+      // snapshots are produced through the REAL write path: provider/client
+      // bytes written through DebugLoggingInspector taps that are
+      // `finalize()`d before the destroy, exactly as response-handler.ts's
+      // onDisconnect teardown does. (Pre-seeding the DebugManager directly
+      // would paper over the production gap this guards against: a cancelled
+      // web TransformStream never runs its flush, so the taps' 'end' handlers
+      // never fire — without the explicit finalize, _destroy would find NO
+      // snapshots at all on a real cancellation.) `pricing` (default
+      // mockPricing) lets tests assert whether calculateCosts ran: when it
+      // runs it always stamps costSource/costTotal, when it doesn't both
+      // stay undefined.
+      const runDestroyedInspectorWithCapturedBodies = async (
+        requestId: string,
+        options: {
+          providerApiType: string;
+          incomingApiType?: string;
+          /** Provider-format body written through the RAW debug tap. */
+          rawBody?: string;
+          /** Client-format body written through the TRANSFORMED debug tap. */
+          transformedBody?: string;
+          pricing?: any;
+        }
+      ): Promise<UsageRecord | null> => {
+        const inspector = new UsageInspector(
+          requestId,
+          mockStorage,
+          { requestId } as Partial<UsageRecord>,
+          options.pricing ?? mockPricing,
+          undefined,
+          Date.now(),
+          false,
+          options.providerApiType,
+          options.incomingApiType,
+          undefined,
+          DEFAULT_GPU_PARAMS,
+          DEFAULT_MODEL
+        );
+
+        const dm = DebugManager.getInstance();
+        dm.startLog(requestId, {});
+
+        const rawDebugLogging = new DebugLoggingInspector(requestId, 'raw');
+        const rawTap = rawDebugLogging.createInspector(options.providerApiType);
+        if (options.rawBody !== undefined) {
+          rawTap.write(options.rawBody);
+        }
+
+        const transformedDebugLogging = new DebugLoggingInspector(requestId, 'transformed');
+        const transformedTap = transformedDebugLogging.createInspector(
+          options.incomingApiType ?? 'chat'
+        );
+        if (options.transformedBody !== undefined) {
+          transformedTap.write(options.transformedBody);
+        }
+
+        let capturedRecord: UsageRecord | null = null;
+        registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+          capturedRecord = record;
+          return Promise.resolve();
+        });
+
+        // Mirror response-handler.ts onDisconnect(): the taps' 'end' events
+        // never fire on a cancellation, so the captures are finalized
+        // explicitly BEFORE the usage inspector is destroyed.
+        rawDebugLogging.finalize();
+        transformedDebugLogging.finalize();
+        inspector.destroy();
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return capturedRecord;
+      };
+
+      const responsesRawBodyWithUsage = () => JSON.stringify(responsesRawSnapshotWithUsage());
+
+      const responsesRawBodyWithoutUsage = () =>
+        JSON.stringify({
+          id: 'resp_raw_d1',
+          object: 'response',
+          status: 'failed',
+          model: 'gpt-4o',
+          output: [],
+          error: { code: 'server_error', message: 'boom' },
+          // No usage block at all.
+        });
+
+      // Client-facing chat SSE, as the transformed tap sees it — the usage
+      // arrives on the final chunk, but the stream is destroyed before the
+      // tap's flush would ever run.
+      const chatTransformedSseWithUsage = () =>
+        'data: {"id":"chatcmpl_t1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Full answer"}}]}\n\n' +
+        'data: {"id":"chatcmpl_t1","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":21,"completion_tokens":7,"total_tokens":28}}\n\n';
+
+      it('raw reconstruction with usage stays authoritative on a destroyed stream (regression)', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies('destroy-raw-authoritative', {
+          providerApiType: 'responses',
+          incomingApiType: 'chat',
+          rawBody: responsesRawBodyWithUsage(),
+          transformedBody: chatTransformedSseWithUsage(),
+        });
+
+        expect(record?.responseStatus).toBe('cancelled');
+        expect(record?.tokensInput).toBe(42);
+        expect(record?.tokensOutput).toBe(8);
+      });
+
+      it('falls back to the transformed-mode snapshot when NO raw reconstruction exists', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies('destroy-raw-absent', {
+          providerApiType: 'responses',
+          incomingApiType: 'chat',
+          transformedBody: chatTransformedSseWithUsage(),
+          pricing: { source: 'simple', input: 1000, output: 2000 },
+        });
+
+        expect(record?.responseStatus).toBe('cancelled');
+        expect(record?.tokensInput).toBe(21);
+        expect(record?.tokensOutput).toBe(7);
+        // Costs are calculated over the fallback tokens too — "tokens
+        // recorded" must mean a fully finalized record, not tokens with a
+        // missing cost: 21/1M * $1000 + 7/1M * $2000 = $0.035.
+        expect(record?.costSource).toBe('simple');
+        expect(record?.costTotal).toBe(0.035);
+      });
+
+      it('falls back when the raw reconstruction exists but carries no usage', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies('destroy-raw-usageless', {
+          providerApiType: 'responses',
+          incomingApiType: 'chat',
+          rawBody: responsesRawBodyWithoutUsage(),
+          transformedBody: chatTransformedSseWithUsage(),
+        });
+
+        expect(record?.tokensInput).toBe(21);
+        expect(record?.tokensOutput).toBe(7);
+      });
+
+      it('records no tokens when nothing was captured on either tap (current behavior unchanged)', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies('destroy-both-absent', {
+          providerApiType: 'responses',
+          incomingApiType: 'chat',
+          pricing: { source: 'simple', input: 1000, output: 2000 },
+        });
+
+        expect(record).not.toBeNull();
+        expect(record?.responseStatus).toBe('cancelled');
+        expect(record?.tokensInput).toBeUndefined();
+        expect(record?.tokensOutput).toBeUndefined();
+        // With neither source, cost calculation must not run at all — even
+        // with pricing configured (calculateCosts always stamps costSource
+        // when it runs).
+        expect(record?.costSource).toBeUndefined();
+        expect(record?.costTotal).toBeUndefined();
+      });
+
+      it('a usage-less raw reconstruction with no transformed snapshot still runs cost calculation (current behavior preserved)', async () => {
+        const record = await runDestroyedInspectorWithCapturedBodies(
+          'destroy-raw-usageless-no-transformed',
+          {
+            providerApiType: 'responses',
+            incomingApiType: 'chat',
+            rawBody: responsesRawBodyWithoutUsage(),
+            pricing: { source: 'simple', input: 1000, output: 2000 },
+          }
+        );
+
+        // No tokens from anywhere...
+        expect(record?.tokensInput).toBeUndefined();
+        // ...but calculateCosts still ran over the (zero) token counts,
+        // exactly as it did before the readObservedUsage refactor whenever a
+        // raw reconstruction existed.
+        expect(record?.costSource).toBe('simple');
+        expect(record?.costTotal).toBe(0);
+      });
+
+      it('finalize() is idempotent — a later stream end after the teardown finalize does not double-capture', async () => {
+        const requestId = 'destroy-finalize-idempotent';
+        const dm = DebugManager.getInstance();
+        dm.startLog(requestId, {});
+
+        const transformedDebugLogging = new DebugLoggingInspector(requestId, 'transformed');
+        const tap = transformedDebugLogging.createInspector('chat');
+        tap.write(chatTransformedSseWithUsage());
+
+        transformedDebugLogging.finalize();
+        const first = dm.getPendingLog(requestId)?.transformedResponseSnapshot;
+        expect(first?.usage?.prompt_tokens).toBe(21);
+
+        // A straggler write + end() after the teardown finalize must not
+        // corrupt or re-run the capture.
+        tap.write('data: {"bogus":true}\n\n');
+        tap.end();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const second = dm.getPendingLog(requestId)?.transformedResponseSnapshot;
+        expect(second).toBe(first);
+      });
+    });
+  });
+
+  describe('estimation must not overwrite extracted usage (estimateTokens: true)', () => {
+    // When `estimateTokens: true` is configured for a provider, estimation is
+    // a FALLBACK for responses that carried no usage at all — it must never
+    // replace real usage extracted from the raw reconstruction or the
+    // transformed-snapshot fallback. (For a 'responses' provider the
+    // estimator has no dialect support and returns zeros, so the overwrite
+    // corrupted costs/quota to zero output tokens.)
+    const runEstimatingInspectorWithSnapshots = async (
+      requestId: string,
+      options: {
+        providerApiType: string;
+        incomingApiType?: string;
+        rawSnapshot?: any;
+        transformedSnapshot?: any;
+        pricing?: any;
+      }
+    ): Promise<UsageRecord | null> => {
+      const inspector = new UsageInspector(
+        requestId,
+        mockStorage,
+        { requestId } as Partial<UsageRecord>,
+        options.pricing ?? mockPricing,
+        undefined,
+        Date.now(),
+        true, // shouldEstimateTokens
+        options.providerApiType,
+        options.incomingApiType,
+        undefined,
+        DEFAULT_GPU_PARAMS,
+        DEFAULT_MODEL
+      );
+
+      const dm = DebugManager.getInstance();
+      dm.startLog(requestId, {});
+      if (options.rawSnapshot !== undefined) {
+        dm.addReconstructedRawResponse(requestId, options.rawSnapshot);
+      }
+      if (options.transformedSnapshot !== undefined) {
+        dm.addTransformedResponseSnapshot(requestId, options.transformedSnapshot);
+      }
+
+      let capturedRecord: UsageRecord | null = null;
+      registerSpy(mockStorage, 'saveRequest').mockImplementation(async (record: UsageRecord) => {
+        capturedRecord = record;
+        return Promise.resolve();
+      });
+
+      const mockStream = new PassThrough();
+      mockStream.pipe(inspector);
+      mockStream.end();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return capturedRecord;
+    };
+
+    it('transformed-snapshot usage survives estimation (raw usage-less responses reconstruction)', async () => {
+      const record = await runEstimatingInspectorWithSnapshots('estimate-transformed-survives', {
+        providerApiType: 'responses',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'resp_est_1',
+          object: 'response',
+          status: 'completed',
+          model: 'gpt-4o',
+          output: [
+            {
+              id: 'msg_1',
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'Full answer' }],
+            },
+          ],
+          // No usage block at all.
+        },
+        transformedSnapshot: {
+          id: 'chatcmpl_est_1',
+          object: 'chat.completion.chunk',
+          model: 'gpt-4o',
+          choices: [{ index: 0, delta: { role: 'assistant', content: 'Full answer' } }],
+          usage: { prompt_tokens: 21, completion_tokens: 7, total_tokens: 28 },
+        },
+        pricing: { source: 'simple', input: 1000, output: 2000 },
+      });
+
+      // The transformed-snapshot counts survive (the 'responses' estimator
+      // would have zeroed them)...
+      expect(record?.tokensInput).toBe(21);
+      expect(record?.tokensOutput).toBe(7);
+      // ...they are not flagged as estimated...
+      expect(record?.tokensEstimated).not.toBe(1);
+      // ...and costs are computed from them:
+      // 21/1M * $1000 + 7/1M * $2000 = $0.035.
+      expect(record?.costSource).toBe('simple');
+      expect(record?.costTotal).toBe(0.035);
+    });
+
+    it('raw-reconstruction usage survives estimation (chat provider that DID report usage)', async () => {
+      const record = await runEstimatingInspectorWithSnapshots('estimate-raw-survives', {
+        providerApiType: 'chat',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'chatcmpl_est_2',
+          object: 'chat.completion',
+          model: 'gpt-4o',
+          choices: [
+            { index: 0, message: { role: 'assistant', content: 'Hello!' }, finish_reason: 'stop' },
+          ],
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        },
+      });
+
+      expect(record?.tokensInput).toBe(100);
+      expect(record?.tokensOutput).toBe(50);
+      expect(record?.tokensEstimated).not.toBe(1);
+    });
+
+    it('estimation still runs when NO usage was extracted from either source (fallback preserved)', async () => {
+      // Streamed-reconstruction shape (delta-based) — the shape the chat
+      // estimator reads content from.
+      const record = await runEstimatingInspectorWithSnapshots('estimate-still-runs', {
+        providerApiType: 'chat',
+        incomingApiType: 'chat',
+        rawSnapshot: {
+          id: 'chatcmpl_est_3',
+          object: 'chat.completion.chunk',
+          model: 'gpt-4o',
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: 'assistant',
+                content: 'A reasonably long answer with enough words to estimate.',
+              },
+              finish_reason: 'stop',
+            },
+          ],
+          // No usage block anywhere, and no transformed snapshot.
+        },
+      });
+
+      expect(record?.tokensEstimated).toBe(1);
+      expect(record?.tokensOutput).toBeGreaterThan(0);
+    });
   });
 });

--- a/packages/backend/src/services/__tests__/usage-logging.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging.test.ts
@@ -394,7 +394,13 @@ describe('UsageInspector', () => {
 
       expect(capturedRecord).not.toBeNull();
       expect(capturedRecord!.tokensInput).toBeGreaterThan(0);
-      expect(capturedRecord!.tokensEstimated).toBe(1);
+      // The provider DID report output usage (candidatesTokenCount: 12), so
+      // output estimation must NOT run (and must not overwrite the real
+      // count) — the record is not flagged as estimated; only the
+      // input-token fallback (which fires whenever the provider reports 0
+      // input tokens) filled in tokensInput above.
+      expect(capturedRecord!.tokensOutput).toBe(12);
+      expect(capturedRecord!.tokensEstimated).not.toBe(1);
     });
 
     it('does not update performance metrics for errored streams', async () => {

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -8,6 +8,14 @@ const MAX_DEBUG_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB
 export class DebugLoggingInspector extends BaseInspector {
   private debugManager = DebugManager.getInstance();
   private mode: 'raw' | 'transformed';
+  // Capture state lives on the INSTANCE (not in createInspector closures) so
+  // finalize() can run the reconstruction from outside the stream lifecycle —
+  // see finalize() below for why that matters on cancellations.
+  private providerApiType: string = 'unknown';
+  private bodyChunks: string[] = [];
+  private totalSize = 0;
+  private truncated = false;
+  private finalized = false;
 
   constructor(requestId: string, mode: 'raw' | 'transformed' = 'raw') {
     super(requestId);
@@ -15,91 +23,123 @@ export class DebugLoggingInspector extends BaseInspector {
   }
 
   createInspector(providerApiType: string): PassThrough {
-    const inspector =
-      providerApiType === 'oauth' ? new PassThrough({ objectMode: true }) : new PassThrough();
+    this.providerApiType = providerApiType;
 
-    const bodyChunks: string[] = [];
-    let totalSize = 0;
-    let truncated = false;
-
-    inspector.on('data', (chunk: any) => {
-      logger.silly(
-        `[Inspector:${this.mode}] Request ${this.requestId} received chunk, length: ${chunk.length || chunk.toString().length}: ${chunk.toString()}`
-      );
-
-      if (truncated) return;
-
-      let chunkStr: string;
-      if (typeof chunk === 'string') {
-        chunkStr = chunk;
-      } else if (Buffer.isBuffer(chunk)) {
-        chunkStr = chunk.toString('utf8');
-      } else if (chunk instanceof Uint8Array) {
-        chunkStr = new TextDecoder().decode(chunk);
-      } else if (chunk && typeof chunk === 'object') {
-        chunkStr = `${JSON.stringify(chunk)}\n`;
-      } else {
-        try {
-          chunkStr = String(chunk);
-        } catch (e) {
-          logger.warn(`[${this.mode}] Failed to convert chunk to string`);
-          return;
-        }
-      }
-
-      const newSize = totalSize + chunkStr.length;
-
-      if (newSize > MAX_DEBUG_BUFFER_SIZE) {
-        truncated = true;
-        bodyChunks.push('\n\n[DEBUG OUTPUT TRUNCATED - Exceeded 10MB limit]');
-        logger.warn(`Request ${this.requestId} debug output truncated at ${totalSize} bytes`);
-        return;
-      }
-
-      totalSize = newSize;
-      bodyChunks.push(chunkStr);
+    // Capture happens synchronously in the transform hook (i.e. at write()
+    // time), NOT in a 'data' listener: 'data' emission for the very first
+    // writes is deferred to the tick after resume() starts the flow, so a
+    // teardown-time finalize() could miss bytes that were already written.
+    // With write-time capture, finalize() deterministically sees every chunk
+    // written up to the instant it runs.
+    const inspector = new PassThrough({
+      ...(providerApiType === 'oauth' ? { objectMode: true } : {}),
+      transform: (chunk: any, _encoding, callback) => {
+        this.captureChunk(chunk);
+        callback(null, chunk);
+      },
     });
 
-    inspector.on('end', () => {
-      const rawBody = bodyChunks.join('');
-      logger.silly(
-        `[Inspector:${this.mode}] Request ${this.requestId} stream ended, captured ${bodyChunks.length} chunks, total size: ${rawBody.length} bytes`
-      );
-      try {
-        let reconstructed: any = null;
-        switch (providerApiType) {
-          case 'chat':
-            reconstructed = this.reconstructChatCompletions(rawBody);
-            break;
-          case 'responses':
-            reconstructed = this.reconstructResponses(rawBody);
-            break;
-          case 'messages':
-            reconstructed = this.reconstructMessages(rawBody);
-            break;
-          case 'gemini':
-            reconstructed = this.reconstructGemini(rawBody);
-            break;
-          case 'oauth':
-            reconstructed = this.reconstructOAuth(rawBody);
-            break;
-          case 'unknown':
-            break;
-          default:
-            logger.warn(`Unknown providerApiType: ${providerApiType}`);
-        }
-        // Always save to memory for usage extraction/estimation
-        this.saveReconstructedResponse(reconstructed);
+    // Nothing external ever reads this tap's readable side — keep it flowing
+    // (into zero listeners) so pushed chunks never accumulate to the
+    // high-water mark and stall the transform hook above.
+    inspector.resume();
 
-        // DebugManager applies global/key/alias/provider capture policy.
-        this.saveRawResponse(rawBody);
-      } catch (err) {
-        logger.error(`[Inspector:${this.mode}] Reconstruction failed: ${err}`);
-        this.saveRawResponse(rawBody);
-      }
-    });
+    inspector.on('end', () => this.finalize());
 
     return inspector;
+  }
+
+  private captureChunk(chunk: any): void {
+    logger.silly(
+      `[Inspector:${this.mode}] Request ${this.requestId} received chunk, length: ${chunk.length || chunk.toString().length}: ${chunk.toString()}`
+    );
+
+    if (this.truncated) return;
+
+    let chunkStr: string;
+    if (typeof chunk === 'string') {
+      chunkStr = chunk;
+    } else if (Buffer.isBuffer(chunk)) {
+      chunkStr = chunk.toString('utf8');
+    } else if (chunk instanceof Uint8Array) {
+      chunkStr = new TextDecoder().decode(chunk);
+    } else if (chunk && typeof chunk === 'object') {
+      chunkStr = `${JSON.stringify(chunk)}\n`;
+    } else {
+      try {
+        chunkStr = String(chunk);
+      } catch (e) {
+        logger.warn(`[${this.mode}] Failed to convert chunk to string`);
+        return;
+      }
+    }
+
+    const newSize = this.totalSize + chunkStr.length;
+
+    if (newSize > MAX_DEBUG_BUFFER_SIZE) {
+      this.truncated = true;
+      this.bodyChunks.push('\n\n[DEBUG OUTPUT TRUNCATED - Exceeded 10MB limit]');
+      logger.warn(`Request ${this.requestId} debug output truncated at ${this.totalSize} bytes`);
+      return;
+    }
+
+    this.totalSize = newSize;
+    this.bodyChunks.push(chunkStr);
+  }
+
+  /**
+   * Reconstructs and persists everything captured so far (snapshot to memory
+   * always; raw body per capture policy). One-shot: the stream's natural
+   * 'end' event and any explicit teardown call share the same guard, so
+   * whichever runs first wins and later calls are no-ops.
+   *
+   * PUBLIC because stream flush is not guaranteed to run: a client
+   * disconnect/timeout cancels the web TransformStream pipeline WITHOUT
+   * running its flush, so this tap's 'end' never fires — response-handler's
+   * cancellation teardown calls finalize() explicitly BEFORE destroying the
+   * usage inspector, so UsageInspector._destroy's snapshot fallback reads a
+   * live capture instead of nothing.
+   */
+  finalize(): void {
+    if (this.finalized) return;
+    this.finalized = true;
+
+    const rawBody = this.bodyChunks.join('');
+    logger.silly(
+      `[Inspector:${this.mode}] Request ${this.requestId} capture finalized, captured ${this.bodyChunks.length} chunks, total size: ${rawBody.length} bytes`
+    );
+    try {
+      let reconstructed: any = null;
+      switch (this.providerApiType) {
+        case 'chat':
+          reconstructed = this.reconstructChatCompletions(rawBody);
+          break;
+        case 'responses':
+          reconstructed = this.reconstructResponses(rawBody);
+          break;
+        case 'messages':
+          reconstructed = this.reconstructMessages(rawBody);
+          break;
+        case 'gemini':
+          reconstructed = this.reconstructGemini(rawBody);
+          break;
+        case 'oauth':
+          reconstructed = this.reconstructOAuth(rawBody);
+          break;
+        case 'unknown':
+          break;
+        default:
+          logger.warn(`Unknown providerApiType: ${this.providerApiType}`);
+      }
+      // Always save to memory for usage extraction/estimation
+      this.saveReconstructedResponse(reconstructed);
+
+      // DebugManager applies global/key/alias/provider capture policy.
+      this.saveRawResponse(rawBody);
+    } catch (err) {
+      logger.error(`[Inspector:${this.mode}] Reconstruction failed: ${err}`);
+      this.saveRawResponse(rawBody);
+    }
   }
 
   private saveRawResponse(fullBody: string): void {
@@ -763,6 +803,29 @@ export class DebugLoggingInspector extends BaseInspector {
 
       case 'response.completed':
         // Final response state
+        if (event.response) {
+          Object.assign(acc, event.response);
+        }
+        break;
+
+      case 'response.failed':
+        // Upstream/client-facing hard failure. Same merge semantics as
+        // response.completed: absorb the final response object (status
+        // 'failed', error, and usage-if-present) so failed/truncated
+        // streams don't get stuck reporting a stale snapshot (usually
+        // 'in_progress') with zero usage.
+        if (event.response) {
+          Object.assign(acc, event.response);
+        }
+        break;
+
+      case 'response.incomplete':
+        // Upstream ended the response early (e.g. max_output_tokens or a
+        // content filter). Same merge semantics as response.completed /
+        // response.failed: absorb the final response object (status
+        // 'incomplete', incomplete_details, and usage-if-present) so
+        // truncated streams don't get stuck reporting a stale snapshot
+        // with zero usage.
         if (event.response) {
           Object.assign(acc, event.response);
         }

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -99,7 +99,12 @@ export class UsageInspector extends PassThrough {
   private providerDiscount?: number;
   private startTime: number;
   private shouldEstimateTokens: boolean;
-  private apiType: string;
+  /** API type of the UPSTREAM PROVIDER's raw response stream — keys how the
+   * raw-mode reconstruction is read (usage/metadata extraction dialect). */
+  private providerApiType: string;
+  /** API type the CLIENT is speaking (matches `request.incomingApiType`
+   * elsewhere) — keys input-token estimation over the original request and
+   * how the transformed-mode (client-facing) snapshot is read. */
   private incomingApiType: string;
   private originalRequest?: any;
   private firstChunk = true;
@@ -118,7 +123,7 @@ export class UsageInspector extends PassThrough {
     providerDiscount: number | undefined,
     startTime: number,
     shouldEstimateTokens: boolean = false,
-    apiType: string = 'chat',
+    providerApiType: string = 'chat',
     incomingApiType?: string,
     originalRequest?: any,
     gpuParams: GpuParams = DEFAULT_GPU_PARAMS,
@@ -133,8 +138,8 @@ export class UsageInspector extends PassThrough {
     this.providerDiscount = providerDiscount;
     this.startTime = startTime;
     this.shouldEstimateTokens = shouldEstimateTokens;
-    this.apiType = apiType;
-    this.incomingApiType = incomingApiType || apiType;
+    this.providerApiType = providerApiType;
+    this.incomingApiType = incomingApiType || providerApiType;
     this.originalRequest = originalRequest;
     this.gpuParams = gpuParams;
     this.modelParams = modelParams;
@@ -164,9 +169,9 @@ export class UsageInspector extends PassThrough {
     try {
       const debugManager = DebugManager.getInstance();
       const reconstructed = debugManager.getReconstructedRawResponse(this.usageRecord.requestId!);
+      const usage = this.readObservedUsage(debugManager, reconstructed);
 
-      if (reconstructed) {
-        const usage = extractUsageFromReconstructed(reconstructed, this.apiType);
+      if (reconstructed || usage) {
         if (usage) {
           stats.inputTokens = usage.inputTokens || 0;
           stats.outputTokens = usage.outputTokens || 0;
@@ -175,27 +180,44 @@ export class UsageInspector extends PassThrough {
           stats.reasoningTokens = usage.reasoningTokens || 0;
         }
 
-        // Extract response metadata (tool calls count and finish reason)
-        const responseMetadata = this.extractResponseMetadataFromReconstructed(
-          reconstructed,
-          this.apiType
-        );
-        this.usageRecord.toolCallsCount = responseMetadata.toolCallsCount;
-        this.usageRecord.finishReason = responseMetadata.finishReason;
+        if (reconstructed) {
+          // Extract response metadata (tool calls count and finish reason) —
+          // raw-mode only: the transformed snapshot never feeds metadata.
+          const responseMetadata = this.extractResponseMetadataFromReconstructed(
+            reconstructed,
+            this.providerApiType
+          );
+          this.usageRecord.toolCallsCount = responseMetadata.toolCallsCount;
+          this.usageRecord.finishReason = responseMetadata.finishReason;
 
-        if (this.shouldEstimateTokens) {
-          logger.debug(
-            `No usage data found for ${this.usageRecord.requestId}, attempting estimation`
-          );
-          const estimated = estimateTokensFromReconstructed(reconstructed, this.apiType);
-          stats.outputTokens = estimated.output;
-          stats.reasoningTokens = estimated.reasoning;
-          this.usageRecord.tokensEstimated = 1;
-          logger.debug(
-            `Estimated tokens for ${this.usageRecord.requestId}: ` +
-              `output=${stats.outputTokens}, reasoning=${stats.reasoningTokens}`
-          );
-          debugManager.discardEphemeral(this.usageRecord.requestId!);
+          if (this.shouldEstimateTokens) {
+            // Estimation is a FALLBACK for responses that carried no usage at
+            // all: it must never overwrite real usage extracted from the raw
+            // reconstruction or the transformed-snapshot fallback above (for
+            // a 'responses' provider the estimator has no dialect support
+            // and returns zeros — the overwrite would zero out real counts
+            // and corrupt costs/quota).
+            if (!usage) {
+              logger.debug(
+                `No usage data found for ${this.usageRecord.requestId}, attempting estimation`
+              );
+              const estimated = estimateTokensFromReconstructed(
+                reconstructed,
+                this.providerApiType
+              );
+              stats.outputTokens = estimated.output;
+              stats.reasoningTokens = estimated.reasoning;
+              this.usageRecord.tokensEstimated = 1;
+              logger.debug(
+                `Estimated tokens for ${this.usageRecord.requestId}: ` +
+                  `output=${stats.outputTokens}, reasoning=${stats.reasoningTokens}`
+              );
+            }
+            // The ephemeral capture was made solely for this estimation pass —
+            // discard it whether estimation ran or real usage won, so the
+            // marker doesn't leak past this request.
+            debugManager.discardEphemeral(this.usageRecord.requestId!);
+          }
         }
 
         if (this.originalRequest && stats.inputTokens === 0) {
@@ -353,15 +375,19 @@ export class UsageInspector extends PassThrough {
 
       const debugManager = DebugManager.getInstance();
       const reconstructed = debugManager.getReconstructedRawResponse(this.usageRecord.requestId!);
-      if (reconstructed) {
-        const usage = extractUsageFromReconstructed(reconstructed, this.apiType);
-        if (usage) {
-          this.usageRecord.tokensInput = usage.inputTokens || null;
-          this.usageRecord.tokensOutput = usage.outputTokens || null;
-          this.usageRecord.tokensCached = usage.cachedTokens || null;
-          this.usageRecord.tokensCacheWrite = usage.cacheWriteTokens || null;
-          this.usageRecord.tokensReasoning = usage.reasoningTokens || null;
-        }
+      // Same read-raw-then-fallback as _flush (readObservedUsage): a stream
+      // destroyed mid-flight can have usage only in the transformed-mode
+      // snapshot, and without the fallback the cancelled/timeout record
+      // would finalize with no tokens at all.
+      const usage = this.readObservedUsage(debugManager, reconstructed);
+      if (usage) {
+        this.usageRecord.tokensInput = usage.inputTokens || null;
+        this.usageRecord.tokensOutput = usage.outputTokens || null;
+        this.usageRecord.tokensCached = usage.cachedTokens || null;
+        this.usageRecord.tokensCacheWrite = usage.cacheWriteTokens || null;
+        this.usageRecord.tokensReasoning = usage.reasoningTokens || null;
+      }
+      if (reconstructed || usage) {
         calculateCosts(this.usageRecord, this.pricing, this.providerDiscount);
       }
 
@@ -378,6 +404,30 @@ export class UsageInspector extends PassThrough {
     }
 
     callback(err);
+  }
+
+  /**
+   * Reads observed usage for this request, shared by BOTH finalization paths
+   * (_flush for streams that end normally, _destroy for cancelled/timed-out
+   * streams). The raw-mode reconstruction is AUTHORITATIVE for usage. Only
+   * when it yields no usage at all (no reconstruction, or a reconstruction
+   * without a usage block) fall back to the transformed-mode snapshot — the
+   * client-facing stream reconstruction the transformed DebugLoggingInspector
+   * writes — mirroring the raw extraction per api type (the transformed
+   * snapshot is keyed by the CLIENT api type).
+   */
+  private readObservedUsage(
+    debugManager: DebugManager,
+    reconstructed: any
+  ): ExtractedObservedUsage | null {
+    let usage = extractUsageFromReconstructed(reconstructed, this.providerApiType);
+    if (!usage) {
+      const transformedSnapshot = debugManager.getPendingLog(
+        this.usageRecord.requestId!
+      )?.transformedResponseSnapshot;
+      usage = extractUsageFromReconstructed(transformedSnapshot, this.incomingApiType);
+    }
+    return usage;
   }
 
   private extractResponseMetadataFromReconstructed(
@@ -448,8 +498,23 @@ export class UsageInspector extends PassThrough {
             (item: any) => item.type === 'function_call'
           ).length;
         }
-        // Responses API doesn't have a direct finish_reason, use status instead
-        const finishReason = reconstructed.status === 'completed' ? 'stop' : reconstructed.status;
+        // Responses API doesn't have a direct finish_reason, use status instead.
+        // 'failed' maps to 'error' so failed/truncated streams are recorded as
+        // errors instead of leaking the raw Responses API status string.
+        // 'incomplete' maps from incomplete_details.reason: 'content_filter'
+        // stays 'content_filter', everything else (including
+        // 'max_output_tokens' and any unknown/absent reason) defaults to
+        // 'length', matching the OpenAI-compatible finish reason vocabulary.
+        const finishReason =
+          reconstructed.status === 'completed'
+            ? 'stop'
+            : reconstructed.status === 'failed'
+              ? 'error'
+              : reconstructed.status === 'incomplete'
+                ? reconstructed.incomplete_details?.reason === 'content_filter'
+                  ? 'content_filter'
+                  : 'length'
+                : reconstructed.status;
         return { toolCallsCount: toolCallsCount > 0 ? toolCallsCount : null, finishReason };
       }
       case 'messages': {

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -216,10 +216,11 @@ export async function handleResponse(
     // TAP THE RAW STREAM for debugging/usage extraction
     // We always capture the stream BEFORE any transformation to enable usage extraction,
     // even with pass-through optimization. Debug mode only controls DB persistence.
-    const rawLogInspector = new DebugLoggingInspector(
-      usageRecord.requestId!,
-      'raw'
-    ).createInspector(providerApiType);
+    // The DebugLoggingInspector INSTANCE is kept (not just its tap stream):
+    // the cancellation teardown below must finalize() the capture explicitly,
+    // because a cancelled pipeline never runs the tap's flush.
+    const rawDebugLogging = new DebugLoggingInspector(usageRecord.requestId!, 'raw');
+    const rawLogInspector = rawDebugLogging.createInspector(providerApiType);
 
     const tapStream = new TransformStream({
       transform(chunk, controller) {
@@ -286,10 +287,11 @@ export async function handleResponse(
 
     // TAP THE TRANSFORMED STREAM for debugging
     // This captures what is actually sent to the client
-    const transformedLogInspector = new DebugLoggingInspector(
+    const transformedDebugLogging = new DebugLoggingInspector(
       usageRecord.requestId!,
       'transformed'
-    ).createInspector(apiType);
+    );
+    const transformedLogInspector = transformedDebugLogging.createInspector(apiType);
 
     const transformedTapStream = new TransformStream({
       transform(chunk, controller) {
@@ -479,6 +481,17 @@ export async function handleResponse(
       } else if (isTimeout) {
         usageRecord.responseStatus = 'timeout';
       }
+      // Flush both debug captures BEFORE tearing the pipeline down: a
+      // cancelled web TransformStream never runs its flush(), so the
+      // raw/transformed taps' 'end' handlers never fire on a real
+      // disconnect/timeout/stall — without this, the snapshots would never
+      // be written and UsageInspector._destroy's usage fallback would find
+      // nothing (cancelled/timeout records finalized with zero tokens).
+      // finalize() is synchronous and idempotent (a later natural 'end' is a
+      // no-op), and it must run before pipeline.destroy(), which invokes
+      // UsageInspector._destroy synchronously.
+      rawDebugLogging.finalize();
+      transformedDebugLogging.finalize();
       // Destroy without passing the error — calling .destroy(err) causes Node.js to
       // emit 'error' on the stream, which becomes an uncaught exception since
       // these streams don't have error listeners. The cancellation still works:

--- a/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
@@ -1,6 +1,8 @@
 import { test, expect, describe } from 'vitest';
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
 import { AnthropicTransformer } from '../anthropic';
 import { transformAnthropicStream } from '../anthropic/stream-transformer';
+import { OpenAITransformer } from '../openai';
 import { UnifiedChatStreamChunk } from '../../types/unified';
 
 describe('AnthropicTransformer Stream Formatting', () => {
@@ -610,7 +612,95 @@ describe('transformAnthropicStream tool call index remapping', () => {
       },
     });
 
+    // Parse the SSE frames structurally (same approach as
+    // openai-stream.test.ts's readOpenAISSEChunks) and assert on the parsed
+    // error object instead of raw-output substrings.
     const reader = transformer.formatStream(stream).getReader();
+    const decoder = new TextDecoder();
+    const events: { event: string | undefined; data: any }[] = [];
+    const parser = createParser({
+      onEvent(event: EventSourceMessage) {
+        events.push({ event: event.event, data: JSON.parse(event.data) });
+      },
+    });
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      parser.feed(decoder.decode(value, { stream: true }));
+    }
+
+    const errorEvents = events.filter((e) => e.event === 'error');
+    expect(errorEvents).toHaveLength(1);
+    // Full parsed Anthropic error payload: `error.type` is the wire "code"
+    // and `error.message` carries the upstream message verbatim.
+    expect(errorEvents[0]?.data).toEqual({
+      type: 'error',
+      error: {
+        type: 'api_error',
+        message:
+          'Upstream Gemini returned MALFORMED_FUNCTION_CALL — please retry your request. [503]',
+      },
+    });
+    // The terminal error must not be followed by a normal stop.
+    expect(events.some((e) => e.event === 'message_stop')).toBe(false);
+  });
+
+  test('maps an Anthropic error event to a unified error chunk', async () => {
+    const sseEvents = [
+      {
+        event: 'message_start',
+        data: {
+          type: 'message_start',
+          message: {
+            id: 'msg_err',
+            model: 'claude-sonnet-4-6',
+            role: 'assistant',
+            content: [],
+            usage: { input_tokens: 10, output_tokens: 0 },
+          },
+        },
+      },
+      {
+        event: 'error',
+        data: {
+          type: 'error',
+          error: { type: 'overloaded_error', message: 'Overloaded: please retry later.' },
+        },
+      },
+    ];
+
+    const rawStream = makeAnthropicSSE(sseEvents);
+    const unifiedStream = transformAnthropicStream(rawStream);
+    const chunks = await drainUnifiedStream(unifiedStream);
+
+    const errorChunk = chunks.find((c) => c.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.message).toBe('Overloaded: please retry later.');
+    expect(errorChunk.error.code).toBe('overloaded_error');
+    expect(errorChunk.id).toBe('msg_err');
+    expect(errorChunk.model).toBe('claude-sonnet-4-6');
+  });
+
+  test('OpenAI client sees the Anthropic error chunk and terminates cleanly with [DONE]', async () => {
+    const sseEvents = [
+      {
+        event: 'message_start',
+        data: {
+          type: 'message_start',
+          message: { id: 'msg_err2', model: 'claude-sonnet-4-6', role: 'assistant', content: [] },
+        },
+      },
+      {
+        event: 'error',
+        data: { type: 'error', error: { type: 'api_error', message: 'Internal server error.' } },
+      },
+    ];
+
+    const rawStream = makeAnthropicSSE(sseEvents);
+    const unifiedStream = transformAnthropicStream(rawStream);
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+
+    const reader = formatted.getReader();
     const decoder = new TextDecoder();
     let output = '';
     while (true) {
@@ -619,8 +709,59 @@ describe('transformAnthropicStream tool call index remapping', () => {
       output += decoder.decode(value);
     }
 
-    expect(output).toContain('event: error');
-    expect(output).toContain('please retry your request');
-    expect(output).not.toContain('event: message_stop');
+    const dataLines = output
+      .split('\n\n')
+      .filter(Boolean)
+      .map((block) => block.replace(/^data:\s*/, ''));
+
+    const errorLine = dataLines.find((line) => line !== '[DONE]' && JSON.parse(line).error);
+    expect(errorLine).toBeDefined();
+    const errorPayload = JSON.parse(errorLine as string);
+    expect(errorPayload.error.message).toBe('Internal server error.');
+    // Propagates Anthropic's own error type as the code — not Gemini's
+    // hardcoded legacy `upstream_malformed_function_call` sentinel.
+    expect(errorPayload.error.code).toBe('api_error');
+    expect(output.trim().endsWith('data: [DONE]')).toBe(true);
+  });
+
+  test('OpenAI client still gets a final finish_reason chunk when the stream ends after message_start with no message_delta', async () => {
+    const sseEvents = [
+      {
+        event: 'message_start',
+        data: {
+          type: 'message_start',
+          message: {
+            id: 'msg_abrupt',
+            model: 'claude-sonnet-4-6',
+            role: 'assistant',
+            content: [],
+          },
+        },
+      },
+    ];
+
+    const rawStream = makeAnthropicSSE(sseEvents);
+    const unifiedStream = transformAnthropicStream(rawStream);
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+
+    const reader = formatted.getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+
+    const dataLines = output
+      .split('\n\n')
+      .filter(Boolean)
+      .map((block) => block.replace(/^data:\s*/, ''));
+
+    const finishLine = dataLines.find(
+      (line) => line !== '[DONE]' && JSON.parse(line).choices?.[0]?.finish_reason === 'stop'
+    );
+    expect(finishLine).toBeDefined();
+    expect(dataLines.at(-1)).toBe('[DONE]');
   });
 });

--- a/packages/backend/src/transformers/__tests__/openai-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/openai-stream.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, test } from 'vitest';
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
+import { OpenAITransformer } from '../openai';
+import { GEMINI_MALFORMED_FUNCTION_CALL_CODE } from '../../utils/gemini-malformed-function-call';
+
+function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+async function readOpenAISSEChunks(stream: ReadableStream<Uint8Array>): Promise<any[]> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const chunks: any[] = [];
+
+  const parser = createParser({
+    onEvent(event: EventSourceMessage) {
+      if (event.data === '[DONE]') {
+        chunks.push('[DONE]');
+        return;
+      }
+      chunks.push(JSON.parse(event.data));
+    },
+  });
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    parser.feed(decoder.decode(value, { stream: true }));
+  }
+
+  return chunks;
+}
+
+describe('OpenAITransformer.formatStream robustness', () => {
+  test('emits a synthesized stop finish chunk before [DONE] when the source ends with no finish_reason', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_1',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'Hi' },
+        finish_reason: null,
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    expect(chunks.at(-1)).toBe('[DONE]');
+
+    const finishChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason);
+    expect(finishChunks).toHaveLength(1);
+    expect(finishChunks[0].choices[0].finish_reason).toBe('stop');
+    expect(finishChunks[0].choices[0].delta).toEqual({});
+    // The flushed stop chunk echoes the id/model seen on the stream.
+    expect(finishChunks[0].id).toBe('chatcmpl_1');
+    expect(finishChunks[0].model).toBe('gpt-4o');
+  });
+
+  test('synthesizes an id on the flushed stop chunk when ZERO chunks arrived', async () => {
+    const formatted = new OpenAITransformer().formatStream(unifiedStreamFromChunks([]));
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    expect(chunks.at(-1)).toBe('[DONE]');
+    const payloadChunks = chunks.filter((c) => c !== '[DONE]');
+    expect(payloadChunks).toHaveLength(1);
+
+    const stopChunk = payloadChunks[0];
+    expect(stopChunk.object).toBe('chat.completion.chunk');
+    expect(stopChunk.choices).toEqual([{ index: 0, delta: {}, finish_reason: 'stop' }]);
+    // No upstream id ever arrived — one must be synthesized so the stop
+    // chunk is still a well-formed chat.completion.chunk.
+    expect(stopChunk.id).toMatch(/^chatcmpl_/);
+    // formatStream's only input is the unified chunk stream itself (the
+    // formatter has no request context); with zero chunks no model is
+    // reachable, so none is fabricated.
+    expect(stopChunk).not.toHaveProperty('model');
+  });
+
+  test('does not synthesize an extra finish chunk when one already arrived', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_2',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { content: 'Hi' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_2',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: {},
+        finish_reason: 'stop',
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const finishChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason);
+    expect(finishChunks).toHaveLength(1);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('renders a unified error chunk carrying a recognizable finish_reason (length) as a normal finish, not an error payload', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_3',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_3',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'length',
+        error: {
+          statusCode: 500,
+          code: 'max_output_tokens',
+          message: 'Response ended incomplete: max_output_tokens',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeUndefined();
+
+    const finishChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'length'
+    );
+    expect(finishChunk).toBeDefined();
+    expect(finishChunk.choices[0].delta).toEqual({});
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('renders a hard unified error chunk (no finish_reason) as an error payload and still terminates with [DONE]', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_4',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_4',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 500,
+          code: 'response_failed',
+          message: 'The model response failed.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.message).toBe('The model response failed.');
+    expect(errorChunk.error.type).toBe('server_error');
+    // The rendered code must be the real upstream code, not Gemini's
+    // hardcoded legacy sentinel (see the MALFORMED_FUNCTION_CALL test below).
+    expect(errorChunk.error.code).toBe('response_failed');
+    expect(chunks.at(-1)).toBe('[DONE]');
+
+    // Never emit two finish/terminal chunks.
+    const terminalChunks = chunks.filter(
+      (c) => c !== '[DONE]' && (c.error || c.choices?.[0]?.finish_reason)
+    );
+    expect(terminalChunks).toHaveLength(1);
+  });
+
+  test('falls back to a neutral generic error code when the upstream error carries none', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_4b',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 500,
+          message: 'Something went wrong upstream with no code attached.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.code).toBe('upstream_error');
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('preserves existing behavior: MALFORMED_FUNCTION_CALL errors keep their exact code and still suppress [DONE]', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_5',
+        model: 'gemini-3.6-flash',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 503,
+          code: GEMINI_MALFORMED_FUNCTION_CALL_CODE,
+          message: 'Upstream Gemini returned MALFORMED_FUNCTION_CALL — please retry your request.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    expect(chunks).not.toContain('[DONE]');
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    // Unchanged legacy rendering — NOT the raw `MALFORMED_FUNCTION_CALL` code.
+    expect(errorChunk.error.code).toBe('upstream_malformed_function_call');
+  });
+
+  test('closes the door after an error-channel length finish: a stray chunk afterward produces no second terminal payload', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_6',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_6',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'length',
+        error: {
+          statusCode: 500,
+          code: 'max_output_tokens',
+          message: 'Response ended incomplete: max_output_tokens',
+        },
+      },
+      // Stray/duplicate chunk arriving after the terminal signal (e.g. a
+      // late or duplicated upstream error) must never reach the client.
+      {
+        id: 'chatcmpl_6',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 500,
+          code: 'response_failed',
+          message: 'This must never reach the client.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const terminalChunks = chunks.filter(
+      (c) => c !== '[DONE]' && (c.error || c.choices?.[0]?.finish_reason)
+    );
+    expect(terminalChunks).toHaveLength(1);
+    expect(terminalChunks[0].choices?.[0]?.finish_reason).toBe('length');
+    expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
+
+    const doneCount = chunks.filter((c) => c === '[DONE]').length;
+    expect(doneCount).toBe(1);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('round-trips a raw stream_options.include_usage fixture: content, one finish, one usage, one [DONE]', async () => {
+    // Mirrors the real OpenAI-compatible wire shape Plexus itself requests
+    // for Copilot-native streaming (services/oauth/oauth-native-request.ts
+    // `adornCopilotBody`): a trailing `{choices: [], usage: {...}}` frame
+    // arrives AFTER the real finish chunk.
+    const rawSSE = [
+      JSON.stringify({
+        id: 'chatcmpl-abc',
+        model: 'gpt-4o',
+        created: 1234567890,
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'Hi' }, finish_reason: null }],
+      }),
+      JSON.stringify({
+        id: 'chatcmpl-abc',
+        model: 'gpt-4o',
+        created: 1234567890,
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      }),
+      JSON.stringify({
+        id: 'chatcmpl-abc',
+        model: 'gpt-4o',
+        created: 1234567890,
+        choices: [],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }),
+    ];
+
+    const rawStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const line of rawSSE) {
+          controller.enqueue(encoder.encode(`data: ${line}\n\n`));
+        }
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.close();
+      },
+    });
+
+    const transformer = new OpenAITransformer();
+    const unifiedStream = transformer.transformStream(rawStream);
+    const formatted = transformer.formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const contentChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.delta?.content === 'Hi'
+    );
+    expect(contentChunk).toBeDefined();
+
+    const finishChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason);
+    expect(finishChunks).toHaveLength(1);
+    expect(finishChunks[0].choices[0].finish_reason).toBe('stop');
+
+    const usageChunks = chunks.filter((c) => c !== '[DONE]' && c.usage);
+    expect(usageChunks).toHaveLength(1);
+    expect(usageChunks[0].choices).toEqual([]);
+    expect(usageChunks[0].usage.total_tokens).toBe(15);
+
+    expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
+    expect(chunks.filter((c) => c === '[DONE]')).toHaveLength(1);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('propagates usage on a recognizable finish (error-channel, e.g. Responses incomplete/content_filter)', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_cf',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_cf',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'content_filter',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+          reasoning_tokens: 0,
+          cached_tokens: 0,
+          cache_creation_tokens: 0,
+        },
+        error: {
+          statusCode: 500,
+          code: 'content_filter',
+          message: 'Response ended incomplete: content_filter',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const finishChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'content_filter'
+    );
+    expect(finishChunk).toBeDefined();
+    expect(finishChunk.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+      prompt_tokens_details: null,
+      reasoning_tokens: 0,
+    });
+  });
+
+  test('propagates usage on a hard error chunk (e.g. Responses response.failed)', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_failusage',
+        model: 'gpt-4o',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_failusage',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        usage: {
+          input_tokens: 20,
+          output_tokens: 8,
+          total_tokens: 28,
+          reasoning_tokens: 0,
+          cached_tokens: 0,
+          cache_creation_tokens: 0,
+        },
+        error: {
+          statusCode: 500,
+          code: 'response_failed',
+          message: 'The model response failed.',
+        },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage.total_tokens).toBe(28);
+  });
+
+  test('does not add a usage field to a hard error chunk when the unified chunk carries none', async () => {
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_nousage',
+        model: 'gpt-4o',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: { statusCode: 500, code: 'response_failed', message: 'The model response failed.' },
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage).toBeUndefined();
+  });
+
+  test('a Gemini trailing done-marker chunk after a normal finish is dropped harmlessly (no crash, no extra terminal payload)', async () => {
+    // Gemini's transformStream always emits a `{event: 'done', delta: {}}`
+    // marker chunk when it sees the raw `[DONE]` sentinel, even after a
+    // normal finish. It carries no usage, so it must NOT hit the new
+    // trailing-usage-passthrough lane — it should simply be dropped, exactly
+    // as it already was.
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_7',
+        model: 'gemini-3.1-flash',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'Hi' },
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_7',
+        model: 'gemini-3.1-flash',
+        created: 1234567890,
+        delta: {},
+        finish_reason: 'stop',
+      },
+      {
+        id: '',
+        model: '',
+        created: 1234567890,
+        event: 'done',
+        delta: {},
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const finishChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason);
+    expect(finishChunks).toHaveLength(1);
+    expect(chunks.some((c) => c !== '[DONE]' && c.usage)).toBe(false);
+    expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
+    expect(chunks.filter((c) => c === '[DONE]')).toHaveLength(1);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+});

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeCompositeResponsesCallIds,
   normalizeResponsesReasoningContent,
 } from '../responses';
+import { OpenAITransformer } from '../openai';
 
 /**
  * Round-trip tests for the Responses API transformer.
@@ -353,12 +354,109 @@ describe('parseRequest conditional-spread hygiene (omitted fields leave no own p
     ]);
   });
 
+  it('a present text.format still forwards as response_format (lock one example)', async () => {
+    const transformer = new ResponsesTransformer();
+    const unified = await transformer.parseRequest({
+      ...MINIMAL_REQUEST,
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'result',
+          schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+        },
+      },
+    });
+
+    expect('response_format' in unified).toBe(true);
+    expect(unified.response_format).toEqual({
+      type: 'json_schema',
+      json_schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+      name: 'result',
+    });
+  });
+
   it('an explicit stream:false still forwards as a real own property', async () => {
     const transformer = new ResponsesTransformer();
     const unified = await transformer.parseRequest({ ...MINIMAL_REQUEST, stream: false });
 
     expect('stream' in unified).toBe(true);
     expect(unified.stream).toBe(false);
+  });
+
+  describe('structured-output descriptor carry (text.format name/description/strict)', () => {
+    // The Responses `text.format` structured-output descriptor is more than
+    // the schema: clients also send `name`, `description`, and `strict`.
+    // Discarding them forces the responses -> chat emission to fabricate
+    // `name: "response_schema"` / `strict: true`, silently overriding what
+    // the client asked for (e.g. strict: false).
+    const DESCRIPTOR_REQUEST = {
+      ...MINIMAL_REQUEST,
+      text: {
+        format: {
+          type: 'json_schema',
+          name: 'weather_report',
+          description: 'A structured weather report',
+          strict: false,
+          schema: { type: 'object', properties: { temp: { type: 'number' } } },
+        },
+      },
+    };
+
+    it('parseRequest carries name/description/strict on the unified response_format', async () => {
+      const unified = await new ResponsesTransformer().parseRequest(DESCRIPTOR_REQUEST);
+
+      expect(unified.response_format).toEqual({
+        type: 'json_schema',
+        json_schema: { type: 'object', properties: { temp: { type: 'number' } } },
+        name: 'weather_report',
+        description: 'A structured weather report',
+        strict: false,
+      });
+    });
+
+    it('the outbound Chat payload emits the client-supplied descriptor values (responses -> chat)', async () => {
+      const unified = await new ResponsesTransformer().parseRequest(DESCRIPTOR_REQUEST);
+      const chatPayload = await new OpenAITransformer().transformRequest(unified);
+
+      expect(chatPayload.response_format).toEqual({
+        type: 'json_schema',
+        json_schema: {
+          name: 'weather_report',
+          description: 'A structured weather report',
+          schema: { type: 'object', properties: { temp: { type: 'number' } } },
+          strict: false,
+        },
+      });
+    });
+
+    it('fallbacks apply ONLY when the client omitted the descriptor fields', async () => {
+      const unified = await new ResponsesTransformer().parseRequest({
+        ...MINIMAL_REQUEST,
+        text: {
+          format: {
+            type: 'json_schema',
+            schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+          },
+        },
+      });
+      const chatPayload = await new OpenAITransformer().transformRequest(unified);
+
+      expect(chatPayload.response_format).toEqual({
+        type: 'json_schema',
+        json_schema: {
+          name: 'response_schema',
+          schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+          strict: true,
+        },
+      });
+    });
+
+    it('strict: false survives to the outbound chat payload (must not be clobbered to true)', async () => {
+      const unified = await new ResponsesTransformer().parseRequest(DESCRIPTOR_REQUEST);
+      const chatPayload = await new OpenAITransformer().transformRequest(unified);
+
+      expect(chatPayload.response_format.json_schema.strict).toBe(false);
+    });
   });
 
   it('explicit values still forward (spot-check stream, max_output_tokens, metadata)', async () => {

--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { ResponsesTransformer } from '../responses';
+import { OpenAITransformer } from '../openai';
 
 async function transformEvents(events: Record<string, unknown>[]): Promise<any[]> {
   const encoder = new TextEncoder();
@@ -179,5 +180,642 @@ describe('ResponsesTransformer stream transformation', () => {
     ]);
 
     expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('tool_calls');
+  });
+});
+
+describe('ResponsesTransformer stream transformation - error handling', () => {
+  test('maps response.failed to a unified error chunk instead of dropping it', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_1', model: 'gpt-5', created_at: 1234567890 },
+      },
+      {
+        type: 'response.failed',
+        response: {
+          id: 'resp_1',
+          status: 'failed',
+          error: { code: 'server_error', message: 'The model encountered an error.' },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.message).toBe('The model encountered an error.');
+    // No phantom success finish should accompany a failure.
+    expect(chunks.some((chunk) => chunk.finish_reason === 'stop')).toBe(false);
+  });
+
+  test('maps response.incomplete (max_output_tokens) to a unified error chunk carrying a length finish hint and incomplete_details', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_2', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Partial output' },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_2',
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.finish_reason).toBe('length');
+    expect(errorChunk.error.code).toBe('max_output_tokens');
+    expect(errorChunk.incomplete_details).toEqual({ reason: 'max_output_tokens' });
+  });
+
+  test('maps response.incomplete (content_filter) to a unified error chunk carrying a content_filter finish hint and incomplete_details', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_cf', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Partial' },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_cf',
+          status: 'incomplete',
+          incomplete_details: { reason: 'content_filter' },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.finish_reason).toBe('content_filter');
+    expect(errorChunk.error.code).toBe('content_filter');
+    expect(errorChunk.incomplete_details).toEqual({ reason: 'content_filter' });
+  });
+
+  test('defaults incomplete_details to reason "unknown" (finish hint "length") when upstream response.incomplete carries none', async () => {
+    // Some upstreams emit response.incomplete with no incomplete_details at
+    // all. The unified chunk must still carry BOTH markers of an "ended
+    // incomplete" outcome — incomplete_details (what the responses-facing
+    // formatStream keys response.incomplete emission on) and an
+    // OpenAI-compatible finish hint ('length': the same
+    // everything-but-content_filter default as usage-logging's raw-mode
+    // incomplete mapping) — otherwise downstream renders the event as a
+    // hard failure.
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_nodetails', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Partial' },
+      {
+        type: 'response.incomplete',
+        response: { id: 'resp_nodetails', status: 'incomplete' },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.incomplete_details).toEqual({ reason: 'unknown' });
+    expect(errorChunk.finish_reason).toBe('length');
+    expect(errorChunk.error.code).toBe('unknown');
+  });
+
+  test('propagates response.usage on response.failed into the unified error chunk', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_failusage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      {
+        type: 'response.failed',
+        response: {
+          id: 'resp_failusage',
+          status: 'failed',
+          error: { code: 'server_error', message: 'boom' },
+          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage).toEqual(
+      expect.objectContaining({ input_tokens: 10, output_tokens: 5, total_tokens: 15 })
+    );
+  });
+
+  test('propagates response.usage on response.incomplete into the unified error chunk', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_incompleteusage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_incompleteusage',
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+          usage: { input_tokens: 20, output_tokens: 8, total_tokens: 28 },
+        },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage).toEqual(
+      expect.objectContaining({ input_tokens: 20, output_tokens: 8, total_tokens: 28 })
+    );
+  });
+
+  test('does not attach a usage field when response.failed/response.incomplete carry none', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_nousage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      {
+        type: 'response.failed',
+        response: { id: 'resp_nousage', status: 'failed', error: { message: 'boom' } },
+      },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.usage).toBeUndefined();
+  });
+
+  test('maps a generic top-level error event to a unified error chunk', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_3', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'error', code: 'server_error', message: 'boom' },
+    ]);
+
+    const errorChunk = chunks.find((chunk) => chunk.event === 'error');
+    expect(errorChunk).toBeDefined();
+    expect(errorChunk.error.message).toBe('boom');
+  });
+});
+
+describe('ResponsesTransformer formatStream - error handling (client-facing)', () => {
+  function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
+    return new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+  }
+
+  async function collectFormatStreamEvents(chunks: any[]): Promise<any[]> {
+    const reader = new ResponsesTransformer()
+      .formatStream(unifiedStreamFromChunks(chunks))
+      .getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+    return output
+      .split('\n\n')
+      .filter((block) => block.trim().length > 0)
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        return JSON.parse((dataLine as string).replace(/^data:\s*/, ''));
+      });
+  }
+
+  test('emits response.failed (not response.completed) when a unified error chunk arrives', async () => {
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_err_1',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_err_1',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: {
+          statusCode: 500,
+          code: 'server_error',
+          message: 'The model encountered an error.',
+        },
+      },
+    ]);
+
+    expect(events.some((e) => e.type === 'response.completed')).toBe(false);
+    const failedEvent = events.find((e) => e.type === 'response.failed');
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.response.status).toBe('failed');
+    expect(failedEvent.response.error.message).toBe('The model encountered an error.');
+  });
+
+  test('surfaces response.incomplete (not response.failed) when the unified chunk carries incomplete_details', async () => {
+    // A hard failure (no incomplete_details) still becomes response.failed —
+    // see the test above. When transformStream marked this as an "ended
+    // incomplete" outcome (incomplete_details present), the Responses-facing
+    // client must see the more specific response.incomplete event, not a
+    // generic hard failure.
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_err_2',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial output' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_err_2',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'length',
+        incomplete_details: { reason: 'max_output_tokens' },
+        error: {
+          statusCode: 500,
+          code: 'max_output_tokens',
+          message: 'Response ended incomplete: max_output_tokens',
+        },
+      },
+    ]);
+
+    expect(events.some((e) => e.type === 'response.completed')).toBe(false);
+    expect(events.some((e) => e.type === 'response.failed')).toBe(false);
+    const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
+    expect(incompleteEvent).toBeDefined();
+    expect(incompleteEvent.response.status).toBe('incomplete');
+    expect(incompleteEvent.response.incomplete_details).toEqual({ reason: 'max_output_tokens' });
+    expect(incompleteEvent.response.output?.[0]?.content?.[0]?.text).toBe('partial output');
+  });
+
+  test('emits response.incomplete (content_filter) with incomplete_details and usage for a Responses-format client', async () => {
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_err_cf',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_err_cf',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'content_filter',
+        incomplete_details: { reason: 'content_filter' },
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+          reasoning_tokens: 0,
+          cached_tokens: 0,
+          cache_creation_tokens: 0,
+        },
+        error: {
+          statusCode: 500,
+          code: 'content_filter',
+          message: 'Response ended incomplete: content_filter',
+        },
+      },
+    ]);
+
+    expect(events.some((e) => e.type === 'response.failed')).toBe(false);
+    const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
+    expect(incompleteEvent).toBeDefined();
+    expect(incompleteEvent.response.status).toBe('incomplete');
+    expect(incompleteEvent.response.incomplete_details).toEqual({ reason: 'content_filter' });
+    expect(incompleteEvent.response.usage.total_tokens).toBe(15);
+  });
+
+  test('a detail-less upstream response.incomplete still reaches a Responses client as response.incomplete (reason "unknown"), not response.failed', async () => {
+    // Full pipeline (transformStream -> formatStream): when the upstream
+    // omits incomplete_details entirely, the defaulted { reason: 'unknown' }
+    // must keep the event on the incomplete path — without the default, the
+    // missing field made formatStream downgrade the outcome to a hard
+    // response.failed.
+    const unified = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_nodetails_rt', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'partial output' },
+      {
+        type: 'response.incomplete',
+        response: { id: 'resp_nodetails_rt', status: 'incomplete' },
+      },
+    ]);
+    const events = await collectFormatStreamEvents(unified);
+
+    expect(events.some((e) => e.type === 'response.failed')).toBe(false);
+    const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
+    expect(incompleteEvent).toBeDefined();
+    expect(incompleteEvent.response.status).toBe('incomplete');
+    expect(incompleteEvent.response.incomplete_details).toEqual({ reason: 'unknown' });
+    expect(incompleteEvent.response.output?.[0]?.content?.[0]?.text).toBe('partial output');
+  });
+
+  test('a detail-less upstream response.incomplete reaches a CHAT client as a normal "length" finish, not an error payload', async () => {
+    // Full pipeline (transformStream -> OpenAI formatStream): the defaulted
+    // finish hint ('length') must make the chat-facing formatter render the
+    // detail-less incomplete as an ordinary finish — the same rendering
+    // known-reason (max_output_tokens) incompletes already get — instead of
+    // the hard-error payload it produced when finish_reason was absent.
+    const unified = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_nodetails_chat', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'partial output' },
+      {
+        type: 'response.incomplete',
+        response: { id: 'resp_nodetails_chat', status: 'incomplete' },
+      },
+    ]);
+
+    const reader = new OpenAITransformer()
+      .formatStream(unifiedStreamFromChunks(unified))
+      .getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+    const chunks = output
+      .split('\n\n')
+      .filter((block) => block.trim().length > 0)
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        const payload = (dataLine as string).replace(/^data:\s*/, '');
+        return payload === '[DONE]' ? '[DONE]' : JSON.parse(payload);
+      });
+
+    expect(chunks.some((chunk) => chunk !== '[DONE]' && chunk.error)).toBe(false);
+    const finishChunk = chunks.find(
+      (chunk) => chunk !== '[DONE]' && chunk.choices?.[0]?.finish_reason
+    );
+    expect(finishChunk).toBeDefined();
+    expect(finishChunk.choices[0].finish_reason).toBe('length');
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('marks still-in-progress output items status "incomplete" when emitting response.incomplete', async () => {
+    // Everything that was mid-stream when the upstream ended incomplete —
+    // the reasoning item, the message item, and the tool call — was never
+    // finished, so the finalized items must carry status 'incomplete', not a
+    // fabricated 'completed'.
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_inc_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', reasoning_content: 'thinking...' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_inc_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { content: 'partial output' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_inc_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'lookup', arguments: '{"q":' },
+            },
+          ],
+        },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_inc_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        finish_reason: 'length',
+        incomplete_details: { reason: 'max_output_tokens' },
+        error: {
+          statusCode: 500,
+          code: 'max_output_tokens',
+          message: 'Response ended incomplete: max_output_tokens',
+        },
+      },
+    ]);
+
+    const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
+    expect(incompleteEvent).toBeDefined();
+    const outputItems = incompleteEvent.response.output;
+    expect(outputItems.map((item: any) => item.type).sort()).toEqual([
+      'function_call',
+      'message',
+      'reasoning',
+    ]);
+    for (const item of outputItems) {
+      expect(item.status).toBe('incomplete');
+    }
+
+    // The finalization output_item.done events on this path carry the same
+    // item-level status as the final response.incomplete output array.
+    const doneEvents = events.filter((e) => e.type === 'response.output_item.done');
+    expect(doneEvents.length).toBe(3);
+    for (const done of doneEvents) {
+      expect(done.item.status).toBe('incomplete');
+    }
+  });
+
+  test('response.failed finalization keeps item statuses unchanged (completed)', async () => {
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_failed_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_failed_items',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: { statusCode: 500, code: 'server_error', message: 'boom' },
+      },
+    ]);
+
+    const failedEvent = events.find((e) => e.type === 'response.failed');
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.response.output).toHaveLength(1);
+    expect(failedEvent.response.output[0].status).toBe('completed');
+  });
+
+  test('keeps emitting response.failed exactly as before for a genuine hard error (no incomplete_details)', async () => {
+    const events = await collectFormatStreamEvents([
+      {
+        id: 'resp_hard_err',
+        model: 'gpt-5',
+        created: 1234567890,
+        delta: { role: 'assistant', content: 'partial' },
+        finish_reason: null,
+      },
+      {
+        id: 'resp_hard_err',
+        model: 'gpt-5',
+        created: 1234567890,
+        event: 'error',
+        delta: {},
+        error: { statusCode: 500, code: 'server_error', message: 'The model response failed.' },
+      },
+    ]);
+
+    expect(events.some((e) => e.type === 'response.incomplete')).toBe(false);
+    const failedEvent = events.find((e) => e.type === 'response.failed');
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.response.status).toBe('failed');
+  });
+});
+
+describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream (cross-format)', () => {
+  // Proves the fix cross-format, not just within ResponsesTransformer: a
+  // Responses-API UPSTREAM feeding a CHAT-format client (e.g. the client
+  // sent Chat Completions but got routed to a Responses-API provider) must
+  // still see the mapped finish reason and the propagated usage.
+  async function transformAndFormatAsChat(events: Record<string, unknown>[]): Promise<any[]> {
+    const encoder = new TextEncoder();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(
+            encoder.encode(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+          );
+        }
+        controller.close();
+      },
+    });
+
+    const unifiedStream = new ResponsesTransformer().transformStream(source);
+    const chatStream = new OpenAITransformer().formatStream(unifiedStream);
+
+    const reader = chatStream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    return buffer
+      .split('\n\n')
+      .map((block) => block.trim())
+      .filter(Boolean)
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        const data = (dataLine as string).replace(/^data:\s*/, '');
+        return data === '[DONE]' ? '[DONE]' : JSON.parse(data);
+      });
+  }
+
+  test('response.incomplete (content_filter) surfaces as a chat finish_reason "content_filter"', async () => {
+    const chunks = await transformAndFormatAsChat([
+      {
+        type: 'response.created',
+        response: { id: 'resp_cf_chat', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'Partial' },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_cf_chat',
+          status: 'incomplete',
+          incomplete_details: { reason: 'content_filter' },
+        },
+      },
+    ]);
+
+    const finishChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'content_filter'
+    );
+    expect(finishChunk).toBeDefined();
+    // A recognized non-fatal finish must NOT be rendered as an error payload.
+    expect(chunks.some((c) => c !== '[DONE]' && c.error)).toBe(false);
+    expect(chunks.at(-1)).toBe('[DONE]');
+  });
+
+  test('response.failed carrying usage propagates that usage to the chat client', async () => {
+    const chunks = await transformAndFormatAsChat([
+      {
+        type: 'response.created',
+        response: { id: 'resp_fail_usage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'partial' },
+      {
+        type: 'response.failed',
+        response: {
+          id: 'resp_fail_usage',
+          status: 'failed',
+          error: { code: 'server_error', message: 'boom' },
+          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        },
+      },
+    ]);
+
+    const usageChunk = chunks.find((c) => c !== '[DONE]' && c.usage);
+    expect(usageChunk).toBeDefined();
+    expect(usageChunk.usage.prompt_tokens).toBe(10);
+    expect(usageChunk.usage.completion_tokens).toBe(5);
+    expect(usageChunk.usage.total_tokens).toBe(15);
+    // Still rendered as an error (this was a hard failure, not an incomplete).
+    const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
+    expect(errorChunk).toBeDefined();
+  });
+
+  test('response.incomplete carrying usage propagates that usage to the chat client alongside the finish_reason', async () => {
+    const chunks = await transformAndFormatAsChat([
+      {
+        type: 'response.created',
+        response: { id: 'resp_incomplete_usage', model: 'gpt-5', created_at: 1234567890 },
+      },
+      { type: 'response.output_text.delta', delta: 'partial' },
+      {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_incomplete_usage',
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+          usage: { input_tokens: 7, output_tokens: 3, total_tokens: 10 },
+        },
+      },
+    ]);
+
+    const finishChunk = chunks.find(
+      (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'length'
+    );
+    expect(finishChunk).toBeDefined();
+    expect(finishChunk.usage.total_tokens).toBe(10);
   });
 });

--- a/packages/backend/src/transformers/anthropic/stream-transformer.ts
+++ b/packages/backend/src/transformers/anthropic/stream-transformer.ts
@@ -166,6 +166,25 @@ export function transformAnthropicStream(stream: ReadableStream): ReadableStream
                     : undefined,
                 };
                 break;
+
+              case 'error':
+                // Anthropic mid-stream error event: `{"type":"error","error":{"type":"...","message":"..."}}`.
+                // Surface it as a unified error chunk (same shape
+                // OpenAITransformer.formatStream already renders) instead of
+                // silently dropping it and truncating the client stream.
+                unifiedChunk = {
+                  id: messageId,
+                  model: model,
+                  created: Math.floor(Date.now() / 1000),
+                  event: 'error',
+                  delta: {},
+                  error: {
+                    statusCode: 500,
+                    code: data.error?.type || 'error',
+                    message: data.error?.message || 'Upstream error',
+                  },
+                };
+                break;
             }
 
             if (unifiedChunk) {

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -3,6 +3,7 @@ import { UnifiedChatRequest, UnifiedChatResponse } from '../types/unified';
 import { createParser, EventSourceMessage } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { normalizeOpenAIChatUsage } from '../utils/usage-normalizer';
+import { GEMINI_MALFORMED_FUNCTION_CALL_CODE } from '../utils/gemini-malformed-function-call';
 
 /**
  * OpenAITransformer
@@ -106,13 +107,21 @@ export class OpenAITransformer implements Transformer {
 
     if (request.response_format) {
       if (request.response_format.type === 'json_schema' && request.response_format.json_schema) {
-        // OpenAI json_schema mode requires {name, schema, strict} wrapping
+        // OpenAI json_schema mode requires {name, schema, strict} wrapping.
+        // The client-supplied descriptor (carried on the unified
+        // response_format — see types/unified.ts) wins; the fabricated
+        // `response_schema` / `strict: true` values are fallbacks ONLY for
+        // clients that omitted them (`?? `— an explicit strict: false must
+        // survive).
         out.response_format = {
           type: 'json_schema',
           json_schema: {
-            name: 'response_schema',
+            name: request.response_format.name ?? 'response_schema',
+            ...(request.response_format.description !== undefined
+              ? { description: request.response_format.description }
+              : {}),
             schema: request.response_format.json_schema,
-            strict: true,
+            strict: request.response_format.strict ?? true,
           },
         };
       } else {
@@ -247,6 +256,47 @@ export class OpenAITransformer implements Transformer {
     const encoder = new TextEncoder();
     const reader = stream.getReader();
     let hasSentError = false;
+    // Only the legacy Gemini MALFORMED_FUNCTION_CALL defect (a transient,
+    // retry-worthy signal — see utils/gemini-malformed-function-call.ts)
+    // intentionally ends the stream WITHOUT `[DONE]`, so it reads as an
+    // aborted stream rather than a clean finish. Any other upstream error
+    // (Anthropic mid-stream error, Responses response.failed/error) is a
+    // genuine terminal condition and should still close cleanly with
+    // `[DONE]` so OpenAI-compatible clients don't hang waiting for one.
+    let suppressDone = false;
+    // Tracks whether any terminal signal (a real finish_reason chunk, an
+    // error chunk rendered as a normal finish, or the hard-error JSON
+    // payload) has already reached the client, so the end-of-stream flush
+    // below never synthesizes a redundant one.
+    let hasSentFinish = false;
+    // Some OpenAI-compatible upstreams (and Plexus itself, for Copilot-native
+    // streaming — see services/oauth/oauth-native-request.ts) request
+    // `stream_options.include_usage`, which sends a trailing
+    // `{choices: [], usage: {...}}` frame AFTER the real finish chunk.
+    // transformStream has no real choice to read there, so it can't tell
+    // that frame apart from a genuinely empty/terminal chunk — this flag lets
+    // exactly one such trailing usage frame still reach the client even
+    // though a terminal signal was already sent, without reopening the door
+    // for a second finish_reason or error chunk.
+    let hasForwardedTrailingUsage = false;
+    let lastChunkId: string | undefined;
+    let lastChunkModel: string | undefined;
+
+    const isEmptyDelta = (delta: any): boolean =>
+      !delta || (!delta.role && !delta.content && !delta.reasoning_content && !delta.tool_calls);
+
+    const buildChatUsagePayload = (usage: any) =>
+      usage
+        ? {
+            prompt_tokens: usage.input_tokens + (usage.cached_tokens || 0),
+            completion_tokens: usage.output_tokens,
+            total_tokens: usage.total_tokens,
+            prompt_tokens_details: usage.cached_tokens
+              ? { cached_tokens: usage.cached_tokens }
+              : null,
+            reasoning_tokens: usage.reasoning_tokens,
+          }
+        : undefined;
 
     return new ReadableStream({
       async start(controller) {
@@ -254,7 +304,36 @@ export class OpenAITransformer implements Transformer {
           while (true) {
             const { done, value: unifiedChunk } = await reader.read();
             if (done) {
-              if (!hasSentError) {
+              if (!hasSentFinish) {
+                // Source ended without ever emitting a finish_reason
+                // (upstream aborted, error dropped upstream of us, or zero
+                // parsable events): synthesize one so OpenAI-compatible
+                // clients never see a stream with no stop chunk.
+                //
+                // With ZERO parsable chunks there is no upstream id to echo,
+                // so synthesize one (this file has no id-generation
+                // convention of its own; `chatcmpl_` matches the OpenAI wire
+                // prefix). No `model` is synthesized in that case: this
+                // formatter's only input is the unified chunk stream itself
+                // — it has no request context — so when no chunk ever
+                // arrived the model is genuinely unknowable here, and the
+                // field is omitted (JSON drops the undefined) rather than
+                // fabricated.
+                controller.enqueue(
+                  encoder.encode(
+                    encode({
+                      data: JSON.stringify({
+                        id: lastChunkId ?? `chatcmpl_${crypto.randomUUID()}`,
+                        object: 'chat.completion.chunk',
+                        created: Math.floor(Date.now() / 1000),
+                        model: lastChunkModel,
+                        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+                      }),
+                    })
+                  )
+                );
+              }
+              if (!suppressDone) {
                 controller.enqueue(encoder.encode(encode({ data: '[DONE]' })));
               }
               break;
@@ -262,7 +341,95 @@ export class OpenAITransformer implements Transformer {
 
             if (hasSentError) continue;
 
+            lastChunkId = unifiedChunk.id ?? lastChunkId;
+            lastChunkModel = unifiedChunk.model ?? lastChunkModel;
+
+            // Once any terminal signal has been rendered — a hard-error
+            // payload OR an error-channel chunk rendered as a normal finish
+            // (e.g. the `length` case below) — close the door on everything
+            // else so a stray/duplicate chunk can never produce a second
+            // terminal payload. Mirrors the unconditional single-latch
+            // pattern used by the sibling formatters (formatAnthropicStream's
+            // `hasSentFinish` guard, formatGeminiStream's `hasSentError`
+            // guard). The one carved-out exception is a single trailing
+            // usage-only frame (see `hasForwardedTrailingUsage` above):
+            // rendered without a finish_reason (whatever transformStream put
+            // there, fabricated or not, is ignored) since it is metadata, not
+            // a second finish.
+            if (hasSentFinish) {
+              const isTrailingUsageOnly =
+                !hasForwardedTrailingUsage &&
+                unifiedChunk.event !== 'error' &&
+                !!unifiedChunk.usage &&
+                isEmptyDelta(unifiedChunk.delta);
+
+              if (!isTrailingUsageOnly) continue;
+
+              hasForwardedTrailingUsage = true;
+              const usagePayload = buildChatUsagePayload(unifiedChunk.usage);
+              controller.enqueue(
+                encoder.encode(
+                  encode({
+                    data: JSON.stringify({
+                      id: unifiedChunk.id,
+                      object: 'chat.completion.chunk',
+                      created: unifiedChunk.created || Math.floor(Date.now() / 1000),
+                      model: unifiedChunk.model,
+                      choices: [],
+                      ...(usagePayload ? { usage: usagePayload } : {}),
+                    }),
+                  })
+                )
+              );
+              continue;
+            }
+
             if (unifiedChunk.event === 'error') {
+              if (unifiedChunk.finish_reason) {
+                // A recognizable, non-fatal finish (e.g. Responses
+                // `response.incomplete` with reason `max_output_tokens` or
+                // `content_filter`) was carried through the error-chunk
+                // channel; render it as a normal finish instead of an error
+                // payload. Forward any final usage the upstream attached to
+                // this same chunk (see responses.ts transformStream) using
+                // the same usage-shaping helper as everywhere else in this
+                // file, so chat-format clients still receive it.
+                const usagePayload = buildChatUsagePayload(unifiedChunk.usage);
+                controller.enqueue(
+                  encoder.encode(
+                    encode({
+                      data: JSON.stringify({
+                        id: unifiedChunk.id,
+                        object: 'chat.completion.chunk',
+                        created: unifiedChunk.created || Math.floor(Date.now() / 1000),
+                        model: unifiedChunk.model,
+                        choices: [
+                          { index: 0, delta: {}, finish_reason: unifiedChunk.finish_reason },
+                        ],
+                        ...(usagePayload ? { usage: usagePayload } : {}),
+                      }),
+                    })
+                  )
+                );
+                hasSentFinish = true;
+                continue;
+              }
+
+              // The legacy Gemini MALFORMED_FUNCTION_CALL defect keeps its
+              // existing, specific rendering (downstream/clients may already
+              // key off this exact code) and its [DONE]-suppression. Any
+              // other hard error (Anthropic mid-stream error, Responses
+              // response.failed/error, or anything else routed through this
+              // channel) propagates its own upstream code instead of being
+              // mislabeled with Gemini's — falling back to a neutral generic
+              // only when the upstream genuinely didn't supply one.
+              const isLegacyGeminiMalformedCall =
+                unifiedChunk.error?.code === GEMINI_MALFORMED_FUNCTION_CALL_CODE;
+              // Same final-usage forwarding as the recognizable-finish
+              // branch above — a hard failure (e.g. Responses
+              // response.failed) can still carry final usage.
+              const usagePayload = buildChatUsagePayload(unifiedChunk.usage);
+
               controller.enqueue(
                 encoder.encode(
                   encode({
@@ -270,14 +437,25 @@ export class OpenAITransformer implements Transformer {
                       error: {
                         message: unifiedChunk.error?.message,
                         type: 'server_error',
-                        code: 'upstream_malformed_function_call',
+                        code: isLegacyGeminiMalformedCall
+                          ? 'upstream_malformed_function_call'
+                          : unifiedChunk.error?.code || 'upstream_error',
                       },
+                      ...(usagePayload ? { usage: usagePayload } : {}),
                     }),
                   })
                 )
               );
               hasSentError = true;
+              hasSentFinish = true;
+              if (isLegacyGeminiMalformedCall) {
+                suppressDone = true;
+              }
               continue;
+            }
+
+            if (unifiedChunk.finish_reason) {
+              hasSentFinish = true;
             }
 
             const choice: any = {

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -181,6 +181,17 @@ export class ResponsesTransformer implements Transformer {
             response_format: {
               type: input.text.format.type,
               json_schema: input.text.format.schema,
+              // Carry the full structured-output descriptor: dropping
+              // name/description/strict would force the responses -> chat
+              // emission to fabricate `name: "response_schema"` /
+              // `strict: true` over the client-supplied values.
+              ...(input.text.format.name !== undefined ? { name: input.text.format.name } : {}),
+              ...(input.text.format.description !== undefined
+                ? { description: input.text.format.description }
+                : {}),
+              ...(input.text.format.strict !== undefined
+                ? { strict: input.text.format.strict }
+                : {}),
             },
           }
         : {}),
@@ -1092,6 +1103,86 @@ export class ResponsesTransformer implements Transformer {
                     hasFunctionCall || completedResponseHasFunctionCall ? 'tool_calls' : 'stop',
                   usage: normalizedUsage,
                 });
+              } else if (data.type === 'response.failed') {
+                // Upstream reported a hard failure mid-stream. Surface it as
+                // a unified error chunk (same shape OpenAITransformer.formatStream
+                // already renders) instead of silently ending the stream.
+                // Propagate final usage (when the upstream included it
+                // alongside the failure) so chat-format clients still
+                // receive an accurate token count for the turn instead of
+                // silently losing it.
+                const err = data.response?.error || {};
+                const usage = data.response?.usage;
+                const normalizedUsage = usage ? normalizeOpenAIResponsesUsage(usage) : undefined;
+                controller.enqueue({
+                  id: responseId || data.response?.id || '',
+                  model: responseModel || data.response?.model || '',
+                  created: Math.floor(Date.now() / 1000),
+                  event: 'error',
+                  delta: {},
+                  error: {
+                    statusCode: 500,
+                    code: err.code || 'response_failed',
+                    message: err.message || 'The model response failed to complete.',
+                  },
+                  ...(normalizedUsage ? { usage: normalizedUsage } : {}),
+                });
+              } else if (data.type === 'response.incomplete') {
+                // Upstream ended the response early (e.g. hitting
+                // max_output_tokens, or a content_filter cutoff) rather than
+                // failing outright. Carry both the OpenAI-compatible finish
+                // reason AND the raw incomplete_details on the unified chunk
+                // — formatStream (both chat- and responses-facing) needs
+                // incomplete_details to tell an "ended incomplete" chunk
+                // apart from a genuine response.failed hard error. When the
+                // upstream omits incomplete_details entirely, default to
+                // { reason: 'unknown' } so the chunk still reads as an
+                // incomplete (not a hard failure) downstream. Also propagate
+                // final usage, same as response.failed above.
+                const incompleteDetails = data.response?.incomplete_details ?? {
+                  reason: 'unknown',
+                };
+                const reason = incompleteDetails.reason || 'unknown';
+                const usage = data.response?.usage;
+                const normalizedUsage = usage ? normalizeOpenAIResponsesUsage(usage) : undefined;
+                controller.enqueue({
+                  id: responseId || data.response?.id || '',
+                  model: responseModel || data.response?.model || '',
+                  created: Math.floor(Date.now() / 1000),
+                  event: 'error',
+                  delta: {},
+                  // 'content_filter' keeps its own finish reason; everything
+                  // else (max_output_tokens, unknown/absent reasons) maps to
+                  // 'length' — the same OpenAI-compatible default as
+                  // usage-logging's raw-mode incomplete mapping — so every
+                  // incomplete chunk carries a recognizable non-fatal finish
+                  // for the chat-facing formatters.
+                  finish_reason: reason === 'content_filter' ? 'content_filter' : 'length',
+                  incomplete_details: incompleteDetails,
+                  error: {
+                    statusCode: 500,
+                    code: reason,
+                    message: `Response ended incomplete: ${reason}`,
+                  },
+                  ...(normalizedUsage ? { usage: normalizedUsage } : {}),
+                });
+              } else if (data.type === 'error') {
+                // Generic Responses API stream error event (top-level, not
+                // nested under `response`) — no incomplete_details, since
+                // this is a hard stream-level error, not an "ended
+                // incomplete" signal.
+                controller.enqueue({
+                  id: responseId,
+                  model: responseModel,
+                  created: Math.floor(Date.now() / 1000),
+                  event: 'error',
+                  delta: {},
+                  error: {
+                    statusCode: 500,
+                    code: data.code || 'error',
+                    message: data.message || 'Upstream error',
+                  },
+                });
               }
             } catch (e) {
               logger.error('Error parsing Responses API streaming chunk', e);
@@ -1330,12 +1421,20 @@ export class ResponsesTransformer implements Transformer {
       });
     };
 
-    const finalizeOutputItems = (controller: ReadableStreamDefaultController): any[] => {
+    // `itemStatus` is the terminal status stamped on items that were still
+    // in progress when the stream ended. The completed and failed paths keep
+    // the pre-existing 'completed' stamp; only the response.incomplete path
+    // passes 'incomplete' (matching the real Responses API, where items cut
+    // off mid-generation surface as status 'incomplete').
+    const finalizeOutputItems = (
+      controller: ReadableStreamDefaultController,
+      itemStatus: 'completed' | 'incomplete' = 'completed'
+    ): any[] => {
       if (reasoningItemSent && reasoningOutputIndex !== null) {
         const reasoningItem = {
           id: reasoningItemId,
           type: 'reasoning',
-          status: 'completed',
+          status: itemStatus,
           content: reasoningText
             ? [
                 {
@@ -1395,7 +1494,7 @@ export class ResponsesTransformer implements Transformer {
         const messageItem = {
           id: messageItemId,
           type: 'message',
-          status: 'completed',
+          status: itemStatus,
           role: 'assistant',
           content: [
             {
@@ -1445,7 +1544,7 @@ export class ResponsesTransformer implements Transformer {
           toolItem = {
             id: itemId,
             type: 'custom_tool_call',
-            status: 'completed',
+            status: itemStatus,
             call_id: callId,
             name: flatName,
             input: this.customToolInput(args),
@@ -1455,7 +1554,7 @@ export class ResponsesTransformer implements Transformer {
           toolItem = {
             id: itemId,
             type: 'function_call',
-            status: 'completed',
+            status: itemStatus,
             call_id: callId,
             name: namespaced ? namespaced.name : flatName,
             ...(namespaced ? { namespace: namespaced.namespace } : {}),
@@ -1474,6 +1573,24 @@ export class ResponsesTransformer implements Transformer {
         .sort(([a], [b]) => a - b)
         .map(([, item]) => item);
     };
+
+    const buildUsagePayload = (usage: any) =>
+      usage
+        ? {
+            input_tokens:
+              (usage.input_tokens || 0) +
+              (usage.cached_tokens || 0) +
+              (usage.cache_creation_tokens || 0),
+            output_tokens: usage.output_tokens,
+            total_tokens: usage.total_tokens,
+            input_tokens_details: {
+              cached_tokens: usage.cached_tokens || 0,
+            },
+            output_tokens_details: {
+              reasoning_tokens: usage.reasoning_tokens || 0,
+            },
+          }
+        : undefined;
 
     return new ReadableStream({
       async start(controller) {
@@ -1520,6 +1637,64 @@ export class ResponsesTransformer implements Transformer {
 
             ensureCreated(controller, unifiedChunk);
             ensureInProgress(controller);
+
+            if (unifiedChunk.event === 'error') {
+              // Upstream failed, ended incomplete, or reported a stream-level
+              // error (surfaced as a unified error chunk by transformStream).
+              // Emit the matching Responses-API terminal event instead of
+              // unconditionally completing, so the client sees the actual
+              // outcome rather than a phantom success:
+              //   - incomplete_details present -> response.incomplete (the
+              //     upstream ended the turn early — max_output_tokens /
+              //     content_filter — not a hard failure).
+              //   - otherwise -> response.failed (a genuine hard error),
+              //     exactly as before.
+              if (unifiedChunk.usage) {
+                lastUsage = unifiedChunk.usage;
+              }
+              // Items still in progress on the incomplete path finalize with
+              // status 'incomplete'; the failed path keeps the pre-existing
+              // 'completed' stamp (see finalizeOutputItems).
+              const outputItems = finalizeOutputItems(
+                controller,
+                unifiedChunk.incomplete_details ? 'incomplete' : 'completed'
+              );
+              const err = unifiedChunk.error || {};
+
+              if (unifiedChunk.incomplete_details) {
+                sendEvent(controller, {
+                  type: 'response.incomplete',
+                  response: {
+                    id: responseId || undefined,
+                    object: 'response',
+                    created_at: responseCreatedAt || Math.floor(Date.now() / 1000),
+                    status: 'incomplete',
+                    model: responseModel,
+                    output: outputItems,
+                    incomplete_details: unifiedChunk.incomplete_details,
+                    usage: buildUsagePayload(lastUsage),
+                  },
+                });
+              } else {
+                sendEvent(controller, {
+                  type: 'response.failed',
+                  response: {
+                    id: responseId || undefined,
+                    object: 'response',
+                    created_at: responseCreatedAt || Math.floor(Date.now() / 1000),
+                    status: 'failed',
+                    model: responseModel,
+                    output: outputItems,
+                    error: {
+                      code: err.code || 'server_error',
+                      message: err.message || 'The model response failed to complete.',
+                    },
+                    usage: buildUsagePayload(lastUsage),
+                  },
+                });
+              }
+              break;
+            }
 
             if (unifiedChunk.usage) {
               lastUsage = unifiedChunk.usage;

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -142,6 +142,15 @@ export interface UnifiedChatRequest {
   response_format?: {
     type: 'text' | 'json_object' | 'json_schema';
     json_schema?: any;
+    /**
+     * Structured-output descriptor fields carried from the client (Responses
+     * `text.format.name` / `description` / `strict`) so cross-format
+     * emission preserves the client-supplied values — fabricated fallbacks
+     * (`response_schema`, `strict: true`) apply only when these are absent.
+     */
+    name?: string;
+    description?: string;
+    strict?: boolean;
   };
   prompt?: string | string[];
   suffix?: string | null;
@@ -293,6 +302,15 @@ export interface UnifiedChatStreamChunk {
   finish_reason?: string | null;
   usage?: UnifiedUsage;
   error?: UnifiedClientError;
+  /**
+   * Present only on an `event: 'error'` chunk that represents a Responses
+   * API "ended incomplete" outcome (`response.incomplete` — e.g.
+   * max_output_tokens or content_filter cutoff) rather than a hard failure
+   * (`response.failed`). Lets a client-facing `formatStream` render the more
+   * specific incomplete semantics (e.g. Responses' own `response.incomplete`
+   * event, status 'incomplete') instead of a generic failure.
+   */
+  incomplete_details?: { reason: string };
 }
 
 // Unified Embeddings Request


### PR DESCRIPTION
## Summary

Part 3/5 of the split of #757 — **stacked on #761** (cumulative diff until predecessors merge; review scope below).

Streams no longer end silently on upstream failures, and cancelled/truncated requests keep their usage and costs.

## What changed

- `ResponsesTransformer.transformStream` handles `response.failed` / `response.incomplete` / `error` events (previously silently discarded): usage and `incomplete_details` propagate; detail-less incompletes default to `{reason: "unknown"}`; `content_filter`/`max_output_tokens` map to proper finishes.
- Client-facing emission: responses clients get `response.failed` or `response.incomplete` (with item-level `status: "incomplete"` on truncation) instead of an unconditional `response.completed`; chat clients get real error payloads with propagated error codes, a guaranteed finish chunk (flush), and exactly one trailing usage frame — plus the Anthropic `error` SSE event now surfaces instead of truncating streams.
- Usage/observability: token estimation no longer overwrites extracted usage; debug snapshots capture at write time with an idempotent `finalize()` invoked before teardown, so disconnect/timeout/stall cancellations record real tokens and costs (end-to-end cancellation test); `response.failed`/`response.incomplete` reconstruct correct finish reasons and usage in the raw-mode billing path; truncations record their cause instead of polluting error metadata.

## Review scope

`transformers/responses.ts` (stream sections), `transformers/openai.ts`, `anthropic/stream-transformer.ts`, `services/inspectors/usage-logging.ts`, `services/inspectors/debug-logging.ts`, `response-handler.ts` teardown ordering, `types/unified.ts`, + their tests.

## Tests

Full suite green on this branch: 229 files / 2453 tests, typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
