### PR TITLE
fix(streaming): preserve tool arguments

### DIFF
--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -63,6 +63,63 @@ describe('DebugLoggingInspector Reconstruction', () => {
     expect(snapshot.choices[0].message.tool_calls).toHaveLength(2);
   });
 
+  test('reconstructChatCompletions initializes streamed tool arguments before appending', async () => {
+    const inspector = new DebugLoggingInspector(requestId, 'raw');
+    const stream = inspector.createInspector('chat');
+    const ended = once(stream, 'end');
+    const chunks = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'Read' },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        id: 'chatcmpl-123',
+        object: 'chat.completion.chunk',
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: '',
+                  type: 'function',
+                  function: { name: '', arguments: '{"file_path":"/tmp/hello.txt"}' },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        id: 'chatcmpl-123',
+        object: 'chat.completion.chunk',
+      },
+    ];
+
+    for (const chunk of chunks) {
+      stream.write(Buffer.from(`data: ${JSON.stringify(chunk)}\n\n`));
+    }
+    stream.end(Buffer.from('data: [DONE]\n\n'));
+    await ended;
+
+    const snapshot = DebugManager.getInstance().getReconstructedRawResponse(requestId);
+    expect(snapshot.choices[0].delta.tool_calls[0].function.arguments).toBe(
+      '{"file_path":"/tmp/hello.txt"}'
+    );
+  });
+
   test('reconstructMessages handles non-streaming JSON (Anthropic style)', async () => {
     const inspector = new DebugLoggingInspector(requestId, 'raw');
     const stream = inspector.createInspector('messages');

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -723,6 +723,10 @@ export class DebugLoggingInspector extends BaseInspector {
               }
 
               const accTool = accChoice.delta.tool_calls[tIdx];
+              if (!accTool.function) accTool.function = { name: '', arguments: '' };
+              if (typeof accTool.function.arguments !== 'string') {
+                accTool.function.arguments = '';
+              }
               if (newTool.id) accTool.id = newTool.id;
               if (newTool.type) accTool.type = newTool.type;
               if (newTool.function?.name) accTool.function.name = newTool.function.name;

--- a/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/anthropic-stream.test.ts
@@ -175,6 +175,158 @@ describe('AnthropicTransformer Stream Formatting', () => {
     expect(data.usage).toBeDefined();
     expect(data.usage.thinkingTokens).toBe(0);
   });
+
+  test('preserves OpenAI tool arguments when continuation chunks use empty metadata', async () => {
+    const chunks = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'Read' },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        id: 'chat_1',
+        model: 'model',
+        object: 'chat.completion.chunk',
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: '',
+                  type: 'function',
+                  function: { name: '', arguments: '{"file_path": ' },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        id: 'chat_1',
+        model: 'model',
+        object: 'chat.completion.chunk',
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: '',
+                  type: 'function',
+                  function: { name: '', arguments: '"/tmp/h' },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        id: 'chat_1',
+        model: 'model',
+        object: 'chat.completion.chunk',
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: '',
+                  type: 'function',
+                  function: { name: '', arguments: 'ello.txt"' },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        id: 'chat_1',
+        model: 'model',
+        object: 'chat.completion.chunk',
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: '',
+                  type: 'function',
+                  function: { name: '', arguments: '}' },
+                },
+              ],
+            },
+            index: 0,
+          },
+        ],
+        id: 'chat_1',
+        model: 'model',
+        object: 'chat.completion.chunk',
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'tool_calls', index: 0 }],
+        id: 'chat_1',
+        model: 'model',
+        object: 'chat.completion.chunk',
+      },
+    ];
+    const encoder = new TextEncoder();
+    const rawStream = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+        }
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.close();
+      },
+    });
+
+    const unifiedStream = new OpenAITransformer().transformStream(rawStream);
+    const formattedStream = new AnthropicTransformer().formatStream(unifiedStream);
+    const events: Array<{ event?: string; data: any }> = [];
+    const parser = createParser({
+      onEvent(event: EventSourceMessage) {
+        events.push({ event: event.event, data: JSON.parse(event.data) });
+      },
+    });
+    const reader = formattedStream.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      parser.feed(decoder.decode(value, { stream: true }));
+    }
+
+    const toolStarts = events.filter(
+      ({ event, data }) =>
+        event === 'content_block_start' && data.content_block?.type === 'tool_use'
+    );
+    const partialJson = events
+      .filter(
+        ({ event, data }) =>
+          event === 'content_block_delta' && data.delta?.type === 'input_json_delta'
+      )
+      .map(({ data }) => data.delta.partial_json)
+      .join('');
+
+    expect(toolStarts).toHaveLength(1);
+    expect(partialJson).toBe('{"file_path": "/tmp/hello.txt"}');
+  });
 });
 
 describe('transformAnthropicStream tool call index remapping', () => {

--- a/packages/backend/src/transformers/anthropic/stream-formatter.ts
+++ b/packages/backend/src/transformers/anthropic/stream-formatter.ts
@@ -174,7 +174,8 @@ export function formatAnthropicStream(stream: ReadableStream): ReadableStream {
             const shouldStartToolBlock =
               activeBlockType !== 'tool_use' ||
               activeBlockIndex === null ||
-              (toolCallId !== undefined && toolCallId !== activeToolCallId);
+              // Empty IDs identify continuation chunks; coerce explicitly to keep this boolean.
+              (Boolean(toolCallId) && toolCallId !== activeToolCallId);
 
             if (shouldStartToolBlock) {
               if (!toolCallId) {


### PR DESCRIPTION
## Summary
Fixes #765 by preserving streamed OpenAI Chat tool arguments when converting responses to Anthropic Messages format. The debug reconstruction display now also accumulates those arguments without prepending the literal `undefined`.

## Why / Context
Some OpenAI-compatible providers emit empty `id` and `name` strings on continuation tool-call chunks instead of omitting those fields. Plexus treated each empty ID as a block transition and discarded its argument fragment, leaving Anthropic clients with `input: {}`.

## Changes
- **Anthropic stream formatter**: treat empty tool-call IDs as continuation metadata and append fragments to the active tool block.
- **Debug reconstruction**: initialize copied tool function argument buffers before concatenating streamed fragments.
- **Regression coverage**: reproduce the reported OpenAI SSE sequence end-to-end and assert the complete Anthropic `partial_json` payload.
- **Display coverage**: verify reconstructed Chat Completions arguments never gain an `undefined` prefix.

## Testing
- Added an end-to-end transformer fixture using empty continuation IDs and fragmented JSON arguments.
- Added a debug reconstruction fixture where the initial tool chunk contains a name but no argument field.
