### PR TITLE
chore(hooks): add advisory PR-Agent plain-diff pre-push review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ plexus
 .grepai/
 mise.local.toml
 
+# Local Python virtualenv for the advisory PR-Agent pre-push hook
+.venv/
+
 # Local raw Claude Code HTTP traces (contain auth tokens — never commit)
 claude1.txt
 claude2.txt

--- a/.lefthook/pre-push/pr-agent-review.sh
+++ b/.lefthook/pre-push/pr-agent-review.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Advisory PR-Agent review of the diff being pushed (plain-diff mode, no PR URL
+# or GitHub credentials involved). This hook is strictly optimistic: every
+# failure path prints a warning and exits 0 so it can NEVER block a push.
+#
+# stdin (forwarded by Lefthook via `use_stdin: true`) carries git's pre-push
+# refs, one line per pushed ref:
+#   <local ref> <local sha> <remote ref> <remote sha>
+#
+# Configuration (environment, never committed):
+#   OPENAI__KEY       LLM provider key (unless CONFIG__MODEL points at a local model)
+#   OPENAI__API_BASE  optional LLM endpoint override
+#   CONFIG__MODEL     model override (e.g. a local Ollama model)
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT" || exit 0
+
+VENV_PY="$REPO_ROOT/.venv/bin/python"
+ZERO_SHA="0000000000000000000000000000000000000000"
+
+info() { printf '[pre-push][pr-agent] %s\n' "$*" >&2; }
+warn() { printf '[pre-push][pr-agent] WARNING: %s\n' "$*" >&2; }
+
+# --- Preflight: PR-Agent installed? ------------------------------------------
+if [ ! -x "$VENV_PY" ]; then
+	warn "PR-Agent virtualenv not found at .venv/ - skipping advisory review."
+	warn "Install it with:  mise install && mise run pr-agent:setup"
+	exit 0
+fi
+
+if ! "$VENV_PY" -m pip show pr-agent >/dev/null 2>&1; then
+	warn "pr-agent is not installed in .venv - skipping advisory review."
+	warn "Re-run:  mise run pr-agent:setup"
+	exit 0
+fi
+
+# --- Preflight: configuration present? ---------------------------------------
+if [ ! -f "$REPO_ROOT/.pr_agent.toml" ]; then
+	warn ".pr_agent.toml not found - skipping advisory review."
+	warn "PR-Agent plain-diff mode needs .pr_agent.toml plus an LLM key"
+	warn "(OPENAI__KEY / OPENAI__API_BASE / CONFIG__MODEL). See CONTRIBUTING.md."
+	exit 0
+fi
+
+# --- Review each ref git is pushing -------------------------------------------
+# Hook mode: ref lines come from git's pre-push stdin (forwarded by Lefthook).
+# Manual mode (`--manual [BASE]`, i.e. `bun run review [BASE]`): synthesize one
+# ref line diffing BASE (default: origin/HEAD) against HEAD.
+{
+	if [ "${1:-}" = "--manual" ]; then
+		MANUAL_BASE="${2:-origin/HEAD}"
+		MANUAL_LOCAL="$(git rev-parse HEAD 2>/dev/null)"
+		MANUAL_REMOTE="$(git rev-parse "$MANUAL_BASE" 2>/dev/null)"
+		if [ -z "$MANUAL_LOCAL" ] || [ -z "$MANUAL_REMOTE" ]; then
+			warn "cannot resolve HEAD or base '$MANUAL_BASE' - nothing to review."
+			exit 0
+		fi
+		info "manual mode: reviewing $MANUAL_BASE...HEAD"
+		printf 'HEAD %s %s %s\n' "$MANUAL_LOCAL" "$MANUAL_BASE" "$MANUAL_REMOTE"
+	else
+		cat
+	fi
+} | while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+	[ -z "$LOCAL_SHA" ] && continue
+
+	# Branch deletion: local side is the zero SHA, nothing to review.
+	if [ "$LOCAL_SHA" = "$ZERO_SHA" ]; then
+		continue
+	fi
+
+	if [ "$REMOTE_SHA" = "$ZERO_SHA" ]; then
+		# New remote branch: no upstream commit to diff against. Fall back to
+		# the merge-base with the remote default branch; skip if unknown.
+		BASE="$(git merge-base "$LOCAL_SHA" origin/HEAD 2>/dev/null)"
+		if [ -z "$BASE" ]; then
+			warn "new remote branch $REMOTE_REF and no origin/HEAD merge-base found -"
+			warn "skipping advisory review for $LOCAL_REF."
+			continue
+		fi
+		warn "new remote branch $REMOTE_REF - reviewing against merge-base with origin/HEAD."
+		DIFF_SPEC="$BASE..$LOCAL_SHA"
+	else
+		# Three-dot: diff from the merge-base, i.e. only what this push adds.
+		DIFF_SPEC="$REMOTE_SHA...$LOCAL_SHA"
+	fi
+
+	if ! DIFF="$(git diff "$DIFF_SPEC" 2>/dev/null)"; then
+		warn "could not compute diff ($DIFF_SPEC) - remote objects missing locally?"
+		warn "Skipping advisory review for $LOCAL_REF."
+		continue
+	fi
+
+	if [ -z "${DIFF//[[:space:]]/}" ]; then
+		info "empty diff for $LOCAL_REF - nothing to review."
+		continue
+	fi
+
+	info "--- Advisory PR-Agent review (non-blocking): $LOCAL_REF -> $REMOTE_REF ---"
+	OUTPUT_FILE="$(mktemp -t pr-agent-review.XXXXXX)"
+	if printf '%s\n' "$DIFF" | "$VENV_PY" -m pr_agent.cli --stdin review >"$OUTPUT_FILE" 2>&1; then
+		sed 's/^/[pr-agent] /' "$OUTPUT_FILE"
+	else
+		warn "PR-Agent review failed (missing LLM key, unreachable API, or other error)."
+		warn "Configure OPENAI__KEY / OPENAI__API_BASE / CONFIG__MODEL - see"
+		warn "CONTRIBUTING.md ('Optional: advisory PR-Agent pre-push review')."
+		warn "Reproduce manually with:  git diff ... | .venv/bin/python -m pr_agent.cli --stdin review"
+	fi
+	rm -f "$OUTPUT_FILE"
+done
+
+# Absolutely never block the push.
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,58 @@ Plexus uses **Pi Assistant** and **PR Agent** for automated coding assistance an
 - **Pi Assistant** (`.github/workflows/pi-assistant-issue.yml` and `.github/workflows/pi-assistant-pr.yml`): Triggered by commenting `/pi` on an issue or PR. It uses the `mcowger/pi-action` action to run an AI-agent-driven coding session directly in the repository context to address requested changes. System prompts live in `.github/prompts/pi-assistant-issue.md` and `.github/prompts/pi-assistant-pr.md`.
 - **PR Agent Review** (`.github/workflows/pr-agent-review.yml`): Triggered automatically when non-draft pull requests are opened/reopened/ready for review, or when comments are made. It performs thorough automated code reviews using the `the-pr-agent/pr-agent` action, configured via `.pr_agent.toml`.
 
+### Optional: advisory PR-Agent pre-push review (local)
+
+A `pre-push` Lefthook hook can run PR-Agent locally on the diff you are about
+to push, in **plain-diff mode** — it pipes a unified diff to PR-Agent's stdin,
+so it needs **no GitHub credentials and no PR URL**. The review is printed to
+your terminal and is purely advisory: the hook **always exits 0** and can never
+block a push. If PR-Agent isn't installed, its config is missing, or the LLM
+call fails, you just get a warning and the push proceeds.
+
+One-time setup (idempotent — safe to re-run), using mise-managed Python:
+
+```bash
+mise install             # installs the pinned Python 3.12 (and other tools)
+mise run pr-agent:setup  # creates .venv and pip-installs a pinned pr-agent
+```
+
+Equivalent explicit commands, if you prefer to do it by hand:
+
+```bash
+mise use python
+mise exec -- python -m venv .venv
+mise exec -- .venv/bin/python -m pip install pr-agent
+```
+
+Configuration is read from the repo's `.pr_agent.toml` plus environment
+variables — supply values in your shell profile or a local, git-ignored file.
+**Never commit keys or secrets.**
+
+| Variable | Purpose |
+|---|---|
+| `OPENAI__KEY` | API key for your LLM provider (not needed when `CONFIG__MODEL` points at a local model, e.g. Ollama) |
+| `OPENAI__API_BASE` | Optional endpoint override (proxy, Azure, or a local server) |
+| `CONFIG__MODEL` | Optional model override (defaults to the PR-Agent built-in default) |
+
+Plain-diff mode works fully offline from GitHub, but still requires an LLM:
+either a provider key (`OPENAI__KEY`) or a locally hosted model
+(`CONFIG__MODEL` + `OPENAI__API_BASE`, e.g. an OpenAI-compatible Ollama server).
+
+To run a review manually (no push needed), use the package script — it diffs
+`origin/HEAD...HEAD` by default, or any base you pass:
+
+```bash
+bun run review                # review origin/HEAD...HEAD
+bun run review origin/main    # review a custom base
+```
+
+Or invoke PR-Agent directly on any diff:
+
+```bash
+git diff origin/main...HEAD | .venv/bin/python -m pr_agent.cli --stdin review
+```
+
 ## Code Style
 
 All code must be formatted with Biome before committing:

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,8 @@
       "!!packages/backend/src/assets/openapi.json",
       "!!packages/cli/src/skill.ts",
       "!!packages/backend/src/transformers/oauth/__tests__/golden-fixtures/**",
-      "!!.claude/**"
+      "!!.claude/**",
+      "!!.venv/**"
     ]
   },
   "formatter": {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -64,3 +64,24 @@ pre-commit:
     backend-tests:
       glob: "packages/backend/src/**"
       run: bun run test
+
+pre-push:
+  # Advisory-only hook — also skipped in CI (nothing local to review there).
+  skip:
+    - CI: "true"
+
+  # --- Advisory PR-Agent plain-diff review (NEVER blocks the push) ---------
+  # Reviews the diff being pushed relative to the upstream remote branch.
+  # Requires a one-time setup: mise run pr-agent:setup (see CONTRIBUTING.md).
+  # Always exits 0 — missing install/config/LLM key only prints a warning.
+  #
+  # Implemented as a lefthook *script* (not a command) because pre-push
+  # commands are skipped by lefthook whenever its @{push}-based file
+  # heuristic yields nothing — which is always the case for upstream-less
+  # branches/worktrees. Script jobs have no such gate.
+  scripts:
+    "pr-agent-review.sh":
+      runner: bash
+      skip:
+        - CI: "true"
+      use_stdin: true # forwards git's pre-push ref lines to the script

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,22 @@ actionlint = "latest"
 bun = "latest"
 lefthook = "latest"
 "npm:greptile" = "latest"
+# Pinned Python for the advisory PR-Agent pre-push hook (pr-agent requires >= 3.12).
+python = "3.12"
 
 [env]
 _.path = ["./node_modules/.bin"]
+
+# Idempotent install of PR-Agent into a local .venv using the mise-managed Python.
+# Used by the advisory (non-blocking) pre-push review hook — see CONTRIBUTING.md.
+# NOTE: plain-diff mode (--stdin) is not in a PyPI release yet (merged after
+# 0.39.0 via qodo-ai/pr-agent#2467), so we install from a pinned commit.
+[tasks."pr-agent:setup"]
+description = "Install PR-Agent into ./.venv for the advisory pre-push review hook"
+run = """
+set -e
+python -m venv .venv
+.venv/bin/python -m pip install --quiet --disable-pip-version-check --upgrade pip
+.venv/bin/python -m pip install --quiet --disable-pip-version-check "pr-agent @ git+https://github.com/The-PR-Agent/pr-agent.git@4a26c38d33d16ea490d6f0dd5c11b06e6c2f2cac"
+echo "PR-Agent ready: .venv/bin/python -m pr_agent.cli"
+"""

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "sync:openapi:write": "bun run scripts/sync-openapi.ts --write",
     "sync:openapi:types": "bun run bundle:openapi && bunx openapi-typescript docs/openapi.yaml -o scripts/openapi-types.ts",
     "generate-migrations": "bun run scripts/generate-migrations.ts",
+    "review": "bash .lefthook/pre-push/pr-agent-review.sh --manual",
     "deploy:staging": "bun run scripts/deploy-staging.ts"
   },
   "type": "module",


