### PR TITLE
fix(oauth): forward the caller's anthropic-beta flags and stop injecting descriptions into server-side tools

### DIFF
--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -194,6 +194,10 @@ export async function buildRequestPayload(
       // request-manager passes for native OAuth routes — Copilot needs it to
       // pick the right endpoint (chat/messages/responses).
       apiType: targetApiType,
+      // The caller's own `anthropic-beta` flags. Merged with REQUIRED_BETAS
+      // rather than discarded, so beta-gated client features (e.g. the advisor
+      // tool) survive the gateway instead of being rejected upstream.
+      callerBetas: request.anthropicBeta,
     });
     (route as any)[NATIVE_OAUTH_STASH] = prepared;
     logger.debug(

--- a/packages/backend/src/services/oauth/__tests__/oauth-native-request-betas.test.ts
+++ b/packages/backend/src/services/oauth/__tests__/oauth-native-request-betas.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression test: the caller's `anthropic-beta` header must survive the native
+ * OAuth path.
+ *
+ * `prepareAnthropicOAuthRequest` used to build the outbound header as
+ * `REQUIRED_BETAS.join(',')`, which OVERWRITES whatever the client sent.
+ * `REQUIRED_BETAS` is a hand-maintained snapshot of a genuine Claude Code
+ * request (see its "TO UPDATE: inspect a genuine Claude Code CLI request"
+ * comment), so it goes stale whenever the client ships a new beta-gated
+ * feature — and every flag the client added beyond the snapshot was silently
+ * dropped. Anthropic then rejected the tool that flag gates, e.g.
+ *
+ *   400 tools.N: Input tag 'advisor_20260301' found using 'type' does not
+ *       match any of the expected tags: ...
+ *
+ * The union must keep REQUIRED_BETAS too: masking-critical flags such as
+ * `oauth-2025-04-20` are never sent by the caller.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { REQUIRED_BETAS } from '../../../transformers/oauth/masking';
+import { prepareOAuthNativeRequest } from '../oauth-native-request';
+
+const AUTH = { mode: 'oauth', token: 'oauth-token-for-test' } as const;
+
+const nativeBody = () => ({
+  model: 'claude-sonnet-4-5',
+  max_tokens: 64,
+  messages: [{ role: 'user', content: 'hello' }],
+});
+
+function betasFor(callerBetas?: string): string[] {
+  const prepared = prepareOAuthNativeRequest(
+    'anthropic',
+    'claude-sonnet-4-5',
+    AUTH,
+    nativeBody(),
+    false,
+    callerBetas === undefined ? undefined : { callerBetas }
+  );
+  const header = prepared.headers['anthropic-beta'];
+  expect(header).toBeDefined();
+  return (header ?? '').split(',');
+}
+
+describe('prepareOAuthNativeRequest — anthropic-beta merging', () => {
+  it("forwards the caller's beta flags alongside REQUIRED_BETAS", () => {
+    const betas = betasFor(
+      'claude-code-20250219,advisor-tool-2026-03-01,some-future-beta-2026-09-09'
+    );
+
+    // Caller-only flags survive instead of being discarded.
+    expect(betas).toContain('advisor-tool-2026-03-01');
+    expect(betas).toContain('some-future-beta-2026-09-09');
+
+    // ...and the masking-critical flags the caller never sends are still there.
+    for (const required of REQUIRED_BETAS) {
+      expect(betas).toContain(required);
+    }
+  });
+
+  it('does not duplicate flags the caller and REQUIRED_BETAS share', () => {
+    const betas = betasFor(
+      'advisor-tool-2026-03-01, claude-code-20250219 ,advisor-tool-2026-03-01'
+    );
+
+    expect(betas).toEqual([...new Set(betas)]);
+    expect(betas.filter((b) => b === 'claude-code-20250219')).toHaveLength(1);
+    expect(betas.filter((b) => b === 'advisor-tool-2026-03-01')).toHaveLength(1);
+    // Whitespace around a caller flag must not leak into the wire value.
+    expect(betas).not.toContain(' claude-code-20250219 ');
+  });
+
+  it('emits exactly REQUIRED_BETAS when the caller sent no header', () => {
+    expect(betasFor(undefined)).toEqual([...REQUIRED_BETAS]);
+    expect(betasFor('')).toEqual([...REQUIRED_BETAS]);
+  });
+});

--- a/packages/backend/src/services/oauth/oauth-native-request.ts
+++ b/packages/backend/src/services/oauth/oauth-native-request.ts
@@ -94,6 +94,35 @@ function resolveOAuthBaseUrl(provider: OAuthProvider, modelId: string): string {
 }
 
 /**
+ * Union the hardcoded `REQUIRED_BETAS` with whatever `anthropic-beta` flags the
+ * caller sent, preserving REQUIRED_BETAS order and appending caller-only flags.
+ *
+ * Why: REQUIRED_BETAS is a hand-maintained snapshot of a genuine Claude Code
+ * request, so it goes stale every time Claude Code ships a new beta-gated
+ * feature. Overwriting the caller's header meant any newer flag was silently
+ * dropped, and Anthropic then rejected the corresponding tool — e.g. a client
+ * sending `advisor-tool-2026-03-01` + `advisor_20260301` got
+ * `tools.N: Input tag 'advisor_20260301' ... does not match any of the expected
+ * tags`, because the gateway stripped the flag that makes that tool legal.
+ *
+ * Merging (not replacing) keeps the masking-critical flags — notably
+ * `oauth-2025-04-20` — which the caller does not send, while letting newer
+ * client betas through without waiting for this constant to be updated.
+ */
+function mergeBetas(callerBetas?: string): string {
+  const merged = [...REQUIRED_BETAS];
+  const seen = new Set(merged);
+  for (const raw of (callerBetas ?? '').split(',')) {
+    const beta = raw.trim();
+    if (beta && !seen.has(beta)) {
+      seen.add(beta);
+      merged.push(beta);
+    }
+  }
+  return merged.join(',');
+}
+
+/**
  * Prepare an Anthropic OAuth request from a native Anthropic `/v1/messages`
  * body. Applies the exact masking sequence `executeRequest` runs today, then
  * returns everything the standard fetch path needs.
@@ -102,7 +131,8 @@ function prepareAnthropicOAuthRequest(
   modelId: string,
   auth: NativeAnthropicAuth,
   nativeBody: any,
-  streaming: boolean
+  streaming: boolean,
+  callerBetas?: string
 ): PreparedOAuthRequest {
   // The token used to GATE masking (not necessarily the auth credential). For
   // the API-key masking route we force the masking's OAuth codepath with the
@@ -145,7 +175,7 @@ function prepareAnthropicOAuthRequest(
     'Content-Type': 'application/json',
     Accept: streaming ? 'text/event-stream' : 'application/json',
     'anthropic-version': '2023-06-01',
-    'anthropic-beta': REQUIRED_BETAS.join(','),
+    'anthropic-beta': mergeBetas(callerBetas),
     ...getStainlessHeaders(),
     // Auth: OAuth → Bearer; masking-API-key → x-api-key (real Anthropic key).
     ...(auth.mode === 'oauth'
@@ -510,10 +540,10 @@ export function prepareOAuthNativeRequest(
   auth: NativeAnthropicAuth,
   nativeBody: any,
   streaming: boolean,
-  options?: { codexPassthrough?: boolean; apiType?: string }
+  options?: { codexPassthrough?: boolean; apiType?: string; callerBetas?: string }
 ): PreparedOAuthRequest {
   if (provider === 'anthropic') {
-    return prepareAnthropicOAuthRequest(modelId, auth, nativeBody, streaming);
+    return prepareAnthropicOAuthRequest(modelId, auth, nativeBody, streaming, options?.callerBetas);
   }
   if (provider === 'openai-codex') {
     if (auth.mode !== 'oauth') {
@@ -615,6 +645,8 @@ export async function prepareNativeOAuthDispatch(params: {
   codexPassthrough?: boolean;
   /** Copilot only: the resolved wire API type (chat/messages/responses). */
   apiType?: string;
+  /** Anthropic only: the caller's raw `anthropic-beta` header, merged with REQUIRED_BETAS. */
+  callerBetas?: string;
 }): Promise<PreparedOAuthRequest> {
   const { provider, modelId, nativeBody, streaming, oauthAccountId, maskingApiKey } = params;
 
@@ -636,5 +668,6 @@ export async function prepareNativeOAuthDispatch(params: {
   return prepareOAuthNativeRequest(provider, modelId, auth, nativeBody, streaming, {
     codexPassthrough: params.codexPassthrough === true,
     apiType: params.apiType,
+    callerBetas: params.callerBetas,
   });
 }

--- a/packages/backend/src/transformers/oauth/masking/__tests__/cc-tools-server-tools.test.ts
+++ b/packages/backend/src/transformers/oauth/masking/__tests__/cc-tools-server-tools.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression test: server-side tools must survive the masking pipeline
+ * byte-identical.
+ *
+ * `stripDescriptionsAndInjectSyntheticTools()` blanks client-authored tool
+ * descriptions so no caller fingerprint reaches Anthropic. It used to do that
+ * with an unconditional `{ ...t, description: note ?? '' }` over every entry in
+ * `tools[]` — including SERVER-SIDE tools (`bash_20250124`, `web_search_*`,
+ * `advisor_20260301`, …), which are identified by a `type` other than "custom".
+ *
+ * Those tools have closed schemas. Adding a key Anthropic doesn't expect makes
+ * it reject the whole request:
+ *
+ *   400 tools.N.advisor_20260301.description: Extra inputs are not permitted
+ *
+ * They also carry no client-authored description to strip, so there was never
+ * anything to gain. `applyClaudeOAuthTransform` already skips them for the same
+ * reason ("Skip built-in tools (they have a `type` field)", oauth-claude.ts);
+ * this locks the masking pass to the same rule.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { stripDescriptionsAndInjectSyntheticTools } from '../cc-tools';
+
+const serverTools = () => [
+  { type: 'advisor_20260301', name: 'advisor', model: 'claude-sonnet-5' },
+  { type: 'bash_20250124', name: 'bash' },
+  { type: 'web_search_20250305', name: 'web_search', max_uses: 5 },
+];
+
+describe('stripDescriptionsAndInjectSyntheticTools — server-side tools', () => {
+  it('passes server tools through untouched (no injected description key)', () => {
+    const input = serverTools();
+    const out = stripDescriptionsAndInjectSyntheticTools({ tools: input });
+
+    for (const original of input) {
+      const emitted = out.tools.find(
+        (t: any) => t.name === original.name && t.type === original.type
+      );
+      expect(emitted, `server tool ${original.type} missing from output`).toBeDefined();
+      // The key itself must be absent — `description: ''` is what upstream rejects.
+      expect(Object.hasOwn(emitted, 'description')).toBe(false);
+      expect(emitted).toEqual(original);
+    }
+  });
+
+  it('still strips descriptions from custom tools alongside server tools', () => {
+    const out = stripDescriptionsAndInjectSyntheticTools({
+      tools: [
+        { type: 'advisor_20260301', name: 'advisor', model: 'claude-sonnet-5' },
+        { name: 'MyTool', description: 'client authored', input_schema: { type: 'object' } },
+        { type: 'custom', name: 'MyOtherTool', description: 'also client authored' },
+      ],
+    });
+
+    const advisor = out.tools.find((t: any) => t.type === 'advisor_20260301');
+    expect(Object.hasOwn(advisor, 'description')).toBe(false);
+
+    // type-less and type:"custom" tools are still blanked — the fingerprint
+    // stripping this function exists for must not regress.
+    expect(out.tools.find((t: any) => t.name === 'MyTool').description).toBe('');
+    expect(out.tools.find((t: any) => t.name === 'MyOtherTool').description).toBe('');
+  });
+
+  it('leaves a body without tools[] untouched', () => {
+    const body = { messages: [] };
+    expect(stripDescriptionsAndInjectSyntheticTools(body)).toBe(body);
+  });
+});

--- a/packages/backend/src/transformers/oauth/masking/cc-tools.ts
+++ b/packages/backend/src/transformers/oauth/masking/cc-tools.ts
@@ -60,6 +60,19 @@ export function stripDescriptionsAndInjectSyntheticTools(
   }
 
   const strippedTools = body.tools.map((t: any) => {
+    // Server-side tools (`bash_20250124`, `web_search_*`, `advisor_20260301`, …)
+    // are identified by a `type` other than "custom", and their schemas are
+    // CLOSED — Anthropic rejects unknown keys with
+    // `tools.N.<type>.description: Extra inputs are not permitted`. They carry
+    // no client-authored description to fingerprint anyway, so there is nothing
+    // to strip. Leave them byte-identical.
+    //
+    // This mirrors the rule `applyClaudeOAuthTransform` already applies in
+    // `oauth-claude.ts` ("Skip built-in tools (they have a `type` field)").
+    const type = typeof t?.type === 'string' ? t.type : undefined;
+    if (type && type !== 'custom') {
+      return t;
+    }
     const note = noteByRenamedName.get(t?.name);
     return { ...t, description: note ?? '' };
   });


### PR DESCRIPTION
## Summary

Two bugs on the **native Anthropic OAuth path** that, together, make every request from a current Claude Code client fail with a `400` from Anthropic. They're sequential — fixing the first one just surfaces the second.

1. The caller's `anthropic-beta` header is **overwritten** by `REQUIRED_BETAS` instead of merged with it, so any beta flag newer than that hand-maintained constant is silently dropped.
2. `stripDescriptionsAndInjectSyntheticTools()` injects a `description` key into **server-side tools**, whose schemas are closed, so Anthropic rejects the request.

---

## Bug 1 — the caller's `anthropic-beta` flags are discarded

`packages/backend/src/services/oauth/oauth-native-request.ts` built its outbound headers with:

```ts
'anthropic-beta': REQUIRED_BETAS.join(','),
```

That **replaces** the caller's `anthropic-beta` rather than merging with it. `REQUIRED_BETAS` (`transformers/oauth/masking/cc-constants.ts`) is a hand-maintained snapshot of a genuine Claude Code request — its own comment says *"TO UPDATE: inspect a genuine Claude Code CLI request"* — so it necessarily goes stale whenever the client ships a new beta-gated feature.

Concretely: a current Claude Code client (v2.1.220) sends nine flags; `REQUIRED_BETAS` covers five of them. One of the dropped ones is `advisor-tool-2026-03-01`, which is what makes the `advisor_20260301` server tool legal. Because the gateway stripped the flag but forwarded the tool, Anthropic rejected every such request:

```
400 tools.N: Input tag 'advisor_20260301' found using 'type' does not match
    any of the expected tags: 'bash_20250124', ...
```

Notably the header is already handled correctly everywhere else — `routes/inference/messages.ts:74` captures it into `unifiedRequest.anthropicBeta`, and `services/providers/provider-request-headers.ts:70` forwards it on the standard `messages` path. It was simply never threaded into the OAuth path.

**Fix:** a `mergeBetas()` helper that unions `REQUIRED_BETAS` with the caller's header (REQUIRED first, caller-only flags appended, trimmed, deduped), plus a `callerBetas` option threaded through `prepareAnthropicOAuthRequest` → `prepareOAuthNativeRequest` → `prepareNativeOAuthDispatch`, supplied by `services/dispatch/request-payload-builder.ts` as `request.anthropicBeta`.

Merging rather than replacing is deliberate: it preserves masking-critical flags the caller never sends (notably `oauth-2025-04-20`) while letting newer client betas through without waiting for the constant to be refreshed.

## Bug 2 — `description` injected into server-side tools

`packages/backend/src/transformers/oauth/masking/cc-tools.ts`, in `stripDescriptionsAndInjectSyntheticTools()`:

```ts
return { ...t, description: note ?? '' };
```

This ran over **every** entry in `tools[]`, including server-side tools (`bash_20250124`, `web_search_*`, `advisor_20260301`, …). Those have closed schemas, so the extra key is rejected outright:

```
400 tools.N.advisor_20260301.description: Extra inputs are not permitted
```

They also carry no client-authored description to strip, so there was never anything to gain by touching them. `applyClaudeOAuthTransform` in `transformers/oauth/oauth-claude.ts` already skips them for exactly this reason (*"Skip built-in tools (they have a `type` field)"*).

**Fix:** skip tools whose `type` is present and `!== 'custom'`, returning them untouched. Custom and type-less tools are still blanked, so the fingerprint-stripping purpose of the function is unchanged.

---

## Reproduction

With a provider on the native Anthropic OAuth path, send a request carrying a beta flag that isn't in `REQUIRED_BETAS` plus the tool it gates:

```bash
curl -sS http://127.0.0.1:4000/v1/messages \
  -H 'x-api-key: <client-key>' \
  -H 'anthropic-version: 2023-06-01' \
  -H 'anthropic-beta: advisor-tool-2026-03-01,claude-code-20250219' \
  -H 'content-type: application/json' \
  -d '{
        "model": "<oauth-anthropic-alias>",
        "max_tokens": 64,
        "messages": [{"role": "user", "content": "hi"}],
        "tools": [{"type": "advisor_20260301", "name": "advisor", "model": "claude-sonnet-4-5"}]
      }'
```

Before: `400 ... Input tag 'advisor_20260301' ... does not match any of the expected tags`.
After fixing only Bug 1: `400 tools.0.advisor_20260301.description: Extra inputs are not permitted`.
After both: `200`.

## Testing

- Full backend suite green: **2656 tests / 238 files** (`bunx --bun vitest run --config vitest.config.ts` from `packages/backend`).
- `bun run typecheck` clean across all workspaces; `bunx biome format` / `bunx biome lint .` clean.
- New unit tests, both verified **non-vacuous** by reverting the corresponding fix and confirming they fail:
  - `packages/backend/src/services/oauth/__tests__/oauth-native-request-betas.test.ts` (3 tests) — caller flags appear alongside `REQUIRED_BETAS`, no duplicates or stray whitespace, and the header is byte-identical to today's behaviour when the caller sends nothing. 2 of 3 fail without the Bug 1 fix.
  - `packages/backend/src/transformers/oauth/masking/__tests__/cc-tools-server-tools.test.ts` (3 tests) — server tools pass through with no `description` key added, custom/type-less tools are still blanked. 2 of 3 fail without the Bug 2 fix.
- Also verified end-to-end against the real Anthropic API through a patched build: the previously-failing request returns `200`, and requests that don't use beta-gated server tools are unaffected.

No schema or migration changes.
