### PR TITLE
fix(models): prevent duplicate alias targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This file is a **guardrail**, not general documentation.
 - **NEVER** run `drizzle-kit generate` directly.
 - **NEVER** produce implementation or summary documents unless specifically requested.
 - **NEVER** assume Plexus supports file-based configuration. Providers, models, keys, quotas, and settings are database-backed; manage them through the Admin UI or Management API. Environment variables are only for server-level settings.
+- **DEBUGGING** Plexus instances: read and use the `plexus-cli` skill. The worktree `.env` contains the relevant staging configuration. When the user specifies `staging`, use `PLEXUS_STAGING_URL` for the staging URL and `PLEXUS_ADMIN_KEY` for the admin key.
 - **AVOID** searching library type definitions for documentation. Use context/search skills first when available.
 - **ASK** when requirements are ambiguous.
 - **NEVER** use --delete-branch on gh commands

--- a/packages/backend/src/__tests__/config-model-targets.test.ts
+++ b/packages/backend/src/__tests__/config-model-targets.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { findDuplicateAliasTargets, ModelConfigSchema } from '../config';
+
+describe('model alias target validation', () => {
+  it('finds duplicate provider/model pairs across target groups', () => {
+    expect(
+      findDuplicateAliasTargets([
+        {
+          targets: [{ provider: 'openrouter', model: 'google/gemini-3.1-pro-preview-customtools' }],
+        },
+        {
+          targets: [{ provider: 'openrouter', model: 'google/gemini-3.1-pro-preview-customtools' }],
+        },
+      ])
+    ).toEqual([{ provider: 'openrouter', model: 'google/gemini-3.1-pro-preview-customtools' }]);
+  });
+
+  it('rejects duplicate targets before persistence', () => {
+    const result = ModelConfigSchema.safeParse({
+      target_groups: [
+        {
+          name: 'primary',
+          selector: 'random',
+          targets: [{ provider: 'openrouter', model: 'duplicate-model' }],
+        },
+        {
+          name: 'fallback',
+          selector: 'in_order',
+          targets: [{ provider: 'openrouter', model: 'duplicate-model' }],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toEqual([
+      {
+        code: 'custom',
+        path: ['target_groups'],
+        message: "Duplicate target 'openrouter/duplicate-model' is not allowed",
+      },
+    ]);
+  });
+
+  it('allows the same model through different providers', () => {
+    const result = ModelConfigSchema.safeParse({
+      target_groups: [
+        {
+          name: 'default',
+          selector: 'random',
+          targets: [
+            { provider: 'openrouter', model: 'shared-model' },
+            { provider: 'local', model: 'shared-model' },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -724,6 +724,23 @@ const ModelTargetGroupSchema = z.object({
   targets: z.array(ModelTargetSchema),
 });
 
+export function findDuplicateAliasTargets(
+  targetGroups: Array<{ targets: Array<{ provider: string; model: string }> }> | undefined
+): Array<{ provider: string; model: string }> {
+  const seen = new Set<string>();
+  const duplicates = new Map<string, { provider: string; model: string }>();
+
+  for (const group of targetGroups ?? []) {
+    for (const target of group.targets) {
+      const key = JSON.stringify([target.provider, target.model]);
+      if (seen.has(key)) duplicates.set(key, target);
+      else seen.add(key);
+    }
+  }
+
+  return Array.from(duplicates.values());
+}
+
 // Shared scope/limit fields applied to every quota-type union member below:
 //  - allowed*/excluded* restrict which provider/model pairs the quota counts
 //    against (see services/scope-match.ts for matching semantics; all-empty
@@ -922,6 +939,18 @@ export const ModelConfigSchema = z
       })
       .optional(),
     compaction: CompactionOverrideSchema.optional(),
+  })
+  .superRefine((data, context) => {
+    const targetGroups =
+      data.target_groups ?? (data.targets ? [{ targets: data.targets }] : undefined);
+
+    for (const target of findDuplicateAliasTargets(targetGroups)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['target_groups'],
+        message: `Duplicate target '${target.provider}/${target.model}' is not allowed`,
+      });
+    }
   })
   .transform((data) => {
     // Normalise legacy flat format to grouped format immediately.

--- a/packages/frontend/src/components/models/AutoAddModal.tsx
+++ b/packages/frontend/src/components/models/AutoAddModal.tsx
@@ -3,6 +3,7 @@ import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
 import { Modal } from '../ui/Modal';
 import type { Provider, Model, AliasTargetGroup } from '../../lib/api';
+import { dedupeModels } from '../../lib/modelOptions';
 
 interface Props {
   isOpen: boolean;
@@ -20,7 +21,7 @@ const getMatchingModels = (query: string, availableModels: Model[], providers: P
 
   const searchLower = searchTerm.toLowerCase();
   const matches: Array<{ model: Model; provider: Provider }> = [];
-  availableModels.forEach((model) => {
+  dedupeModels(availableModels).forEach((model) => {
     const provider = providers.find((p) => p.id === model.providerId);
     if (
       provider &&
@@ -98,7 +99,7 @@ export function AutoAddModal({
     setSelectedModels(new Set());
   };
 
-  const group0Targets = targetGroups[0]?.targets ?? [];
+  const existingTargets = targetGroups.flatMap((group) => group.targets);
 
   return (
     <Modal
@@ -163,7 +164,7 @@ export function AutoAddModal({
                         filteredModels.every(
                           (m) =>
                             selectedModels.has(`${m.provider.id}|${m.model.id}`) ||
-                            group0Targets.some(
+                            existingTargets.some(
                               (t: any) => t.provider === m.provider.id && t.model === m.model.id
                             )
                         )
@@ -175,7 +176,7 @@ export function AutoAddModal({
                             filteredModels.forEach((m) => {
                               const key = `${m.provider.id}|${m.model.id}`;
                               if (
-                                !group0Targets.some(
+                                !existingTargets.some(
                                   (t: any) => t.provider === m.provider.id && t.model === m.model.id
                                 )
                               ) {
@@ -207,7 +208,7 @@ export function AutoAddModal({
               <tbody>
                 {filteredModels.map(({ model, provider }) => {
                   const key = `${provider.id}|${model.id}`;
-                  const alreadyExists = group0Targets.some(
+                  const alreadyExists = existingTargets.some(
                     (t: any) => t.provider === provider.id && t.model === model.id
                   );
                   const isSelected = selectedModels.has(key);

--- a/packages/frontend/src/components/models/ModelMetadataEditor.tsx
+++ b/packages/frontend/src/components/models/ModelMetadataEditor.tsx
@@ -15,6 +15,7 @@ import { Switch } from '../ui/Switch';
 import { MetadataOverrideForm } from './MetadataOverrideForm';
 import { useMetadataEditor } from '../../hooks/useMetadataEditor';
 import { api } from '../../lib/api';
+import { dedupeById } from '../../lib/modelOptions';
 import { useToast } from '../../contexts/ToastContext';
 import type {
   Alias,
@@ -623,7 +624,7 @@ export function ModelMetadataEditor({ editingAlias, setEditingAlias, isModalOpen
                           }}
                         >
                           <option value="">Select model...</option>
-                          {piModels.map((m) => (
+                          {dedupeById(piModels).map((m) => (
                             <option key={m.id} value={m.id} title={m.api}>
                               {m.name} ({m.id}){m.custom ? ' — custom' : ''}
                             </option>
@@ -820,7 +821,7 @@ export function ModelMetadataEditor({ editingAlias, setEditingAlias, isModalOpen
               overflowY: 'auto',
             }}
           >
-            {metadataResults.map((result) => (
+            {dedupeById(metadataResults).map((result) => (
               <button
                 key={result.id}
                 type="button"

--- a/packages/frontend/src/components/models/TargetGroupEditor.tsx
+++ b/packages/frontend/src/components/models/TargetGroupEditor.tsx
@@ -3,6 +3,7 @@ import { GripVertical, ChevronUp, ChevronDown, Plus, Trash2 } from 'lucide-react
 import { Switch } from '../ui/Switch';
 import { Button } from '../ui/Button';
 import { AliasTargetGroup } from '../../lib/api';
+import { dedupeModels, getModelOptionKey } from '../../lib/modelOptions';
 
 interface TargetGroupEditorProps {
   groups: AliasTargetGroup[];
@@ -289,6 +290,20 @@ export const TargetGroupEditor: React.FC<TargetGroupEditorProps> = ({
                   dragOver?.mode === 'target' &&
                   dragOver.groupIdx === groupIdx &&
                   dragOver.targetIdx === targetIdx;
+                const modelOptions = dedupeModels(
+                  availableModels.filter((model) => model.providerId === target.provider)
+                ).filter(
+                  (model) =>
+                    model.id === target.model ||
+                    !groups.some((candidateGroup, candidateGroupIdx) =>
+                      candidateGroup.targets.some(
+                        (candidateTarget, candidateTargetIdx) =>
+                          (candidateGroupIdx !== groupIdx || candidateTargetIdx !== targetIdx) &&
+                          getModelOptionKey(candidateTarget.provider, candidateTarget.model) ===
+                            getModelOptionKey(model.providerId, model.id)
+                      )
+                    )
+                );
 
                 return (
                   <div
@@ -367,13 +382,14 @@ export const TargetGroupEditor: React.FC<TargetGroupEditorProps> = ({
                       disabled={!target.provider}
                     >
                       <option value="">Model...</option>
-                      {availableModels
-                        .filter((m) => m.providerId === target.provider)
-                        .map((m) => (
-                          <option key={m.id} value={m.id}>
-                            {m.name}
-                          </option>
-                        ))}
+                      {modelOptions.map((model) => (
+                        <option
+                          key={getModelOptionKey(model.providerId, model.id)}
+                          value={model.id}
+                        >
+                          {model.name}
+                        </option>
+                      ))}
                     </select>
                     <Switch
                       checked={target.enabled !== false}

--- a/packages/frontend/src/hooks/useMetadataEditor.ts
+++ b/packages/frontend/src/hooks/useMetadataEditor.ts
@@ -8,6 +8,7 @@ import {
   MetadataSource,
   NormalizedModelMetadata,
 } from '../lib/api';
+import { dedupeById } from '../lib/modelOptions';
 
 /**
  * Encapsulates all state and logic related to the metadata accordion in the
@@ -238,7 +239,7 @@ export function useMetadataEditor(
       metadataSearchRef.current = setTimeout(async () => {
         try {
           const resp = await api.searchModelMetadata(source, query, 30);
-          setMetadataResults(resp.data);
+          setMetadataResults(dedupeById(resp.data));
         } catch {
           setMetadataResults([]);
         } finally {

--- a/packages/frontend/src/hooks/useModels.ts
+++ b/packages/frontend/src/hooks/useModels.ts
@@ -243,7 +243,7 @@ export const useModels = () => {
       return true;
     } catch (e) {
       console.error('Failed to save alias', e);
-      toast.error('Failed to save alias');
+      toast.error(e instanceof Error ? e.message : 'Failed to save alias');
       return false;
     } finally {
       setIsSaving(false);

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { formatNumber, formatPoints } from './format';
 import { normalizeApiAccessList } from './apiFormats';
+import { dedupeAliasTargets, dedupeById, dedupeModels } from './modelOptions';
 
 import type { QuotaCheckerInfo } from '../types/quota';
 
@@ -1150,6 +1151,8 @@ export interface ModelResolutionPreview {
 }
 
 function aliasToConfigPayload(alias: Alias): Record<string, unknown> {
+  const targetGroups = dedupeAliasTargets(alias.target_groups);
+
   return {
     priority: alias.priority || 'selector',
     additional_aliases: alias.aliases,
@@ -1165,7 +1168,7 @@ function aliasToConfigPayload(alias: Alias): Record<string, unknown> {
     ...(alias.extraBody && Object.keys(alias.extraBody).length > 0
       ? { extraBody: alias.extraBody }
       : {}),
-    target_groups: alias.target_groups.map((group) => ({
+    target_groups: targetGroups.map((group) => ({
       name: group.name,
       selector: group.selector,
       targets: group.targets.map((target) => ({
@@ -2123,7 +2126,9 @@ export const api = {
     );
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(err.error || 'Failed to save alias');
+      const detail =
+        Array.isArray(err.details) && err.details[0]?.message ? `: ${err.details[0].message}` : '';
+      throw new Error(`${err.error || 'Failed to save alias'}${detail}`);
     }
 
     // Delete old alias only after new one is saved successfully
@@ -2173,7 +2178,7 @@ export const api = {
           }
         }
       });
-      return models;
+      return dedupeModels(models);
     } catch (e) {
       console.error('API Error getModels', e);
       return [];
@@ -2777,7 +2782,12 @@ export const api = {
       if (res.status === 503) return { data: [], count: 0 };
       throw new Error(`Failed to search model metadata: ${res.statusText}`);
     }
-    return res.json();
+    const result = (await res.json()) as {
+      data: { id: string; name: string }[];
+      count: number;
+    };
+    const data = dedupeById(result.data);
+    return { data, count: data.length };
   },
 
   /**
@@ -2828,7 +2838,7 @@ export const api = {
     const json = (await res.json()) as {
       data: Array<{ id: string; name: string; api: string; custom: boolean }>;
     };
-    return json.data;
+    return dedupeById(json.data);
   },
 
   getOAuthProviderModels: async (

--- a/packages/frontend/src/lib/modelOptions.test.ts
+++ b/packages/frontend/src/lib/modelOptions.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+
+import type { AliasTargetGroup, Model } from './api';
+import { dedupeAliasTargets, dedupeById, dedupeModels, getModelOptionKey } from './modelOptions';
+
+describe('model option helpers', () => {
+  test('deduplicates provider model options without merging providers', () => {
+    const models: Model[] = [
+      { id: 'duplicate', name: 'Duplicate', providerId: 'openrouter' },
+      { id: 'duplicate', name: 'Duplicate again', providerId: 'openrouter' },
+      { id: 'duplicate', name: 'Duplicate local', providerId: 'local' },
+    ];
+
+    expect(dedupeModels(models)).toEqual([models[0], models[2]]);
+    expect(getModelOptionKey('openrouter', 'duplicate')).not.toBe(
+      getModelOptionKey('local', 'duplicate')
+    );
+  });
+
+  test('deduplicates catalog results by id', () => {
+    expect(
+      dedupeById([
+        { id: 'model-1', name: 'First' },
+        { id: 'model-1', name: 'Duplicate' },
+        { id: 'model-2', name: 'Second' },
+      ])
+    ).toEqual([
+      { id: 'model-1', name: 'First' },
+      { id: 'model-2', name: 'Second' },
+    ]);
+  });
+
+  test('keeps only the first occurrence of an alias target', () => {
+    const groups: AliasTargetGroup[] = [
+      {
+        name: 'primary',
+        selector: 'random',
+        targets: [{ provider: 'openrouter', model: 'model-1' }],
+      },
+      {
+        name: 'fallback',
+        selector: 'in_order',
+        targets: [
+          { provider: 'openrouter', model: 'model-1' },
+          { provider: 'local', model: 'model-1' },
+        ],
+      },
+    ];
+
+    expect(dedupeAliasTargets(groups)).toEqual([
+      groups[0],
+      {
+        ...groups[1],
+        targets: [{ provider: 'local', model: 'model-1' }],
+      },
+    ]);
+  });
+});

--- a/packages/frontend/src/lib/modelOptions.ts
+++ b/packages/frontend/src/lib/modelOptions.ts
@@ -1,0 +1,39 @@
+import type { AliasTargetGroup, Model } from './api';
+
+export const getModelOptionKey = (providerId: string, modelId: string) =>
+  `${providerId}\u0000${modelId}`;
+
+export const dedupeModels = <T extends Pick<Model, 'id' | 'providerId'>>(models: T[]): T[] => {
+  const seen = new Set<string>();
+
+  return models.filter((model) => {
+    const key = getModelOptionKey(model.providerId, model.id);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+export const dedupeById = <T extends { id: string }>(items: T[]): T[] => {
+  const seen = new Set<string>();
+
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+};
+
+export const dedupeAliasTargets = (groups: AliasTargetGroup[]): AliasTargetGroup[] => {
+  const seen = new Set<string>();
+
+  return groups.map((group) => ({
+    ...group,
+    targets: group.targets.filter((target) => {
+      const key = getModelOptionKey(target.provider, target.model);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    }),
+  }));
+};

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo } from 'react';
 import { Alias } from '../lib/api';
+import { getModelOptionKey } from '../lib/modelOptions';
 import { useModels } from '../hooks/useModels';
 import { AliasTableRow } from '../components/models/AliasTableRow';
 import { AliasMobileCard } from '../components/models/AliasMobileCard';
@@ -189,13 +190,16 @@ export const Models = () => {
     (targets: Array<{ provider: string; model: string }>) => {
       setEditingAlias((prev: Alias) => {
         const updatedTargets = [...(prev.target_groups[0]?.targets ?? [])];
+        const existingTargetKeys = new Set(
+          prev.target_groups.flatMap((group) =>
+            group.targets.map((target) => getModelOptionKey(target.provider, target.model))
+          )
+        );
         for (const t of targets) {
-          const alreadyExists = updatedTargets.some(
-            (x: { provider: string; model: string }) =>
-              x.provider === t.provider && x.model === t.model
-          );
-          if (!alreadyExists) {
+          const key = getModelOptionKey(t.provider, t.model);
+          if (!existingTargetKeys.has(key)) {
             updatedTargets.push({ ...t, enabled: true });
+            existingTargetKeys.add(key);
           }
         }
         const groups = [...prev.target_groups];

--- a/paseo.json
+++ b/paseo.json
@@ -1,6 +1,6 @@
 {
   "worktree": {
-    "setup": ["bun run scripts/init_worktree.ts"],
+    "setup": ["cp \"$PASEO_SOURCE_CHECKOUT_PATH/.env\" .env", "bun run scripts/init_worktree.ts"],
     "teardown": "bun run dev:stop",
     "servicePorts": {
       "portScript": "scripts/dev-port-allocator.ts",


### PR DESCRIPTION
## Summary
Fixes model-alias editing failures caused by duplicate target entries and duplicate React model keys. Alias saves now validate cleanly, while the Models UI deduplicates model data and prevents duplicate provider/model selections.

## Why / Context
Staging was returning HTTP 500 from the alias PUT endpoint when the same provider/model pair appeared more than once. The editor also rendered duplicate model options, producing React key warnings and making duplicate target configuration easier to create.

## Changes
- **Backend**: validate duplicate provider/model pairs across alias target groups before persistence and return a descriptive 400 response.
- **Models UI**: deduplicate provider and catalog model options, use scoped stable option keys, and prevent selecting a target already used in another group.
- **Auto Add/save flow**: consider all target groups and deduplicate outgoing alias payloads; surface backend validation details in the toast.
- **Worktree tooling**: copy the source checkout `.env` during Paseo setup and document the staging `plexus-cli` workflow in `AGENTS.md`.
- **Tests**: add backend validation and frontend model-option regression coverage.

## Testing
- Passed the pre-commit hooks: 239 test files / 2,659 tests, typecheck, lint, formatting, frontend build, and migration guard.
- Ran the focused frontend regression suite: 3 tests passed.
- Manually verified the Models editor in Chromium: alias save succeeds, duplicate targets are unavailable across groups, and no console warnings are emitted.
