### PR TITLE
feat(transformers): typed image outputs with per-format markdown rendering

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-empty-completion.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-empty-completion.test.ts
@@ -536,4 +536,37 @@ describe('Dispatcher empty-completion failover (T5)', () => {
     expect(meta?.attemptCount).toBe(1);
     expect(meta?.finalAttemptProvider).toBe('p1');
   });
+
+  test('an image_generation_call-only completion on the TRANSFORMED path (chat client -> responses provider) is not retried as empty', async () => {
+    setConfigForTesting(makeResponsesConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => imageOnlyResponsesResponse())
+      .mockImplementationOnce(async () => {
+        throw new Error('should not be called — failing over here would be the bug');
+      });
+
+    const dispatcher = new Dispatcher();
+    // A CHAT-format client request against the responses-target alias:
+    // incoming 'chat' !== target 'responses' means NO passthrough/bypass, so
+    // the unified response is the TRANSFORMED one — PURE content (null, no
+    // baked image markdown), typed `image_generation_calls`, no rawResponse.
+    // The typed empty-completion signal is the only thing keeping this from
+    // being misclassified as empty and failed over.
+    const response = await dispatcher.dispatch({
+      model: 'responses-alias',
+      messages: [{ role: 'user', content: 'draw a cat' }],
+      incomingApiType: 'chat',
+      stream: false,
+    } as UnifiedChatRequest);
+    const meta = (response as any).plexus;
+
+    // A single fetch call proves NO failover happened.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(meta?.attemptCount).toBe(1);
+    expect(meta?.finalAttemptProvider).toBe('p1');
+    // Transformed path, not bypass: pure content + typed carry.
+    expect(response.bypassTransformation).toBeUndefined();
+    expect(response.content).toBeNull();
+    expect(response.image_generation_calls?.[0]?.result).toBe('base64-image-data');
+  });
 });

--- a/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
@@ -9,6 +9,7 @@ import {
   observeStreamChunk,
   type StreamVisibilityTracker,
 } from '../empty-completion';
+import { ResponsesTransformer } from '../../../transformers/responses';
 import type { UnifiedChatResponse } from '../../../types/unified';
 
 // A bare, all-absent UnifiedChatResponse — the "truly empty" fixture shared
@@ -322,6 +323,83 @@ describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — image_genera
     } as UnifiedChatResponse & { images: unknown[] };
 
     expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+});
+
+describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — typed image_generation_calls signal (transformed path)', () => {
+  // With PURE unified content (image markdown is composed by the
+  // client-facing formatters, never baked into `content`), an image-only
+  // TRANSFORMED (non-bypass) response has no text and no rawResponse — the
+  // typed `image_generation_calls` carry is its only visibility signal.
+  it('typed image_generation_calls with a non-empty result count as visible output (no failover)', () => {
+    const response = {
+      ...emptyResponse(),
+      image_generation_calls: [{ id: 'ig_1', status: 'completed', result: 'aGVsbG8=' }],
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(1);
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('multiple typed entries are all counted', () => {
+    const response = {
+      ...emptyResponse(),
+      image_generation_calls: [
+        { id: 'ig_1', status: 'completed', result: 'aGVsbG8=' },
+        { id: 'ig_2', status: 'completed', result: 'd29ybGQ=' },
+      ],
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+
+  it('typed entries with an empty or missing result contribute zero (defensive)', () => {
+    const response = {
+      ...emptyResponse(),
+      image_generation_calls: [{ id: 'ig_1', status: 'completed', result: '' }, { id: 'ig_2' }],
+    } as any;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(0);
+    expect(isEmptyUnifiedResponse(response)).toBe(true);
+  });
+
+  it('typed entries combine with the rawResponse count (bypass path unchanged)', () => {
+    const response = {
+      ...emptyResponse(),
+      image_generation_calls: [{ id: 'ig_1', status: 'completed', result: 'aGVsbG8=' }],
+      rawResponse: {
+        output: [{ type: 'image_generation_call', id: 'ig_2', status: 'completed' }],
+      },
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).imageCount).toBe(2);
+  });
+
+  // End-to-end across the two layers: a REAL ResponsesTransformer transform
+  // of an image-only completion (the transformed/non-bypass dispatch path —
+  // no rawResponse attached) must read as non-empty purely via the typed
+  // carry, since pure unified content gives it no text signal. This is the
+  // regression lock for the production empty-completion bug: if the typed
+  // signal ever regresses, image-only completions would be misclassified as
+  // empty and failed over again.
+  it('a real transformed image-only Responses completion is NOT empty (typed carry is the only signal)', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_transformed',
+      object: 'response',
+      created_at: 1,
+      status: 'completed',
+      model: 'image-model',
+      output: [
+        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: 'aGVsbG8=' },
+      ],
+    });
+
+    // Pure content, no raw body: the typed carry must be what keeps this
+    // visible.
+    expect(unified.content).toBeNull();
+    expect(unified.rawResponse).toBeUndefined();
+    expect(getResponseVisibilitySignals(unified).imageCount).toBe(1);
+    expect(isEmptyUnifiedResponse(unified)).toBe(false);
   });
 });
 

