### PR TITLE
fix(dispatch): sanitize foreign tool ids on Anthropic-bound requests

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -245,7 +245,7 @@ OAuth providers are not supported by the raw endpoint.
 
 Adapters rewrite request payloads outbound to a provider and raw response payloads inbound, fixing provider-specific field-name incompatibilities without modifying the core transformer pipeline.
 
-Adapters can be set at **provider level** (applied to every model under the provider) or at **model level** (appended after provider-level adapters for a specific model). Both accept a single name or a list. Use `{ "name": "...", "enabled": false }` at model level to disable an inherited or automatic adapter; a later enabled entry restores it.
+Adapters can be set at **provider level** (applied to every model under the provider) or at **model level** (appended after provider-level adapters for a specific model). Both accept a single name or a list. Use `{ "name": "...", "enabled": false }` at provider or model level to disable an inherited or automatic adapter; a later enabled entry restores it.
 
 | Adapter | Description |
 |---------|-------------|
@@ -255,6 +255,7 @@ Adapters can be set at **provider level** (applied to every model under the prov
 | `reasoning_rewrite` | Manually rewrites reasoning/thinking request fields for providers with bespoke compatibility requirements. Prefer `auto_compat` for models linked to the pi-ai builtin registry; this adapter is now best treated as an escape hatch. |
 | `web_search_coercion` | Translates server-side web search tool entries to the format expected by the target provider. Clients can use any web search format; Plexus rewrites it transparently. See [Web Search Coercion Adapter](#web-search-coercion-adapter) below. |
 | `suppress_unsupported_gpt5_options` | Removes generation options unsupported by GPT-5 models. Enabled automatically for the GPT-5 family; set `enabled: false` for a model to opt out. |
+| `normalize_anthropic_tool_ids` | Rewrites `tool_use` / `tool_result` ids that violate Anthropic's `^[a-zA-Z0-9_-]+$` charset (e.g. Moonshot's `functions.WebSearch:3`), which Anthropic rejects with a hard HTTP 400. Enabled automatically when the outbound wire format is Anthropic Messages **and** the provider looks Anthropic (base URL containing `anthropic.com`, Anthropic OAuth, or Claude masking). Add `{ "name": "normalize_anthropic_tool_ids", "options": {}, "enabled": true }` to force it on for an Anthropic-compatible gateway hosted on another domain; set `enabled: false` to opt out. |
 
 **Example — provider-level:**
 ```json
@@ -277,7 +278,7 @@ PUT /v0/management/providers/fireworks
 }
 ```
 
-Adapters are applied in order on outbound (preDispatch) and in reverse on inbound (postDispatch). Pass-through optimisation is automatically disabled when any adapter is active.
+Adapters are applied in order on outbound (preDispatch) and in reverse on inbound (postDispatch). They run whether or not the pass-through optimisation is active: a same-format request skips the transformer, but its body is still cloned, given the target model and the provider/model config fields, and run through the adapter chain before dispatch.
 
 ### Model Override Adapter
 

--- a/docs/openapi/components/schemas/ProviderConfig.yaml
+++ b/docs/openapi/components/schemas/ProviderConfig.yaml
@@ -170,6 +170,14 @@ properties:
                             type: object
                             additionalProperties: true
                             description: Adapter-specific options.
+                          enabled:
+                            type: boolean
+                            default: true
+                            description: >
+                              Set to `false` to remove earlier instances of this
+                              adapter, including provider-level and implicitly
+                              injected ones. A later entry with `enabled: true`
+                              restores it.
               description: >
                 Adapter name(s) applied to this specific model. Appended after
                 any provider-level adapters. Accepts bare strings or
@@ -294,6 +302,13 @@ properties:
                   type: object
                   additionalProperties: true
                   description: Adapter-specific options.
+                enabled:
+                  type: boolean
+                  default: true
+                  description: >
+                    Set to `false` to remove earlier instances of this adapter,
+                    including implicitly injected defaults. A later entry with
+                    `enabled: true` restores it.
     description: >
       Adapter name(s) applied to every model under this provider.
       Adapters rewrite outbound request payloads (preDispatch) and inbound
@@ -343,8 +358,21 @@ properties:
         Messages, OpenAI Responses, and Gemini native).
         See [`WebSearchCoercionAdapterOptions`](#/components/schemas/WebSearchCoercionAdapterOptions).
 
-      Pass-through optimisation is automatically disabled when any adapter
-      is active.
+      - `normalize_anthropic_tool_ids` — Rewrites `tool_use` / `tool_result`
+        identifiers that violate Anthropic's tool-id charset
+        `^[a-zA-Z0-9_-]+$` (e.g. Moonshot's `functions.WebSearch:3`), which
+        Anthropic rejects with a hard HTTP 400. Injected automatically when the
+        route's outbound wire format is Anthropic Messages AND the provider
+        looks Anthropic (base URL containing `anthropic.com`, Anthropic OAuth,
+        or Claude masking). Override per provider or model with
+        `{ name: 'normalize_anthropic_tool_ids', options: {}, enabled: true }`
+        to force it on for an Anthropic-compatible gateway hosted elsewhere, or
+        `{ name: 'normalize_anthropic_tool_ids', enabled: false }` to opt out.
+
+      Adapters run on the outbound body whether or not the pass-through
+      optimisation is active — a same-format request skips the transformer, but
+      its body is still cloned, given the target model and the provider/model
+      config fields, and run through the adapter chain before dispatch.
   timeoutMs:
     type: integer
     minimum: 1

--- a/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
+++ b/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { resolveAdapters } from '../../services/dispatch/adapter-resolver';
 import type { RouteResult } from '../../services/routing/router';
+import { apiAccessToKey } from '../../utils/api-format';
 
 // Minimal RouteResult factory
 function makeRoute(providerAdapter?: any[], modelAdapter?: any[]): RouteResult {
@@ -218,5 +219,72 @@ describe('resolveAdapters', () => {
     const resolved = resolveAdapters(route);
     expect(resolved).toHaveLength(1);
     expect(resolved[0]!.adapter.name).toBe('model_override');
+  });
+});
+
+describe('resolveAdapters — Anthropic tool-id normalization by outbound wire format', () => {
+  it('auto-injects the tool-id normalizer when the effective API type is messages', () => {
+    const resolved = resolveAdapters(makeRoute(undefined, undefined), 'messages');
+    expect(resolved.map((r) => r.adapter.name)).toEqual(['normalize_anthropic_tool_ids']);
+  });
+
+  it('auto-injects the tool-id normalizer for a messages subtype', () => {
+    // Subtype keys are minted by apiAccessToKey from a configured
+    // `access_via: [{ type, subtype }]` entry, so the injection has to match on
+    // the base type rather than the whole string. No `messages:*` subtype ships
+    // today ('responses:lite' is the only named one), but the config schema
+    // accepts any type/subtype pair, so one is constructible.
+    const subtypeApiType = apiAccessToKey({ type: 'Messages', subtype: 'Lite' });
+    expect(subtypeApiType).toBe('messages:lite');
+    expect(
+      resolveAdapters(makeRoute(undefined, undefined), subtypeApiType).map((r) => r.adapter.name)
+    ).toEqual(['normalize_anthropic_tool_ids']);
+  });
+
+  it('does not auto-inject the tool-id normalizer for non-messages API types', () => {
+    for (const apiType of [
+      'chat',
+      'responses',
+      'responses:lite',
+      'gemini',
+      'completions',
+      'ollama',
+    ]) {
+      expect(resolveAdapters(makeRoute(undefined, undefined), apiType)).toHaveLength(0);
+    }
+  });
+
+  it('does not auto-inject the tool-id normalizer when no API type is passed', () => {
+    expect(resolveAdapters(makeRoute(undefined, undefined))).toHaveLength(0);
+  });
+
+  it('allows a provider adapter entry to disable the tool-id normalizer', () => {
+    const route = makeRoute([{ name: 'normalize_anthropic_tool_ids', enabled: false }]);
+    expect(resolveAdapters(route, 'messages')).toHaveLength(0);
+  });
+
+  it('allows a model adapter entry to restore the tool-id normalizer disabled by its provider', () => {
+    const route = makeRoute(
+      [{ name: 'normalize_anthropic_tool_ids', enabled: false }],
+      [{ name: 'normalize_anthropic_tool_ids', enabled: true }]
+    );
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([
+      'normalize_anthropic_tool_ids',
+    ]);
+  });
+
+  it('runs the tool-id normalizer after other implicit adapters and before configured ones', () => {
+    const base = makeRoute([{ name: 'reasoning_content', options: {} }]);
+    const route: RouteResult = {
+      ...base,
+      model: 'gpt-5.2',
+      config: { ...base.config, pi_ai_provider: 'openrouter' },
+    };
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([
+      'suppress_unsupported_gpt5_options',
+      'strip_unsupported_tool_search',
+      'normalize_anthropic_tool_ids',
+      'reasoning_content',
+    ]);
   });
 });

--- a/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
+++ b/packages/backend/src/__tests__/adapters/adapter-resolver.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { resolveAdapters } from '../../services/dispatch/adapter-resolver';
+import {
+  isAnthropicTargetProvider,
+  resolveAdapters,
+} from '../../services/dispatch/adapter-resolver';
 import type { RouteResult } from '../../services/routing/router';
 import { apiAccessToKey } from '../../utils/api-format';
 
-// Minimal RouteResult factory
-function makeRoute(providerAdapter?: any[], modelAdapter?: any[]): RouteResult {
+// Minimal RouteResult factory. `configOverrides` is spread LAST so a test can
+// replace any baseline config field (api_base_url, useClaudeMasking, …).
+function makeRoute(
+  providerAdapter?: any[],
+  modelAdapter?: any[],
+  configOverrides?: Record<string, any>
+): RouteResult {
   return {
     provider: 'test-provider',
     model: 'test-model',
@@ -16,6 +24,7 @@ function makeRoute(providerAdapter?: any[], modelAdapter?: any[]): RouteResult {
       estimateTokens: false,
       useClaudeMasking: false,
       adapter: providerAdapter,
+      ...configOverrides,
     } as any,
     modelConfig: modelAdapter !== undefined ? ({ adapter: modelAdapter } as any) : undefined,
   } as RouteResult;
@@ -222,13 +231,62 @@ describe('resolveAdapters', () => {
   });
 });
 
-describe('resolveAdapters — Anthropic tool-id normalization by outbound wire format', () => {
-  it('auto-injects the tool-id normalizer when the effective API type is messages', () => {
-    const resolved = resolveAdapters(makeRoute(undefined, undefined), 'messages');
-    expect(resolved.map((r) => r.adapter.name)).toEqual(['normalize_anthropic_tool_ids']);
+describe('resolveAdapters — Anthropic tool-id normalization gate', () => {
+  // The gate has TWO parts: the outbound wire format must be Anthropic Messages
+  // AND the target must look like Anthropic. Not every messages-format target is
+  // Anthropic — a plain Messages-speaking proxy does not enforce Anthropic's
+  // tool-id charset, and rewriting ids there would corrupt ids the client
+  // matches against on its next turn.
+  const NORMALIZER = 'normalize_anthropic_tool_ids';
+
+  it('auto-injects for a string anthropic.com base URL on the messages wire format', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'https://api.anthropic.com',
+    });
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([NORMALIZER]);
   });
 
-  it('auto-injects the tool-id normalizer for a messages subtype', () => {
+  it('auto-injects for a record base URL whose messages value is anthropic.com', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: { messages: 'https://gw.anthropic.com/v1' },
+    });
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([NORMALIZER]);
+  });
+
+  it('matches the anthropic.com host case-insensitively', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'https://API.ANTHROPIC.COM',
+    });
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([NORMALIZER]);
+  });
+
+  it('auto-injects for an Anthropic OAuth route (string oauth:// URL)', () => {
+    // Native-OAuth Anthropic routes reach the resolver with effectiveApiType
+    // already resolved to 'messages' (request-manager.ts), never 'oauth'.
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'oauth://anthropic',
+      oauth_provider: 'anthropic',
+    });
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([NORMALIZER]);
+  });
+
+  it('auto-injects for an Anthropic OAuth route (record oauth:// URL)', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: { messages: 'oauth://anthropic' },
+      oauth_provider: 'anthropic',
+    });
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([NORMALIZER]);
+  });
+
+  it('auto-injects for a Claude-masking route regardless of its base URL', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'https://example.com',
+      useClaudeMasking: true,
+    });
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([NORMALIZER]);
+  });
+
+  it('auto-injects for a messages subtype on an Anthropic target', () => {
     // Subtype keys are minted by apiAccessToKey from a configured
     // `access_via: [{ type, subtype }]` entry, so the injection has to match on
     // the base type rather than the whole string. No `messages:*` subtype ships
@@ -236,12 +294,52 @@ describe('resolveAdapters — Anthropic tool-id normalization by outbound wire f
     // accepts any type/subtype pair, so one is constructible.
     const subtypeApiType = apiAccessToKey({ type: 'Messages', subtype: 'Lite' });
     expect(subtypeApiType).toBe('messages:lite');
-    expect(
-      resolveAdapters(makeRoute(undefined, undefined), subtypeApiType).map((r) => r.adapter.name)
-    ).toEqual(['normalize_anthropic_tool_ids']);
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'https://api.anthropic.com',
+    });
+    expect(resolveAdapters(route, subtypeApiType).map((r) => r.adapter.name)).toEqual([NORMALIZER]);
+  });
+
+  it('does NOT auto-inject for a non-Anthropic messages proxy', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'https://p1.example.com/v1',
+    });
+    expect(resolveAdapters(route, 'messages')).toHaveLength(0);
+  });
+
+  it('does NOT auto-inject for a record whose anthropic.com URL is not the dispatched one', () => {
+    // The messages request goes to r8.example; the chat URL is never dispatched
+    // for this wire format and must not pull the normalizer in.
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: { messages: 'https://r8.example/v1', chat: 'https://api.anthropic.com/v1' },
+    });
+    expect(resolveAdapters(route, 'messages')).toHaveLength(0);
+  });
+
+  it('does NOT auto-inject for a Copilot OAuth route serving a Claude model over messages', () => {
+    // The real-world non-Anthropic messages-wire OAuth case: GitHub Copilot
+    // fronts Claude models, so nativeOAuthApiType() resolves this route's wire
+    // type to 'messages' — yet the upstream is Copilot, not Anthropic, and it
+    // does not enforce Anthropic's tool-id charset.
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'oauth://github-copilot',
+      oauth_provider: 'github-copilot',
+    });
+    expect(resolveAdapters(route, 'messages')).toHaveLength(0);
+  });
+
+  it('does NOT auto-inject for a non-Anthropic OAuth provider', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'oauth://openai-codex',
+      oauth_provider: 'openai-codex',
+    });
+    expect(resolveAdapters(route, 'messages')).toHaveLength(0);
   });
 
   it('does not auto-inject the tool-id normalizer for non-messages API types', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'https://api.anthropic.com',
+    });
     for (const apiType of [
       'chat',
       'responses',
@@ -250,41 +348,287 @@ describe('resolveAdapters — Anthropic tool-id normalization by outbound wire f
       'completions',
       'ollama',
     ]) {
-      expect(resolveAdapters(makeRoute(undefined, undefined), apiType)).toHaveLength(0);
+      expect(resolveAdapters(route, apiType)).toHaveLength(0);
     }
   });
 
   it('does not auto-inject the tool-id normalizer when no API type is passed', () => {
-    expect(resolveAdapters(makeRoute(undefined, undefined))).toHaveLength(0);
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'https://api.anthropic.com',
+    });
+    expect(resolveAdapters(route)).toHaveLength(0);
   });
 
   it('allows a provider adapter entry to disable the tool-id normalizer', () => {
-    const route = makeRoute([{ name: 'normalize_anthropic_tool_ids', enabled: false }]);
+    const route = makeRoute([{ name: NORMALIZER, enabled: false }], undefined, {
+      api_base_url: 'https://api.anthropic.com',
+    });
     expect(resolveAdapters(route, 'messages')).toHaveLength(0);
+  });
+
+  it('allows a model adapter entry to disable the tool-id normalizer', () => {
+    // Same tombstone override as the provider level, one scope down.
+    const route = makeRoute(undefined, [{ name: NORMALIZER, enabled: false }], {
+      api_base_url: 'https://api.anthropic.com',
+    });
+    expect(resolveAdapters(route, 'messages')).toHaveLength(0);
+  });
+
+  it('allows a provider adapter entry to force-enable the normalizer on a non-Anthropic proxy', () => {
+    // The escape hatch for an Anthropic-compatible gateway on some other host
+    // that DOES enforce the tool-id charset.
+    const route = makeRoute([{ name: NORMALIZER, options: {}, enabled: true }], undefined, {
+      api_base_url: 'https://p1.example.com/v1',
+    });
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([NORMALIZER]);
   });
 
   it('allows a model adapter entry to restore the tool-id normalizer disabled by its provider', () => {
     const route = makeRoute(
-      [{ name: 'normalize_anthropic_tool_ids', enabled: false }],
-      [{ name: 'normalize_anthropic_tool_ids', enabled: true }]
+      [{ name: NORMALIZER, enabled: false }],
+      [{ name: NORMALIZER, enabled: true }],
+      { api_base_url: 'https://api.anthropic.com' }
     );
+    expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([NORMALIZER]);
+  });
+
+  it('resolves the normalizer TWICE when an Anthropic route also enables it explicitly', () => {
+    // Pins the tolerated duplicate: the implicit injection and the explicit
+    // enabled entry both land in the list. Harmless because the sanitizer is
+    // idempotent (f(f(x)) === f(x)), so the second pass rewrites nothing. This
+    // test exists so that adding de-duplication later is a conscious decision
+    // rather than an accidental behaviour change.
+    const route = makeRoute([{ name: NORMALIZER, options: {}, enabled: true }], undefined, {
+      api_base_url: 'https://api.anthropic.com',
+    });
     expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([
-      'normalize_anthropic_tool_ids',
+      NORMALIZER,
+      NORMALIZER,
     ]);
   });
 
   it('runs the tool-id normalizer after other implicit adapters and before configured ones', () => {
-    const base = makeRoute([{ name: 'reasoning_content', options: {} }]);
-    const route: RouteResult = {
-      ...base,
-      model: 'gpt-5.2',
-      config: { ...base.config, pi_ai_provider: 'openrouter' },
-    };
+    const route = makeRoute([{ name: 'reasoning_content', options: {} }], undefined, {
+      pi_ai_provider: 'openrouter',
+      useClaudeMasking: true,
+    });
+    route.model = 'gpt-5.2';
     expect(resolveAdapters(route, 'messages').map((r) => r.adapter.name)).toEqual([
       'suppress_unsupported_gpt5_options',
       'strip_unsupported_tool_search',
       'normalize_anthropic_tool_ids',
       'reasoning_content',
     ]);
+  });
+});
+
+describe('isAnthropicTargetProvider', () => {
+  // Contract: "is the URL this dispatch would actually be sent to an Anthropic
+  // one?". For the record form of api_base_url the answer is therefore scoped to
+  // the key `resolveProviderBaseUrl` would pick for the given wire type (exact
+  // key, then base type); with no wire type passed, every value is scanned.
+
+  it('matches a string anthropic.com base URL', () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, { api_base_url: 'https://api.anthropic.com' })
+      )
+    ).toBe(true);
+  });
+
+  it('matches a string anthropic.com base URL case-insensitively', () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, { api_base_url: 'https://API.ANTHROPIC.COM/v1' })
+      )
+    ).toBe(true);
+  });
+
+  it('matches a string base URL regardless of the API type passed', () => {
+    // Nothing to select in the string form — the same URL serves every type.
+    const route = makeRoute(undefined, undefined, { api_base_url: 'https://api.anthropic.com' });
+    for (const apiType of [undefined, 'messages', 'messages:lite', 'chat']) {
+      expect(isAnthropicTargetProvider(route, apiType)).toBe(true);
+    }
+  });
+
+  it('matches a record base URL whose messages value is anthropic.com', () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { messages: 'https://gw.anthropic.com/v1' },
+        }),
+        'messages'
+      )
+    ).toBe(true);
+  });
+
+  it("matches the record's messages value even when another key points elsewhere", () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { chat: 'https://x.example.com', messages: 'https://y.anthropic.com' },
+        }),
+        'messages'
+      )
+    ).toBe(true);
+  });
+
+  it('does NOT match a record whose anthropic.com value sits under an unused key', () => {
+    // The bug this scoping exists for: dispatch sends the messages request to
+    // r8.example, so the (unused) chat URL must not make it look Anthropic.
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { messages: 'https://r8.example/v1', chat: 'https://api.anthropic.com/v1' },
+        }),
+        'messages'
+      )
+    ).toBe(false);
+  });
+
+  it('matches that same record when the dispatched key IS the anthropic.com one', () => {
+    // Chat is not the Messages wire format, so resolveAdapters' gate would never
+    // inject for it — but the helper's own contract is per-key, and the URL a
+    // 'chat' dispatch uses here really is Anthropic's.
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { messages: 'https://r8.example/v1', chat: 'https://api.anthropic.com/v1' },
+        }),
+        'chat'
+      )
+    ).toBe(true);
+  });
+
+  it('scans every record value when no API type is passed', () => {
+    // Legacy/unscoped callers keep the pre-scoping any-value behaviour.
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { messages: 'https://r8.example/v1', chat: 'https://api.anthropic.com/v1' },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('resolves a messages subtype to the exact key first, then the base-type key', () => {
+    // Mirrors resolveProviderBaseUrl's `urlMap[typeKey] || urlMap[baseType]`.
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { messages: 'https://gw.anthropic.com/v1' },
+        }),
+        'messages:lite'
+      )
+    ).toBe(true);
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: {
+            'messages:lite': 'https://r8.example/v1',
+            messages: 'https://gw.anthropic.com/v1',
+          },
+        }),
+        'messages:lite'
+      )
+    ).toBe(false);
+  });
+
+  it('does not match when the record has no key for the dispatched API type', () => {
+    // resolveProviderBaseUrl would fall back further (default key, aliases, first
+    // key); the gate deliberately treats a provider that doesn't advertise the
+    // wire type as no evidence of an Anthropic target.
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { chat: 'https://api.anthropic.com/v1' },
+        }),
+        'messages'
+      )
+    ).toBe(false);
+  });
+
+  it('does not match a record base URL with no anthropic.com value', () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { messages: 'https://p1.example.com/v1' },
+        }),
+        'messages'
+      )
+    ).toBe(false);
+  });
+
+  it('does not match a plain string proxy URL', () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, { api_base_url: 'https://p1.example.com/v1' })
+      )
+    ).toBe(false);
+  });
+
+  it('matches an oauth:// route whose oauth_provider is anthropic', () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: 'oauth://anthropic',
+          oauth_provider: 'anthropic',
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('does not match an oauth:// route for a non-Anthropic OAuth provider', () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: 'oauth://openai-codex',
+          oauth_provider: 'openai-codex',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('falls back to the provider slug when oauth_provider is unset', () => {
+    // Same `oauth_provider || route.provider` resolution request-manager.ts uses.
+    const route = makeRoute(undefined, undefined, { api_base_url: 'oauth://anthropic' });
+    route.provider = 'anthropic';
+    expect(isAnthropicTargetProvider(route)).toBe(true);
+  });
+
+  it('matches an oauth:// value inside a record base URL', () => {
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { messages: 'oauth://anthropic' },
+          oauth_provider: 'anthropic',
+        }),
+        'messages'
+      )
+    ).toBe(true);
+  });
+
+  it('does NOT match an oauth:// value sitting under an unused key', () => {
+    // The key scoping applies to the oauth:// signal too, not just the host test.
+    expect(
+      isAnthropicTargetProvider(
+        makeRoute(undefined, undefined, {
+          api_base_url: { messages: 'https://r8.example/v1', chat: 'oauth://anthropic' },
+          oauth_provider: 'anthropic',
+        }),
+        'messages'
+      )
+    ).toBe(false);
+  });
+
+  it('matches a Claude-masking route regardless of its base URL or API type', () => {
+    const route = makeRoute(undefined, undefined, {
+      api_base_url: 'https://example.com',
+      useClaudeMasking: true,
+    });
+    for (const apiType of [undefined, 'messages', 'chat']) {
+      expect(isAnthropicTargetProvider(route, apiType)).toBe(true);
+    }
   });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-anthropic-tool-id-normalization.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-anthropic-tool-id-normalization.test.ts