### PR DESCRIPTION
## Summary

Adds an optional, advisory-only PR-Agent review that runs locally on every `git push`: the pushed commits' unified diff is piped to PR-Agent's plain-diff stdin mode, so the review needs no GitHub credentials, no PR URL, and no GitHub API access. The hook **always exits 0** — it can never block a push; missing tooling, missing config, or a failed LLM call just prints a warning. The same review is available on demand via `bun run review`.

## Why / Context

Local pre-PR feedback without waiting for the GitHub Actions PR-Agent workflow, and usable against local/self-hosted LLMs. Plain-diff mode (`pr-agent --stdin`) is only available upstream on `main` (merged after the 0.39.0 PyPI release via qodo-ai/pr-agent#2467), so installation is pinned to a specific commit.

## Changes

- **Lefthook**: new `pre-push` section in `lefthook.yml` wired to a script job (`use_stdin: true`, skipped in CI). A *script* job is used deliberately: lefthook skips pre-push *commands* when its `@{push}` file heuristic is empty, which is always the case for this repo's upstream-less worktree pushes.
- **Hook script** (`.lefthook/pre-push/pr-agent-review.sh`): reads git's pre-push ref lines from stdin, diffs `git diff "$REMOTE_SHA...$LOCAL_SHA"` per ref, handles zero SHAs (deletion → skip; new remote branch → merge-base fallback against `origin/HEAD` with a warning), skips empty diffs, labels output as an advisory review, and exits 0 unconditionally.
- **mise**: pins `python = "3.12"` (pr-agent requires >=3.12) and adds idempotent task `pr-agent:setup` that creates `.venv` and pip-installs pr-agent from the pinned commit.
- **package.json**: `bun run review [BASE]` runs the same review manually (default base `origin/HEAD...HEAD`).
- **Docs**: CONTRIBUTING section covering setup, `OPENAI__KEY` / `OPENAI__API_BASE` / `CONFIG__MODEL` env configuration (Dynaconf naming, no values committed), and local-model usage.
- **Repo hygiene**: `.venv/` added to `.gitignore` and excluded in `biome.json` so repo-wide `biome lint .` doesn't scan the virtualenv.

## Testing

- `lefthook validate` passes.
- Dry-runs via `lefthook run pre-push` with crafted stdin (no real pushes) covered: missing venv, real diff with failing LLM call, empty diff, branch deletion (zero local SHA), new remote branch (zero remote SHA fallback), empty stdin — all exit 0.
- `mise run pr-agent:setup` run twice to confirm idempotency.
- `bun run review` / `bun run review HEAD~1` verified end-to-end (arg passthrough, diff computed, PR-Agent invoked).
- The real `git push -u` of this branch exercised the hook live: the new-branch fallback fired, PR-Agent ran, and the push proceeded normally.

## Notes / Follow-ups

- One-time opt-in per clone: `mise install && mise run pr-agent:setup`, plus an LLM key (`OPENAI__KEY`) or a local model (`CONFIG__MODEL` + `OPENAI__API_BASE`).
- Once a PyPI release > 0.39.0 ships with plain-diff mode, the pinned commit in `mise.toml` can move back to a released version.
- Hook is skipped when `CI=true` and can be bypassed locally with `LEFTHOOK=0`, like the other hooks.