--- a/packages/backend/src/services/dispatch/empty-completion.ts
+++ b/packages/backend/src/services/dispatch/empty-completion.ts
@@ -70,23 +70,52 @@ function hasVisibleText(value: string | null | undefined): boolean {
  * (rather than `UnifiedChatResponse` verbatim) so forward-compatible fields
  * not yet on the unified type — e.g. a future `images` array for multimodal
  * chat output — are picked up defensively without requiring a type change
- * here. No current transformer populates the `images` array, so the
- * `images`-array contribution is exercised directly by the unit tests rather
- * than via a real transformer fixture.
+ * here. No current transformer populates the `images` array (Responses image
+ * output travels on the typed `image_generation_calls` carry — see
+ * countTypedImageGenerationCalls below), so the `images`-array contribution
+ * is exercised directly by the unit tests rather than via a real transformer
+ * fixture.
  */
 type VisibilityCheckableResponse = Pick<
   UnifiedChatResponse,
-  'content' | 'reasoning_content' | 'thinking' | 'tool_calls' | 'annotations' | 'finishReason'
+  | 'content'
+  | 'reasoning_content'
+  | 'thinking'
+  | 'tool_calls'
+  | 'annotations'
+  | 'finishReason'
+  | 'image_generation_calls'
 > & { images?: unknown[] | null; rawResponse?: unknown };
+
+/**
+ * Counts typed `image_generation_calls` entries with a non-empty base64
+ * `result` on the unified response (see UnifiedImageGenerationCall in
+ * types/unified.ts). This is the PRIMARY image signal on the transformed
+ * (non-bypass) path: unified `content` stays PURE authored text (image
+ * markdown is composed per client format by the renderers, never baked into
+ * content — see transformers/image-rendering.ts), so an image-only
+ * completion has no text and this typed count is what proves the model
+ * produced visible output. Without it, image-only completions would be
+ * misclassified as empty and needlessly failed over.
+ */
+function countTypedImageGenerationCalls(
+  imageGenerationCalls: UnifiedChatResponse['image_generation_calls']
+): number {
+  if (!Array.isArray(imageGenerationCalls)) return 0;
+  return imageGenerationCalls.filter(
+    (imageCall) => typeof imageCall?.result === 'string' && imageCall.result.length > 0
+  ).length;
+}
 
 /**
  * Counts `image_generation_call` built-in-tool-call output items
  * (types/responses.ts `ResponsesBuiltInToolCallItem`) on a raw (pre-transform)
- * Responses API body — the bypass-transformation path (`rawResponse` is
- * populated by dispatcher.ts's `handleNonStreamingResponse`, the ORIGINAL
- * body available at the empty-completion call seam). Result-less items (an
- * `image_generation_call` without a base64 `result`) still count: the model
- * demonstrably produced output.
+ * Responses API body. This raw count covers what the typed carry above
+ * cannot see: the bypass-transformation path (`rawResponse` is populated by
+ * dispatcher.ts's `handleNonStreamingResponse`, the ORIGINAL body available
+ * at the empty-completion call seam) and result-less items (an
+ * `image_generation_call` without a base64 `result` gets no typed carry but
+ * still proves the model produced output).
  */
 function countRawImageGenerationCalls(rawResponse: unknown): number {
   const output = (rawResponse as { output?: unknown })?.output;
@@ -105,6 +134,7 @@ export function getResponseVisibilitySignals(
     toolCallCount: response.tool_calls?.length ?? 0,
     annotationCount: response.annotations?.length ?? 0,
     imageCount:
+      countTypedImageGenerationCalls(response.image_generation_calls) +
       (Array.isArray(response.images) ? response.images.length : 0) +
       countRawImageGenerationCalls(response.rawResponse),
   };

--- a/packages/backend/src/transformers/__tests__/image-content-composition.test.ts
+++ b/packages/backend/src/transformers/__tests__/image-content-composition.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'vitest';
+import { composeContentWithImageMarkdown } from '../image-rendering';
+import { OpenAITransformer } from '../openai';
+import { AnthropicTransformer } from '../anthropic';
+import { GeminiTransformer } from '../gemini';
+import { OllamaTransformer } from '../ollama';
+import { OpenAICompletionTransformer } from '../completions';
+import type { UnifiedChatResponse } from '../../types/unified';
+
+// Consumer audit for the pure-content split: unified `content` carries ONLY
+// authored text, and every CHAT-FORMAT unary formatter (chat, anthropic
+// messages, gemini, ollama, legacy completions) composes the size-guarded
+// image markdown itself from the typed `image_generation_calls` carry — the
+// exact client-visible bytes the pre-split design baked into unified content.
+// The responses-facing formatter is the one format that must NOT compose
+// (native re-emit instead) — covered in responses-stream.test.ts.
+
+const TINY_IMAGE_B64 = 'aGVsbG8=';
+const TINY_IMAGE_MARKDOWN = `![generated image](data:image/png;base64,${TINY_IMAGE_B64})`;
+
+function unifiedWithImage(content: string | null): UnifiedChatResponse {
+  return {
+    id: 'resp_compose',
+    model: 'image-model',
+    created: 1234567890,
+    content,
+    image_generation_calls: [{ id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 }],
+    usage: {
+      input_tokens: 5,
+      output_tokens: 1,
+      total_tokens: 6,
+      reasoning_tokens: 0,
+      cached_tokens: 0,
+      cache_creation_tokens: 0,
+    },
+  };
+}
+
+describe('composeContentWithImageMarkdown (shared helper)', () => {
+  test('appends one markdown segment per typed item after the authored text, joined with \\n', () => {
+    const composed = composeContentWithImageMarkdown('Here you go:', [
+      { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      { id: 'ig_2', status: 'completed', result: TINY_IMAGE_B64 },
+    ]);
+    expect(composed).toBe(`Here you go:\n${TINY_IMAGE_MARKDOWN}\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('null/empty content with images renders the markdown alone', () => {
+    expect(composeContentWithImageMarkdown(null, [{ id: 'ig_1', result: TINY_IMAGE_B64 }])).toBe(
+      TINY_IMAGE_MARKDOWN
+    );
+    expect(composeContentWithImageMarkdown('', [{ id: 'ig_1', result: TINY_IMAGE_B64 }])).toBe(
+      TINY_IMAGE_MARKDOWN
+    );
+  });
+
+  test('no images (undefined, empty array, or result-less entries) returns content UNCHANGED', () => {
+    expect(composeContentWithImageMarkdown('text', undefined)).toBe('text');
+    expect(composeContentWithImageMarkdown('text', [])).toBe('text');
+    expect(composeContentWithImageMarkdown('text', [{ result: '' } as any])).toBe('text');
+    // Byte-transparency for image-less responses: null stays null, empty
+    // string stays empty string, undefined stays undefined — no coercion.
+    expect(composeContentWithImageMarkdown(null, undefined)).toBeNull();
+    expect(composeContentWithImageMarkdown('', undefined)).toBe('');
+    expect(composeContentWithImageMarkdown(undefined, undefined)).toBeUndefined();
+  });
+
+  test('an oversized result composes the omission placeholder, never the base64', () => {
+    const oversized = 'B'.repeat(2 * 8 * 1024 * 1024);
+    const composed = composeContentWithImageMarkdown('note', [{ id: 'ig_big', result: oversized }]);
+    expect(composed).toBe('note\n[generated image omitted: 12.0 MB exceeds inline limit]');
+  });
+});
+
+describe('every chat-format unary formatter composes image markdown from the typed carry', () => {
+  test('chat (OpenAITransformer.formatResponse)', async () => {
+    const formatted = await new OpenAITransformer().formatResponse(unifiedWithImage('Here:'));
+    expect(formatted.choices[0].message.content).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('anthropic messages (AnthropicTransformer.formatResponse)', async () => {
+    const formatted = await new AnthropicTransformer().formatResponse(unifiedWithImage('Here:'));
+    const textBlocks = formatted.content.filter((block: any) => block.type === 'text');
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0].text).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('anthropic messages renders a text block even for an image-only response', async () => {
+    const formatted = await new AnthropicTransformer().formatResponse(unifiedWithImage(null));
+    const textBlocks = formatted.content.filter((block: any) => block.type === 'text');
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0].text).toBe(TINY_IMAGE_MARKDOWN);
+  });
+
+  test('gemini (GeminiTransformer.formatResponse)', async () => {
+    const formatted = await new GeminiTransformer().formatResponse(unifiedWithImage('Here:'));
+    const textParts = formatted.candidates[0].content.parts.filter(
+      (part: any) => typeof part.text === 'string' && !part.thought
+    );
+    expect(textParts).toHaveLength(1);
+    expect(textParts[0].text).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('ollama (OllamaTransformer.formatResponse)', async () => {
+    const formatted = await new OllamaTransformer().formatResponse(unifiedWithImage('Here:'));
+    expect(formatted.choices[0].message.content).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('legacy completions (OpenAICompletionTransformer.formatResponse)', async () => {
+    const formatted = await new OpenAICompletionTransformer().formatResponse(
+      unifiedWithImage('Here:')
+    );
+    expect(formatted.choices[0].text).toBe(`Here:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  test('image-less responses stay byte-identical through the chat formatter (null content passthrough)', async () => {
+    const formatted = await new OpenAITransformer().formatResponse({
+      id: 'resp_plain',
+      model: 'text-model',
+      content: null,
+    } as UnifiedChatResponse);
+    expect(formatted.choices[0].message.content).toBeNull();
+  });
+});

--- a/packages/backend/src/transformers/__tests__/openai-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/openai-stream.test.ts
@@ -500,4 +500,41 @@ describe('OpenAITransformer.formatStream robustness', () => {
     expect(chunks.filter((c) => c === '[DONE]')).toHaveLength(1);
     expect(chunks.at(-1)).toBe('[DONE]');
   });
+
+  test('a unified chunk carrying typed image_generation_calls renders ONLY the markdown content into chat SSE', async () => {
+    // responses.ts transformStream pairs each completed image item's typed
+    // carry (chunk-level `image_generation_calls`, full base64) with its
+    // chat-format markdown rendering on `delta.content`. A chat-format
+    // client must receive exactly the markdown — the typed field (which can
+    // hold multi-megabyte, uncapped base64) must never leak into the chat
+    // wire chunk.
+    const markdown = '![generated image](data:image/png;base64,aGVsbG8=)';
+    const unifiedStream = unifiedStreamFromChunks([
+      {
+        id: 'chatcmpl_img',
+        model: 'gpt-image-model',
+        created: 1234567890,
+        delta: { content: markdown },
+        image_generation_calls: [{ id: 'ig_1', status: 'completed', result: 'aGVsbG8=' }],
+        finish_reason: null,
+      },
+      {
+        id: 'chatcmpl_img',
+        model: 'gpt-image-model',
+        created: 1234567890,
+        delta: {},
+        finish_reason: 'stop',
+      },
+    ]);
+
+    const formatted = new OpenAITransformer().formatStream(unifiedStream);
+    const chunks = await readOpenAISSEChunks(formatted as ReadableStream<Uint8Array>);
+
+    const contentChunks = chunks.filter((c) => c !== '[DONE]' && c.choices?.[0]?.delta?.content);
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].choices[0].delta.content).toBe(markdown);
+    expect(
+      chunks.some((c) => c !== '[DONE]' && JSON.stringify(c).includes('image_generation_calls'))
+    ).toBe(false);
+  });
 });

--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -363,6 +363,924 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 });
 
