### PR TITLE
feat(dispatch): empty-completion detection, failover, and per-attempt diagnostics tags

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-empty-completion.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-empty-completion.test.ts
@@ -1,0 +1,539 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { Dispatcher } from '../dispatch/dispatcher';
+import { setConfigForTesting } from '../../config';
+import type { UnifiedChatRequest } from '../../types/unified';
+import { CooldownManager } from '../runtime/cooldown-manager';
+import { EMPTY_COMPLETION_REASON } from '../dispatch/empty-completion';
+
+// T5 — dispatch-level empty-completion failover.
+//
+// Fixture setup mirrors dispatcher-failover.test.ts (same style: makeConfig
+// builds an `in_order` alias with N targets, fetchMock stands in for
+// upstream HTTP). Kept in its own file rather than appended to
+// dispatcher-failover.test.ts because that file has unrelated in-flight
+// changes from other tasks in the working tree.
+
+const fetchMock: any = vi.fn(async (): Promise<any> => {
+  throw new Error('fetch mock not configured for test');
+});
+
+global.fetch = fetchMock as any;
+
+function makeConfig(options?: { failoverEnabled?: boolean; targetCount?: number }) {
+  const failoverEnabled = options?.failoverEnabled ?? true;
+  const targetCount = options?.targetCount ?? 2;
+
+  const providers: Record<string, any> = {
+    p1: {
+      type: 'chat',
+      api_base_url: 'https://p1.example.com/v1',
+      api_key: 'test-key-p1',
+      models: { 'model-1': {} },
+    },
+    p2: {
+      type: 'chat',
+      api_base_url: 'https://p2.example.com/v1',
+      api_key: 'test-key-p2',
+      models: { 'model-2': {} },
+    },
+    p3: {
+      type: 'chat',
+      api_base_url: 'https://p3.example.com/v1',
+      api_key: 'test-key-p3',
+      models: { 'model-3': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+    { provider: 'p3', model: 'model-3' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'test-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: failoverEnabled,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+function makeChatRequest(): UnifiedChatRequest {
+  return {
+    model: 'test-alias',
+    messages: [{ role: 'user', content: 'hello' }],
+    incomingApiType: 'chat',
+    stream: false,
+  };
+}
+
+/** A 200 OpenAI chat completion whose message has visible text content. */
+function contentChatResponse(model: string, content = 'ok') {
+  return new Response(
+    JSON.stringify({
+      id: `chatcmpl-${model}`,
+      object: 'chat.completion',
+      created: 1,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+/**
+ * A 200 OpenAI chat completion with zero visible output: no text, no tool
+ * calls, no reasoning. This is the "upstream 200 but empty" case the task
+ * targets — e.g. LobeHub `ModelEmptyCompletion` / KiloCode blank replies.
+ */
+function emptyChatResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: `chatcmpl-${model}`,
+      object: 'chat.completion',
+      created: 1,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: '' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+// --- Fix round 2: image_generation_call output is visible output -----------
+
+/**
+ * A single-target Responses-API alias config. `api_base_url` uses the
+ * record/map form (`{ responses: <url> }`) so getProviderTypes() resolves
+ * the 'responses' API type explicitly (mirrors makeAnthropicMessagesConfig's
+ * `{ messages: <url> }` / makeGeminiConfig's `{ gemini: <url> }` pattern).
+ */
+function makeResponsesConfig(options?: { targetCount?: number }) {
+  const targetCount = options?.targetCount ?? 2;
+
+  const providers: Record<string, any> = {
+    p1: {
+      api_base_url: { responses: 'https://p1.example.com' },
+      api_key: 'test-key-p1',
+      models: { 'model-1': {} },
+    },
+    p2: {
+      api_base_url: { responses: 'https://p2.example.com' },
+      api_key: 'test-key-p2',
+      models: { 'model-2': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'responses-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+// incomingApiType === targetApiType ('responses') with `originalBody` set
+// satisfies shouldUsePassThrough (request-payload-builder.ts) -> bypassTransformation
+// true -> dispatcher.ts's handleNonStreamingResponse attaches the ORIGINAL
+// parsed body as `unifiedResponse.rawResponse`, which is exactly the seam
+// getResponseVisibilitySignals reads image_generation_call items from.
+function makeResponsesRequest(): UnifiedChatRequest {
+  return {
+    model: 'responses-alias',
+    messages: [{ role: 'user', content: 'draw a cat' }],
+    incomingApiType: 'responses',
+    stream: false,
+    originalBody: {
+      model: 'responses-alias',
+      input: 'draw a cat',
+    },
+  } as any;
+}
+
+/** A 200 Responses API completion whose ONLY output item is an image_generation_call — no message, no text. */
+function imageOnlyResponsesResponse() {
+  return new Response(
+    JSON.stringify({
+      id: 'resp_img_1',
+      object: 'response',
+      created_at: 1,
+      status: 'completed',
+      model: 'model-1',
+      output: [
+        {
+          type: 'image_generation_call',
+          id: 'ig_1',
+          status: 'completed',
+          result: 'base64-image-data',
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+/**
+ * A 200 OpenAI chat completion with null content AND a terminal
+ * `content_filter` finish reason — a deliberate provider safety decision,
+ * not "the model produced nothing". Must NOT be classified as an empty
+ * completion (must not fail over to another provider).
+ */
+function contentFilterChatResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: `chatcmpl-${model}`,
+      object: 'chat.completion',
+      created: 1,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: null },
+          finish_reason: 'content_filter',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+// --- Fix round 1: clientError must take precedence over empty-completion retry ---
+//
+// transformGeminiResponse (transformers/gemini/response-transformer.ts) sets
+// `clientError` on a non-streaming UnifiedChatResponse for Gemini's
+// MALFORMED_FUNCTION_CALL defect — a response that also has zero visible
+// output (no text, no tool_calls). response-handler.ts's
+// `!unifiedResponse.stream && unifiedResponse.clientError` branch signals
+// that to the client directly, deliberately WITHOUT failover or cooldown.
+// This config/request pair drives a real request through the real
+// GeminiTransformer (not the 'chat'/OpenAI one used above) so the fixture
+// below exercises production code, not a hand-rolled stand-in.
+function makeGeminiConfig(options?: { targetCount?: number }) {
+  const targetCount = options?.targetCount ?? 2;
+
+  const providers: Record<string, any> = {
+    p1: {
+      api_base_url: { gemini: 'https://p1.example.com' },
+      api_key: 'test-key-p1',
+      models: { 'model-1': {} },
+    },
+    p2: {
+      api_base_url: { gemini: 'https://p2.example.com' },
+      api_key: 'test-key-p2',
+      models: { 'model-2': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'gemini-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+// Incoming type is deliberately 'chat' (not 'gemini') so selectTargetApiType
+// falls through to the only available provider type ('gemini') via the
+// normal transform pipeline (bypassTransformation stays false — pass-through
+// requires incomingApiType === targetApiType, see shouldUsePassThrough in
+// request-payload-builder.ts) — i.e. the REAL GeminiTransformer.transformResponse
+// runs on the mocked upstream body below, exactly as production would.
+function makeGeminiRequest(): UnifiedChatRequest {
+  return {
+    model: 'gemini-alias',
+    messages: [{ role: 'user', content: 'hello' }],
+    incomingApiType: 'chat',
+    stream: false,
+  };
+}
+
+/**
+ * A 200 Gemini response whose only candidate ends in MALFORMED_FUNCTION_CALL
+ * — detectGeminiMalformedFunctionCall (utils/gemini-malformed-function-call.ts)
+ * fires on finishReason alone, regardless of parts content. Empty `parts`
+ * means transformGeminiResponse also produces zero visible output (content
+ * null, no tool_calls) — the exact collision this test locks down.
+ */
+function geminiMalformedFunctionCallResponse() {
+  return new Response(
+    JSON.stringify({
+      candidates: [
+        {
+          finishReason: 'MALFORMED_FUNCTION_CALL',
+          content: { parts: [] },
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+/** A normal 200 Gemini response with visible text — used to prove failover would have "worked" if it fired. */
+function geminiContentResponse(text = 'ok') {
+  return new Response(
+    JSON.stringify({
+      candidates: [
+        {
+          finishReason: 'STOP',
+          content: { parts: [{ text }] },
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+describe('Dispatcher empty-completion failover (T5)', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+    setConfigForTesting(makeConfig());
+    CooldownManager.resetForTesting();
+  });
+
+  test('empty completion (200, no visible output) on target 1 fails over to target 2', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => emptyChatResponse('model-1'))
+      .mockImplementationOnce(async () => contentChatResponse('model-2'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+    const meta = (response as any).plexus;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.attemptCount).toBe(2);
+    expect(meta?.finalAttemptProvider).toBe('p2');
+    expect(response.content).toBe('ok');
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(2);
+    expect(retryHistory[0]?.status).toBe('failed');
+    expect(retryHistory[0]?.reason).toBe(EMPTY_COMPLETION_REASON);
+    expect(retryHistory[0]?.retryable).toBe(true);
+    expect(retryHistory[1]?.status).toBe('success');
+  });
+
+  test('all targets empty: returns the last empty response as-is (200), does not throw', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 3 }));
+    fetchMock
+      .mockImplementationOnce(async () => emptyChatResponse('model-1'))
+      .mockImplementationOnce(async () => emptyChatResponse('model-2'))
+      .mockImplementationOnce(async () => emptyChatResponse('model-3'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+    const meta = (response as any).plexus;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(meta?.attemptCount).toBe(3);
+    expect(meta?.finalAttemptProvider).toBe('p3');
+    // Empty completion means the transformed content is null (empty string
+    // normalizes to null in the OpenAI chat transformer) — returned as-is,
+    // not converted into a 5xx.
+    expect(response.content).toBeNull();
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(3);
+    expect(retryHistory[0]?.status).toBe('failed');
+    expect(retryHistory[1]?.status).toBe('failed');
+    expect(retryHistory[2]?.status).toBe('success');
+  });
+
+  test('single target, empty completion: no next target to fail over to, returns as-is', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock.mockImplementationOnce(async () => emptyChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+    const meta = (response as any).plexus;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(response.content).toBeNull();
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(1);
+    expect(retryHistory[0]?.status).toBe('success');
+  });
+
+  test('empty-completion failover does NOT trigger provider cooldown', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => emptyChatResponse('model-1'))
+      .mockImplementationOnce(async () => contentChatResponse('model-2'));
+
+    const dispatcher = new Dispatcher();
+    const cm = CooldownManager.getInstance();
+    await cm.clearCooldown();
+
+    await dispatcher.dispatch(makeChatRequest());
+
+    // p1 returned an empty completion (not a provider health failure) — it
+    // must not be on cooldown, mirroring how caller-errors (400 non-quota,
+    // 413, 422) skip markProviderFailure.
+    const cooldowns = cm.getCooldowns();
+    expect(cooldowns).toHaveLength(0);
+  });
+
+  test('no failover when failover is disabled: empty completion from the only target returns as-is', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2, failoverEnabled: false }));
+    fetchMock.mockImplementation(async () => emptyChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.content).toBeNull();
+  });
+
+  test('intermediate empty-completion failure is saved during failover', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => emptyChatResponse('model-1'))
+      .mockImplementationOnce(async () => contentChatResponse('model-2'));
+
+    const saveErrorSpy = vi.fn();
+    const dispatcher = new Dispatcher();
+    dispatcher.setUsageStorage({
+      saveError: saveErrorSpy,
+      recordFailedAttempt: vi.fn(),
+      recordSuccessfulAttempt: vi.fn(),
+      emitUpdatedAsync: vi.fn(),
+    } as any);
+
+    await dispatcher.dispatch({ ...makeChatRequest(), requestId: 'req-empty-intermediate' });
+
+    expect(saveErrorSpy).toHaveBeenCalledTimes(1);
+    const [savedRequestId, savedError] = saveErrorSpy.mock.calls[0] as any[];
+    expect(savedRequestId).toBe('req-empty-intermediate');
+    expect(savedError?.message).toBe(EMPTY_COMPLETION_REASON);
+  });
+
+  test('a clientError-carrying response (e.g. Gemini MALFORMED_FUNCTION_CALL) is NEVER retried as an empty completion, even with a next target available', async () => {
+    setConfigForTesting(makeGeminiConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => geminiMalformedFunctionCallResponse())
+      .mockImplementationOnce(async () => geminiContentResponse());
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeGeminiRequest());
+    const meta = (response as any).plexus;
+
+    // A single fetch call proves NO failover happened — target 2 (which
+    // would have returned visible content) was never reached.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+
+    // The response still has zero visible output (this is precisely why the
+    // bug existed: isEmptyUnifiedResponse alone would say "empty") AND still
+    // carries clientError intact for response-handler.ts's dedicated
+    // no-failover/no-cooldown handling to pick up downstream.
+    expect(response.content).toBeNull();
+    expect(response.tool_calls).toBeUndefined();
+    expect(response.clientError?.statusCode).toBe(503);
+    expect(response.clientError?.code).toBe('MALFORMED_FUNCTION_CALL');
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(1);
+    expect(retryHistory[0]?.status).toBe('success');
+  });
+
+  // --- Fix round 2: terminal finish reasons must never be classified empty ---
+  test('a content_filter completion (null content, terminal finish reason) is NEVER retried as an empty completion, even with a next target available', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => contentFilterChatResponse('model-1'))
+      .mockImplementationOnce(async () => contentChatResponse('model-2'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatRequest());
+    const meta = (response as any).plexus;
+
+    // A single fetch call proves NO failover happened — target 2 (which
+    // would have returned visible content) was never reached: routing
+    // around a content-filter decision via failover would be exactly the
+    // bug this guards against.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+    expect(response.content).toBeNull();
+    expect(response.finishReason).toBe('content_filter');
+
+    const retryHistory = JSON.parse(meta?.retryHistory || '[]');
+    expect(retryHistory).toHaveLength(1);
+    expect(retryHistory[0]?.status).toBe('success');
+  });
+
+  test('an image_generation_call-only Responses API completion is NEVER retried as an empty completion, even with a next target available', async () => {
+    setConfigForTesting(makeResponsesConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => imageOnlyResponsesResponse())
+      .mockImplementationOnce(async () => {
+        throw new Error('should not be called — failing over here would be the bug');
+      });
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeResponsesRequest());
+    const meta = (response as any).plexus;
+
+    // A single fetch call proves NO failover happened.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+  });
+});

--- a/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
@@ -296,7 +296,9 @@ describe('Dispatcher Failover', () => {
       throw new Error('expected dispatch to fail');
     } catch (error: any) {
       expect(error.message).toContain('All targets failed');
-      expect(error.message).toContain('p1/model-1, p2/model-2');
+      // T6: the client-visible message now carries each attempt's own HTTP
+      // status code (500 from p1, 503 from p2) instead of a bare provider list.
+      expect(error.message).toContain('p1/model-1 (500), p2/model-2 (503)');
       expect(error.routingContext?.attemptCount).toBe(2);
     }
   });

--- a/packages/backend/src/services/dispatch/__tests__/attempt-history.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/attempt-history.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendFailureAttempt,
+  appendSkippedAttempt,
+  buildAllTargetsFailedError,
+  type ErrorSummaryFormatter,
+  type FailureReasonFormatter,
+} from '../attempt-history';
+import { EMPTY_COMPLETION_REASON } from '../empty-completion';
+import type { RouteResult } from '../../routing/router';
+import type { RetryAttemptRecord } from '../dispatcher-types';
+
+// Minimal RouteResult factory — attempt-history only reads `provider`/`model`,
+// so `config` is stubbed out (mirrors adapter-resolver.test.ts's makeRoute).
+function makeRoute(provider: string, model: string): RouteResult {
+  return {
+    provider,
+    model,
+    config: {} as any,
+  } as RouteResult;
+}
+
+function httpError(statusCode: number, message: string) {
+  const error = new Error(message) as any;
+  error.routingContext = { statusCode };
+  return error;
+}
+
+// Mirrors the failed attempt the empty-completion failover records in
+// standard-attempt-request.ts: the HTTP call itself succeeded (statusCode
+// 200) but the completion carried no visible output.
+function emptyCompletionError() {
+  const error = new Error(EMPTY_COMPLETION_REASON) as any;
+  error.routingContext = { statusCode: 200, cooldownTriggered: false };
+  return error;
+}
+
+// Pass-through stand-ins for the real Dispatcher.formatFailureReason /
+// compactProviderErrorSummary — buildAllTargetsFailedError takes both as
+// injected dependencies, so tests don't need the real implementations.
+const formatFailureReason: FailureReasonFormatter = (error) =>
+  error?.message ?? 'Unknown provider error';
+const compactErrorSummary: ErrorSummaryFormatter = (value) => String(value);
+
+describe('buildAllTargetsFailedError', () => {
+  it('includes the HTTP status code recorded for each attempt in the provider list', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const routeA = makeRoute('openai', 'gpt-5.5');
+    const routeB = makeRoute('OpenLimits/openai', 'gpt-5.5');
+
+    appendFailureAttempt(retryHistory, routeA, httpError(400, 'bad request'), formatFailureReason);
+    appendFailureAttempt(retryHistory, routeB, httpError(400, 'bad request'), formatFailureReason);
+
+    const error = buildAllTargetsFailedError(
+      httpError(400, 'bad request'),
+      ['openai/gpt-5.5', 'OpenLimits/openai/gpt-5.5'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe(
+      'All targets failed: openai/gpt-5.5 (400), OpenLimits/openai/gpt-5.5 (400). Last error: bad request'
+    );
+  });
+
+  it('uses the status code recorded for each attempt, not just the last error', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const routeA = makeRoute('p1', 'model-1');
+    const routeB = makeRoute('p2', 'model-2');
+
+    appendFailureAttempt(retryHistory, routeA, httpError(400, 'first failed'), formatFailureReason);
+    appendFailureAttempt(
+      retryHistory,
+      routeB,
+      httpError(503, 'second failed'),
+      formatFailureReason
+    );
+
+    const error = buildAllTargetsFailedError(
+      httpError(503, 'second failed'),
+      ['p1/model-1', 'p2/model-2'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe(
+      'All targets failed: p1/model-1 (400), p2/model-2 (503). Last error: second failed'
+    );
+  });
+
+  it('tags an empty-completion failover attempt as (empty), not the misleading (200)', () => {
+    // A failed attempt whose HTTP status was 200 can only mean the call
+    // succeeded but the completion was unusable — rendering the raw "(200)"
+    // next to real failure codes reads like a contradiction to clients.
+    const retryHistory: RetryAttemptRecord[] = [];
+    const emptyRoute = makeRoute('p1', 'm1');
+    const failedRoute = makeRoute('p2', 'm2');
+
+    appendFailureAttempt(
+      retryHistory,
+      emptyRoute,
+      emptyCompletionError(),
+      formatFailureReason,
+      undefined,
+      true
+    );
+    appendFailureAttempt(retryHistory, failedRoute, httpError(500, 'boom'), formatFailureReason);
+
+    const error = buildAllTargetsFailedError(
+      httpError(500, 'boom'),
+      ['p1/m1', 'p2/m2'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: p1/m1 (empty), p2/m2 (500). Last error: boom');
+  });
+
+  it('tags a network/transport failure that has no status code as (network)', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const route = makeRoute('p1', 'model-1');
+    const networkError = new Error('fetch failed');
+
+    appendFailureAttempt(retryHistory, route, networkError, formatFailureReason);
+
+    const error = buildAllTargetsFailedError(
+      networkError,
+      ['p1/model-1'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe(
+      'All targets failed: p1/model-1 (network). Last error: fetch failed'
+    );
+  });
+
+  it('tags a stalled attempt as (stall) instead of (network)', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const route = makeRoute('p1', 'model-1');
+    // Em-dash matches the production stall message verbatim (see
+    // standard-attempt-request.ts's "Stream stalled: TTFB timeout — ...").
+    const stallError = new Error('Stream stalled: TTFB timeout — no response within 5000ms');
+
+    appendFailureAttempt(retryHistory, route, stallError, formatFailureReason, undefined, true);
+
+    const error = buildAllTargetsFailedError(
+      stallError,
+      ['p1/model-1'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe(
+      'All targets failed: p1/model-1 (stall). Last error: Stream stalled: TTFB timeout — no response within 5000ms'
+    );
+  });
+
+  it('excludes a skipped attempt from the summary, matching attemptedProviders as-is (current dispatch behavior)', () => {
+    const retryHistory: RetryAttemptRecord[] = [];
+    const skippedRoute = makeRoute('p1', 'model-1');
+    const attemptedRoute = makeRoute('p2', 'model-2');
+
+    appendSkippedAttempt(retryHistory, skippedRoute, 'Provider p1/model-1 is on cooldown');
+    appendFailureAttempt(retryHistory, attemptedRoute, httpError(500, 'boom'), formatFailureReason);
+
+    // Only p2/model-2 was actually attempted — the dispatch loop never adds
+    // a skipped target (p1/model-1) to attemptedProviders, and the summary
+    // must not grow to include it either.
+    const error = buildAllTargetsFailedError(
+      httpError(500, 'boom'),
+      ['p2/model-2'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: p2/model-2 (500). Last error: boom');
+    expect(error.message).not.toContain('p1/model-1');
+  });
+
+  it('renders a joined-list entry untagged when its only recorded retryHistory attempt was a skip', () => {
+    // Defensive/future-proofing case from the T6 brief: today's dispatch
+    // loops never put a skipped target into attemptedProviders. Skipped
+    // retryHistory entries are excluded from the FIFO provider/model queues
+    // (see formatAttemptedProvidersSummary) precisely so a skip can never be
+    // matched up with a LATER real attempt that shares its key. If a future
+    // caller did list a skipped-only target in attemptedProviders, there is
+    // now no matching queued record to tag it with, so it renders untagged
+    // rather than mislabeled as the wrong outcome.
+    const retryHistory: RetryAttemptRecord[] = [];
+    const skippedRoute = makeRoute('p1', 'model-1');
+    appendSkippedAttempt(retryHistory, skippedRoute, 'Provider p1/model-1 is on cooldown');
+
+    const error = buildAllTargetsFailedError(
+      new Error('boom'),
+      ['p1/model-1'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: p1/model-1. Last error: boom');
+  });
+
+  it('renders the real attempt tag, not (skipped), when a skip shares a provider/model key with a later real attempt', () => {
+    // The bug this guards: formatAttemptedProvidersSummary used to build its
+    // FIFO provider/model queues from ALL retryHistory entries, including
+    // skips. A skip recorded for a key that a LATER real attempt reuses
+    // (e.g. the same target skipped once via cooldown, then actually
+    // dispatched — and rejected — as the final failover candidate) would
+    // occupy the front of that queue, so the real attempt's `.shift()`
+    // consumed the skip entry instead and rendered `(skipped)` in place of
+    // the real HTTP status. Production only ever lists the REAL attempt in
+    // `attemptedProviders` for this key (skips never reach it), so the
+    // summary must reflect the real attempt's outcome.
+    const retryHistory: RetryAttemptRecord[] = [];
+    const route = makeRoute('p1', 'model-1');
+
+    appendSkippedAttempt(retryHistory, route, 'Provider p1/model-1 is on cooldown');
+    appendFailureAttempt(retryHistory, route, httpError(400, 'bad request'), formatFailureReason);
+
+    const error = buildAllTargetsFailedError(
+      httpError(400, 'bad request'),
+      ['p1/model-1'],
+      retryHistory,
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: p1/model-1 (400). Last error: bad request');
+  });
+
+  it('keeps the "All targets failed: " prefix, ". Last error: " suffix, and the "none" fallback', () => {
+    const error = buildAllTargetsFailedError(
+      new Error('boom'),
+      [],
+      [],
+      formatFailureReason,
+      compactErrorSummary
+    );
+
+    expect(error.message).toBe('All targets failed: none. Last error: boom');
+  });
+});

--- a/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createStreamVisibilityTracker,
+  EMPTY_COMPLETION_REASON,
+  getResponseVisibilitySignals,
+  isEmptyCompletion,
+  isEmptyUnifiedResponse,
+  isStreamEmpty,
+  observeStreamChunk,
+  type StreamVisibilityTracker,
+} from '../empty-completion';
+import type { UnifiedChatResponse } from '../../../types/unified';
+
+// A bare, all-absent UnifiedChatResponse — the "truly empty" fixture shared
+// by several tests below.
+function emptyResponse(): UnifiedChatResponse {
+  return {
+    id: 'resp-1',
+    model: 'model-1',
+    content: null,
+  };
+}
+
+describe('isEmptyCompletion (pure signal decision)', () => {
+  it('text-only is non-empty', () => {
+    expect(isEmptyCompletion({ hasText: true })).toBe(false);
+  });
+
+  it('tool-call-only is non-empty', () => {
+    expect(isEmptyCompletion({ toolCallCount: 1 })).toBe(false);
+  });
+
+  it('reasoning-only is non-empty', () => {
+    expect(isEmptyCompletion({ hasReasoning: true })).toBe(false);
+  });
+
+  it('image-only is non-empty', () => {
+    expect(isEmptyCompletion({ imageCount: 1 })).toBe(false);
+  });
+
+  it('citations-only (annotation-only) is non-empty', () => {
+    expect(isEmptyCompletion({ annotationCount: 1 })).toBe(false);
+  });
+
+  it('truly empty (no signals at all) is empty', () => {
+    expect(isEmptyCompletion({})).toBe(true);
+  });
+
+  it('all-zero/false signals explicitly are still empty', () => {
+    expect(
+      isEmptyCompletion({
+        hasText: false,
+        hasReasoning: false,
+        toolCallCount: 0,
+        annotationCount: 0,
+        imageCount: 0,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('getResponseVisibilitySignals / isEmptyUnifiedResponse (non-streaming adapter)', () => {
+  it('text-only response is non-empty', () => {
+    const response: UnifiedChatResponse = { ...emptyResponse(), content: 'Hello there' };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+    expect(getResponseVisibilitySignals(response).hasText).toBe(true);
+  });
+
+  it('whitespace-only content is still treated as empty text', () => {
+    const response: UnifiedChatResponse = { ...emptyResponse(), content: '   \n\t  ' };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('tool-call-only response is non-empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      tool_calls: [
+        { id: 'call_1', type: 'function', function: { name: 'lookup', arguments: '{}' } },
+      ],
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('reasoning-only (reasoning_content) response is non-empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      reasoning_content: 'thinking it through...',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('reasoning-only (thinking.content) response is non-empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      thinking: { content: 'pondering...' },
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('image-only response is non-empty (forward-compatible `images` field)', () => {
+    // UnifiedChatResponse has no `images` field today — no transformer
+    // populates one — but the signals adapter reads it defensively so a
+    // future multimodal chat-output field is picked up without code changes
+    // here. Cast to exercise that path directly.
+    const response = {
+      ...emptyResponse(),
+      images: [{ data: 'base64...' }],
+    } as UnifiedChatResponse & {
+      images: unknown[];
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('citations-only (annotations) response is non-empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      annotations: [
+        {
+          type: 'url_citation',
+          url_citation: {
+            url: 'https://example.com',
+            title: 'Example',
+            content: 'snippet',
+            start_index: 0,
+            end_index: 10,
+          },
+        },
+      ],
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('truly empty response (no text/tool-calls/reasoning/images/annotations) is empty', () => {
+    expect(isEmptyUnifiedResponse(emptyResponse())).toBe(true);
+  });
+
+  it('empty string content, empty tool_calls array, and empty annotations array are still empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: '',
+      tool_calls: [],
+      annotations: [],
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+});
+
+describe('isEmptyUnifiedResponse — terminal finish reasons are never retryable-empty', () => {
+  // A `content_filter` (or other terminal) response with null content is a
+  // deliberate provider/safety decision, NOT "the model produced nothing on
+  // an ordinary turn" — classifying it as empty routes the request around
+  // that decision via failover to a different provider instead of relaying
+  // it to the client, which is exactly the bug this guards against.
+  it('content_filter finish reason with no visible output is NOT empty (no failover)', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: 'content_filter',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('length finish reason with no visible output is NOT empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: 'length',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('an error/refusal-shaped finish reason with no visible output is NOT empty', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: 'error',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+
+    const refusal: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: 'refusal',
+    };
+    expect(isEmptyUnifiedResponse(refusal)).toBe(false);
+  });
+
+  it('a terminal finish reason takes precedence even if a signal WOULD otherwise look empty', () => {
+    // Guards against a future refactor accidentally checking signals first.
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: '',
+      tool_calls: [],
+      finishReason: 'content_filter',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('absent finish reason with no visible output STILL fails over (existing behavior guarded)', () => {
+    // No finishReason set at all (undefined) — the pre-existing "truly
+    // empty" case. Must remain retryable-empty.
+    expect(isEmptyUnifiedResponse(emptyResponse())).toBe(true);
+  });
+
+  it('null finish reason with no visible output STILL fails over (existing behavior guarded)', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: null,
+      finishReason: null,
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('"stop" finish reason with no visible output STILL fails over (existing behavior guarded)', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: '',
+      finishReason: 'stop',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('"end_turn" (Anthropic-style stop) finish reason with no visible output STILL fails over', () => {
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: '',
+      finishReason: 'end_turn',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('a terminal finish reason does not suppress a genuinely non-empty response either way', () => {
+    // Sanity check: a content_filter response that DOES have visible text
+    // (e.g. a partial answer before the cutoff) is non-empty regardless.
+    const response: UnifiedChatResponse = {
+      ...emptyResponse(),
+      content: 'partial answer before cutoff',
+      finishReason: 'content_filter',
+    };
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+});
+
+describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — image_generation_call visibility (rawResponse / bypass path)', () => {
+  // The Responses API returns `image_generation_call` output items
+  // (types/responses.ts ResponsesBuiltInToolCallItem). On the
+  // bypass-transformation path the unified response carries no typed items —
+  // `rawResponse` (populated by dispatcher.ts's handleNonStreamingResponse)
+  // is the ORIGINAL body available at the call seam; detect the built-in
+  // tool call there. It also covers result-less items, which get no typed
+  // carry on the transformed path but still prove the model produced output.
+  it('image_generation_call-only rawResponse is non-empty (no failover)', () => {
+    const response = {
+      ...emptyResponse(),
+      rawResponse: {
+        id: 'resp-img-1',
+        object: 'response',
+        output: [
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: 'base64-image-data',
+          },
+        ],
+      },
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(1);
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('a rawResponse with no image_generation_call items contributes zero imageCount', () => {
+    const response = {
+      ...emptyResponse(),
+      rawResponse: {
+        id: 'resp-text-1',
+        object: 'response',
+        output: [{ type: 'message', id: 'msg_1', status: 'completed', content: [] }],
+      },
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(0);
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('multiple image_generation_call items are all counted', () => {
+    const response = {
+      ...emptyResponse(),
+      rawResponse: {
+        output: [
+          { type: 'image_generation_call', id: 'ig_1', status: 'completed' },
+          { type: 'image_generation_call', id: 'ig_2', status: 'completed' },
+        ],
+      },
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+
+  it('a rawResponse with no output array (or no rawResponse at all) does not throw and counts zero', () => {
+    expect(getResponseVisibilitySignals(emptyResponse()).imageCount).toBe(0);
+    expect(
+      getResponseVisibilitySignals({ ...emptyResponse(), rawResponse: {} } as UnifiedChatResponse)
+        .imageCount
+    ).toBe(0);
+    expect(
+      getResponseVisibilitySignals({
+        ...emptyResponse(),
+        rawResponse: { output: 'not-an-array' },
+      } as UnifiedChatResponse).imageCount
+    ).toBe(0);
+  });
+
+  it('the forward-compat `images` array field and rawResponse image_generation_call items both contribute to imageCount', () => {
+    const response = {
+      ...emptyResponse(),
+      images: [{ data: 'base64...' }],
+      rawResponse: {
+        output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
+      },
+    } as UnifiedChatResponse & { images: unknown[] };
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+});
+
+describe('createStreamVisibilityTracker / observeStreamChunk / isStreamEmpty (streaming adapter)', () => {
+  it('starts empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+
+  it('a content delta marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: { content: 'Hi' } } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('a whitespace-only content delta does NOT mark the tracker non-empty by itself', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: { content: '   ' } } as any);
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+
+  it('a tool-call delta marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: { tool_calls: [{ index: 0, function: { name: 'lookup' } }] },
+    } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('a reasoning delta marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: { reasoning_content: 'hmm' } } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('a thinking delta marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: { thinking: { content: 'hmm' } } } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('chunks with no delta at all leave the tracker empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {} as any);
+    observeStreamChunk(tracker, { delta: {} } as any);
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+
+  it('accumulates across multiple chunks: only the last chunk carries content', () => {
+    const tracker: StreamVisibilityTracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: {} } as any);
+    observeStreamChunk(tracker, { delta: {} } as any);
+    observeStreamChunk(tracker, { delta: { content: 'answer' } } as any);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+});
+
+describe('observeStreamChunk — chunk-level annotations/images branches (forward-compat contract)', () => {
+  // No current transformer streams chunk-level `annotations` or `images`,
+  // but the tracker reads both defensively so a future transformer that does
+  // is picked up without changes here. These tests pin that contract with
+  // synthetic unified chunks. Note both branches sit AFTER the `delta`
+  // presence guard, so the synthetic chunks carry an (empty) delta object.
+  it('a chunk-level annotations array marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: {},
+      annotations: [
+        {
+          type: 'url_citation',
+          url_citation: { url: 'https://example.com', title: 'Example' },
+        },
+      ],
+    } as any);
+
+    expect(tracker.annotationCount).toBe(1);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('a chunk-level images array marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: {},
+      images: [{ data: 'base64...' }],
+    } as any);
+
+    expect(tracker.imageCount).toBe(1);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('annotation and image counts accumulate across chunks', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: {},
+      annotations: [{ type: 'url_citation' }, { type: 'url_citation' }],
+    } as any);
+    observeStreamChunk(tracker, { delta: {}, annotations: [{ type: 'url_citation' }] } as any);
+    observeStreamChunk(tracker, { delta: {}, images: [{ data: 'a' }, { data: 'b' }] } as any);
+    observeStreamChunk(tracker, { delta: {}, images: [{ data: 'c' }] } as any);
+
+    expect(tracker.annotationCount).toBe(3);
+    expect(tracker.imageCount).toBe(3);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('empty annotations/images arrays (and non-array values) leave the tracker empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: {}, annotations: [], images: [] } as any);
+    observeStreamChunk(tracker, {
+      delta: {},
+      annotations: 'not-an-array',
+      images: { data: 'not-an-array' },
+    } as any);
+
+    expect(tracker.annotationCount).toBe(0);
+    expect(tracker.imageCount).toBe(0);
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+});
+
+describe('EMPTY_COMPLETION_REASON', () => {
+  it('is the exact reason string documented in the task brief', () => {
+    expect(EMPTY_COMPLETION_REASON).toBe('Empty completion (no visible output)');
+  });
+});

--- a/packages/backend/src/services/dispatch/attempt-history.ts
+++ b/packages/backend/src/services/dispatch/attempt-history.ts
@@ -93,6 +93,74 @@ export function attachAttemptMetadata(
   } as any;
 }
 
+/**
+ * Per-attempt annotation for a single `attemptedProviders` entry: an HTTP
+ * status code when the failure carried one, `empty` for a failed attempt
+ * recorded with HTTP 200 (the empty-completion failover — the call itself
+ * succeeded but the completion carried no visible output, so echoing the
+ * raw "(200)" next to real failure codes would read like a contradiction;
+ * a malformed/unparseable body on an HTTP 200 also lands here, since
+ * dispatcher.ts's parse-failure path stamps the attempt with statusCode
+ * 200 — same story: the call "succeeded" but yielded nothing usable),
+ * a short reason tag when there's no status code (network/transport errors,
+ * mid-stream or TTFB stalls), `skipped` for a target that was never
+ * actually dispatched, or `undefined` when there's nothing worth surfacing
+ * (e.g. no matching retryHistory record).
+ */
+function describeAttemptTag(entry: RetryAttemptRecord | undefined): string | undefined {
+  if (!entry) return undefined;
+  if (entry.status === 'skipped') return 'skipped';
+  if (entry.status !== 'failed') return undefined;
+  if (entry.statusCode === 200) return 'empty';
+  if (typeof entry.statusCode === 'number') return String(entry.statusCode);
+  return /stall/i.test(entry.reason) ? 'stall' : 'network';
+}
+
+/**
+ * Renders the "provider/model (tag), provider/model (tag)" summary for the
+ * client-visible failover error. `attemptedProviders` stays the single
+ * source of truth for WHICH targets are listed and in what order — this
+ * only decorates each entry with a tag drawn from its matching retryHistory
+ * record, it never adds or removes targets.
+ *
+ * Dispatch loops push to `attemptedProviders` and append the corresponding
+ * retryHistory record (skipped targets never reach `attemptedProviders`) in
+ * lockstep, so matching by `provider/model` key — consumed in encountered
+ * order to stay correct even if the same target is attempted twice — lines
+ * each summary entry up with its own outcome instead of the last one seen.
+ */
+function formatAttemptedProvidersSummary(
+  attemptedProviders: string[],
+  retryHistory: RetryAttemptRecord[]
+): string {
+  if (attemptedProviders.length === 0) return 'none';
+
+  const byProviderModel = new Map<string, RetryAttemptRecord[]>();
+  for (const entry of retryHistory) {
+    // Skipped targets never reach `attemptedProviders` (every skip path
+    // `continue`s before pushing to it), so they must never occupy a FIFO
+    // slot here either. Otherwise a skip that shares a provider/model key
+    // with a LATER real attempt would have its slot consumed first,
+    // rendering that real attempt's outcome as `(skipped)` instead of its
+    // actual status/tag.
+    if (entry.status === 'skipped') continue;
+    const key = `${entry.provider}/${entry.model}`;
+    const queue = byProviderModel.get(key);
+    if (queue) {
+      queue.push(entry);
+    } else {
+      byProviderModel.set(key, [entry]);
+    }
+  }
+
+  return attemptedProviders
+    .map((provider) => {
+      const tag = describeAttemptTag(byProviderModel.get(provider)?.shift());
+      return tag ? `${provider} (${tag})` : provider;
+    })
+    .join(', ');
+}
+
 export function buildAllTargetsFailedError(
   lastError: any,
   attemptedProviders: string[],
@@ -100,7 +168,7 @@ export function buildAllTargetsFailedError(
   formatFailureReason: FailureReasonFormatter,
   compactErrorSummary: ErrorSummaryFormatter
 ): Error {
-  const summary = attemptedProviders.length > 0 ? attemptedProviders.join(', ') : 'none';
+  const summary = formatAttemptedProvidersSummary(attemptedProviders, retryHistory);
   const baseMessage = compactErrorSummary(
     formatFailureReason(lastError) || lastError?.message || 'Unknown provider error'
   );

--- a/packages/backend/src/services/dispatch/empty-completion.ts
+++ b/packages/backend/src/services/dispatch/empty-completion.ts
@@ -1,0 +1,204 @@
+import type { UnifiedChatResponse, UnifiedChatStreamChunk } from '../../types/unified';
+
+/**
+ * T5 — Empty-completion detection.
+ *
+ * Plexus never used to inspect completion content: an upstream 200 whose
+ * transformed completion has zero user-visible output (no text, no tool
+ * calls, no reasoning, no images, no citations) was returned to the client
+ * as a successful empty turn. Clients like LobeHub (`ModelEmptyCompletion`)
+ * and KiloCode treat that as a hard error.
+ *
+ * This module is a small, pure, unit-testable core: given a set of
+ * "did any visible output show up" signals, decide whether the completion
+ * counts as empty. It mirrors the spirit of LobeChat's
+ * `isEmptyModelCompletion` — a completion is empty only when NONE of the
+ * visible-output categories are present. Grounding/citation-only responses
+ * are treated as non-empty as long as at least one annotation/citation is
+ * present.
+ *
+ * Two call sites feed this:
+ *   - `standard-attempt-request.ts` (non-streaming): a fully-materialized
+ *     `UnifiedChatResponse` is available, so `isEmptyUnifiedResponse` reads
+ *     signals straight off it.
+ *   - `response-handler.ts` (streaming): the response is consumed
+ *     incrementally, so `createStreamVisibilityTracker`/`observeStreamChunk`
+ *     accumulate presence flags (never the actual text — see the
+ *     buffering-for-retry note in response-handler.ts) as unified stream
+ *     chunks pass through, and `isStreamEmpty` makes the same decision once
+ *     the stream ends.
+ */
+
+/** Reason string used for the non-streaming failover path (attempt-history reason, log messages). */
+export const EMPTY_COMPLETION_REASON = 'Empty completion (no visible output)';
+
+/**
+ * Presence signals used to decide whether a completion produced any
+ * user-visible output. Each flag/count is truthy when that category of
+ * output was present anywhere in the completion (a single non-streaming
+ * response, or accumulated across an entire stream).
+ */
+export interface CompletionVisibilitySignals {
+  hasText?: boolean;
+  hasReasoning?: boolean;
+  toolCallCount?: number;
+  annotationCount?: number;
+  imageCount?: number;
+}
+
+/**
+ * Pure decision function — no I/O, no side effects. A completion is
+ * "empty" only when none of the visible-output signals are present.
+ */
+export function isEmptyCompletion(signals: CompletionVisibilitySignals): boolean {
+  return !(
+    signals.hasText ||
+    signals.hasReasoning ||
+    (signals.toolCallCount ?? 0) > 0 ||
+    (signals.annotationCount ?? 0) > 0 ||
+    (signals.imageCount ?? 0) > 0
+  );
+}
+
+/** True when `value` is a string containing at least one non-whitespace character. */
+function hasVisibleText(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Shape read from a fully-materialized non-streaming response. Widened
+ * (rather than `UnifiedChatResponse` verbatim) so forward-compatible fields
+ * not yet on the unified type — e.g. a future `images` array for multimodal
+ * chat output — are picked up defensively without requiring a type change
+ * here. No current transformer populates the `images` array, so the
+ * `images`-array contribution is exercised directly by the unit tests rather
+ * than via a real transformer fixture.
+ */
+type VisibilityCheckableResponse = Pick<
+  UnifiedChatResponse,
+  'content' | 'reasoning_content' | 'thinking' | 'tool_calls' | 'annotations' | 'finishReason'
+> & { images?: unknown[] | null; rawResponse?: unknown };
+
+/**
+ * Counts `image_generation_call` built-in-tool-call output items
+ * (types/responses.ts `ResponsesBuiltInToolCallItem`) on a raw (pre-transform)
+ * Responses API body — the bypass-transformation path (`rawResponse` is
+ * populated by dispatcher.ts's `handleNonStreamingResponse`, the ORIGINAL
+ * body available at the empty-completion call seam). Result-less items (an
+ * `image_generation_call` without a base64 `result`) still count: the model
+ * demonstrably produced output.
+ */
+function countRawImageGenerationCalls(rawResponse: unknown): number {
+  const output = (rawResponse as { output?: unknown })?.output;
+  if (!Array.isArray(output)) return 0;
+  return output.filter((item: any) => item?.type === 'image_generation_call').length;
+}
+
+/** Extracts visibility signals from a fully-materialized non-streaming response. */
+export function getResponseVisibilitySignals(
+  response: VisibilityCheckableResponse
+): CompletionVisibilitySignals {
+  return {
+    hasText: hasVisibleText(response.content),
+    hasReasoning:
+      hasVisibleText(response.reasoning_content) || hasVisibleText(response.thinking?.content),
+    toolCallCount: response.tool_calls?.length ?? 0,
+    annotationCount: response.annotations?.length ?? 0,
+    imageCount:
+      (Array.isArray(response.images) ? response.images.length : 0) +
+      countRawImageGenerationCalls(response.rawResponse),
+  };
+}
+
+/**
+ * Finish reasons that represent a NORMAL, retryable-if-empty completion —
+ * the model simply produced no visible output on an otherwise-ordinary
+ * turn. Absent/null covers responses (and transformers) that don't set a
+ * finish reason at all — the pre-existing "truly empty" case, which must
+ * stay retryable.
+ */
+function isRetryableEmptyFinishReason(finishReason: string | null | undefined): boolean {
+  return finishReason == null || finishReason === 'stop' || finishReason === 'end_turn';
+}
+
+/**
+ * Convenience wrapper for the non-streaming dispatch seam
+ * (standard-attempt-request.ts). A completion is only "empty" (and thus
+ * retryable via failover) when BOTH:
+ *   - none of the visible-output signals are present, AND
+ *   - the finish reason is a normal one (absent/null/'stop'/'end_turn').
+ * Any other finish reason (content_filter, refusal, length, error, etc.) is
+ * a TERMINAL, provider-chosen outcome: the provider deliberately ended the
+ * turn for a reason unrelated to "the model produced nothing", so treating
+ * it as an empty-completion failover would silently route around a
+ * safety/terminal decision (e.g. resending a content-filtered prompt to a
+ * different provider) instead of relaying it to the client as intended.
+ */
+export function isEmptyUnifiedResponse(response: VisibilityCheckableResponse): boolean {
+  if (!isRetryableEmptyFinishReason(response.finishReason)) return false;
+  return isEmptyCompletion(getResponseVisibilitySignals(response));
+}
+
+/**
+ * Mutable per-stream accumulator for the streaming seam. Tracks only
+ * PRESENCE (booleans/counts) — it never holds accumulated text, so it
+ * cannot be used to reconstruct or retry the response (streaming can't
+ * fail over anyway; headers are already sent by the time this runs).
+ */
+export interface StreamVisibilityTracker {
+  hasText: boolean;
+  hasReasoning: boolean;
+  toolCallCount: number;
+  annotationCount: number;
+  imageCount: number;
+}
+
+export function createStreamVisibilityTracker(): StreamVisibilityTracker {
+  return {
+    hasText: false,
+    hasReasoning: false,
+    toolCallCount: 0,
+    annotationCount: 0,
+    imageCount: 0,
+  };
+}
+
+/**
+ * Observes a single unified stream chunk, updating the tracker in place.
+ * Only inspects `delta.content` / `delta.tool_calls` / `delta.reasoning_content`
+ * / `delta.thinking` (plus a defensive, forward-compatible `annotations`/
+ * `images` check — no current transformer streams either) — it never
+ * stores the actual delta text anywhere.
+ */
+export function observeStreamChunk(
+  tracker: StreamVisibilityTracker,
+  chunk: Pick<UnifiedChatStreamChunk, 'delta'> & {
+    annotations?: unknown[] | null;
+    images?: unknown[] | null;
+  }
+): void {
+  const delta = chunk?.delta;
+  if (!delta) return;
+
+  if (hasVisibleText(delta.content)) tracker.hasText = true;
+  if (hasVisibleText(delta.reasoning_content) || hasVisibleText(delta.thinking?.content)) {
+    tracker.hasReasoning = true;
+  }
+  if (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0) {
+    // Exact count doesn't matter — isEmptyCompletion only checks for > 0 —
+    // so over-counting across multiple arg-delta chunks for the same tool
+    // call is harmless.
+    tracker.toolCallCount += delta.tool_calls.length;
+  }
+  if (Array.isArray(chunk.annotations) && chunk.annotations.length > 0) {
+    tracker.annotationCount += chunk.annotations.length;
+  }
+  if (Array.isArray(chunk.images) && chunk.images.length > 0) {
+    tracker.imageCount += chunk.images.length;
+  }
+}
+
+/** Convenience wrapper for the streaming observability seam (response-handler.ts). */
+export function isStreamEmpty(tracker: StreamVisibilityTracker): boolean {
+  return isEmptyCompletion(tracker);
+}

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -17,6 +17,7 @@ import {
   MAX_THINKING_SIGNATURE_STRIP_RETRIES,
   MAX_UNSUPPORTED_PARAM_STRIP_RETRIES,
 } from './dispatcher-auto-compat';
+import { EMPTY_COMPLETION_REASON, isEmptyUnifiedResponse } from './empty-completion';
 
 export type StandardAttemptResult =
   | { outcome: 'success'; response: UnifiedChatResponse }
@@ -486,6 +487,62 @@ export async function executeStandardAttempt(
     bypassTransformation,
     adapters
   );
+
+  // T5: empty-completion failover (see empty-completion.ts). An upstream 200
+  // whose transformed completion has zero visible output (no text, tool
+  // calls, reasoning, images, or citations) reads as a hard error to clients
+  // like LobeHub (`ModelEmptyCompletion`) / KiloCode. Treat it as a
+  // retryable target failure so normal failover proceeds to the next
+  // candidate — UNLESS this is the last target, in which case the empty
+  // response is returned as-is: an empty 200 from every candidate is still a
+  // valid upstream answer, so failover-exhaustion semantics must stay
+  // unchanged (no conversion into a 5xx).
+  //
+  // `clientError` is excluded on purpose: some transformers (e.g. Gemini's
+  // MALFORMED_FUNCTION_CALL — transformGeminiResponse) deliberately populate
+  // a clientError-carrying response with no visible output — a distinct,
+  // pre-existing "signal the client directly, no failover, no cooldown"
+  // mechanism handled later in response-handler.ts (see its
+  // `!unifiedResponse.stream && unifiedResponse.clientError` branch). Letting
+  // empty-completion failover fire here would silently discard that specific
+  // diagnostic and introduce retries where they were deliberately excluded,
+  // so any clientError takes precedence and is never treated as empty.
+  const canRetryEmptyCompletion =
+    failoverEnabled &&
+    hasNextTarget &&
+    !nonStreamingResponse.clientError &&
+    isEmptyUnifiedResponse(nonStreamingResponse);
+  if (canRetryEmptyCompletion) {
+    attemptTimeout.cleanup();
+    doRelease();
+    await host.recordAttemptMetric(route, currentRequest.requestId, false, {
+      isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,
+      isDescriptorRequest: (currentRequest as any)._isVisionDescriptorRequest,
+      visionFallthroughModel: (currentRequest as any)._visionFallthroughModel,
+    });
+    const emptyCompletionError = new Error(EMPTY_COMPLETION_REASON) as any;
+    emptyCompletionError.routingContext = {
+      provider: route.provider,
+      targetModel: route.model,
+      targetApiType,
+      statusCode: 200,
+      // Not a provider-health issue — the HTTP call itself succeeded, it
+      // just carried no visible output — so cooldown must be skipped here,
+      // mirroring how caller-errors (400 non-quota, 413, 422) skip
+      // CooldownManager.markProviderFailure above.
+      cooldownTriggered: false,
+    };
+    host.appendFailureAttempt(retryHistory, route, emptyCompletionError, targetApiType, true);
+    host.saveIntermediateError(
+      currentRequest.requestId,
+      targetApiType || 'chat',
+      emptyCompletionError
+    );
+    logger.warn(
+      `Failover: retrying after empty completion (no visible output) from ${route.provider}/${route.model}`
+    );
+    return { outcome: 'retry', error: emptyCompletionError };
+  }
 
   await host.recordAttemptMetric(route, currentRequest.requestId, true, {
     isVisionFallthrough: (currentRequest as any)._hasVisionFallthrough,

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -22,6 +22,11 @@ import { CooldownManager } from '../runtime/cooldown-manager';
 import { sanitizeHeaders } from '../../utils/sanitize-headers';
 import { getApiBaseType } from '../../utils/api-format';
 import { rewriteGeminiMalformedFunctionCallStream } from '../../utils/gemini-malformed-function-call';
+import {
+  createStreamVisibilityTracker,
+  isStreamEmpty,
+  observeStreamChunk,
+} from '../dispatch/empty-completion';
 
 function getHeaderValue(request: FastifyRequest, headerName: string): string | undefined {
   const value = request.headers?.[headerName];
@@ -263,7 +268,11 @@ export async function handleResponse(
 
     if (unifiedResponse.bypassTransformation) {
       // Direct pass-through, except for retryable reclassification of Gemini's
-      // MALFORMED_FUNCTION_CALL terminal frame.
+      // MALFORMED_FUNCTION_CALL terminal frame. T5 empty-completion detection
+      // (below) does not run on this path: bypass mode never produces unified
+      // chunk objects to inspect (the client receives raw provider bytes
+      // verbatim), and re-parsing every provider's raw SSE format just to
+      // detect emptiness is out of scope here.
       finalClientStream = rawStream;
     } else {
       /**
@@ -279,10 +288,76 @@ export async function handleResponse(
         ? providerTransformer.transformStream(rawStream)
         : rawStream;
 
+      // T5: empty-completion observability. Streaming can't fail over —
+      // headers are already sent by the time we'd know the completion was
+      // empty — so this is log/metadata only: tap the UNIFIED chunk stream
+      // (the actual UnifiedChatStreamChunk objects `formatStream` is about to
+      // consume, not client-encoded bytes) and count content/tool-call/
+      // reasoning presence as chunks pass through. Only counts are kept
+      // (see empty-completion.ts) — the delta text itself is never buffered,
+      // so this can't be (and isn't meant to be) used to retry/replay the
+      // response; buffering the full stream purely to support a retry is
+      // explicitly out of scope for T5.
+      //
+      // Only attached when transformStream() actually produced unified chunk
+      // objects (the same condition step 1 above already branches on) —
+      // otherwise `unifiedStream === rawStream` (raw bytes) and there is
+      // nothing chunk-shaped to inspect.
+      const visibilityTracker = createStreamVisibilityTracker();
+      const observedUnifiedStream = providerTransformer.transformStream
+        ? unifiedStream.pipeThrough(
+            new TransformStream({
+              transform(chunk, controller) {
+                observeStreamChunk(visibilityTracker, chunk);
+                // A unified error chunk WITHOUT a finish_reason
+                // (response.failed / a mid-stream provider error — however
+                // transformStream renders it) means the completion did not
+                // finish cleanly. Mark the usage record accordingly (once)
+                // so it's never reported as a plain success, nor — via the
+                // flush's empty-downgrade below, which only ever upgrades a
+                // 'success' into 'empty' — silently reclassified as merely
+                // "empty" once the stream ends. Error chunks that DO carry
+                // a finish_reason are "ended incomplete" outcomes
+                // (response.incomplete → 'length'/'content_filter'): they
+                // ride the unified error channel for routing but are
+                // rendered as a normal finish for chat clients (and as
+                // response.incomplete for Responses clients) — a
+                // successful-if-truncated turn, not an error — so they keep
+                // 'success' (or, when the truncation left zero visible
+                // output, the flush's 'empty' downgrade below).
+                if (
+                  chunk?.event === 'error' &&
+                  !chunk.finish_reason &&
+                  usageRecord.responseStatus !== 'error'
+                ) {
+                  usageRecord.responseStatus = 'error';
+                }
+                controller.enqueue(chunk);
+              },
+              flush() {
+                // Only ever downgrade a plain 'success' into 'empty' — never
+                // clobber a more specific status (e.g. 'error', set above
+                // when a unified error chunk passed through, or 'error' from
+                // the Gemini MALFORMED_FUNCTION_CALL tap above) that may have
+                // already been set while this stream was flowing.
+                if (isStreamEmpty(visibilityTracker) && usageRecord.responseStatus === 'success') {
+                  usageRecord.responseStatus = 'empty';
+                  logger.warn(
+                    `Empty completion (no visible output) streamed to client for ` +
+                      `${usageRecord.provider ?? 'unknown'}/${usageRecord.selectedModelName ?? 'unknown'} ` +
+                      `(alias=${usageRecord.canonicalModelName ?? usageRecord.incomingModelAlias ?? 'n/a'}, ` +
+                      `requestId=${usageRecord.requestId})`
+                  );
+                }
+              },
+            })
+          )
+        : unifiedStream;
+
       // Step 2: Unified internal objects -> Client SSE format
       finalClientStream = clientTransformer.formatStream
-        ? clientTransformer.formatStream(unifiedStream)
-        : unifiedStream;
+        ? clientTransformer.formatStream(observedUnifiedStream)
+        : observedUnifiedStream;
     }
 
     // TAP THE TRANSFORMED STREAM for debugging

--- a/packages/backend/src/utils/__tests__/response-handler.test.ts
+++ b/packages/backend/src/utils/__tests__/response-handler.test.ts
@@ -2,9 +2,12 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { handleResponse } from '../../services/responses/response-handler';
 import { FastifyReply, FastifyRequest } from 'fastify';
 import { UsageStorageService } from '../../services/observability/usage-storage';
+import { TransformerFactory } from '../../services/dispatch/transformer-factory';
 import { Transformer } from '../../types/transformer';
 import { UnifiedChatResponse } from '../../types/unified';
 import { UsageRecord } from '../../types/usage';
+import { registerSpy } from '../../../test/test-utils';
+import { logger } from '../../utils/logger';
 import { DebugManager } from '../../services/observability/debug-manager';
 
 describe('handleResponse', () => {
@@ -410,6 +413,401 @@ describe('handleResponse', () => {
       expect(usageRecord.tokensCached).toBe(55);
       expect(usageRecord.tokensCacheWrite).toBe(66);
       expect(mockStorage.saveRequest).toHaveBeenCalled();
+    });
+  });
+
+  describe('streaming empty-completion detection (T5)', () => {
+    // Fake transformer whose "provider" wire format is newline-delimited
+    // JSON — each line IS already a UnifiedChatStreamChunk object. This
+    // sidesteps any specific real provider SSE format so the test exercises
+    // exactly the response-handler.ts seam under test (the tap inserted
+    // between transformStream's output and formatStream's input), independent
+    // of any one real transformer's implementation.
+    function makeFakeStreamingTransformer(): Transformer {
+      return {
+        name: 'fake-stream-transformer',
+        defaultEndpoint: '/test',
+        parseRequest: vi.fn(),
+        transformRequest: vi.fn(),
+        transformResponse: vi.fn(),
+        extractUsage: vi.fn(),
+        formatResponse: vi.fn(),
+        transformStream(stream: ReadableStream): ReadableStream {
+          const decoder = new TextDecoder();
+          return new ReadableStream({
+            async start(controller) {
+              const reader = stream.getReader();
+              let buffer = '';
+              try {
+                while (true) {
+                  const { done, value } = await reader.read();
+                  if (done) break;
+                  buffer += decoder.decode(value, { stream: true });
+                }
+              } finally {
+                reader.releaseLock();
+              }
+              for (const line of buffer.split('\n')) {
+                const trimmed = line.trim();
+                if (!trimmed) continue;
+                controller.enqueue(JSON.parse(trimmed));
+              }
+              controller.close();
+            },
+          });
+        },
+        formatStream(stream: ReadableStream): ReadableStream {
+          const encoder = new TextEncoder();
+          return new ReadableStream({
+            async start(controller) {
+              const reader = stream.getReader();
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                controller.enqueue(encoder.encode(`${JSON.stringify(value)}\n`));
+              }
+              controller.close();
+            },
+          });
+        },
+      };
+    }
+
+    function makeRawChunkStream(chunks: unknown[]): ReadableStream<Uint8Array> {
+      const encoder = new TextEncoder();
+      return new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(encoder.encode(`${JSON.stringify(chunk)}\n`));
+          }
+          controller.close();
+        },
+      });
+    }
+
+    /** Drains a Node Readable to completion, the way reply.send(pipeline) would in production. */
+    function drainNodeStream(stream: any): Promise<void> {
+      return new Promise((resolve, reject) => {
+        stream.on('data', () => {});
+        stream.once('end', () => resolve());
+        stream.once('error', reject);
+      });
+    }
+
+    test('stream with zero visible deltas marks responseStatus="empty" and logs a warn', async () => {
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-empty-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          { id: 'c1', model: 'model-1', delta: {}, finish_reason: null },
+          { id: 'c1', model: 'model-1', delta: {}, finish_reason: 'stop' },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-empty-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      // Let any pending microtasks (e.g. fire-and-forget saveRequest) settle.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('empty');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Empty completion (no visible output)')
+      );
+    });
+
+    test('stream with visible content keeps responseStatus="success"', async () => {
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-content-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          { id: 'c1', model: 'model-1', delta: { content: 'Hello' }, finish_reason: null },
+          { id: 'c1', model: 'model-1', delta: {}, finish_reason: 'stop' },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-content-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('success');
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('Empty completion (no visible output)')
+      );
+    });
+
+    test('stream with an error chunk (no content) marks responseStatus="error", not "empty"/"success"', async () => {
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-error-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          {
+            id: 'c1',
+            model: 'model-1',
+            event: 'error',
+            delta: {},
+            error: { statusCode: 500, code: 'response_failed', message: 'boom' },
+          },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-error-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Not 'empty' (would silently hide the failure) and not the initial
+      // 'success' default — the error chunk must win over both.
+      expect(usageRecord.responseStatus).toBe('error');
+    });
+
+    test('stream with visible content THEN an error chunk still marks responseStatus="error"', async () => {
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-content-then-error-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          { id: 'c1', model: 'model-1', delta: { content: 'Partial' }, finish_reason: null },
+          {
+            id: 'c1',
+            model: 'model-1',
+            event: 'error',
+            delta: {},
+            error: { statusCode: 500, code: 'response_failed', message: 'boom mid-stream' },
+          },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-content-then-error-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('error');
+    });
+
+    test('stream with content then an incomplete-as-length error chunk (finish_reason present) keeps responseStatus="success"', async () => {
+      // "Ended incomplete" outcomes (Responses response.incomplete →
+      // max_output_tokens/content_filter) deliberately travel the unified
+      // error channel WITH a finish_reason and are rendered as a normal
+      // finish for chat clients — a successful-if-truncated turn, not an
+      // error. Only finish_reason-less error chunks (hard failures) may
+      // stamp the usage record 'error'.
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-incomplete-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          { id: 'c1', model: 'model-1', delta: { content: 'Partial' }, finish_reason: null },
+          {
+            id: 'c1',
+            model: 'model-1',
+            event: 'error',
+            delta: {},
+            finish_reason: 'length',
+            incomplete_details: { reason: 'max_output_tokens' },
+            error: {
+              statusCode: 500,
+              code: 'max_output_tokens',
+              message: 'Response ended incomplete: max_output_tokens',
+            },
+          },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-incomplete-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('success');
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('Empty completion (no visible output)')
+      );
+    });
+
+    test('incomplete stream with ZERO visible output is downgraded to "empty" at flush, not recorded as "error"', async () => {
+      // Locked deliberately: an incomplete-as-length chunk no longer stamps
+      // 'error' (it is a finish, not a failure), so the record still holds
+      // the baseline 'success' when the flush runs — and a stream that
+      // delivered zero visible output to the client is exactly what the
+      // flush's empty-downgrade exists to flag, regardless of WHY it ended.
+      // The truncation detail is not lost: the record's finishReason
+      // ('length'/'content_filter', via usage-logging's raw-mode incomplete
+      // mapping) still says the turn was cut off — 'empty' + that
+      // finishReason together read "truncated before any visible output".
+      const fakeTransformer = makeFakeStreamingTransformer();
+      registerSpy(TransformerFactory, 'getTransformer').mockReturnValue(fakeTransformer);
+
+      const unifiedResponse: UnifiedChatResponse = {
+        id: 'resp-incomplete-empty-stream',
+        model: 'model-1',
+        content: null,
+        stream: makeRawChunkStream([
+          {
+            id: 'c1',
+            model: 'model-1',
+            event: 'error',
+            delta: {},
+            finish_reason: 'length',
+            incomplete_details: { reason: 'max_output_tokens' },
+            error: {
+              statusCode: 500,
+              code: 'max_output_tokens',
+              message: 'Response ended incomplete: max_output_tokens',
+            },
+          },
+        ]),
+        plexus: {
+          provider: 'test-provider',
+          model: 'model-orig',
+          apiType: 'chat',
+        },
+      };
+
+      const usageRecord: Partial<UsageRecord> = {
+        requestId: 'req-incomplete-empty-stream',
+        canonicalModelName: 'test-alias',
+      };
+
+      await handleResponse(
+        mockRequest,
+        mockReply,
+        unifiedResponse,
+        fakeTransformer,
+        usageRecord,
+        mockStorage,
+        Date.now(),
+        'chat'
+      );
+
+      const lastCall = (mockReply.send as any).mock.calls.at(-1);
+      await drainNodeStream(lastCall[0]);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(usageRecord.responseStatus).toBe('empty');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Empty completion (no visible output)')
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Part 4/5 of the split of #757 — **stacked on #762** (cumulative diff until predecessors merge; review scope below).

A 200 with zero visible output is no longer returned as a "successful" empty turn, and failover errors finally say what happened per target.

## What changed

- **Empty-completion detection** (`services/dispatch/empty-completion.ts`, pure helpers): non-streaming responses with no text/tool calls/reasoning/annotations fail over to the next target (finish-reason gated so `content_filter`/refusal/`length` terminals and `clientError` responses are never re-routed; no provider cooldown; all-targets-empty returns the last empty 200 as a valid upstream answer). Streaming can't retry after headers — a visibility tap flags empty streams in the usage record (`responseStatus: "empty"`) with a warn; genuine hard-error chunks (no finish_reason) record `"error"`.
- **Failover diagnostics** (`attempt-history.ts`): "All targets failed" now tags each attempt — `openai/gpt-5.5 (400), aggregator/gpt-5.5 (empty)` — with `(network)`/`(stall)`/`(skipped)` for non-HTTP outcomes; skipped records no longer steal FIFO slots from real attempts sharing a provider/model key.

## Review scope

`empty-completion.ts` + tests, `standard-attempt-request.ts` empty-failover block, `response-handler.ts` visibility tap, `attempt-history.ts` + tests.

## Tests

Full suite green on this branch: 232 files / 2520 tests, typecheck and biome clean. Includes dispatcher-level failover integration tests through real transformers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