@@ -1,0 +1,588 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { setConfigForTesting } from '../../config';
+import type { UnifiedChatRequest } from '../../types/unified';
+import { CooldownManager } from '../runtime/cooldown-manager';
+// Globally mocked in test/vitest.setup.ts — imported here only to assert on the
+// warn the normalize_anthropic_tool_ids adapter emits when it rewrites ids.
+import { logger } from '../../utils/logger';
+
+// @earendil-works/pi-ai is mocked globally in vitest.setup.ts — do not add a
+// per-file vi.mock() call here. Dispatcher is imported dynamically so it
+// resolves after that registration, mirroring dispatcher-claude-masking.test.ts.
+const { Dispatcher } = await import('../dispatch/dispatcher');
+import * as piAi from '@earendil-works/pi-ai/compat';
+
+const fetchMock: any = vi.fn(async (): Promise<any> => {
+  throw new Error('fetch mock not configured for test');
+});
+
+global.fetch = fetchMock as any;
+
+// ---------------------------------------------------------------------------
+// Wire-level proof for the `normalize_anthropic_tool_ids` adapter.
+//
+// The adapter is injected implicitly by adapter-resolver.ts for every route
+// whose FINAL outbound wire type is Anthropic Messages. These tests drive the
+// REAL Dispatcher end to end and read the outbound bytes off `fetch`, so they
+// prove the injection point, the ordering relative to Claude-Code masking, and
+// the per-attempt behaviour — not just the pure function.
+//
+// `functions.WebSearch:3` is the real Moonshot/Kimi id shape that makes
+// Anthropic hard-400 with
+//   `messages.N.content.M.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'`.
+// ---------------------------------------------------------------------------
+
+/** A tool id outside Anthropic's `^[a-zA-Z0-9_-]+$` charset (dot + colon). */
+const POISONED_ID = 'functions.WebSearch:3';
+/**
+ * What the sanitizer must produce: every offending char replaced with `_`,
+ * suffixed with the first 8 hex chars of sha256 OVER THE ORIGINAL id, hashed
+ * as UTF-16 code units (see the adapter — UTF-8 would collapse lone surrogates).
+ * Pinned as a literal so a silent change to the derivation fails loudly here.
+ */
+const SANITIZED_ID = 'functions_WebSearch_3_0ad6c974';
+/** An Anthropic-native id that is already charset-valid — must be untouched. */
+const VALID_ID = 'toolu_01GoodId';
+
+function messagesSuccessResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: 'msg-1',
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'ok' }],
+      model,
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function chatSuccessResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      id: `chatcmpl-${model}`,
+      object: 'chat.completion',
+      created: 1,
+      model,
+      choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function errorResponse(status: number, message: string) {
+  return new Response(JSON.stringify({ error: { type: 'api_error', message } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * An Anthropic Messages body carrying TWO tool pairs:
+ *   - a poisoned pair (`tool_use.id` + the `tool_result.tool_use_id` that
+ *     references it) that must be rewritten consistently, and
+ *   - a already-valid `toolu_` pair that must survive byte-identical.
+ */
+function poisonedMessagesBody(model: string) {
+  return {
+    model,
+    max_tokens: 1024,
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'search please' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'searching' },
+          { type: 'tool_use', id: POISONED_ID, name: 'web_search', input: {} },
+        ],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: POISONED_ID, content: 'ok' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: VALID_ID, name: 'read_file', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: VALID_ID, content: 'ok' }],
+      },
+    ],
+  };
+}
+
+/** The same two tool pairs in CHAT wire shape (message-level, not content blocks). */
+function poisonedChatBody(model: string) {
+  return {
+    model,
+    messages: [
+      { role: 'user', content: 'search please' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: POISONED_ID, type: 'function', function: { name: 'web_search', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: POISONED_ID, content: 'ok' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: VALID_ID, type: 'function', function: { name: 'read_file', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: VALID_ID, content: 'ok' },
+    ],
+  };
+}
+
+/**
+ * Collects every tool id out of an Anthropic body's `messages[].content[]`, in
+ * document order. Position-independent so it also works on a body the
+ * Claude-Code masking pipeline has restructured.
+ */
+function collectAnthropicToolIds(body: any): { toolUseIds: unknown[]; toolResultIds: unknown[] } {
+  const toolUseIds: unknown[] = [];
+  const toolResultIds: unknown[] = [];
+  for (const message of body?.messages ?? []) {
+    if (!Array.isArray(message?.content)) continue;
+    for (const block of message.content) {
+      if (block?.type === 'tool_use') toolUseIds.push(block.id);
+      if (block?.type === 'tool_result') toolResultIds.push(block.tool_use_id);
+    }
+  }
+  return { toolUseIds, toolResultIds };
+}
+
+/** Parses the JSON body of the Nth `fetch` call. */
+function outboundBody(callIndex: number): any {
+  const call = fetchMock.mock.calls[callIndex] as [string, RequestInit];
+  return JSON.parse(call[1].body as string);
+}
+
+/** The signed CCH field inside the Claude Code billing header block. */
+const CCH_PATTERN = /cch=([0-9a-f]{5});/;
+
+/**
+ * Recomputes the Claude-Code billing signature (CCH) over a transmitted body,
+ * replaying `transformers/oauth/masking/sign-billing.ts` exactly:
+ * `sha256(JSON.stringify(body-with-the-cch=00000-placeholder)).slice(0, 5)`.
+ *
+ * The recompute is possible because that algorithm is a pure function of the
+ * transmitted body — no salt, no clock, no secret. Restoring the placeholder
+ * (same length as the signature it replaced) reconstructs the exact bytes that
+ * were hashed: `signBillingHeader` rebuilds the body by spreading, which
+ * preserves key order, and `JSON.parse`/`JSON.stringify` round-trip that order
+ * too, so `JSON.stringify(unsigned)` here is byte-identical to what was signed.
+ */
+function recomputeCch(transmittedBody: any): string {
+  const [firstBlock, ...restSystem] = transmittedBody.system as any[];
+  const unsigned = {
+    ...transmittedBody,
+    system: [
+      { ...firstBlock, text: String(firstBlock.text).replace(CCH_PATTERN, 'cch=00000;') },
+      ...restSystem,
+    ],
+  };
+  return createHash('sha256').update(JSON.stringify(unsigned)).digest('hex').slice(0, 5);
+}
+
+/**
+ * A plain (no masking, no OAuth) Anthropic-Messages provider. `api_base_url`
+ * uses the record/map form so getProviderTypes() resolves the 'messages' API
+ * type explicitly — the string-URL inference path only recognizes 'messages'
+ * for URLs containing "anthropic.com" (see config.ts's getProviderTypes()).
+ */
+function makeMessagesConfig(options?: { targetCount?: number }) {
+  const targetCount = options?.targetCount ?? 1;
+
+  const providers: Record<string, any> = {
+    p1: {
+      type: 'messages',
+      api_base_url: { messages: 'https://p1.example.com/v1' },
+      api_key: 'test-key-p1',
+      useClaudeMasking: false,
+      models: { 'model-1': {} },
+    },
+    p2: {
+      type: 'messages',
+      api_base_url: { messages: 'https://p2.example.com/v1' },
+      api_key: 'test-key-p2',
+      useClaudeMasking: false,
+      models: { 'model-2': {} },
+    },
+  };
+
+  const orderedTargets = [
+    { provider: 'p1', model: 'model-1' },
+    { provider: 'p2', model: 'model-2' },
+  ].slice(0, targetCount);
+
+  return {
+    providers,
+    models: {
+      'claude-alias': {
+        selector: 'in_order',
+        targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+/** An OpenAI-compatible chat provider — the negative control. */
+function makeChatConfig() {
+  return {
+    providers: {
+      p1: {
+        type: 'chat',
+        api_base_url: 'https://p1.example.com/v1',
+        api_key: 'test-key-p1',
+        models: { 'model-1': {} },
+      },
+    },
+    models: {
+      'chat-alias': {
+        selector: 'in_order',
+        targets: [{ provider: 'p1', model: 'model-1' }],
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+/** Verbatim copy of dispatcher-claude-masking.test.ts's masked-route config. */
+function maskedAnthropicConfig() {
+  return {
+    providers: {
+      claude_masked: {
+        type: 'messages',
+        api_base_url: 'https://api.anthropic.com',
+        api_key: 'sk-ant-api03-masked-test-key',
+        useClaudeMasking: true,
+        models: {
+          'claude-test': {
+            pricing: { source: 'simple', input: 0, output: 0 },
+          },
+        },
+      },
+    },
+    models: {
+      'test-model': {
+        targets: [{ provider: 'claude_masked', model: 'claude-test' }],
+      },
+    },
+    keys: {},
+  } as any;
+}
+
+/** A same-format (messages -> messages) client request: the pass-through path. */
+function makeMessagesRequest(alias: string): UnifiedChatRequest {
+  return {
+    model: alias,
+    // Unified `messages` is required by the type but unused on the pass-through
+    // path — the bypass path clones `originalBody` verbatim.
+    messages: [{ role: 'user', content: 'search please' }],
+    incomingApiType: 'messages',
+    stream: false,
+    originalBody: poisonedMessagesBody(alias),
+  } as any;
+}
+
+/**
+ * A cross-format client request: chat in, Anthropic Messages out. No
+ * `originalBody`, so `shouldUsePassThrough` is false and the real
+ * `transformers/anthropic/request-builder.ts` runs, carrying `tool_calls[].id`
+ * / `tool_call_id` straight into `tool_use` / `tool_result` blocks.
+ */
+function makeChatToAnthropicRequest(alias: string): UnifiedChatRequest {
+  return {
+    model: alias,
+    messages: [
+      { role: 'user', content: 'search please' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: POISONED_ID, type: 'function', function: { name: 'web_search', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: POISONED_ID, content: 'ok' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: VALID_ID, type: 'function', function: { name: 'read_file', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: VALID_ID, content: 'ok' },
+    ],
+    incomingApiType: 'chat',
+    stream: false,
+  } as UnifiedChatRequest;
+}
+
+/** The adapter's own operator-visible trace, used to prove it was injected. */
+function normalizeWarns(): string[] {
+  return vi
+    .mocked(logger.warn)
+    .mock.calls.map((call) => String(call[0]))
+    .filter((message) => message.includes('normalize_anthropic_tool_ids'));
+}
+
+describe('Dispatcher Anthropic tool-id normalization', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+    CooldownManager.resetForTesting();
+    // Re-apply since mockReset: true clears vi.fn() state between tests. No
+    // assertion depends on the value; it only keeps the pi-ai executor from
+    // throwing if a route were ever misrouted onto it.
+    vi.mocked(piAi.complete).mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      stopReason: 'stop',
+      usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+      provider: 'anthropic',
+      model: 'claude-test',
+    } as any);
+  });
+
+  test('the pinned sanitized id is <replaced>_<first 8 hex of sha256(ORIGINAL id as utf16le)>', () => {
+    // Documents where the literal above comes from, independently of the
+    // adapter module, so the exact-match assertions below stay readable.
+    // `update(<string>)` would encode UTF-8, which is lossy for lone
+    // surrogates; the adapter hashes the UTF-16 code units instead.
+    const hash8 = createHash('sha256')
+      .update(Buffer.from(POISONED_ID, 'utf16le'))
+      .digest('hex')
+      .slice(0, 8);
+    expect(SANITIZED_ID).toBe(`functions_WebSearch_3_${hash8}`);
+    expect(SANITIZED_ID).toMatch(/^functions_WebSearch_3_[0-9a-f]{8}$/);
+  });
+
+  test('messages -> messages pass-through: poisoned tool ids are rewritten on the wire, valid ids untouched', async () => {
+    setConfigForTesting(makeMessagesConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () => messagesSuccessResponse('model-1'));
+
+    // Dispatch THIS instance and assert against a snapshot of its own
+    // originalBody afterwards — inspecting a freshly built request instead
+    // would inspect a pristine copy the dispatcher never saw.
+    const request = makeMessagesRequest('claude-alias');
+    const originalBodyBefore = structuredClone((request as any).originalBody);
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(request);
+
+    expect(response).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://p1.example.com/v1/messages');
+
+    const body = outboundBody(0);
+    // Pass-through rewrites the alias to the target's real model id.
+    expect(body.model).toBe('model-1');
+
+    // BOTH halves of the poisoned pair land on the SAME sanitized value —
+    // that consistency is what keeps the conversation referentially intact.
+    expect(body.messages[1].content[1]).toEqual({
+      type: 'tool_use',
+      id: SANITIZED_ID,
+      name: 'web_search',
+      input: {},
+    });
+    expect(body.messages[2].content[0]).toEqual({
+      type: 'tool_result',
+      tool_use_id: SANITIZED_ID,
+      content: 'ok',
+    });
+    expect(SANITIZED_ID).toMatch(/^functions_WebSearch_3_[0-9a-f]{8}$/);
+
+    // The already-valid Anthropic pair is byte-identical.
+    expect(body.messages[3].content[0]).toEqual({
+      type: 'tool_use',
+      id: VALID_ID,
+      name: 'read_file',
+      input: {},
+    });
+    expect(body.messages[4].content[0]).toEqual({
+      type: 'tool_result',
+      tool_use_id: VALID_ID,
+      content: 'ok',
+    });
+
+    // Non-tool content is left completely alone.
+    expect(body.messages[0].content).toEqual([{ type: 'text', text: 'search please' }]);
+    expect(body.messages[1].content[0]).toEqual({ type: 'text', text: 'searching' });
+
+    // The adapter really ran (implicit injection for the messages wire format),
+    // and rewrote exactly the two offending ids — not the two valid ones.
+    const warns = normalizeWarns();
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('rewrote 2 tool id(s)');
+
+    // The client's own body must not be mutated — the payload the adapter
+    // rewrites is an attempt-local deep clone. Compared against a snapshot of
+    // the DISPATCHED request's body, taken before dispatch.
+    const originalBodyAfter = (request as any).originalBody;
+    expect(originalBodyAfter).toEqual(originalBodyBefore);
+    expect(originalBodyAfter.messages[1].content[1].id).toBe(POISONED_ID);
+    expect(originalBodyAfter.messages[2].content[0].tool_use_id).toBe(POISONED_ID);
+  });
+
+  test('Claude-masking route: tool ids are sanitized BEFORE masking/CCH signing wraps the body', async () => {
+    setConfigForTesting(maskedAnthropicConfig());
+    fetchMock.mockImplementation(async () => messagesSuccessResponse('claude-test'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch({
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'search please' }],
+      incomingApiType: 'messages',
+      stream: false,
+      originalBody: poisonedMessagesBody('test-model'),
+    } as any);
+
+    expect(response).toBeDefined();
+    // The masked API-key route goes NATIVE (real fetch, x-api-key), not pi-ai.
+    expect(vi.mocked(piAi.complete)).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.anthropic.com/v1/messages');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('sk-ant-api03-masked-test-key');
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers['anthropic-beta']).toBeTruthy();
+
+    const body = outboundBody(0);
+    // Masking markers: identity system block rebuilt + billing header signed.
+    expect(Array.isArray(body.system)).toBe(true);
+    expect(body.system[0].text).toContain('x-anthropic-billing-header');
+
+    // ...and the tool ids inside that SIGNED body are the sanitized ones.
+    const { toolUseIds, toolResultIds } = collectAnthropicToolIds(body);
+    expect(toolUseIds).toEqual([SANITIZED_ID, VALID_ID]);
+    expect(toolResultIds).toEqual([SANITIZED_ID, VALID_ID]);
+
+    // Ordering proof, not just co-presence: recompute the CCH over the body as
+    // transmitted (sanitized ids and all) and require it to match the signature
+    // actually emitted. Had normalization run AFTER signing, the emitted
+    // signature would cover the POISONED body and this would not match — the
+    // exact silent-corruption mode this adapter's placement exists to avoid.
+    const emittedCch = CCH_PATTERN.exec(body.system[0].text)?.[1];
+    expect(emittedCch).toBeDefined();
+    expect(emittedCch).not.toBe('00000');
+    expect(recomputeCch(body)).toBe(emittedCch);
+
+    // The recompute is genuinely id-sensitive: putting the poisoned ids back
+    // changes the hash, so the match above cannot be an accident.
+    const poisonedBody = JSON.parse(JSON.stringify(body).replaceAll(SANITIZED_ID, POISONED_ID));
+    expect(recomputeCch(poisonedBody)).not.toBe(emittedCch);
+
+    expect(normalizeWarns()).toHaveLength(1);
+  });
+
+  test('chat -> messages transform: ids carried across by the Anthropic request-builder are sanitized', async () => {
+    setConfigForTesting(makeMessagesConfig({ targetCount: 1 }));
+    fetchMock.mockImplementation(async () => messagesSuccessResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeChatToAnthropicRequest('claude-alias'));
+
+    expect(response).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const body = outboundBody(0);
+    // No pass-through: the real request-builder produced these content blocks
+    // from `tool_calls[].id` / `tool_call_id`.
+    const { toolUseIds, toolResultIds } = collectAnthropicToolIds(body);
+    expect(toolUseIds).toEqual([SANITIZED_ID, VALID_ID]);
+    expect(toolResultIds).toEqual([SANITIZED_ID, VALID_ID]);
+    // Same value on both halves of the poisoned pair, again.
+    expect(toolUseIds[0]).toBe(toolResultIds[0]);
+
+    expect(normalizeWarns()).toHaveLength(1);
+  });
+
+  test('chat -> chat target: the adapter is NOT injected and message-level tool ids are byte-identical', async () => {
+    setConfigForTesting(makeChatConfig());
+    fetchMock.mockImplementation(async () => chatSuccessResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch({
+      model: 'chat-alias',
+      messages: [{ role: 'user', content: 'search please' }],
+      incomingApiType: 'chat',
+      stream: false,
+      originalBody: poisonedChatBody('chat-alias'),
+    } as any);
+
+    expect(response).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const body = outboundBody(0);
+    // The OpenAI wire has no tool-id charset rule — rewriting here would
+    // silently corrupt ids the client will match against on the next turn.
+    expect(body.messages[1].tool_calls[0].id).toBe(POISONED_ID);
+    expect(body.messages[2].tool_call_id).toBe(POISONED_ID);
+    expect(body.messages[3].tool_calls[0].id).toBe(VALID_ID);
+    expect(body.messages[4].tool_call_id).toBe(VALID_ID);
+    expect(body.messages).toEqual(poisonedChatBody('chat-alias').messages);
+
+    // Not merely a no-op rewrite — the adapter was never in the chain.
+    expect(normalizeWarns()).toHaveLength(0);
+  });
+
+  test('failover: every attempt gets its own freshly sanitized body', async () => {
+    setConfigForTesting(makeMessagesConfig({ targetCount: 2 }));
+    fetchMock
+      .mockImplementationOnce(async () => errorResponse(500, 'upstream boom'))
+      .mockImplementationOnce(async () => messagesSuccessResponse('model-2'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeMessagesRequest('claude-alias'));
+    const meta = (response as any).plexus;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(meta?.attemptCount).toBe(2);
+    expect(meta?.finalAttemptProvider).toBe('p2');
+
+    // Each attempt re-clones `originalBody` and re-runs the adapter. The
+    // sanitizer being pure and deterministic is what makes the second attempt
+    // land on the SAME ids as the first — no cross-attempt id bookkeeping.
+    for (const callIndex of [0, 1]) {
+      const body = outboundBody(callIndex);
+      const { toolUseIds, toolResultIds } = collectAnthropicToolIds(body);
+      expect(toolUseIds).toEqual([SANITIZED_ID, VALID_ID]);
+      expect(toolResultIds).toEqual([SANITIZED_ID, VALID_ID]);
+    }
+    expect(String((fetchMock.mock.calls[0] as any[])[0])).toBe(
+      'https://p1.example.com/v1/messages'
+    );
+    expect(String((fetchMock.mock.calls[1] as any[])[0])).toBe(
+      'https://p2.example.com/v1/messages'
+    );
+
+    // One warn per attempt — the rewrite genuinely re-ran, it was not carried
+    // over from a mutated shared payload.
+    expect(normalizeWarns()).toHaveLength(2);
+  });
+});

--- a/packages/backend/src/services/__tests__/dispatcher-anthropic-tool-id-normalization.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-anthropic-tool-id-normalization.test.ts
@@ -22,11 +22,14 @@ global.fetch = fetchMock as any;
 // ---------------------------------------------------------------------------
 // Wire-level proof for the `normalize_anthropic_tool_ids` adapter.
 //
-// The adapter is injected implicitly by adapter-resolver.ts for every route
-// whose FINAL outbound wire type is Anthropic Messages. These tests drive the
-// REAL Dispatcher end to end and read the outbound bytes off `fetch`, so they
-// prove the injection point, the ordering relative to Claude-Code masking, and
-// the per-attempt behaviour — not just the pure function.
+// The adapter is injected implicitly by adapter-resolver.ts for routes that
+// satisfy BOTH halves of its gate: the FINAL outbound wire type is Anthropic
+// Messages AND the target looks like Anthropic (anthropic.com base URL,
+// Anthropic OAuth, or Claude masking). A provider/model `adapter` entry
+// overrides that either way. These tests drive the REAL Dispatcher end to end
+// and read the outbound bytes off `fetch`, so they prove the injection point,
+// the ordering relative to Claude-Code masking, and the per-attempt behaviour —
+// not just the pure function.
 //
 // `functions.WebSearch:3` is the real Moonshot/Kimi id shape that makes
 // Anthropic hard-400 with
@@ -198,6 +201,9 @@ function recomputeCch(transmittedBody: any): string {
  * uses the record/map form so getProviderTypes() resolves the 'messages' API
  * type explicitly — the string-URL inference path only recognizes 'messages'
  * for URLs containing "anthropic.com" (see config.ts's getProviderTypes()).
+ * The hosts are anthropic.com gateways so the routes also satisfy the second
+ * half of the injection gate; keeping the record form means these tests
+ * wire-prove the record branch of `isAnthropicTargetProvider` at the same time.
  */
 function makeMessagesConfig(options?: { targetCount?: number }) {
   const targetCount = options?.targetCount ?? 1;
@@ -205,14 +211,14 @@ function makeMessagesConfig(options?: { targetCount?: number }) {
   const providers: Record<string, any> = {
     p1: {
       type: 'messages',
-      api_base_url: { messages: 'https://p1.example.com/v1' },
+      api_base_url: { messages: 'https://gw1.anthropic.com/v1' },
       api_key: 'test-key-p1',
       useClaudeMasking: false,
       models: { 'model-1': {} },
     },
     p2: {
       type: 'messages',
-      api_base_url: { messages: 'https://p2.example.com/v1' },
+      api_base_url: { messages: 'https://gw2.anthropic.com/v1' },
       api_key: 'test-key-p2',
       useClaudeMasking: false,
       models: { 'model-2': {} },
@@ -230,6 +236,40 @@ function makeMessagesConfig(options?: { targetCount?: number }) {
       'claude-alias': {
         selector: 'in_order',
         targets: orderedTargets,
+      },
+    },
+    keys: {},
+    failover: {
+      enabled: true,
+      retryableStatusCodes: [500, 502, 503, 504, 429],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'],
+    },
+    quotas: [],
+  } as any;
+}
+
+/**
+ * A Messages-format provider that is NOT Anthropic: same record/map shape as
+ * `makeMessagesConfig`, but hosted on a plain proxy domain. The route's outbound
+ * wire type is still Anthropic Messages, so it isolates the second half of the
+ * injection gate. `adapter` optionally sets the provider-level override.
+ */
+function makeProxyMessagesConfig(adapter?: any[]) {
+  return {
+    providers: {
+      p1: {
+        type: 'messages',
+        api_base_url: { messages: 'https://p1.example.com/v1' },
+        api_key: 'test-key-p1',
+        useClaudeMasking: false,
+        ...(adapter ? { adapter } : {}),
+        models: { 'model-1': {} },
+      },
+    },
+    models: {
+      'proxy-alias': {
+        selector: 'in_order',
+        targets: [{ provider: 'p1', model: 'model-1' }],
       },
     },
     keys: {},
@@ -269,11 +309,16 @@ function makeChatConfig() {
   } as any;
 }
 
-/** Verbatim copy of dispatcher-claude-masking.test.ts's masked-route config. */
-function maskedAnthropicConfig() {
+/**
+ * Verbatim copy of dispatcher-claude-masking.test.ts's masked-route config.
+ * The provider SLUG is a parameter because `useClaudeMasking` is
+ * provider-name-agnostic: any static provider can carry it, including one whose
+ * name collides with a native-OAuth provider id.
+ */
+function maskedAnthropicConfig(providerSlug = 'claude_masked') {
   return {
     providers: {
-      claude_masked: {
+      [providerSlug]: {
         type: 'messages',
         api_base_url: 'https://api.anthropic.com',
         api_key: 'sk-ant-api03-masked-test-key',
@@ -287,10 +332,21 @@ function maskedAnthropicConfig() {
     },
     models: {
       'test-model': {
-        targets: [{ provider: 'claude_masked', model: 'claude-test' }],
+        targets: [{ provider: providerSlug, model: 'claude-test' }],
       },
     },
     keys: {},
+  } as any;
+}
+
+/** The masked-route client request (same-format Messages, poisoned tool ids). */
+function makeMaskedRequest(): UnifiedChatRequest {
+  return {
+    model: 'test-model',
+    messages: [{ role: 'user', content: 'search please' }],
+    incomingApiType: 'messages',
+    stream: false,
+    originalBody: poisonedMessagesBody('test-model'),
   } as any;
 }
 
@@ -394,7 +450,7 @@ describe('Dispatcher Anthropic tool-id normalization', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://p1.example.com/v1/messages');
+    expect(url).toBe('https://gw1.anthropic.com/v1/messages');
 
     const body = outboundBody(0);
     // Pass-through rewrites the alias to the target's real model id.
@@ -452,13 +508,7 @@ describe('Dispatcher Anthropic tool-id normalization', () => {
     fetchMock.mockImplementation(async () => messagesSuccessResponse('claude-test'));
 
     const dispatcher = new Dispatcher();
-    const response = await dispatcher.dispatch({
-      model: 'test-model',
-      messages: [{ role: 'user', content: 'search please' }],
-      incomingApiType: 'messages',
-      stream: false,
-      originalBody: poisonedMessagesBody('test-model'),
-    } as any);
+    const response = await dispatcher.dispatch(makeMaskedRequest());
 
     expect(response).toBeDefined();
     // The masked API-key route goes NATIVE (real fetch, x-api-key), not pi-ai.
@@ -496,6 +546,42 @@ describe('Dispatcher Anthropic tool-id normalization', () => {
     // changes the hash, so the match above cannot be an accident.
     const poisonedBody = JSON.parse(JSON.stringify(body).replaceAll(SANITIZED_ID, POISONED_ID));
     expect(recomputeCch(poisonedBody)).not.toBe(emittedCch);
+
+    expect(normalizeWarns()).toHaveLength(1);
+  });
+
+  test('Claude-masking route whose provider slug collides with a native-OAuth id still dispatches as Messages', async () => {
+    // `useClaudeMasking` is provider-name-agnostic, so nothing stops an operator
+    // from naming a masked provider 'openai-codex'. The masked route carries no
+    // oauth_provider, so the slug used to fall through to nativeOAuthApiType()
+    // and resolve the wire type to 'responses' — which would drop the native
+    // Anthropic path (no masking, no x-api-key, wrong endpoint) AND, because the
+    // effective wire type was no longer 'messages', skip the tool-id normalizer.
+    setConfigForTesting(maskedAnthropicConfig('openai-codex'));
+    fetchMock.mockImplementation(async () => messagesSuccessResponse('claude-test'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeMaskedRequest());
+
+    expect(response).toBeDefined();
+    expect(vi.mocked(piAi.complete)).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.anthropic.com/v1/messages');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('sk-ant-api03-masked-test-key');
+    expect(headers.Authorization).toBeUndefined();
+    expect(headers['anthropic-beta']).toBeTruthy();
+
+    const body = outboundBody(0);
+    // Masking markers: identity system block rebuilt + billing header signed.
+    expect(Array.isArray(body.system)).toBe(true);
+    expect(body.system[0].text).toContain('x-anthropic-billing-header');
+
+    const { toolUseIds, toolResultIds } = collectAnthropicToolIds(body);
+    expect(toolUseIds).toEqual([SANITIZED_ID, VALID_ID]);
+    expect(toolResultIds).toEqual([SANITIZED_ID, VALID_ID]);
 
     expect(normalizeWarns()).toHaveLength(1);
   });
@@ -551,6 +637,57 @@ describe('Dispatcher Anthropic tool-id normalization', () => {
     expect(normalizeWarns()).toHaveLength(0);
   });
 
+  test('non-Anthropic messages proxy: the adapter is NOT injected and tool ids pass through verbatim', async () => {
+    setConfigForTesting(makeProxyMessagesConfig());
+    fetchMock.mockImplementation(async () => messagesSuccessResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeMessagesRequest('proxy-alias'));
+
+    expect(response).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String((fetchMock.mock.calls[0] as any[])[0])).toBe(
+      'https://p1.example.com/v1/messages'
+    );
+
+    const body = outboundBody(0);
+    // Only the alias -> target model rewrite; every message is byte-identical,
+    // poisoned ids included. A Messages-speaking proxy does not enforce
+    // Anthropic's charset, and rewriting here would break the ids the client
+    // matches against on its next turn.
+    expect(body.model).toBe('model-1');
+    expect(body.messages).toEqual(poisonedMessagesBody('proxy-alias').messages);
+
+    // Not merely a no-op rewrite — the adapter was never in the chain.
+    expect(normalizeWarns()).toHaveLength(0);
+  });
+
+  test('non-Anthropic messages proxy: an explicit provider adapter entry force-enables normalization', async () => {
+    setConfigForTesting(
+      makeProxyMessagesConfig([
+        { name: 'normalize_anthropic_tool_ids', options: {}, enabled: true },
+      ])
+    );
+    fetchMock.mockImplementation(async () => messagesSuccessResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch(makeMessagesRequest('proxy-alias'));
+
+    expect(response).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Still the proxy host — the escape hatch is the only thing that changed.
+    expect(String((fetchMock.mock.calls[0] as any[])[0])).toBe(
+      'https://p1.example.com/v1/messages'
+    );
+
+    const body = outboundBody(0);
+    const { toolUseIds, toolResultIds } = collectAnthropicToolIds(body);
+    expect(toolUseIds).toEqual([SANITIZED_ID, VALID_ID]);
+    expect(toolResultIds).toEqual([SANITIZED_ID, VALID_ID]);
+
+    expect(normalizeWarns()).toHaveLength(1);
+  });
+
   test('failover: every attempt gets its own freshly sanitized body', async () => {
     setConfigForTesting(makeMessagesConfig({ targetCount: 2 }));
     fetchMock
@@ -575,10 +712,10 @@ describe('Dispatcher Anthropic tool-id normalization', () => {
       expect(toolResultIds).toEqual([SANITIZED_ID, VALID_ID]);
     }
     expect(String((fetchMock.mock.calls[0] as any[])[0])).toBe(
-      'https://p1.example.com/v1/messages'
+      'https://gw1.anthropic.com/v1/messages'
     );
     expect(String((fetchMock.mock.calls[1] as any[])[0])).toBe(
-      'https://p2.example.com/v1/messages'
+      'https://gw2.anthropic.com/v1/messages'
     );
 
     // One warn per attempt — the rewrite genuinely re-ran, it was not carried

--- a/packages/backend/src/services/dispatch/adapter-resolver.ts
+++ b/packages/backend/src/services/dispatch/adapter-resolver.ts
@@ -1,9 +1,11 @@
-import type { ProviderAdapter, ResolvedAdapter } from '../../types/provider-adapter';
+import type { ResolvedAdapter } from '../../types/provider-adapter';
 import type { RouteResult } from '../routing/router';
 import type { AdapterEntry } from '../../config';
 import { ADAPTER_REGISTRY } from '../../transformers/adapters/index';
+import { normalizeAnthropicToolIdsAdapter } from '../../transformers/adapters/normalize-anthropic-tool-ids.adapter';
 import { stripUnsupportedToolSearchAdapter } from '../../transformers/adapters/strip-unsupported-tool-search.adapter';
 import { suppressUnsupportedGpt5OptionsAdapter } from '../../transformers/adapters/suppress-unsupported-gpt5-options.adapter';
+import { getApiBaseType } from '../../utils/api-format';
 import { logger } from '../../utils/logger';
 
 /**
@@ -12,8 +14,10 @@ import { logger } from '../../utils/logger';
  * Resolution order:
  *   1. Implicit adapters automatically injected for the route's target
  *      provider (currently: tool-search stripping for `pi_ai_provider ===
- *      'openrouter'`). These run first so user-configured adapters see the
- *      cleaned-up payload if they inspect it.
+ *      'openrouter'`), its model (GPT-5 option suppression) and its outbound
+ *      wire format (Anthropic tool-id normalization for every route whose
+ *      final wire type is Anthropic Messages). These run first so
+ *      user-configured adapters see the cleaned-up payload if they inspect it.
  *   2. Provider-level `adapter` (applies to all models under the provider)
  *   3. Model-level `adapter`   (appended after provider-level adapters)
  *
@@ -25,10 +29,15 @@ import { logger } from '../../utils/logger';
  * adapter doesn't take down the whole route.
  *
  * Returns an empty array when no adapters are configured — zero-cost path.
+ *
+ * @param effectiveApiType Pass the FINAL outbound wire type — request-manager's
+ *   `effectiveApiType`, NOT `targetApiType` (which can be 'oauth' or
+ *   subtype-carrying). When omitted (e.g. legacy callers/tests), no
+ *   format-scoped implicit adapters are injected.
  */
-export function resolveAdapters(route: RouteResult): ResolvedAdapter[] {
+export function resolveAdapters(route: RouteResult, effectiveApiType?: string): ResolvedAdapter[] {
   const entries: AdapterEntry[] = [
-    ...resolveImplicitAdapters(route),
+    ...resolveImplicitAdapters(route, effectiveApiType),
     ...(route.config.adapter ?? []),
     ...(route.modelConfig?.adapter ?? []),
   ];
@@ -57,26 +66,40 @@ export function resolveAdapters(route: RouteResult): ResolvedAdapter[] {
 
 /**
  * Adapters automatically injected for a route based on its target pi-ai
- * provider, independent of user-configured adapters.
+ * provider, its model id and its outbound wire format, independent of
+ * user-configured adapters.
  *
- * Today this fires for `pi_ai_provider === 'openrouter'`, because OpenRouter's
+ * The `pi_ai_provider === 'openrouter'` entry fires because OpenRouter's
  * Anthropic-compat /v1/messages endpoint only accepts a small subset of
  * Anthropic server-tool shorthands and rejects the rest with HTTP 400
  * "Unknown server-tool shorthand". We strip the unsupported ones (currently
  * `tool_search_tool_*`) so that messages<>messages pass-through and the
  * transformer-driven dispatch both end up with a body OpenRouter will accept.
  *
+ * The format-scoped entry fires for every route whose FINAL outbound wire type
+ * is Anthropic Messages (base type of `effectiveApiType`, so subtypes such as
+ * `messages:<subtype>` are covered too). Anthropic — and every
+ * Anthropic-compatible upstream — hard-400s on tool ids outside
+ * `^[a-zA-Z0-9_-]+$`, and foreign ids reach an Anthropic-shaped body both
+ * through the messages->messages pass-through and through cross-format
+ * transforms, so the repair has to be wire-format-scoped rather than
+ * provider-scoped. `effectiveApiType` (not `targetApiType`) is the only value
+ * that reflects the real protocol for native-OAuth routes.
+ *
  * Implicit adapters go through the same registry path as user-configured
  * adapters, so an unresolved name here would fail loudly rather than
  * silently no-op.
  */
-function resolveImplicitAdapters(route: RouteResult): AdapterEntry[] {
+function resolveImplicitAdapters(route: RouteResult, effectiveApiType?: string): AdapterEntry[] {
   const adapters: AdapterEntry[] = [];
   if (isGpt5Model(route.model)) {
     adapters.push({ name: suppressUnsupportedGpt5OptionsAdapter.name, options: {}, enabled: true });
   }
   if (route.config.pi_ai_provider === 'openrouter') {
     adapters.push({ name: stripUnsupportedToolSearchAdapter.name, options: {}, enabled: true });
+  }
+  if (effectiveApiType && getApiBaseType(effectiveApiType) === 'messages') {
+    adapters.push({ name: normalizeAnthropicToolIdsAdapter.name, options: {}, enabled: true });
   }
   return adapters;
 }

--- a/packages/backend/src/services/dispatch/adapter-resolver.ts
+++ b/packages/backend/src/services/dispatch/adapter-resolver.ts
@@ -14,15 +14,22 @@ import { logger } from '../../utils/logger';
  * Resolution order:
  *   1. Implicit adapters automatically injected for the route's target
  *      provider (currently: tool-search stripping for `pi_ai_provider ===
- *      'openrouter'`), its model (GPT-5 option suppression) and its outbound
- *      wire format (Anthropic tool-id normalization for every route whose
- *      final wire type is Anthropic Messages). These run first so
+ *      'openrouter'`), its model (GPT-5 option suppression) and its
+ *      provider+wire-format pair (Anthropic tool-id normalization, gated on
+ *      BOTH the outbound wire format being Anthropic Messages AND the target
+ *      looking like an Anthropic provider — an `anthropic.com` base URL,
+ *      Anthropic OAuth, or Claude masking). These run first so
  *      user-configured adapters see the cleaned-up payload if they inspect it.
  *   2. Provider-level `adapter` (applies to all models under the provider)
  *   3. Model-level `adapter`   (appended after provider-level adapters)
  *
  * An `{ name, enabled: false }` entry removes earlier instances of that adapter,
- * including implicit defaults. A later enabled entry restores it.
+ * including implicit defaults. A later enabled entry restores it. That makes the
+ * provider/model `adapter` array the override channel in BOTH directions: a
+ * `{ name, enabled: false }` tombstone opts a detected-Anthropic route out, and
+ * a `{ name, options: {}, enabled: true }` entry force-enables the adapter on a
+ * route the implicit gate skipped (e.g. an Anthropic-compatible gateway hosted
+ * on some other domain).
  *
  * Each entry is an { name, options } object. Unknown adapter names are logged
  * as warnings and skipped (rather than throwing) so that a misconfigured
@@ -66,8 +73,8 @@ export function resolveAdapters(route: RouteResult, effectiveApiType?: string): 
 
 /**
  * Adapters automatically injected for a route based on its target pi-ai
- * provider, its model id and its outbound wire format, independent of
- * user-configured adapters.
+ * provider, its model id and its provider/outbound-wire-format pair,
+ * independent of user-configured adapters.
  *
  * The `pi_ai_provider === 'openrouter'` entry fires because OpenRouter's
  * Anthropic-compat /v1/messages endpoint only accepts a small subset of
@@ -76,15 +83,30 @@ export function resolveAdapters(route: RouteResult, effectiveApiType?: string): 
  * `tool_search_tool_*`) so that messages<>messages pass-through and the
  * transformer-driven dispatch both end up with a body OpenRouter will accept.
  *
- * The format-scoped entry fires for every route whose FINAL outbound wire type
- * is Anthropic Messages (base type of `effectiveApiType`, so subtypes such as
- * `messages:<subtype>` are covered too). Anthropic — and every
- * Anthropic-compatible upstream — hard-400s on tool ids outside
- * `^[a-zA-Z0-9_-]+$`, and foreign ids reach an Anthropic-shaped body both
- * through the messages->messages pass-through and through cross-format
- * transforms, so the repair has to be wire-format-scoped rather than
- * provider-scoped. `effectiveApiType` (not `targetApiType`) is the only value
- * that reflects the real protocol for native-OAuth routes.
+ * The tool-id normalizer's gate has TWO parts, and both must hold:
+ *
+ *   1. The route's FINAL outbound wire type is Anthropic Messages (base type of
+ *      `effectiveApiType`, so subtypes such as `messages:<subtype>` are covered
+ *      too). Foreign ids reach an Anthropic-shaped body both through the
+ *      messages->messages pass-through and through cross-format transforms, so
+ *      the repair cannot be attached to a single transformer.
+ *   2. The target actually looks like an Anthropic provider
+ *      (`isAnthropicTargetProvider`: an `anthropic.com` base URL, Anthropic
+ *      OAuth, or Claude masking) — judged on the URL this very dispatch would
+ *      use, so a record `api_base_url` is read at its `effectiveApiType` key
+ *      rather than collectively. Not every messages-format target is
+ *      Anthropic — plenty of proxies and self-hosted gateways speak the
+ *      Messages wire format without enforcing Anthropic's tool-id charset, and
+ *      rewriting ids there would mutate ids the client matches against on the
+ *      next turn for no benefit.
+ *
+ * Anthropic itself hard-400s on tool ids outside `^[a-zA-Z0-9_-]+$`. For an
+ * Anthropic-compatible gateway on some other host that enforces the same
+ * charset, add `{ name: 'normalize_anthropic_tool_ids', options: {}, enabled:
+ * true }` to that provider's (or model's) `adapter` array; conversely a
+ * `{ name: 'normalize_anthropic_tool_ids', enabled: false }` entry opts a
+ * detected-Anthropic route out. `effectiveApiType` (not `targetApiType`) is the
+ * only value that reflects the real protocol for native-OAuth routes.
  *
  * Implicit adapters go through the same registry path as user-configured
  * adapters, so an unresolved name here would fail loudly rather than
@@ -98,10 +120,95 @@ function resolveImplicitAdapters(route: RouteResult, effectiveApiType?: string):
   if (route.config.pi_ai_provider === 'openrouter') {
     adapters.push({ name: stripUnsupportedToolSearchAdapter.name, options: {}, enabled: true });
   }
-  if (effectiveApiType && getApiBaseType(effectiveApiType) === 'messages') {
+  if (
+    effectiveApiType &&
+    getApiBaseType(effectiveApiType) === 'messages' &&
+    isAnthropicTargetProvider(route, effectiveApiType)
+  ) {
     adapters.push({ name: normalizeAnthropicToolIdsAdapter.name, options: {}, enabled: true });
   }
   return adapters;
+}
+
+/**
+ * Does this route target Anthropic itself (as opposed to some other upstream
+ * that merely speaks the Messages wire format)?
+ *
+ * Three signals, any of which is sufficient:
+ *
+ *   - An `anthropic.com` base URL. This mirrors the idiom `getProviderTypes()`
+ *     already uses to infer the 'messages' type from a string URL
+ *     (`config.ts`), extended to the record form so that
+ *     `{ messages: 'https://…anthropic.com/v1' }` is recognized too.
+ *   - An `oauth://` base URL whose OAuth provider is `anthropic`. The
+ *     `oauth://` test mirrors `isOAuthRouteForNative`
+ *     (`request-payload-builder.ts`) minus its `targetApiType === 'oauth'`
+ *     short-circuit: this resolver only ever sees `effectiveApiType`, and
+ *     native-OAuth Anthropic routes arrive here already resolved to 'messages'.
+ *     The `oauth_provider || route.provider` slug fallback copies
+ *     `request-manager.ts`'s own resolution of the native OAuth provider.
+ *     `isNativeOAuthRoute` is deliberately NOT reused: it matches codex and
+ *     copilot too, which are not Anthropic targets.
+ *   - `useClaudeMasking`, the provider-name-agnostic Claude-masking API-key
+ *     route, which is Anthropic by construction (and so is URL-independent).
+ *
+ * The `includes('anthropic.com')` substring test is as loose as
+ * `getProviderTypes()`'s — accepted for parity. A false positive only injects an
+ * idempotent, deterministic id rewrite that a
+ * `{ name: 'normalize_anthropic_tool_ids', enabled: false }` adapter entry
+ * disables.
+ *
+ * @param effectiveApiType The FINAL outbound wire type. For the RECORD form of
+ *   `api_base_url` this scopes the URL check to the entry the dispatcher would
+ *   actually send to (see `selectDispatchUrls`), so a provider whose `messages`
+ *   URL is a third-party proxy is not judged by an unrelated `chat` URL that
+ *   happens to point at anthropic.com. Omit it (legacy callers/tests) to fall
+ *   back to scanning every value in the record.
+ */
+export function isAnthropicTargetProvider(route: RouteResult, effectiveApiType?: string): boolean {
+  if (route.config.useClaudeMasking === true) return true;
+  const lowered = selectDispatchUrls(route.config.api_base_url, effectiveApiType).map((url) =>
+    url.toLowerCase()
+  );
+  if (lowered.some((url) => url.includes('anthropic.com'))) return true;
+  const isOAuth = lowered.some((url) => url.startsWith('oauth://'));
+  return isOAuth && (route.config.oauth_provider || route.provider) === 'anthropic';
+}
+
+/**
+ * The base URL(s) a dispatch for `effectiveApiType` would be sent to.
+ *
+ * String form: the one URL, whatever the API type — there is nothing to select.
+ *
+ * Record form with an API type: mirrors `resolveProviderBaseUrl`'s key
+ * selection (`provider-api-selection.ts`) — the exact lower-cased API-type key
+ * first, then the base-type key, so a `messages:<subtype>` route resolves to the
+ * same `messages` URL the dispatcher uses. Only that URL is returned, because
+ * only that URL is the one the request reaches.
+ *
+ * A miss on BOTH keys returns nothing, i.e. "not Anthropic". `resolveProviderBaseUrl`
+ * does keep going in that case (`default` key, `API_TYPE_ALIASES`, then the first
+ * key with a warning), but those fallbacks are deliberately NOT treated as an
+ * Anthropic signal: a provider that doesn't advertise the wire type at all is
+ * not evidence of an Anthropic target, and mis-injecting rewrites ids on a
+ * non-Anthropic upstream. The `{ name: 'normalize_anthropic_tool_ids', options:
+ * {}, enabled: true }` escape hatch covers the residual case.
+ *
+ * Record form without an API type: every value, preserving the pre-scoping
+ * behaviour for callers that have no wire type to scope by.
+ */
+function selectDispatchUrls(
+  base: string | Record<string, string> | undefined,
+  effectiveApiType?: string
+): string[] {
+  if (typeof base === 'string') return [base];
+  const urlMap = base ?? {};
+  if (!effectiveApiType) {
+    return Object.values(urlMap).filter((value): value is string => typeof value === 'string');
+  }
+  const typeKey = effectiveApiType.toLowerCase();
+  const selected = urlMap[typeKey] || urlMap[getApiBaseType(typeKey)];
+  return typeof selected === 'string' && selected.length > 0 ? [selected] : [];
 }
 
 function isGpt5Model(model: string): boolean {

--- a/packages/backend/src/services/dispatch/request-manager.ts
+++ b/packages/backend/src/services/dispatch/request-manager.ts
@@ -13,6 +13,7 @@ import { preprocessVisionRequest } from '../vision/vision-request-preprocessor';
 import { resolveRouteCandidates } from '../routing/route-candidates';
 import { executeStandardAttempt } from './standard-attempt-request';
 import { isNativeOAuthRoute } from './request-payload-builder';
+import { isClaudeMaskingApiKeyRoute } from '../oauth/oauth-dispatcher';
 import { nativeOAuthApiType } from '../oauth/oauth-native-request';
 import type { RetryAttemptRecord } from './dispatcher-types';
 import type { ResolveTimeoutMs } from './upstream-execution';
@@ -163,10 +164,18 @@ export class RequestManager {
               `Supported OAuth providers: anthropic, openai-codex, github-copilot.`
           );
         }
-        const effectiveApiType = nativeOAuth
-          ? (nativeOAuthApiType(route.config.oauth_provider || route.provider, route.model) ??
-            'messages')
-          : targetApiType;
+        // Claude-masking API-key routes are Anthropic Messages by construction
+        // and carry NO oauth_provider, so the slug fallback below would hand an
+        // arbitrary provider name to the native-OAuth mapping: a provider
+        // unluckily named 'openai-codex' or 'github-copilot' would resolve to
+        // 'responses' / Copilot's per-model wire type and break the route.
+        // Resolve them explicitly instead.
+        const effectiveApiType = isClaudeMaskingApiKeyRoute(route, targetApiType)
+          ? 'messages'
+          : nativeOAuth
+            ? (nativeOAuthApiType(route.config.oauth_provider || route.provider, route.model) ??
+              'messages')
+            : targetApiType;
         const transformer = TransformerFactory.getTransformer(effectiveApiType);
 
         // 3. Transform Request

--- a/packages/backend/src/services/dispatch/request-manager.ts
+++ b/packages/backend/src/services/dispatch/request-manager.ts
@@ -173,7 +173,7 @@ export class RequestManager {
         const requestWithTargetModel = { ...currentRequest, model: route.model };
 
         // Resolve adapters for this specific provider+model combination
-        const adapters = resolveAdapters(route);
+        const adapters = resolveAdapters(route, effectiveApiType);
 
         const { payload: providerPayload, bypassTransformation } =
           await host.transformRequestPayload(

--- a/packages/backend/src/transformers/adapters/__tests__/normalize-anthropic-tool-ids.adapter.test.ts
+++ b/packages/backend/src/transformers/adapters/__tests__/normalize-anthropic-tool-ids.adapter.test.ts
@@ -1,0 +1,422 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  normalizeAnthropicToolIds,
+  normalizeAnthropicToolIdsAdapter,
+  sanitizeAnthropicToolId,
+} from '../normalize-anthropic-tool-ids.adapter';
+import { logger } from '../../../utils/logger';
+
+const VALID_ANTHROPIC_TOOL_ID = /^[a-zA-Z0-9_-]{1,64}$/;
+
+function makePayload(messages: any[]): Record<string, any> {
+  return { model: 'claude-sonnet-4', max_tokens: 1024, messages };
+}
+
+// ── sanitizeAnthropicToolId ────────────────────────────────────────────────
+
+describe('sanitizeAnthropicToolId', () => {
+  it('rewrites a Kimi/Moonshot id and is deterministic', () => {
+    const sanitized = sanitizeAnthropicToolId('functions.WebSearch:3');
+
+    expect(sanitized).toMatch(/^functions_WebSearch_3_[0-9a-f]{8}$/);
+    expect(sanitizeAnthropicToolId('functions.WebSearch:3')).toBe(sanitized);
+  });
+
+  it('rewrites a pi-ai composite id', () => {
+    expect(sanitizeAnthropicToolId('call_x|fc_y')).toMatch(/^call_x_fc_y_[0-9a-f]{8}$/);
+  });
+
+  it('rewrites a dotted MCP/Gemini tool name used as an id', () => {
+    expect(sanitizeAnthropicToolId('mcp.search.web')).toMatch(/^mcp_search_web_[0-9a-f]{8}$/);
+  });
+
+  it('returns charset-valid ids untouched regardless of length', () => {
+    expect(sanitizeAnthropicToolId('toolu_01AbC123')).toBe('toolu_01AbC123');
+    expect(sanitizeAnthropicToolId('srvtoolu_XYZ')).toBe('srvtoolu_XYZ');
+
+    const long = 'a'.repeat(200);
+    expect(sanitizeAnthropicToolId(long)).toBe(long);
+  });
+
+  it('maps the empty string onto the sha256("") prefix', () => {
+    expect(sanitizeAnthropicToolId('')).toBe('tool_e3b0c442');
+  });
+
+  it('maps non-string inputs onto a hashed tool_ id', () => {
+    for (const input of [undefined, null, 42, {}]) {
+      const sanitized = sanitizeAnthropicToolId(input);
+      expect(sanitized).toMatch(/^tool_[0-9a-f]{8}$/);
+      expect(sanitizeAnthropicToolId(input)).toBe(sanitized);
+    }
+  });
+
+  // `String(value)` runs value-controlled coercion, and the value arrives from
+  // a client JSON body: `{"id":{"toString":null}}` parses fine and then throws
+  // a TypeError on coercion. A throw here would become an internal error
+  // mid-dispatch instead of a sanitized id.
+  it('never throws on a value whose coercion is hostile', () => {
+    const hostile: unknown[] = [
+      JSON.parse('{"toString": null}'),
+      {
+        toString() {
+          throw new Error('boom');
+        },
+      },
+      { valueOf: null, toString: null },
+      Object.create(null),
+      Symbol('nope'),
+    ];
+
+    for (const input of hostile) {
+      const sanitized = sanitizeAnthropicToolId(input);
+      expect(sanitized).toMatch(/^tool_[0-9a-f]{8}$/);
+      // Deterministic despite the fallback marker.
+      expect(sanitizeAnthropicToolId(input)).toBe(sanitized);
+      expect(sanitizeAnthropicToolId(sanitized)).toBe(sanitized);
+    }
+  });
+
+  // Arrays coerce fine — they must keep taking the normal `String()` path
+  // rather than being swept into the uncoercible fallback.
+  it('hashes a coercible non-string over its coerced text', () => {
+    const fromArray = sanitizeAnthropicToolId([1, 2]);
+
+    expect(fromArray).toMatch(/^tool_[0-9a-f]{8}$/);
+    // Same hash material as the string "1,2" — proof of the `String()` path.
+    expect(fromArray.slice('tool_'.length)).toBe(sanitizeAnthropicToolId('1,2').slice(-8));
+    expect(fromArray).not.toBe(sanitizeAnthropicToolId(JSON.parse('{"toString": null}')));
+  });
+
+  // A JSON string may carry lone surrogates. UTF-8 encoding (what
+  // `createHash().update(<string>)` does) maps every one of them onto U+FFFD,
+  // which would collapse these three distinct inputs onto one id.
+  it('keeps lone surrogates distinct from each other and from U+FFFD', () => {
+    const highSurrogate = sanitizeAnthropicToolId('\ud800');
+    const otherHighSurrogate = sanitizeAnthropicToolId('\ud801');
+    const replacementChar = sanitizeAnthropicToolId('�');
+
+    expect(new Set([highSurrogate, otherHighSurrogate, replacementChar]).size).toBe(3);
+
+    for (const sanitized of [highSurrogate, otherHighSurrogate, replacementChar]) {
+      expect(sanitized).toMatch(VALID_ANTHROPIC_TOOL_ID);
+      expect(sanitizeAnthropicToolId(sanitized)).toBe(sanitized);
+    }
+  });
+
+  it('truncates the prefix but never the hash suffix', () => {
+    const monster = 'x.'.repeat(100);
+    expect(monster.length).toBe(200);
+
+    const sanitized = sanitizeAnthropicToolId(monster);
+
+    expect(sanitized.length).toBe(64);
+    expect(sanitized).toMatch(/_[0-9a-f]{8}$/);
+    expect(sanitized.slice(0, 55)).toBe(monster.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 55));
+  });
+
+  it('is idempotent for every input shape', () => {
+    const inputs: unknown[] = [
+      'functions.WebSearch:3',
+      'call_x|fc_y',
+      'mcp.search.web',
+      'toolu_01AbC123',
+      'srvtoolu_XYZ',
+      'a'.repeat(200),
+      '',
+      undefined,
+      null,
+      42,
+      {},
+      'x.'.repeat(100),
+    ];
+
+    for (const input of inputs) {
+      const once = sanitizeAnthropicToolId(input);
+      expect(sanitizeAnthropicToolId(once)).toBe(once);
+    }
+  });
+
+  // The suffix hashes the ORIGINAL id, so ids that collapse to the same
+  // replaced form stay distinguishable.
+  it('keeps ids distinct when character replacement collapses them', () => {
+    expect(sanitizeAnthropicToolId('a.b')).not.toBe(sanitizeAnthropicToolId('a:b'));
+  });
+
+  it('always emits a charset-valid id for invalid inputs', () => {
+    const inputs: unknown[] = [
+      'functions.WebSearch:3',
+      'call_x|fc_y',
+      'mcp.search.web',
+      '',
+      undefined,
+      null,
+      42,
+      {},
+      'x.'.repeat(100),
+      '한글 도구 이름',
+    ];
+
+    for (const input of inputs) {
+      expect(sanitizeAnthropicToolId(input)).toMatch(VALID_ANTHROPIC_TOOL_ID);
+    }
+  });
+});
+
+// ── preDispatch / walker ───────────────────────────────────────────────────
+
+describe('normalizeAnthropicToolIdsAdapter.preDispatch', () => {
+  beforeEach(() => {
+    vi.mocked(logger.warn).mockClear();
+  });
+
+  it('rewrites a tool_use/tool_result pair to the same sanitized id and warns once', () => {
+    const payload = makePayload([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'searching' },
+          {
+            type: 'tool_use',
+            id: 'functions.WebSearch:3',
+            name: 'WebSearch',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'functions.WebSearch:3',
+            content: 'results',
+          },
+        ],
+      },
+    ]);
+
+    normalizeAnthropicToolIdsAdapter.preDispatch(payload);
+
+    const toolUseId = payload.messages[0].content[1].id;
+    expect(toolUseId).toMatch(/^functions_WebSearch_3_[0-9a-f]{8}$/);
+    expect(payload.messages[1].content[0].tool_use_id).toBe(toolUseId);
+    expect(payload.messages[0].content[0]).toEqual({
+      type: 'text',
+      text: 'searching',
+    });
+
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('rewrote 2 tool id(s)')
+    );
+  });
+
+  it('rewrites an orphan tool_result whose id has no matching tool_use', () => {
+    const payload = makePayload([
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'functions.X:1', content: 'ok' }],
+      },
+    ]);
+
+    normalizeAnthropicToolIdsAdapter.preDispatch(payload);
+
+    expect(payload.messages[0].content[0].tool_use_id).toMatch(/^functions_X_1_[0-9a-f]{8}$/);
+  });
+
+  // End-to-end version of the hostile-coercion case: the object reaches the
+  // walker exactly as it would off a client body, so a throw inside the
+  // sanitizer would escape preDispatch and abort the dispatch.
+  it('rewrites an id whose coercion throws instead of blowing up the walker', () => {
+    const payload = JSON.parse(
+      JSON.stringify({
+        model: 'claude-sonnet-4',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: { toString: null }, name: 'X', input: {} }],
+          },
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'functions.X:1', content: 'ok' }],
+          },
+        ],
+      })
+    );
+
+    expect(() => normalizeAnthropicToolIdsAdapter.preDispatch(payload)).not.toThrow();
+
+    const rewrittenId = payload.messages[0].content[0].id;
+    expect(rewrittenId).toMatch(/^tool_[0-9a-f]{8}$/);
+    expect(rewrittenId).toMatch(VALID_ANTHROPIC_TOOL_ID);
+    expect(payload.messages[1].content[0].tool_use_id).toMatch(/^functions_X_1_[0-9a-f]{8}$/);
+
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('rewrote 2 tool id(s)')
+    );
+  });
+
+  it('leaves system, tools, tool_choice, text blocks and valid ids untouched', () => {
+    const payload = makePayload([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'calling has.dots' },
+          {
+            type: 'tool_use',
+            id: 'toolu_01AbC123',
+            name: 'has.dots',
+            input: {},
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_01AbC123',
+            content: 'done',
+          },
+        ],
+      },
+    ]);
+    payload.system = 'You may call has.dots';
+    payload.tools = [
+      {
+        name: 'has.dots',
+        description: 'dotted name',
+        input_schema: { type: 'object' },
+      },
+    ];
+    payload.tool_choice = { type: 'tool', name: 'has.dots' };
+
+    const before = structuredClone(payload);
+
+    expect(normalizeAnthropicToolIds(payload)).toBe(0);
+    expect(normalizeAnthropicToolIdsAdapter.preDispatch(payload)).toEqual(before);
+    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
+  });
+
+  // Chat-format tool ids live at message level and the OpenAI wire has no
+  // charset rule, so the walker must not reach them.
+  it('leaves a chat-shaped body completely untouched', () => {
+    const payload = makePayload([
+      { role: 'user', content: 'find something' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'functions.X:1',
+            type: 'function',
+            function: { name: 'X', arguments: '{}' },
+          },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'functions.X:1', content: 'result' },
+    ]);
+
+    const before = structuredClone(payload);
+
+    expect(normalizeAnthropicToolIds(payload)).toBe(0);
+    expect(payload).toEqual(before);
+  });
+
+  it('ignores bodies without a messages array', () => {
+    const responsesBody: Record<string, any> = {
+      model: 'gpt-5.5',
+      input: [
+        {
+          type: 'function_call',
+          call_id: 'call_x|fc_y',
+          name: 'X',
+          arguments: '{}',
+        },
+      ],
+    };
+    const noMessages: Record<string, any> = { model: 'claude-sonnet-4' };
+    const badMessages: Record<string, any> = {
+      model: 'claude-sonnet-4',
+      messages: 'nope',
+    };
+
+    for (const body of [responsesBody, noMessages, badMessages]) {
+      const before = structuredClone(body);
+      expect(normalizeAnthropicToolIds(body)).toBe(0);
+      expect(normalizeAnthropicToolIdsAdapter.preDispatch(body)).toEqual(before);
+    }
+
+    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
+  });
+
+  it('handles server/mcp block variants and malformed blocks', () => {
+    const payload = makePayload([
+      {
+        role: 'assistant',
+        content: [
+          null,
+          { type: 'thinking', thinking: 'hmm' },
+          { type: 'tool_use', name: 'no-id-here', input: {} },
+          { id: 'no.type.here' },
+          {
+            type: 'server_tool_use',
+            id: 'server.search:1',
+            name: 'web_search',
+            input: {},
+          },
+          {
+            type: 'mcp_tool_use',
+            id: 'mcp.search.web',
+            name: 'search',
+            server_name: 'mcp',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'mcp_tool_result',
+            tool_use_id: 'mcp.search.web',
+            content: [],
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_01Valid',
+            content: [],
+          },
+        ],
+      },
+    ]);
+
+    const count = normalizeAnthropicToolIds(payload);
+
+    const blocks = payload.messages[0].content;
+    expect(blocks[0]).toBeNull();
+    expect(blocks[1]).toEqual({ type: 'thinking', thinking: 'hmm' });
+    expect(blocks[2].id).toBeUndefined();
+    expect(blocks[3].id).toBe('no.type.here');
+    expect(blocks[4].id).toMatch(/^server_search_1_[0-9a-f]{8}$/);
+    expect(blocks[5].id).toMatch(/^mcp_search_web_[0-9a-f]{8}$/);
+
+    expect(payload.messages[1].content[0].tool_use_id).toBe(blocks[5].id);
+    expect(payload.messages[1].content[1].tool_use_id).toBe('srvtoolu_01Valid');
+
+    expect(count).toBe(3);
+  });
+});
+
+// ── postDispatch ───────────────────────────────────────────────────────────
+
+describe('normalizeAnthropicToolIdsAdapter.postDispatch', () => {
+  it('returns the response unchanged', () => {
+    const response = {
+      id: 'msg_1',
+      content: [{ type: 'tool_use', id: 'functions.X:1' }],
+    };
+
+    expect(normalizeAnthropicToolIdsAdapter.postDispatch(response)).toBe(response);
+  });
+});

--- a/packages/backend/src/transformers/adapters/index.ts
+++ b/packages/backend/src/transformers/adapters/index.ts
@@ -6,6 +6,7 @@ import { reasoningRewriteAdapter } from './reasoning-rewrite.adapter';
 import { webSearchCoercionAdapter } from './web-search-coercion.adapter';
 import { stripUnsupportedToolSearchAdapter } from './strip-unsupported-tool-search.adapter';
 import { suppressUnsupportedGpt5OptionsAdapter } from './suppress-unsupported-gpt5-options.adapter';
+import { normalizeAnthropicToolIdsAdapter } from './normalize-anthropic-tool-ids.adapter';
 
 /**
  * Registry of all built-in provider adapters.
@@ -19,4 +20,5 @@ export const ADAPTER_REGISTRY: Record<string, ProviderAdapter> = {
   [webSearchCoercionAdapter.name]: webSearchCoercionAdapter,
   [stripUnsupportedToolSearchAdapter.name]: stripUnsupportedToolSearchAdapter,
   [suppressUnsupportedGpt5OptionsAdapter.name]: suppressUnsupportedGpt5OptionsAdapter,
+  [normalizeAnthropicToolIdsAdapter.name]: normalizeAnthropicToolIdsAdapter,
 };

--- a/packages/backend/src/transformers/adapters/normalize-anthropic-tool-ids.adapter.ts
+++ b/packages/backend/src/transformers/adapters/normalize-anthropic-tool-ids.adapter.ts
@@ -32,8 +32,17 @@ import { logger } from '../../utils/logger';
  *     `prepareNativeOAuthDispatch`, which runs *after* adapters. Mutating the
  *     body post-signing would invalidate that signature, so the rewrite has to
  *     happen up front.
- *   - Failover cannot rescue the request either: every messages-format target
- *     enforces the same charset, so the identical body 400s on each attempt.
+ *   - Failover cannot rescue the request either: every Anthropic
+ *     messages-format target enforces the same charset, so the identical body
+ *     400s on each attempt.
+ *
+ * Where it is injected: `adapter-resolver.ts` adds this adapter implicitly only
+ * when the outbound wire format is Anthropic Messages AND the target looks like
+ * Anthropic (anthropic.com base URL, Anthropic OAuth, or Claude masking) —
+ * other Messages-speaking proxies do not enforce the charset. A provider- or
+ * model-level `adapter` entry overrides that either way
+ * (`{ name, options: {}, enabled: true }` to force it on, `{ name, enabled:
+ * false }` to opt out).
  *
  * (Same decision rule as the NOTE in
  * `suppress-unsupported-gpt5-options.adapter.ts`: strip statically when every

--- a/packages/backend/src/transformers/adapters/normalize-anthropic-tool-ids.adapter.ts
+++ b/packages/backend/src/transformers/adapters/normalize-anthropic-tool-ids.adapter.ts
@@ -1,0 +1,186 @@
+import { createHash } from 'node:crypto';
+import type { ProviderAdapter } from '../../types/provider-adapter';
+import { logger } from '../../utils/logger';
+
+/**
+ * normalize_anthropic_tool_ids adapter
+ *
+ * Rewrites `tool_use` / `tool_result` identifiers inside an Anthropic Messages
+ * body so they satisfy Anthropic's tool-id charset constraint
+ * `^[a-zA-Z0-9_-]+$`.
+ *
+ * Why this exists:
+ *
+ * Anthropic rejects any tool id outside that charset with a hard HTTP 400, e.g.
+ * `messages.222.content.1.tool_use.id: String should match pattern
+ * '^[a-zA-Z0-9_-]+$'`. Plenty of foreign providers mint ids that violate it —
+ * Moonshot/Kimi emits `functions.WebSearch:3`, pi-ai replays composite
+ * `call_x|fc_y` ids, and Gemini uses the dotted tool name as the id. Those ids
+ * reach an Anthropic-shaped body through two separate routes:
+ *
+ *   1. The messages -> messages pass-through, where the dispatcher forwards a
+ *      verbatim deep clone of the client body (`request-payload-builder.ts`)
+ *      and `transformers/anthropic/request-builder.ts` never runs at all. A
+ *      client that accumulated foreign ids in an earlier turn replays them
+ *      here untouched.
+ *   2. Cross-format transforms, which carry the upstream id straight across
+ *      from `tool_calls[].id` / `tool_call_id`.
+ *
+ * Why proactive rather than reactive (strip-and-retry on the 400):
+ *
+ *   - Claude-Code masking computes its billing signature during
+ *     `prepareNativeOAuthDispatch`, which runs *after* adapters. Mutating the
+ *     body post-signing would invalidate that signature, so the rewrite has to
+ *     happen up front.
+ *   - Failover cannot rescue the request either: every messages-format target
+ *     enforces the same charset, so the identical body 400s on each attempt.
+ *
+ * (Same decision rule as the NOTE in
+ * `suppress-unsupported-gpt5-options.adapter.ts`: strip statically when every
+ * upstream on the path rejects the shape, reactively when only some do.)
+ *
+ * Outbound (preDispatch): rewrites offending ids in place and emits one warn
+ * summarising the count. Ids already inside the charset — including Anthropic's
+ * own `toolu_` / `srvtoolu_` ids of any length — are never touched.
+ *
+ * Inbound (postDispatch) and stream hooks: no-op. This is a request-side-only
+ * repair, and adapters run in reverse on the way back, so identity is correct.
+ */
+
+const ANTHROPIC_TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const ANTHROPIC_TOOL_ID_MAX_LENGTH = 64;
+const HASH_SUFFIX_LENGTH = 8;
+
+const TOOL_USE_BLOCK_TYPES = new Set(['tool_use', 'server_tool_use', 'mcp_tool_use']);
+const TOOL_RESULT_BLOCK_TYPES = new Set(['tool_result', 'mcp_tool_result']);
+
+/**
+ * Coerces a non-string id to the string the hash is taken over.
+ *
+ * `String(value)` runs VALUE-CONTROLLED coercion, and the value here came
+ * straight off a client request body: `{"id": {"toString": null}}` is valid
+ * JSON that parses fine and then makes `String()` throw a TypeError, which
+ * would surface as an internal error mid-dispatch instead of a sanitized id.
+ * Anything that refuses to coerce falls back to a per-`typeof` marker, keeping
+ * the sanitizer total. All uncoercible values of one typeof therefore collapse
+ * onto a single id — acceptable for input that is already garbage, since
+ * determinism (the same input always yielding the same id) is the property
+ * that matters, not distinctness.
+ */
+function coerceToolIdToString(id: unknown): string {
+  try {
+    return String(id);
+  } catch {
+    return `[uncoercible ${typeof id}]`;
+  }
+}
+
+/**
+ * Maps any value onto an id matching `^[a-zA-Z0-9_-]+$` and at most 64 chars.
+ *
+ * The function is pure and deterministic, which is what makes it safe without
+ * any cross-turn bookkeeping: a `tool_use.id` and the `tool_result.tool_use_id`
+ * that references it start from the same original string, so they always land
+ * on the same sanitized value — across turns, retries and failover attempts,
+ * with no id map to keep in sync.
+ *
+ * The hash suffix is taken over the ORIGINAL input, not the replaced form, so
+ * ids that collapse together under character replacement (`a.b` and `a:b` both
+ * become `a_b`) stay distinct. Every generated output is itself charset-valid,
+ * so the function is idempotent: f(f(x)) === f(x).
+ */
+export function sanitizeAnthropicToolId(id: unknown): string {
+  if (typeof id === 'string' && ANTHROPIC_TOOL_ID_PATTERN.test(id)) return id;
+
+  // The hash is taken over UTF-16 code units, not `update(<string>)`'s implicit
+  // UTF-8 encoding. UTF-8 is LOSSY for the malformed UTF-16 a JSON string can
+  // legally carry: every lone surrogate encodes as U+FFFD, so `"\ud800"`,
+  // `"\ud801"` and `"�"` would all hash identically and collide onto one
+  // id. `utf16le` round-trips every code unit, so distinct inputs stay
+  // distinct. Applied uniformly (well-formed strings too) — one path is
+  // simpler than two, and only determinism matters here; nothing outside this
+  // process ever recomputes these hashes.
+  const hash8 = createHash('sha256')
+    .update(Buffer.from(typeof id === 'string' ? id : coerceToolIdToString(id), 'utf16le'))
+    .digest('hex')
+    .slice(0, HASH_SUFFIX_LENGTH);
+
+  if (typeof id !== 'string' || id.length === 0) return `tool_${hash8}`;
+
+  const replaced = id.replace(/[^a-zA-Z0-9_-]/g, '_');
+  // Truncate the prefix, never the suffix, so the disambiguating hash survives.
+  const prefix = replaced.slice(0, ANTHROPIC_TOOL_ID_MAX_LENGTH - HASH_SUFFIX_LENGTH - 1);
+  return `${prefix}_${hash8}`;
+}
+
+/**
+ * Rewrites offending tool ids inside `payload.messages[].content[]` in place and
+ * returns how many were changed.
+ *
+ * Scope is deliberately narrow — only ids nested inside message content blocks.
+ * `system`, `tools`, `tool_choice`, message-level fields (chat-format
+ * `tool_calls[]` / `tool_call_id` live there, and the OpenAI wire has no such
+ * charset rule) and top-level ids are all left alone.
+ *
+ * `tool_use_id` is rewritten whenever it is a string, regardless of block type.
+ * That covers result blocks this list doesn't enumerate
+ * (`web_search_tool_result`, `code_execution_tool_result`, ...) and keeps every
+ * reference consistent with its `tool_use` partner; for the valid `srvtoolu_`
+ * ids those blocks normally carry it is a no-op.
+ */
+export function normalizeAnthropicToolIds(payload: Record<string, any>): number {
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.messages)) return 0;
+
+  let rewrittenCount = 0;
+
+  for (const message of payload.messages) {
+    if (!message || typeof message !== 'object' || !Array.isArray(message.content)) continue;
+
+    for (const block of message.content) {
+      if (!block || typeof block !== 'object') continue;
+
+      if (TOOL_USE_BLOCK_TYPES.has(block.type) && block.id !== undefined) {
+        const sanitized = sanitizeAnthropicToolId(block.id);
+        if (sanitized !== block.id) {
+          block.id = sanitized;
+          rewrittenCount++;
+        }
+      }
+
+      if (
+        typeof block.tool_use_id === 'string' ||
+        (TOOL_RESULT_BLOCK_TYPES.has(block.type) && block.tool_use_id !== undefined)
+      ) {
+        const sanitized = sanitizeAnthropicToolId(block.tool_use_id);
+        if (sanitized !== block.tool_use_id) {
+          block.tool_use_id = sanitized;
+          rewrittenCount++;
+        }
+      }
+    }
+  }
+
+  return rewrittenCount;
+}
+
+export const normalizeAnthropicToolIdsAdapter: ProviderAdapter = {
+  name: 'normalize_anthropic_tool_ids',
+
+  // Mutating in place is safe here: at the adapter hook the payload is always
+  // attempt-local — either a fresh deep clone of the client body or freshly
+  // built transformer output (see request-payload-builder.ts).
+  preDispatch(payload: Record<string, any>): Record<string, any> {
+    const rewrittenCount = normalizeAnthropicToolIds(payload);
+    if (rewrittenCount > 0) {
+      logger.warn(
+        `normalize_anthropic_tool_ids: rewrote ${rewrittenCount} tool id(s) to Anthropic charset ` +
+          `(model=${payload?.model ?? 'unknown'})`
+      );
+    }
+    return payload;
+  },
+
+  postDispatch(response: Record<string, any>): Record<string, any> {
+    return response;
+  },
+};

--- a/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
+++ b/packages/frontend/src/components/providers/ProviderAdvancedEditor.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
-import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
+import { ChevronDown, ChevronRight, Info, Plus, Trash2 } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { DebouncedInput } from '../ui/DebouncedInput';
 import { Switch } from '../ui/Switch';
 import { Badge } from '../ui/Badge';
+import { Tooltip } from '../ui/Tooltip';
 import { GPU_PROFILE_OPTIONS, resolveGpuParams } from '@plexus/shared';
 import type { Provider, CompactionSettings } from '../../lib/api';
 import { api } from '../../lib/api';
@@ -39,6 +40,8 @@ export const KNOWN_ADAPTERS: { value: string; label: string; description: string
       'Coerces server-side web search tool entries to the format expected by this provider (Anthropic, OpenAI, or OpenRouter).',
   },
 ];
+
+const ANTHROPIC_TOOL_ID_ADAPTER = 'normalize_anthropic_tool_ids';
 
 const WEB_SEARCH_TARGETS = [
   { value: 'anthropic', label: 'Anthropic (web_search_20250305)' },
@@ -398,6 +401,133 @@ export function ProviderAdvancedEditor({
                           )}
                         </div>
                       )}
+                    </div>
+                  );
+                })()}
+
+                {/* Anthropic Tool-ID Normalization — Auto | Enabled | Disabled */}
+                {(() => {
+                  const entries: any[] = editingProvider.adapter ?? [];
+                  // The backend replays adapter entries in order, so a LATER
+                  // entry overrides an earlier one — read the last match, not
+                  // the first (resolveAdapters, adapter-resolver.ts).
+                  let entry: any;
+                  for (const candidate of entries) {
+                    const name = typeof candidate === 'string' ? candidate : candidate?.name;
+                    if (name === ANTHROPIC_TOOL_ID_ADAPTER) entry = candidate;
+                  }
+                  const mode: 'auto' | 'on' | 'off' = !entry
+                    ? 'auto'
+                    : typeof entry === 'string' || entry.enabled !== false
+                      ? 'on'
+                      : 'off';
+
+                  const setMode = (value: 'auto' | 'on' | 'off') => {
+                    const withoutEntry = entries.filter(
+                      (e: any) =>
+                        (typeof e === 'string' ? e : e?.name) !== ANTHROPIC_TOOL_ID_ADAPTER
+                    );
+                    const next =
+                      value === 'auto'
+                        ? withoutEntry
+                        : [
+                            ...withoutEntry,
+                            {
+                              name: ANTHROPIC_TOOL_ID_ADAPTER,
+                              options: {},
+                              enabled: value === 'on',
+                            },
+                          ];
+                    setEditingProvider({ ...editingProvider, adapter: next });
+                  };
+
+                  // Advisory mirror of the backend gate (adapter-resolver.ts):
+                  // it only fires on the Messages wire format, so a record base
+                  // URL counts only where the Messages dispatch would go — a
+                  // chat-only anthropic.com entry never receives one. A string
+                  // base URL containing anthropic.com IS a Messages provider by
+                  // inference (getProviderTypes), so it counts as-is.
+                  const isAnthropicUrl = (url: string) => {
+                    const lowered = url.toLowerCase();
+                    return (
+                      lowered.includes('anthropic.com') ||
+                      (lowered.startsWith('oauth://') &&
+                        (editingProvider.oauthProvider || editingProvider.id) === 'anthropic')
+                    );
+                  };
+                  const baseUrls = editingProvider.apiBaseUrl;
+                  const autoDetected =
+                    editingProvider.useClaudeMasking === true ||
+                    (typeof baseUrls === 'string'
+                      ? isAnthropicUrl(baseUrls)
+                      : Object.entries(baseUrls ?? {}).some(([key, value]) => {
+                          const type = key.toLowerCase();
+                          return (
+                            (type === 'messages' || type.startsWith('messages:')) &&
+                            typeof value === 'string' &&
+                            isAnthropicUrl(value)
+                          );
+                        }));
+
+                  return (
+                    <div
+                      style={{
+                        gridColumn: '1 / -1',
+                        padding: '4px 8px',
+                        borderRadius: 'var(--radius-sm)',
+                        border: '1px solid var(--color-border-glass)',
+                        background:
+                          mode === 'auto' ? 'var(--color-bg-glass)' : 'var(--color-bg-hover)',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '6px',
+                      }}
+                    >
+                      <div>
+                        <div className="flex items-center gap-1.5">
+                          <div className="font-body text-[12px] font-medium text-text">
+                            Anthropic Tool-ID Normalization
+                          </div>
+                          <Tooltip
+                            position="top"
+                            content={
+                              <div className="w-64 whitespace-normal font-body leading-relaxed">
+                                Auto enables this only for Anthropic-like targets on this provider's
+                                Messages endpoint: base URL containing anthropic.com, Anthropic
+                                OAuth, or Claude masking. Choose Enabled to force it for
+                                Anthropic-compatible gateways on other hosts.
+                              </div>
+                            }
+                          >
+                            <button
+                              type="button"
+                              aria-label="About Anthropic Tool-ID Normalization"
+                              className="flex h-4 w-4 items-center justify-center rounded-full text-text-muted transition-colors hover:bg-bg-hover hover:text-text-secondary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+                            >
+                              <Info size={12} />
+                            </button>
+                          </Tooltip>
+                        </div>
+                        <div
+                          className="font-body text-[11px] text-text-secondary"
+                          style={{ lineHeight: 1.35 }}
+                        >
+                          Rewrites tool ids that violate Anthropic's ^[a-zA-Z0-9_-]+$ charset before
+                          dispatch. Anthropic rejects such ids with HTTP 400.
+                        </div>
+                      </div>
+                      <select
+                        className="w-full py-1 pl-2 pr-2 font-body text-[12px] text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        value={mode === 'auto' ? '' : mode}
+                        onChange={(e) => {
+                          const raw = e.target.value;
+                          setMode(raw === 'on' ? 'on' : raw === 'off' ? 'off' : 'auto');
+                        }}
+                      >
+                        <option value="">{`Auto (currently: ${autoDetected ? 'enabled' : 'disabled'})`}</option>
+                        <option value="on">Enabled</option>
+                        <option value="off">Disabled</option>
+                      </select>
                     </div>
                   );
                 })()}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1993,7 +1993,7 @@ export const api = {
       ...(provider.gpu_power_draw_watts != null
         ? { gpu_power_draw_watts: provider.gpu_power_draw_watts }
         : {}),
-      ...(provider.adapter && provider.adapter.length > 0 ? { adapter: provider.adapter } : {}),
+      adapter: provider.adapter ?? [],
       ...(provider.timeoutMs != null ? { timeoutMs: provider.timeoutMs } : {}),
       ...(provider.maxConcurrency != null ? { maxConcurrency: provider.maxConcurrency } : {}),
       ...(provider.stallTtfbMs != null ? { stallTtfbMs: provider.stallTtfbMs } : {}),


### PR DESCRIPTION
## Summary

Sessions that switch models mid-conversation (subagents, review passes) accumulate tool-call IDs minted by non-Anthropic providers in the client's history — Moonshot/Kimi emits `functions.WebSearch:3`, pi-ai replays composite `call_x|fc_y` ids, Gemini uses dotted tool names as ids. Anthropic hard-400s any `tool_use.id` / `tool_result.tool_use_id` outside `^[a-zA-Z0-9_-]+$`, and because the same poisoned body goes to every failover target, the whole alias group is exhausted and the session is permanently stuck:

```
All targets failed: cc/claude-opus-5 (400), ... Last error: messages.222.content.1.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'
```

(Observed in production 2026-07-28: 29 of 100 recent gateway errors, one Claude Code session unable to continue at all.)

## What changed

- New provider adapter **`normalize_anthropic_tool_ids`** (`transformers/adapters/normalize-anthropic-tool-ids.adapter.ts`), auto-injected for every route whose **final** outbound wire type is Anthropic Messages (`getApiBaseType(effectiveApiType) === 'messages'`).
- `resolveAdapters(route, effectiveApiType?)` gains an optional second parameter; the sole production call site (`request-manager.ts`) passes the already-computed `effectiveApiType`. Existing single-arg callers keep compiling and get no format-scoped injection.
- Running in the `preDispatch` loop means one implementation covers all four Anthropic-bound dispatch shapes — **messages↔messages pass-through** (the failing prod path, where the anthropic request-builder never runs), cross-format transforms, native OAuth, and masked API-key routes — and lands **before** `prepareNativeOAuthDispatch`, so the CC masking billing signature is computed over the sanitized body.

### Sanitizer semantics

Pure, deterministic, idempotent. Charset-valid ids of any length pass through untouched (Anthropic's own `toolu_`/`srvtoolu_` ids are never rewritten). Offenders get invalid chars replaced with `_` plus an 8-hex sha256 suffix of the original (utf16le-encoded so lone surrogates stay distinct), capped at 64 chars, e.g. `functions.WebSearch:3` → `functions_WebSearch_3_0ad6c974`. Purity keeps `tool_use`/`tool_result` pairs consistent with zero state — across turns, same-target strip-retries, and failover attempts. Values that refuse string coercion (`{"toString": null}` is valid JSON) fall back to a deterministic marker instead of throwing. Proactive-only by the same decision rule as the GPT-5 option suppression NOTE: the defect is visible in the request and rejected identically by every messages-format target, and a reactive post-400 mutation would run after CCH signing.

## Testing

- 17 unit tests on the sanitizer/walker (charset edge cases, lone-surrogate distinctness, hostile coercion, idempotence, pair consistency, chat/responses bodies untouched).
- 7 resolver-injection tests (base type + subtype scoping, disable/re-enable mechanism, implicit ordering); all 21 pre-existing resolver tests pass unmodified.
- 6 wire-level dispatcher tests against the real `Dispatcher` with mocked fetch: pass-through, masked route (including recomputing the CC billing hash over the transmitted body to prove sign-after-sanitize ordering, with an anti-vacuity control), chat→anthropic transform, non-anthropic control (byte-identical), and failover re-sanitization per attempt.
- Full suite: 235 files / 2608 tests green; typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)