### PR TITLE
fix(logs): correct in-flight token rate estimate

### DIFF
--- a/packages/backend/src/routes/__tests__/raw-passthrough.test.ts
+++ b/packages/backend/src/routes/__tests__/raw-passthrough.test.ts
@@ -439,11 +439,25 @@ describe('raw passthrough routes', () => {
     expect(usageStorage.registerInFlight).toHaveBeenCalledWith(
       requestId,
       expect.any(StallInspector),
-      'allowed'
+      'allowed',
+      false
     );
     const inspector = (usageStorage.registerInFlight as any).mock.calls[0][1] as StallInspector;
     expect(inspector.getStats().bytesReceived).toBe(upstreamResponseBody.byteLength);
     expect(usageStorage.deregisterInFlight).toHaveBeenCalledWith(requestId);
+  });
+
+  test('marks streamed raw responses in live progress updates', async () => {
+    upstreamResponseHeaders = { 'content-type': 'text/event-stream' };
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/raw/openrouter/v1/events',
+      headers: { authorization: 'Bearer plexus-secret' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect((usageStorage.registerInFlight as any).mock.calls[0]?.[3]).toBe(true);
   });
 
   test('deregisters in-flight progress tracking when the upstream request fails', async () => {

--- a/packages/backend/src/routes/raw-passthrough.ts
+++ b/packages/backend/src/routes/raw-passthrough.ts
@@ -431,7 +431,8 @@ export async function registerRawPassthroughRoutes(
           usageStorage.registerInFlight(
             requestId,
             stallInspector,
-            (request as any).keyName ?? null
+            (request as any).keyName ?? null,
+            usageRecord.isStreamed
           );
           // pipeline() (not .pipe()) so an upstream error destroys the inspector
           // too and the for-await below terminates instead of hanging.

--- a/packages/backend/src/services/observability/usage-storage.ts
+++ b/packages/backend/src/services/observability/usage-storage.ts
@@ -14,6 +14,7 @@ import type { StallInspector } from '../inspectors/stall-inspector';
 export interface ProgressUpdate {
   requestId: string;
   apiKey: string | null;
+  isStreamed: boolean;
   bytesReceived: number;
   bytesPerSec: number | null;
   state: 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED';
@@ -68,11 +69,16 @@ export class UsageStorageService extends EventEmitter {
   private telemetryQueue: Promise<void> = Promise.resolve();
   private inFlightRegistry = new Map<
     string,
-    { inspector: StallInspector; apiKey: string | null }
+    { inspector: StallInspector; apiKey: string | null; isStreamed: boolean }
   >();
 
-  registerInFlight(requestId: string, inspector: StallInspector, apiKey: string | null): void {
-    this.inFlightRegistry.set(requestId, { inspector, apiKey });
+  registerInFlight(
+    requestId: string,
+    inspector: StallInspector,
+    apiKey: string | null,
+    isStreamed = false
+  ): void {
+    this.inFlightRegistry.set(requestId, { inspector, apiKey, isStreamed });
   }
 
   deregisterInFlight(requestId: string): void {
@@ -81,10 +87,10 @@ export class UsageStorageService extends EventEmitter {
 
   getProgressUpdates(): ProgressUpdate[] {
     const updates: ProgressUpdate[] = [];
-    for (const [requestId, { inspector, apiKey }] of this.inFlightRegistry) {
+    for (const [requestId, { inspector, apiKey, isStreamed }] of this.inFlightRegistry) {
       try {
         const stats = inspector.getStats();
-        updates.push({ requestId, apiKey, ...stats });
+        updates.push({ requestId, apiKey, isStreamed, ...stats });
       } catch {
         // Inspector may have been destroyed; skip it
       }

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -416,7 +416,8 @@ export async function handleResponse(
       usageStorage.registerInFlight(
         usageRecord.requestId!,
         stallInspector,
-        (usageRecord.apiKey as string | null) ?? null
+        (usageRecord.apiKey as string | null) ?? null,
+        !!unifiedResponse.stream
       );
     }
 

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -252,6 +252,7 @@ export const Logs = () => {
     requestId: string;
     bytesReceived: number;
     bytesPerSec: number | null;
+    isStreamed: boolean;
     state: 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED';
     elapsedMs: number;
   }
@@ -1553,7 +1554,10 @@ export const Logs = () => {
                               ? e2eOutputTokens / (log.durationMs / 1000)
                               : null;
                           if (progress) {
-                            const bytesPerToken = getEstimatedBytesPerToken(log);
+                            const bytesPerToken = getEstimatedBytesPerToken({
+                              ...log,
+                              isStreamed: progress.isStreamed,
+                            });
                             const effectiveBytesPerSec =
                               progress.bytesPerSec != null && progress.bytesPerSec > 0
                                 ? progress.bytesPerSec


### PR DESCRIPTION
## Summary
Correct in-flight token-per-second estimates for streamed responses in the Logs view. Live progress now uses the actual response stream mode instead of the pending usage record's default, preventing SSE traffic from being estimated with the non-streamed bytes-per-token ratio.

## Why / Context
Pending usage records are created before the response mode is known and default `isStreamed` to false. The Logs UI therefore treated live SSE payload bytes as bulk JSON, producing implausibly high token-rate estimates such as ~14,000 tok/s.

## Changes
- **Progress tracking**: carry `isStreamed` through the in-flight registry and progress SSE payload.
- **Response handling**: register transformed and raw responses with their resolved stream mode.
- **Logs UI**: select the framing-aware bytes-per-token estimate from live progress data.
- **Tests**: cover both non-streamed and SSE raw-response progress registration.

## Testing
- Manually opened the authenticated Logs page in the worktree dev stack and confirmed it renders without runtime errors.
- Exercised raw passthrough progress registration for both bulk and `text/event-stream` responses.
