### PR TITLE
fix(models): refresh MiniMax-M3 pricing and add MiniMax-M2.7

### DIFF
--- a/scripts/default-populate.json
+++ b/scripts/default-populate.json
@@ -91,13 +91,23 @@
         "minimax/minimax-m3:nitro": {
           "pricing": {
             "source": "simple",
-            "input": 0.3,
-            "output": 1.2,
-            "cached": 0.06,
-            "cache_write": 0.3
+            "input": 0.6,
+            "output": 2.4,
+            "cached": 0.12
           },
           "access_via": [],
           "pi_ai_model_id": "minimax/minimax-m3"
+        },
+        "minimax/minimax-m2.7:nitro": {
+          "pricing": {
+            "source": "simple",
+            "input": 0.3,
+            "output": 1.2,
+            "cached": 0.06,
+            "cache_write": 0.375
+          },
+          "access_via": [],
+          "pi_ai_model_id": "minimax/minimax-m2.7"
         },
         "openai/gpt-5.4:nitro": {
           "pricing": {


### PR DESCRIPTION
Reason: MiniMax-M3 catalog pricing is stale (input 0.30, output 1.20, cache_read 0.06, cache_write 0.30 per million tokens) and must be refreshed to input 0.60, output 2.40, cache_read 0.12 with no cache-write price; MiniMax-M2.7 is also missing from the default catalog.

Changes (limited to `scripts/default-populate.json`, the committed default fixture):
- Update `minimax/minimax-m3:nitro` pricing to `input: 0.6`, `output: 2.4`, `cached: 0.12` and remove the stale `cache_write` field (no cache-write price for MiniMax-M3).
- Add `minimax/minimax-m2.7:nitro` with `input: 0.3`, `output: 1.2`, `cached: 0.06`, `cache_write: 0.375`, and `pi_ai_model_id: minimax/minimax-m2.7`.

Checks run:
- `python3 -m json.tool scripts/default-populate.json` (fixture still parses as valid JSON).
- A structural invariant check mirroring `scripts/__tests__/build-populate.test.ts`: asserted the MiniMax-M3/M2.7 pricing fields equal the target values and that every committed provider URL still resolves to `localhost`.