+// Tiny fake base64 payload — content is irrelevant, only the data-URI
+// plumbing matters.
+const TINY_IMAGE_B64 = 'aGVsbG8=';
+const TINY_IMAGE_MARKDOWN = `![generated image](data:image/png;base64,${TINY_IMAGE_B64})`;
+
+describe('ResponsesTransformer image_generation_call rendering (pure unified content + chat composition)', () => {
+  // The chat-visible text for a unified response, exactly as a CHAT-format
+  // client receives it: OpenAITransformer.formatResponse composes the
+  // authored text + rendered image markdown from the typed carry
+  // (transformers/image-rendering.ts). The expected strings in this describe
+  // are the pre-split baked-content bytes — chat clients must keep receiving
+  // them byte-identically.
+  const chatVisibleContent = async (unified: any): Promise<string | null> => {
+    const chat = await new OpenAITransformer().formatResponse(unified);
+    return chat.choices[0].message.content;
+  };
+
+  test('an image_generation_call with a base64 result renders markdown data-URI content for chat clients', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      ],
+      usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+    });
+
+    // Unified content stays PURE — no message item, no text. The image
+    // travels typed; the markdown exists only in the chat projection.
+    expect(unified.content).toBeNull();
+    expect(unified.image_generation_calls).toEqual([
+      { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+    ]);
+    expect(await chatVisibleContent(unified)).toBe(TINY_IMAGE_MARKDOWN);
+  });
+
+  test('chat composition appends image markdown after the authored message text', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_order',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          id: 'msg_1',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Here is your image:' }],
+        },
+        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      ],
+    });
+
+    expect(unified.content).toBe('Here is your image:');
+    expect(await chatVisibleContent(unified)).toBe(`Here is your image:\n${TINY_IMAGE_MARKDOWN}`);
+  });
+
+  // `output_format` is a REQUEST-side image tool field — it is not present
+  // on image_generation_call output items, so the mime subtype is sniffed
+  // from the decoded base64 head's magic bytes instead (PNG/JPEG/WebP/GIF,
+  // defaulting to png).
+  describe('mime subtype sniffing from the base64 signature', () => {
+    const b64 = (bytes: number[]) => Buffer.from(bytes).toString('base64');
+
+    const renderImage = async (result: string) => {
+      const unified = await new ResponsesTransformer().transformResponse({
+        id: 'resp_img_sniff',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result }],
+      });
+      return chatVisibleContent(unified);
+    };
+
+    test('PNG signature (\\x89PNG) renders image/png', async () => {
+      const png = b64([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
+      expect(await renderImage(png)).toBe(`![generated image](data:image/png;base64,${png})`);
+    });
+
+    test('JPEG signature (\\xFF\\xD8) renders image/jpeg', async () => {
+      const jpeg = b64([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01]);
+      expect(await renderImage(jpeg)).toBe(`![generated image](data:image/jpeg;base64,${jpeg})`);
+    });
+
+    test('WebP signature (RIFF....WEBP) renders image/webp', async () => {
+      const webp = b64([
+        0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38,
+        0x20,
+      ]);
+      expect(await renderImage(webp)).toBe(`![generated image](data:image/webp;base64,${webp})`);
+    });
+
+    test('GIF signature (GIF8) renders image/gif', async () => {
+      const gif = b64([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00]);
+      expect(await renderImage(gif)).toBe(`![generated image](data:image/gif;base64,${gif})`);
+    });
+
+    test('an unrecognized signature defaults to image/png', async () => {
+      // TINY_IMAGE_B64 decodes to "hello" — no known magic bytes.
+      expect(await renderImage(TINY_IMAGE_B64)).toBe(TINY_IMAGE_MARKDOWN);
+    });
+
+    test('a request-style output_format field on the item is IGNORED (not a response field)', async () => {
+      const unified = await new ResponsesTransformer().transformResponse({
+        id: 'resp_img_webp',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+            output_format: 'webp',
+          },
+        ],
+      });
+
+      // The payload's actual bytes ("hello" — no signature) decide: png.
+      expect(await chatVisibleContent(unified)).toBe(TINY_IMAGE_MARKDOWN);
+    });
+
+    test('RIFF head WITHOUT the WEBP tag does not sniff as webp', async () => {
+      const riffOnly = b64([
+        0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x41, 0x56, 0x49, 0x20,
+      ]);
+      expect(await renderImage(riffOnly)).toBe(
+        `![generated image](data:image/png;base64,${riffOnly})`
+      );
+    });
+  });
+
+  test('an image_generation_call without a base64 result contributes nothing', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_noresult',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
+    });
+
+    expect(unified.content).toBeNull();
+    expect(unified.image_generation_calls).toBeUndefined();
+    expect(await chatVisibleContent(unified)).toBeNull();
+  });
+
+  test('a text-only response keeps its existing unified content shape (happy path unchanged)', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_text_only',
+      object: 'response',
+      model: 'gpt-4o',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          id: 'msg_1',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Full answer' }],
+        },
+      ],
+    });
+
+    expect(unified.content).toBe('Full answer');
+  });
+
+  test('a base64 result over the inline limit renders the omission placeholder for chat clients, not a data URI', async () => {
+    // One char past MAX_INLINE_IMAGE_BASE64_CHARS (8 * 1024 * 1024).
+    // Approximate decoded size = 8388609 * 3/4 bytes ≈ 6.0 MB.
+    const oversized = 'A'.repeat(8 * 1024 * 1024 + 1);
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_oversized',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: oversized },
+      ],
+    });
+
+    // Pure unified content; the size guard applies only to the chat
+    // projection — the typed carry keeps the full payload.
+    expect(unified.content).toBeNull();
+    expect(unified.image_generation_calls?.[0]?.result).toBe(oversized);
+    expect(await chatVisibleContent(unified)).toBe(
+      '[generated image omitted: 6.0 MB exceeds inline limit]'
+    );
+  });
+
+  test('a base64 result exactly at the inline limit still renders as a data URI (boundary)', async () => {
+    const atLimit = 'A'.repeat(8 * 1024 * 1024);
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_img_at_limit',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result: atLimit }],
+    });
+
+    expect(await chatVisibleContent(unified)).toBe(
+      `![generated image](data:image/png;base64,${atLimit})`
+    );
+  });
+});
+
+describe('ResponsesTransformer transformStream - image_generation_call rendering', () => {
+  test('a completed image_generation_call output item becomes a unified content delta (markdown data URI)', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s1', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      },
+      { type: 'response.completed', response: {} },
+    ]);
+
+    const contentChunks = chunks.filter(
+      (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
+    );
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].delta.content).toBe(TINY_IMAGE_MARKDOWN);
+  });
+
+  test('an image_generation_call present only in response.completed still renders, before the final chunk', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s2', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'resp_img_s2',
+          status: 'completed',
+          output: [
+            {
+              id: 'ig_1',
+              type: 'image_generation_call',
+              status: 'completed',
+              result: TINY_IMAGE_B64,
+            },
+          ],
+          usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+        },
+      },
+    ]);
+
+    const contentIndex = chunks.findIndex((chunk) => chunk.delta?.content === TINY_IMAGE_MARKDOWN);
+    const finishIndex = chunks.findIndex((chunk) => chunk.finish_reason);
+    expect(contentIndex).toBeGreaterThan(-1);
+    expect(finishIndex).toBeGreaterThan(contentIndex);
+  });
+
+  test('does not double-render an item that streamed via output_item.done AND appears in response.completed', async () => {
+    const imageItem = {
+      id: 'ig_1',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    };
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s3', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      { type: 'response.output_item.done', output_index: 0, item: imageItem },
+      { type: 'response.completed', response: { id: 'resp_img_s3', output: [imageItem] } },
+    ]);
+
+    const contentChunks = chunks.filter((chunk) => chunk.delta?.content === TINY_IMAGE_MARKDOWN);
+    expect(contentChunks).toHaveLength(1);
+  });
+
+  test('partial-image delta events are skipped (explicitly out of scope) — only the completed item renders', async () => {
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s4', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.image_generation_call.partial_image',
+        output_index: 0,
+        item_id: 'ig_1',
+        partial_image_index: 0,
+        partial_image_b64: 'UEFSVElBTA==',
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      },
+      { type: 'response.completed', response: {} },
+    ]);
+
+    const contentChunks = chunks.filter(
+      (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
+    );
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].delta.content).toBe(TINY_IMAGE_MARKDOWN);
+    expect(chunks.some((chunk) => JSON.stringify(chunk).includes('UEFSVElBTA=='))).toBe(false);
+  });
+
+  test('a base64 result over the inline limit streams the omission placeholder instead of the data URI', async () => {
+    // Twice MAX_INLINE_IMAGE_BASE64_CHARS (8 * 1024 * 1024).
+    // Approximate decoded size = 16777216 * 3/4 bytes = 12.0 MB.
+    const oversized = 'B'.repeat(2 * 8 * 1024 * 1024);
+    const chunks = await transformEvents([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_s5', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: oversized,
+        },
+      },
+      { type: 'response.completed', response: {} },
+    ]);
+
+    const contentChunks = chunks.filter(
+      (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
+    );
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].delta.content).toBe(
+      '[generated image omitted: 12.0 MB exceeds inline limit]'
+    );
+    // The oversized base64 payload must never reach a CONTENT delta (chat/
+    // messages clients render content strings — that's what the inline size
+    // guard protects). The chunk-level `image_generation_calls` typed carry
+    // deliberately DOES hold the full base64 so responses-facing clients can
+    // receive the native item byte-intact — see the typed-carry describe
+    // below.
+    expect(
+      chunks.some(
+        (chunk) =>
+          typeof chunk.delta?.content === 'string' && chunk.delta.content.includes('BBBBBBBB')
+      )
+    ).toBe(false);
+    expect(contentChunks[0].image_generation_calls?.[0]?.result).toBe(oversized);
+  });
+});
+
+// A markdown-only collapse would be lossy for SAME-format clients: a
+// non-bypass responses -> responses route (e.g. a responses:lite subtype,
+// adapter active, vision fallthrough) would receive `message`/`output_text`
+// markdown instead of the native `image_generation_call` item — and the
+// oversized placeholder would destroy the base64 for clients that take it
+// natively. The typed carry (UnifiedImageGenerationCall) keeps the item
+// intact through the unified layer; the responses-facing formatStream /
+// formatResponse re-emit it natively. On the unary path the typed carry is
+// the ONLY image carrier (unified content stays pure); on the streaming path
+// it rides chunk-level, paired with the chat markdown delta on the same
+// chunk, which the responses-facing formatStream structurally skips.
+describe('ResponsesTransformer typed image_generation_call carry (responses -> responses)', () => {
+  function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
+    return new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+  }
+
+  async function collectFormatStreamEvents(
+    chunks: any[],
+    transformer = new ResponsesTransformer()
+  ): Promise<any[]> {
+    const reader = transformer.formatStream(unifiedStreamFromChunks(chunks)).getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+    return output
+      .split('\n\n')
+      .filter((block) => block.trim().length > 0)
+      .map((block) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        return JSON.parse((dataLine as string).replace(/^data:\s*/, ''));
+      });
+  }
+
+  describe('transformStream carries the typed item alongside the markdown', () => {
+    test('a completed image item carries a typed entry on the SAME chunk as its markdown delta', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_typed_1', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: {
+            id: 'ig_1',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        },
+        { type: 'response.completed', response: {} },
+      ]);
+
+      const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
+      expect(imageChunks).toHaveLength(1);
+      expect(imageChunks[0].image_generation_calls).toEqual([
+        { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      ]);
+      // The chat-format markdown rendering rides the same chunk's content.
+      expect(imageChunks[0].delta.content).toBe(TINY_IMAGE_MARKDOWN);
+    });
+
+    test('the typed entry is chunk-level, NOT inside delta (chat formatters forward delta by reference)', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_typed_2', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: {
+            id: 'ig_1',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        },
+        { type: 'response.completed', response: {} },
+      ]);
+
+      const imageChunk = chunks.find((chunk) => chunk.image_generation_calls);
+      expect(imageChunk).toBeDefined();
+      expect(imageChunk.delta.image_generation_calls).toBeUndefined();
+    });
+
+    test('the completed-fallback also carries the typed entry, without double-carrying deduped items', async () => {
+      const imageItem = {
+        id: 'ig_1',
+        type: 'image_generation_call',
+        status: 'completed',
+        result: TINY_IMAGE_B64,
+      };
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_typed_3', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        { type: 'response.output_item.done', output_index: 0, item: imageItem },
+        { type: 'response.completed', response: { id: 'resp_typed_3', output: [imageItem] } },
+      ]);
+
+      const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
+      expect(imageChunks).toHaveLength(1);
+    });
+
+    test('a completed-only item (never streamed via output_item.done) still gets the typed carry', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_typed_4', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_typed_4',
+            status: 'completed',
+            output: [
+              {
+                id: 'ig_9',
+                type: 'image_generation_call',
+                status: 'completed',
+                result: TINY_IMAGE_B64,
+              },
+            ],
+          },
+        },
+      ]);
+
+      const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
+      expect(imageChunks).toHaveLength(1);
+      expect(imageChunks[0].image_generation_calls[0]).toEqual({
+        id: 'ig_9',
+        status: 'completed',
+        result: TINY_IMAGE_B64,
+      });
+    });
+  });
+
+  describe('formatStream re-emits typed items as native output items', () => {
+    const imageChunkFor = (result: string) => ({
+      id: 'resp_native_1',
+      model: 'gpt-image-model',
+      created: 1234567890,
+      delta: { content: `![generated image](data:image/png;base64,${result})` },
+      image_generation_calls: [{ id: 'ig_1', status: 'completed', result }],
+      finish_reason: null,
+    });
+
+    const finishChunk = () => ({
+      id: 'resp_native_1',
+      model: 'gpt-image-model',
+      created: 1234567890,
+      finish_reason: 'stop',
+      usage: {
+        input_tokens: 5,
+        output_tokens: 1,
+        total_tokens: 6,
+        reasoning_tokens: 0,
+        cached_tokens: 0,
+        cache_creation_tokens: 0,
+      },
+    });
+
+    test('emits a native image_generation_call output item (byte-intact) instead of markdown text', async () => {
+      const events = await collectFormatStreamEvents([
+        imageChunkFor(TINY_IMAGE_B64),
+        finishChunk(),
+      ]);
+
+      const doneEvents = events.filter(
+        (e) => e.type === 'response.output_item.done' && e.item?.type === 'image_generation_call'
+      );
+      expect(doneEvents).toHaveLength(1);
+      expect(doneEvents[0].item).toEqual({
+        id: 'ig_1',
+        type: 'image_generation_call',
+        status: 'completed',
+        result: TINY_IMAGE_B64,
+      });
+
+      // The paired markdown must NOT also stream as output_text — the native
+      // item is the only carrier for a Responses-format client.
+      expect(events.some((e) => e.type === 'response.output_text.delta')).toBe(false);
+      expect(JSON.stringify(events).includes('![generated image]')).toBe(false);
+    });
+
+    test('the final response.completed output array includes the native image item', async () => {
+      const events = await collectFormatStreamEvents([
+        imageChunkFor(TINY_IMAGE_B64),
+        finishChunk(),
+      ]);
+
+      const completed = events.find((e) => e.type === 'response.completed');
+      expect(completed).toBeDefined();
+      const imageItems = completed.response.output.filter(
+        (item: any) => item.type === 'image_generation_call'
+      );
+      expect(imageItems).toHaveLength(1);
+      expect(imageItems[0].result).toBe(TINY_IMAGE_B64);
+    });
+
+    test('an OVERSIZED result re-emits with the FULL base64 — the native format has no inline cap', async () => {
+      const oversized = 'C'.repeat(2 * 8 * 1024 * 1024);
+      // transformStream renders the placeholder on content for oversized
+      // items — mirror that pairing here.
+      const events = await collectFormatStreamEvents([
+        {
+          id: 'resp_native_2',
+          model: 'gpt-image-model',
+          created: 1234567890,
+          delta: { content: '[generated image omitted: 12.0 MB exceeds inline limit]' },
+          image_generation_calls: [{ id: 'ig_big', status: 'completed', result: oversized }],
+          finish_reason: null,
+        },
+        finishChunk(),
+      ]);
+
+      const doneEvent = events.find(
+        (e) => e.type === 'response.output_item.done' && e.item?.type === 'image_generation_call'
+      );
+      expect(doneEvent).toBeDefined();
+      expect(doneEvent.item.result).toBe(oversized);
+      // The placeholder must not leak into any text.
+      expect(JSON.stringify(events).includes('exceeds inline limit')).toBe(false);
+    });
+
+    test('message text on OTHER chunks still streams normally alongside a native image item', async () => {
+      const events = await collectFormatStreamEvents([
+        {
+          id: 'resp_native_3',
+          model: 'gpt-image-model',
+          created: 1234567890,
+          delta: { content: 'Here is your image:' },
+          finish_reason: null,
+        },
+        imageChunkFor(TINY_IMAGE_B64),
+        finishChunk(),
+      ]);
+
+      const textDeltas = events.filter((e) => e.type === 'response.output_text.delta');
+      expect(textDeltas).toHaveLength(1);
+      expect(textDeltas[0].delta).toBe('Here is your image:');
+
+      const completed = events.find((e) => e.type === 'response.completed');
+      const types = completed.response.output.map((item: any) => item.type);
+      expect(types).toContain('message');
+      expect(types).toContain('image_generation_call');
+      const messageItem = completed.response.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe('Here is your image:');
+    });
+
+    test('full streaming round-trip (provider SSE -> unified -> client SSE) keeps the item byte-intact', async () => {
+      const unifiedChunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_rt_1', model: 'gpt-image-model', created_at: 1234567890 },
+        },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: {
+            id: 'ig_rt',
+            type: 'image_generation_call',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        },
+        {
+          type: 'response.completed',
+          response: { usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 } },
+        },
+      ]);
+
+      const events = await collectFormatStreamEvents(unifiedChunks);
+      const doneEvent = events.find(
+        (e) => e.type === 'response.output_item.done' && e.item?.type === 'image_generation_call'
+      );
+      expect(doneEvent).toBeDefined();
+      expect(doneEvent.item.result).toBe(TINY_IMAGE_B64);
+      expect(events.some((e) => e.type === 'response.output_text.delta')).toBe(false);
+    });
+  });
+
+  describe('formatResponse (unary) re-emits typed items as native output items', () => {
+    test('transformResponse attaches the typed items and keeps unified content PURE', async () => {
+      const unified = await new ResponsesTransformer().transformResponse({
+        id: 'resp_unary_typed',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            id: 'msg_1',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Here is your image:' }],
+          },
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        ],
+      });
+
+      expect(unified.image_generation_calls).toEqual([
+        { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+      ]);
+      // PURE authored text — the chat-format markdown projection is composed
+      // by the client-facing renderers, never baked in here.
+      expect(unified.content).toBe('Here is your image:');
+    });
+
+    test('a result-less image item still contributes no typed entry', async () => {
+      const unified = await new ResponsesTransformer().transformResponse({
+        id: 'resp_unary_noresult',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
+      });
+
+      expect(unified.image_generation_calls).toBeUndefined();
+    });
+
+    test('formatResponse emits the native item and strips the paired markdown from the message text', async () => {
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_unary_rt',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            id: 'msg_1',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Here is your image:' }],
+          },
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        ],
+      });
+
+      const formatted = await transformer.formatResponse(unified as any);
+
+      const imageItems = formatted.output.filter(
+        (item: any) => item.type === 'image_generation_call'
+      );
+      expect(imageItems).toHaveLength(1);
+      expect(imageItems[0]).toMatchObject({
+        type: 'image_generation_call',
+        id: 'ig_1',
+        status: 'completed',
+        result: TINY_IMAGE_B64,
+      });
+
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe('Here is your image:');
+      expect(JSON.stringify(formatted).includes('![generated image]')).toBe(false);
+    });
+
+    test('an image-only unary response round-trips as a native item (no markdown text)', async () => {
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_unary_imgonly',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'image_generation_call',
+            id: 'ig_1',
+            status: 'completed',
+            result: TINY_IMAGE_B64,
+          },
+        ],
+      });
+
+      // Pure unified content: nothing authored, nothing baked. The typed
+      // carry is what keeps the empty-completion detector seeing visible
+      // output (see empty-completion.ts countTypedImageGenerationCalls).
+      expect(unified.content).toBeNull();
+      expect(unified.image_generation_calls?.[0]?.result).toBe(TINY_IMAGE_B64);
+
+      const formatted = await transformer.formatResponse(unified as any);
+      const imageItems = formatted.output.filter(
+        (item: any) => item.type === 'image_generation_call'
+      );
+      expect(imageItems).toHaveLength(1);
+      expect(imageItems[0].result).toBe(TINY_IMAGE_B64);
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe('');
+    });
+
+    test('an OVERSIZED unary result re-emits byte-intact natively — the placeholder never reaches the client', async () => {
+      const oversized = 'D'.repeat(8 * 1024 * 1024 + 1);
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_unary_big',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          { type: 'image_generation_call', id: 'ig_big', status: 'completed', result: oversized },
+        ],
+      });
+
+      // Pure unified content (the guarded placeholder exists only in the
+      // chat projection)...
+      expect(unified.content).toBeNull();
+      // ...while the typed carry keeps the full payload.
+      expect(unified.image_generation_calls?.[0]?.result).toBe(oversized);
+
+      const formatted = await transformer.formatResponse(unified as any);
+      const imageItem = formatted.output.find((item: any) => item.type === 'image_generation_call');
+      expect(imageItem.result).toBe(oversized);
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe('');
+      expect(JSON.stringify(formatted).includes('exceeds inline limit')).toBe(false);
+    });
+  });
+
+  describe('unary content-corruption probe — authored text colliding with rendered image segments', () => {
+    // The model can legitimately AUTHOR text containing the exact string of a
+    // rendered image segment (echoing a small image's markdown, or quoting
+    // the oversized-omission placeholder). The authored copy is genuine
+    // message content and must reach every client byte-intact; the rendered
+    // segment is a chat-format projection a responses client never sees (it
+    // gets the native item instead). Any indexOf-based "remove the rendered
+    // segment" surgery removes the FIRST occurrence — the authored copy —
+    // and leaks the appended rendering: content corruption.
+
+    const authoredWithMarkdown = `Check this markdown I wrote myself:\n${TINY_IMAGE_MARKDOWN}\nNeat, right?`;
+
+    const collisionResponseBody = () => ({
+      id: 'resp_probe_md',
+      object: 'response',
+      model: 'gpt-image-model',
+      created_at: 1234567890,
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          id: 'msg_1',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: authoredWithMarkdown }],
+        },
+        {
+          type: 'image_generation_call',
+          id: 'ig_1',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      ],
+    });
+
+    test('authored text containing an exact copy of the image markdown reaches a responses client byte-intact', async () => {
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse(collisionResponseBody());
+      const formatted = await transformer.formatResponse(unified as any);
+
+      // The native item is the image's only carrier...
+      const imageItems = formatted.output.filter(
+        (item: any) => item.type === 'image_generation_call'
+      );
+      expect(imageItems).toHaveLength(1);
+      expect(imageItems[0].result).toBe(TINY_IMAGE_B64);
+
+      // ...and the AUTHORED text — including its own copy of the markdown —
+      // survives byte-intact: nothing removed, no appended rendering leaked.
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe(authoredWithMarkdown);
+    });
+
+    test('authored text quoting the oversized-omission placeholder reaches a responses client byte-intact', async () => {
+      const oversized = 'B'.repeat(2 * 8 * 1024 * 1024); // placeholder reads "12.0 MB"
+      const placeholder = '[generated image omitted: 12.0 MB exceeds inline limit]';
+      const authored = `If a file is too large you may see "${placeholder}" instead of the image.`;
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_probe_ph',
+        object: 'response',
+        model: 'gpt-image-model',
+        created_at: 1234567890,
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            id: 'msg_1',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: authored }],
+          },
+          { type: 'image_generation_call', id: 'ig_big', status: 'completed', result: oversized },
+        ],
+      });
+
+      const formatted = await transformer.formatResponse(unified as any);
+
+      const imageItem = formatted.output.find((item: any) => item.type === 'image_generation_call');
+      expect(imageItem.result).toBe(oversized);
+
+      const messageItem = formatted.output.find((item: any) => item.type === 'message');
+      expect(messageItem.content[0].text).toBe(authored);
+      // Exactly ONE occurrence — the authored quote. The rendered
+      // placeholder itself must never leak into the responses payload.
+      expect(messageItem.content[0].text.split(placeholder).length - 1).toBe(1);
+    });
+
+    test('the same authored-collision response renders authored text + appended markdown for a CHAT client (duplication is genuine content)', async () => {
+      const unified = await new ResponsesTransformer().transformResponse(collisionResponseBody());
+      const chat = await new OpenAITransformer().formatResponse(unified as any);
+
+      expect(chat.choices[0].message.content).toBe(
+        `${authoredWithMarkdown}\n${TINY_IMAGE_MARKDOWN}`
+      );
+    });
+  });
+});
+
 describe('ResponsesTransformer formatStream - error handling (client-facing)', () => {
   function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
     return new ReadableStream({
@@ -792,6 +1710,54 @@ describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream
     // Still rendered as an error (this was a hard failure, not an incomplete).
     const errorChunk = chunks.find((c) => c !== '[DONE]' && c.error);
     expect(errorChunk).toBeDefined();
+  });
+
+  test('a streamed completed image_generation_call reaches a chat client as a markdown data-URI content delta', async () => {
+    const chunks = await transformAndFormatAsChat([
+      {
+        type: 'response.created',
+        response: { id: 'resp_img_chat', model: 'gpt-image-model', created_at: 1234567890 },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      },
+      {
+        type: 'response.completed',
+        response: {
+          id: 'resp_img_chat',
+          status: 'completed',
+          output: [
+            {
+              id: 'ig_1',
+              type: 'image_generation_call',
+              status: 'completed',
+              result: TINY_IMAGE_B64,
+            },
+          ],
+          usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+        },
+      },
+    ]);
+
+    const contentChunks = chunks.filter(
+      (c) =>
+        c !== '[DONE]' &&
+        typeof c.choices?.[0]?.delta?.content === 'string' &&
+        c.choices[0].delta.content.length > 0
+    );
+    expect(contentChunks).toHaveLength(1);
+    expect(contentChunks[0].choices[0].delta.content).toBe(TINY_IMAGE_MARKDOWN);
+    expect(chunks.some((c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'stop')).toBe(
+      true
+    );
+    expect(chunks.at(-1)).toBe('[DONE]');
   });
 
   test('response.incomplete carrying usage propagates that usage to the chat client alongside the finish_reason', async () => {

--- a/packages/backend/src/transformers/anthropic/response-formatter.ts
+++ b/packages/backend/src/transformers/anthropic/response-formatter.ts
@@ -1,4 +1,5 @@
 import { UnifiedChatResponse } from '../../types/unified';
+import { composeContentWithImageMarkdown } from '../image-rendering';
 
 /**
  * Formats a unified response back to Anthropic's format for returning to clients.
@@ -40,8 +41,15 @@ export async function formatAnthropicResponse(response: UnifiedChatResponse): Pr
     });
   }
 
-  if (response.content) {
-    content.push({ type: 'text', text: response.content });
+  // Messages-format clients see image_generation_call output as size-guarded
+  // markdown composed after the authored text (see
+  // transformers/image-rendering.ts) — unified `content` itself stays pure.
+  const textContent = composeContentWithImageMarkdown(
+    response.content,
+    response.image_generation_calls
+  );
+  if (textContent) {
+    content.push({ type: 'text', text: textContent });
   }
 
   if (response.tool_calls) {

--- a/packages/backend/src/transformers/completions.ts
+++ b/packages/backend/src/transformers/completions.ts
@@ -4,6 +4,7 @@ import { createParser, EventSourceMessage } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { normalizeOpenAIChatUsage } from '../utils/usage-normalizer';
 import { getApiBaseType } from '../utils/api-format';
+import { composeContentWithImageMarkdown } from './image-rendering';
 
 const FIM_PREFIX_TOKEN = '<|fim_prefix|>';
 const FIM_SUFFIX_TOKEN = '<|fim_suffix|>';
@@ -196,7 +197,13 @@ export class OpenAICompletionTransformer implements Transformer {
   }
 
   async formatResponse(response: UnifiedChatResponse): Promise<any> {
-    const content = response.content || '';
+    // Image output renders as size-guarded markdown composed after the
+    // authored text (see transformers/image-rendering.ts) — unified
+    // `content` itself stays pure. Composed BEFORE FIM normalization so the
+    // combined text flows through the same pipeline the baked content
+    // previously did.
+    const content =
+      composeContentWithImageMarkdown(response.content, response.image_generation_calls) || '';
     const normalizedContent =
       this.fimUserPrompt === null ? content : normalizeFimResponse(content, this.fimUserPrompt);
 

--- a/packages/backend/src/transformers/gemini/response-formatter.ts
+++ b/packages/backend/src/transformers/gemini/response-formatter.ts
@@ -1,5 +1,6 @@
 import { Part } from '@google/genai';
 import { UnifiedChatResponse } from '../../types/unified';
+import { composeContentWithImageMarkdown } from '../image-rendering';
 
 /**
  * Formats a unified response back to Gemini's format for returning to clients.
@@ -19,7 +20,14 @@ export async function formatGeminiResponse(response: UnifiedChatResponse): Promi
     parts.push(part);
   }
 
-  if (response.content) parts.push({ text: response.content });
+  // Gemini-format clients see image_generation_call output as size-guarded
+  // markdown composed after the authored text (see
+  // transformers/image-rendering.ts) — unified `content` itself stays pure.
+  const textContent = composeContentWithImageMarkdown(
+    response.content,
+    response.image_generation_calls
+  );
+  if (textContent) parts.push({ text: textContent });
 
   if (response.tool_calls) {
     response.tool_calls.forEach((tc, index) => {

--- a/packages/backend/src/transformers/image-rendering.ts
+++ b/packages/backend/src/transformers/image-rendering.ts
@@ -1,0 +1,123 @@
+import { UnifiedImageGenerationCall } from '../types/unified';
+
+/**
+ * Chat-format rendering of Responses API `image_generation_call` output.
+ *
+ * The unified layer carries completed image items TYPED ONLY
+ * (`image_generation_calls`, full base64, never size-capped — see
+ * types/unified.ts). Unified `content` stays PURE authored message text.
+ * Client-facing renderers that want a text projection of the image (chat,
+ * anthropic/messages, gemini, ollama, legacy completions) compose it HERE,
+ * from the typed items; the responses-facing formatters re-emit the native
+ * item instead and never perform string surgery on the text. That split is
+ * what makes authored text that happens to contain the same characters as a
+ * rendered image segment (the markdown of a small image, or the oversized
+ * placeholder) impossible to corrupt.
+ */
+
+// Largest image_generation_call base64 `result` (in characters) that
+// renderImageResultMarkdown will inline as a data URI. Anything larger is
+// rendered as an omission placeholder instead: the markdown lands in a single
+// composed content string / SSE content delta, and a multi-megabyte data URI
+// there can blow past client/proxy message-size limits.
+export const MAX_INLINE_IMAGE_BASE64_CHARS = 8 * 1024 * 1024;
+
+/**
+ * Sniffs the image mime SUBTYPE from the magic bytes at the head of a base64
+ * payload. `output_format` is a REQUEST-side image tool field — it is not
+ * present on image_generation_call output items — so the payload's own
+ * signature is the only reliable source:
+ *   - PNG:  \x89 P N G
+ *   - JPEG: \xFF \xD8
+ *   - WebP: R I F F ...(4 size bytes)... W E B P
+ *   - GIF:  G I F 8
+ * Anything unrecognized defaults to png. Only the markdown data-URI rendering
+ * needs a mime — the native typed re-emit carries raw base64 with no URI.
+ */
+function sniffImageMimeSubtype(base64Result: string): string {
+  // 24 base64 chars decode to 18 bytes — enough for every signature above
+  // (WebP needs 12).
+  const head = Buffer.from(base64Result.slice(0, 24), 'base64');
+  if (
+    head.length >= 4 &&
+    head[0] === 0x89 &&
+    head[1] === 0x50 &&
+    head[2] === 0x4e &&
+    head[3] === 0x47
+  ) {
+    return 'png';
+  }
+  if (head.length >= 2 && head[0] === 0xff && head[1] === 0xd8) {
+    return 'jpeg';
+  }
+  if (
+    head.length >= 12 &&
+    head.toString('latin1', 0, 4) === 'RIFF' &&
+    head.toString('latin1', 8, 12) === 'WEBP'
+  ) {
+    return 'webp';
+  }
+  if (head.length >= 4 && head.toString('latin1', 0, 4) === 'GIF8') {
+    return 'gif';
+  }
+  return 'png';
+}
+
+/**
+ * Renders one base64 image `result` as a markdown data-URI image for
+ * chat-format text surfaces. Returns null for a missing/empty payload.
+ * Results larger than MAX_INLINE_IMAGE_BASE64_CHARS are NOT inlined: a short
+ * placeholder text segment (naming the approximate decoded size) is rendered
+ * instead, so a huge image can't flood a single content string/SSE delta.
+ * The mime subtype is sniffed from the payload's magic bytes (see
+ * sniffImageMimeSubtype).
+ */
+function renderImageResultMarkdown(result: unknown): string | null {
+  if (typeof result !== 'string' || result.length === 0) return null;
+  if (result.length > MAX_INLINE_IMAGE_BASE64_CHARS) {
+    // Base64 decodes to ~3/4 of its character count; report the
+    // approximate decoded size with one decimal.
+    const approxDecodedMb = ((result.length * 3) / 4 / (1024 * 1024)).toFixed(1);
+    return `[generated image omitted: ${approxDecodedMb} MB exceeds inline limit]`;
+  }
+  const format = sniffImageMimeSubtype(result);
+  return `![generated image](data:image/${format};base64,${result})`;
+}
+
+/**
+ * Renders a COMPLETED image_generation_call output item's base64 `result`
+ * as chat-format markdown (minimal-scope rendering: completed items only —
+ * partial-image preview deltas are explicitly out of scope, see
+ * responses.ts transformStream). Returns null when the item is not an
+ * image_generation_call or carries no base64 `result` payload. Size guard
+ * and mime sniff per renderImageResultMarkdown.
+ */
+export function imageGenerationCallMarkdown(item: any): string | null {
+  if (!item || item.type !== 'image_generation_call') return null;
+  return renderImageResultMarkdown(item.result);
+}
+
+/**
+ * Composes the client-visible text for a CHAT-FORMAT unary response: the
+ * pure authored `content`, followed by one rendered markdown segment per
+ * typed image item (data URI, or the oversized placeholder), joined with
+ * single `\n`s — the same client-visible bytes the pre-split design baked
+ * into unified content.
+ *
+ * When no image renders (the overwhelmingly common path), the original
+ * `content` value is returned UNCHANGED — no coercion, no copy — so
+ * image-less responses stay byte-identical through every chat-format
+ * formatter that previously passed `content` straight through.
+ */
+export function composeContentWithImageMarkdown(
+  content: string | null | undefined,
+  imageGenerationCalls: UnifiedImageGenerationCall[] | undefined
+): string | null | undefined {
+  const markdownSegments: string[] = [];
+  for (const imageCall of imageGenerationCalls ?? []) {
+    const markdown = renderImageResultMarkdown(imageCall?.result);
+    if (markdown) markdownSegments.push(markdown);
+  }
+  if (markdownSegments.length === 0) return content;
+  return (content ? [content, ...markdownSegments] : markdownSegments).join('\n');
+}

--- a/packages/backend/src/transformers/ollama.ts
+++ b/packages/backend/src/transformers/ollama.ts
@@ -1,5 +1,6 @@
 import { Transformer } from '../types/transformer';
 import { UnifiedChatRequest, UnifiedChatResponse, UnifiedChatStreamChunk } from '../types/unified';
+import { composeContentWithImageMarkdown } from './image-rendering';
 
 /**
  * OllamaTransformer
@@ -154,7 +155,13 @@ export class OllamaTransformer implements Transformer {
           index: 0,
           message: {
             role: 'assistant',
-            content: response.content,
+            // Image output renders as size-guarded markdown composed after
+            // the authored text (see transformers/image-rendering.ts) —
+            // unified `content` itself stays pure.
+            content: composeContentWithImageMarkdown(
+              response.content,
+              response.image_generation_calls
+            ),
             tool_calls: response.tool_calls,
           },
           finish_reason: response.tool_calls ? 'tool_calls' : response.finishReason || 'stop',

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -4,6 +4,7 @@ import { createParser, EventSourceMessage } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { normalizeOpenAIChatUsage } from '../utils/usage-normalizer';
 import { GEMINI_MALFORMED_FUNCTION_CALL_CODE } from '../utils/gemini-malformed-function-call';
+import { composeContentWithImageMarkdown } from './image-rendering';
 
 /**
  * OpenAITransformer
@@ -165,7 +166,12 @@ export class OpenAITransformer implements Transformer {
     // which normalizes incoming assistant messages into pi-ai's array format.
     const message: any = {
       role: 'assistant',
-      content: response.content,
+      // Chat-format clients receive image_generation_call output as
+      // size-guarded markdown (data URI or omission placeholder) appended
+      // after the authored text — composed HERE from the typed unified
+      // carry, never baked into unified `content` (which stays pure). See
+      // transformers/image-rendering.ts.
+      content: composeContentWithImageMarkdown(response.content, response.image_generation_calls),
       reasoning_content: response.reasoning_content,
       tool_calls: response.tool_calls,
       ...(response.annotations && response.annotations.length > 0

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -11,14 +11,35 @@ import {
   ResponsesReasoningTextPart,
   ResponsesSummaryTextPart,
 } from '../types/responses';
-import { UnifiedChatRequest, UnifiedChatResponse, UnifiedMessage } from '../types/unified';
+import {
+  UnifiedChatRequest,
+  UnifiedChatResponse,
+  UnifiedImageGenerationCall,
+  UnifiedMessage,
+} from '../types/unified';
 import { createParser } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { logger } from '../utils/logger';
 import { normalizeOpenAIChatUsage, normalizeOpenAIResponsesUsage } from '../utils/usage-normalizer';
+import { imageGenerationCallMarkdown } from './image-rendering';
 
 const OPENAI_RESPONSES_CALL_ID_MAX_LENGTH = 64;
 const OPENAI_RESPONSES_REASONING_CONTENT_MAX_ITEMS = 0;
+
+/**
+ * Projects a completed image_generation_call output item (with a non-empty
+ * base64 `result`) onto the typed unified carry — see
+ * UnifiedImageGenerationCall in types/unified.ts. The `result` is carried
+ * byte-intact: the inline size cap applies only to the chat-format markdown
+ * rendering (see transformers/image-rendering.ts), never to the typed item.
+ */
+function toUnifiedImageGenerationCall(item: any): UnifiedImageGenerationCall {
+  return {
+    ...(typeof item.id === 'string' ? { id: item.id } : {}),
+    ...(typeof item.status === 'string' ? { status: item.status } : {}),
+    result: item.result,
+  };
+}
 
 // Some Responses clients have been observed replaying tool calls with composite
 // IDs like "call_...|fc_...". OpenAI-compatible providers validate call_id
@@ -392,7 +413,29 @@ export class ResponsesTransformer implements Transformer {
 
       // Find the first message output item for content
       const messageItem = response.output?.find((item: any) => item.type === 'message');
-      const content = messageItem?.content?.map((part: any) => part.text).join('\n') || null;
+      const messageText = messageItem?.content?.map((part: any) => part.text).join('\n') || null;
+
+      // Completed image_generation_call items (non-empty base64 `result`)
+      // are carried TYPED ONLY, byte-intact and never size-capped, on
+      // `image_generation_calls` — see UnifiedImageGenerationCall in
+      // types/unified.ts. The unified `content` stays PURE authored message
+      // text: chat-format client renderers compose their own markdown
+      // projection from the typed items (composeContentWithImageMarkdown in
+      // transformers/image-rendering.ts), and the responses-facing
+      // formatResponse re-emits the native item with NO string surgery on
+      // the text — so authored text that happens to contain the same
+      // characters as a rendered image segment can never be corrupted.
+      const imageGenerationCalls: UnifiedImageGenerationCall[] = [];
+      for (const item of response.output ?? []) {
+        if (
+          item?.type === 'image_generation_call' &&
+          typeof item.result === 'string' &&
+          item.result.length > 0
+        ) {
+          imageGenerationCalls.push(toUnifiedImageGenerationCall(item));
+        }
+      }
+      const content = messageText;
 
       // Collect url_citation annotations from all output_text content parts
       const annotations: any[] = [];
@@ -458,6 +501,9 @@ export class ResponsesTransformer implements Transformer {
         reasoning_content,
         annotations: annotations.length > 0 ? annotations : undefined,
         tool_calls: toolCalls && toolCalls.length > 0 ? toolCalls : undefined,
+        ...(imageGenerationCalls.length > 0
+          ? { image_generation_calls: imageGenerationCalls }
+          : {}),
         usage,
       };
     } else {
@@ -900,6 +946,24 @@ export class ResponsesTransformer implements Transformer {
       }
     }
 
+    // Re-emit typed image_generation_call items natively (full base64 — the
+    // native format has no inline-markdown size concern). Unified `content`
+    // is PURE authored text (transformResponse never bakes a rendered image
+    // segment into it — see transformers/image-rendering.ts), so the message
+    // text below needs NO string surgery: it reaches the client byte-intact
+    // even when the authored text happens to contain the same characters as
+    // a rendered image segment (markdown or oversized placeholder).
+    const messageText = response.content || '';
+    for (const imageCall of response.image_generation_calls ?? []) {
+      if (typeof imageCall.result !== 'string' || imageCall.result.length === 0) continue;
+      items.push({
+        type: 'image_generation_call',
+        id: imageCall.id ?? this.generateItemId('ig'),
+        status: (imageCall.status as 'in_progress' | 'completed' | 'failed') ?? 'completed',
+        result: imageCall.result,
+      });
+    }
+
     // Add main message
     items.push({
       type: 'message',
@@ -909,7 +973,7 @@ export class ResponsesTransformer implements Transformer {
       content: [
         {
           type: 'output_text',
-          text: response.content || '',
+          text: messageText,
           annotations: response.annotations || [],
         },
       ],
@@ -978,7 +1042,10 @@ export class ResponsesTransformer implements Transformer {
     const toolCallIndexByItemId = new Map<string, number>();
     let nextToolCallIndex = 0;
     let hasFunctionCall = false;
-
+    // image_generation_call items already rendered as a content delta from
+    // their response.output_item.done event, so the response.completed
+    // fallback below doesn't render them a second time.
+    const renderedImageItemIds = new Set<string>();
     const getToolCallIndex = (data: any): number => {
       const outputIndex =
         typeof data.output_index === 'number' ? (data.output_index as number) : undefined;
@@ -1085,6 +1152,38 @@ export class ResponsesTransformer implements Transformer {
                   },
                   finish_reason: null,
                 });
+              } else if (
+                data.type === 'response.output_item.done' &&
+                data.item?.type === 'image_generation_call'
+              ) {
+                // Minimal image rendering, COMPLETED items only: a finished
+                // image_generation_call with a base64 result becomes a
+                // markdown data-URI content delta for chat-format clients,
+                // PAIRED with the chunk-level typed carry
+                // (`image_generation_calls`, full base64 — see
+                // types/unified.ts) that responses-facing formatters re-emit
+                // natively instead of the markdown. Partial-image preview
+                // events (response.image_generation_call.partial_image) are
+                // deliberately NOT handled — rendering progressive previews
+                // as chat content deltas has no sensible mapping, so they
+                // are explicitly skipped as out of scope; only the final
+                // completed image renders.
+                const imageMarkdown = imageGenerationCallMarkdown(data.item);
+                if (imageMarkdown) {
+                  if (typeof data.item.id === 'string') {
+                    renderedImageItemIds.add(data.item.id);
+                  }
+                  controller.enqueue({
+                    id: responseId,
+                    model: responseModel,
+                    created: Math.floor(Date.now() / 1000),
+                    delta: {
+                      content: imageMarkdown,
+                    },
+                    image_generation_calls: [toUnifiedImageGenerationCall(data.item)],
+                    finish_reason: null,
+                  });
+                }
               } else if (data.type === 'response.completed') {
                 // Final chunk with usage data and an OpenAI-compatible finish reason.
                 // `response.completed` includes the full output as a fallback because some
@@ -1094,6 +1193,28 @@ export class ResponsesTransformer implements Transformer {
                 const completedResponseHasFunctionCall = data.response?.output?.some(
                   (item: any) => item?.type === 'function_call'
                 );
+                // Same fallback as function calls above: render any completed
+                // image_generation_call items that only appear in the final
+                // response (skipping ones already rendered from their own
+                // response.output_item.done event) BEFORE the terminal chunk,
+                // so the content delta still reaches the client — with the
+                // same paired typed carry as the output_item.done path.
+                for (const item of data.response?.output ?? []) {
+                  if (item?.type !== 'image_generation_call') continue;
+                  if (typeof item.id === 'string' && renderedImageItemIds.has(item.id)) continue;
+                  const imageMarkdown = imageGenerationCallMarkdown(item);
+                  if (!imageMarkdown) continue;
+                  controller.enqueue({
+                    id: responseId,
+                    model: responseModel,
+                    created: Math.floor(Date.now() / 1000),
+                    delta: {
+                      content: imageMarkdown,
+                    },
+                    image_generation_calls: [toUnifiedImageGenerationCall(item)],
+                    finish_reason: null,
+                  });
+                }
                 controller.enqueue({
                   id: responseId,
                   model: responseModel,
@@ -1421,6 +1542,38 @@ export class ResponsesTransformer implements Transformer {
       });
     };
 
+    // Re-emits typed image_generation_call carries (see types/unified.ts) as
+    // native Responses output items — full base64 `result`, no inline size
+    // cap (the markdown guard exists for content strings; the native format
+    // has no such concern). Each item is registered in outputItemsByIndex so
+    // the terminal response.completed's output array includes it.
+    const emitImageGenerationCallItems = (
+      controller: ReadableStreamDefaultController,
+      imageCalls: Array<{ id?: string; status?: string; result: string }>
+    ) => {
+      for (const imageCall of imageCalls) {
+        const outputIndex = reserveOutputIndex();
+        const itemId = imageCall.id || this.generateItemId('ig');
+        const doneItem = {
+          id: itemId,
+          type: 'image_generation_call',
+          status: imageCall.status || 'completed',
+          result: imageCall.result,
+        };
+        sendEvent(controller, {
+          type: 'response.output_item.added',
+          output_index: outputIndex,
+          item: { ...doneItem, status: 'in_progress', result: null },
+        });
+        sendEvent(controller, {
+          type: 'response.output_item.done',
+          output_index: outputIndex,
+          item: doneItem,
+        });
+        outputItemsByIndex.set(outputIndex, doneItem);
+      }
+    };
+
     // `itemStatus` is the terminal status stamped on items that were still
     // in progress when the stream ended. The completed and failed paths keep
     // the pre-existing 'completed' stamp; only the response.incomplete path
@@ -1706,6 +1859,22 @@ export class ResponsesTransformer implements Transformer {
             const reasoningSummaryDelta =
               typeof delta.thinking?.content === 'string' ? delta.thinking.content : null;
 
+            // Typed image_generation_call carries re-emit as NATIVE output
+            // items for this Responses-format client. The same chunk's
+            // `delta.content` is the chat-format markdown rendering of these
+            // exact items (transformStream pairs them 1:1), so the content
+            // delta is skipped below — the native item is the only carrier
+            // here (a chat client would render the markdown instead).
+            const typedImageCalls = Array.isArray(unifiedChunk.image_generation_calls)
+              ? unifiedChunk.image_generation_calls.filter(
+                  (imageCall: any) =>
+                    imageCall && typeof imageCall.result === 'string' && imageCall.result.length > 0
+                )
+              : [];
+            if (typedImageCalls.length > 0) {
+              emitImageGenerationCallItems(controller, typedImageCalls);
+            }
+
             if (reasoningDelta && reasoningDelta.length > 0) {
               ensureReasoningItem(controller);
               reasoningText += reasoningDelta;
@@ -1743,7 +1912,11 @@ export class ResponsesTransformer implements Transformer {
               });
             }
 
-            if (typeof delta.content === 'string' && delta.content.length > 0) {
+            if (
+              typeof delta.content === 'string' &&
+              delta.content.length > 0 &&
+              typedImageCalls.length === 0
+            ) {
               ensureMessageItem(controller);
               messageText += delta.content;
               sendEvent(controller, {

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -200,6 +200,32 @@ export interface UnifiedUsage {
   cache_creation_tokens: number;
 }
 
+/**
+ * A COMPLETED Responses-API `image_generation_call` output item carried typed
+ * through the unified layer (mirroring how tool_calls are carried) so
+ * same-format (responses -> responses) non-bypass routes can re-emit the
+ * native item instead of a lossy markdown rendering. The typed item always
+ * carries the full base64 `result`, never size-capped.
+ *
+ * UNARY: transformResponse carries images typed ONLY — unified `content`
+ * stays pure authored text, and chat/messages-facing formatters compose the
+ * size-guarded markdown projection themselves from this field (see
+ * transformers/image-rendering.ts) while responses-facing formatters re-emit
+ * the native item with no string surgery.
+ *
+ * STREAMING: transformStream pairs the typed chunk-level carry with the
+ * chat-format markdown rendering on the SAME chunk's `delta.content`;
+ * responses-facing formatStream re-emits the native item and structurally
+ * skips that paired content delta (keyed on the typed items being present on
+ * the chunk — never on string matching).
+ */
+export interface UnifiedImageGenerationCall {
+  id?: string;
+  status?: string;
+  /** Base64 image payload, byte-intact (no inline-size cap at this layer). */
+  result: string;
+}
+
 export interface UnifiedChatResponse {
   id: string;
   model: string;
@@ -238,6 +264,16 @@ export interface UnifiedChatResponse {
       arguments: string;
     };
   }>;
+  /**
+   * Completed image_generation_call output items, typed (see
+   * UnifiedImageGenerationCall). The ONLY carrier of unary image output:
+   * `content` stays pure authored text. Chat/messages-facing formatters
+   * compose their markdown projection from these (see
+   * transformers/image-rendering.ts); responses-facing formatters re-emit
+   * them natively with no string surgery on the text; empty-completion
+   * detection counts entries with a non-empty `result` as visible output.
+   */
+  image_generation_calls?: UnifiedImageGenerationCall[];
   annotations?: Annotation[];
   stream?: ReadableStream | any;
   bypassTransformation?: boolean;
@@ -311,6 +347,19 @@ export interface UnifiedChatStreamChunk {
    * event, status 'incomplete') instead of a generic failure.
    */
   incomplete_details?: { reason: string };
+  /**
+   * Completed image_generation_call items carried typed (see
+   * UnifiedImageGenerationCall), paired with their chat-format markdown
+   * rendering on `delta.content` in the SAME chunk. Deliberately a CHUNK-level
+   * field (not inside `delta`, where tool_calls live): the chat-facing
+   * formatters (openai.ts, ollama.ts) forward `delta` BY REFERENCE into the
+   * client SSE chunk, so a delta-level field would leak the (possibly
+   * multi-megabyte, uncapped) base64 into chat-format wire chunks — top-level
+   * unified-chunk fields are never copied by those formatters. The
+   * responses-facing formatStream re-emits these as native output items and
+   * skips the paired markdown content delta.
+   */
+  image_generation_calls?: UnifiedImageGenerationCall[];
 }
 
 // Unified Embeddings Request


### PR DESCRIPTION
## Summary

Part 5/5 of the split of #757 — **stacked on #763** (cumulative diff until predecessors merge; review scope below).

`image_generation_call` outputs stop vanishing: Responses-format clients get the native items byte-intact, chat-style clients get rendered markdown.

## What changed

- Typed `image_generation_call` items travel through the unified layer (carried chunk-level, deliberately not in `delta` — chat formatters forward `delta` by reference to the wire).
- Responses-format clients receive native items unchanged (full base64, streaming and unary). Chat-style formatters (openai, anthropic, gemini, ollama, completions) compose markdown data-URIs at render time via the shared `transformers/image-rendering.ts`: 8 MB inline cap with an explicit omission placeholder, mime sniffed from the base64 magic bytes (PNG/JPEG/WebP/GIF).
- Composition happens per-format instead of being baked into unified content, so assistant-authored text that happens to contain identical markdown can never be corrupted, and image-only completions register as visible output in the empty-completion detector (no spurious failover) on both the transformed and bypass paths.

## Review scope

`transformers/image-rendering.ts` (new) + composition test, image hunks in `transformers/responses.ts` / `openai.ts`, `anthropic/response-formatter.ts`, `gemini/response-formatter.ts`, `ollama.ts`, `completions.ts`, `types/unified.ts` image types, typed-signal hunk in `empty-completion.ts`.

## Tests

Full suite green on this branch: 233 files / 2574 tests, typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
