### PR TITLE
feat(frontend): add display-only currency conversion for costs

### DIFF
--- a/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
@@ -111,7 +111,7 @@ import {
 // IMPORTS -- Formatting utilities
 //
 import {
-  formatCost,
+  formatCostIn,
   formatMs,
   formatNumber,
   formatTimeAgo,
@@ -122,6 +122,7 @@ import { formatMsToMinSec } from '@plexus/shared';
 import { clsx } from 'clsx';
 import { useAuth } from '../../../contexts/AuthContext';
 import { useToast } from '../../../contexts/ToastContext';
+import { useCurrency } from '../../../lib/CurrencyContext';
 
 //
 // LOCAL TYPES
@@ -415,38 +416,42 @@ const aggregateByEntity = (
  * The name is truncated to 25 characters with an ellipsis and a title
  * attribute for the full string on hover.
  */
-const EntityRow: React.FC<{ entity: EntityStats; isModel?: boolean }> = ({ entity, isModel }) => (
-  <div className="rounded-md border border-border-glass bg-bg-glass/50 px-3 py-2 hover:bg-bg-glass transition-colors">
-    <div className="flex items-center justify-between gap-2 mb-1">
-      <div className="flex items-center gap-2 min-w-0">
-        {isModel ? (
-          <Cpu size={14} className="text-text-muted shrink-0" />
-        ) : (
-          <Server size={14} className="text-text-muted shrink-0" />
-        )}
-        <span className="text-sm text-text font-medium truncate" title={entity.name}>
-          {entity.name.length > 25 ? entity.name.slice(0, 22) + '...' : entity.name}
-        </span>
+const EntityRow: React.FC<{ entity: EntityStats; isModel?: boolean }> = ({ entity, isModel }) => {
+  const { currency, rate, symbol } = useCurrency();
+
+  return (
+    <div className="rounded-md border border-border-glass bg-bg-glass/50 px-3 py-2 hover:bg-bg-glass transition-colors">
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <div className="flex items-center gap-2 min-w-0">
+          {isModel ? (
+            <Cpu size={14} className="text-text-muted shrink-0" />
+          ) : (
+            <Server size={14} className="text-text-muted shrink-0" />
+          )}
+          <span className="text-sm text-text font-medium truncate" title={entity.name}>
+            {entity.name.length > 25 ? entity.name.slice(0, 22) + '...' : entity.name}
+          </span>
+        </div>
+        <span className="text-xs text-text-secondary">{formatNumber(entity.requests, 0)} req</span>
       </div>
-      <span className="text-xs text-text-secondary">{formatNumber(entity.requests, 0)} req</span>
+      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-text-secondary">
+        <span>
+          Success:{' '}
+          {entity.successRate >= 95 ? (
+            <span className="text-emerald-500 font-medium">{entity.successRate.toFixed(1)}%</span>
+          ) : entity.successRate >= 80 ? (
+            <span className="text-amber-500 font-medium">{entity.successRate.toFixed(1)}%</span>
+          ) : (
+            <span className="text-red-500 font-medium">{entity.successRate.toFixed(1)}%</span>
+          )}
+        </span>
+        <span>Latency: {formatMs(entity.avgLatency)}</span>
+        <span>Cost: {formatCostIn(entity.cost, { currency, rate, symbol, decimals: 4 })}</span>
+        <span>TPS: {formatNumber(entity.avgTps, 1)}</span>
+      </div>
     </div>
-    <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-text-secondary">
-      <span>
-        Success:{' '}
-        {entity.successRate >= 95 ? (
-          <span className="text-emerald-500 font-medium">{entity.successRate.toFixed(1)}%</span>
-        ) : entity.successRate >= 80 ? (
-          <span className="text-amber-500 font-medium">{entity.successRate.toFixed(1)}%</span>
-        ) : (
-          <span className="text-red-500 font-medium">{entity.successRate.toFixed(1)}%</span>
-        )}
-      </span>
-      <span>Latency: {formatMs(entity.avgLatency)}</span>
-      <span>Cost: {formatCost(entity.cost, 4)}</span>
-      <span>TPS: {formatNumber(entity.avgTps, 1)}</span>
-    </div>
-  </div>
-);
+  );
+};
 
 /**
  * CooldownRow renders a single provider/model cooldown alert row.
@@ -615,6 +620,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
 }) => {
   const { isAdmin, principal } = useAuth();
   const toast = useToast();
+  const { currency, rate, symbol } = useCurrency();
   const limitedAllowedProviders =
     principal?.role === 'limited' ? (principal.allowedProviders ?? []) : null;
   // ---------------------------------------------------------------------------
@@ -2000,7 +2006,15 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                             Number(request.tokensCacheWrite || 0)
                         )}
                       </span>
-                      <span>Cost: {formatCost(Number(request.costTotal || 0), 6)}</span>
+                      <span>
+                        Cost:{' '}
+                        {formatCostIn(Number(request.costTotal || 0), {
+                          currency,
+                          rate,
+                          symbol,
+                          decimals: 6,
+                        })}
+                      </span>
                       <span>Latency: {formatMs(Number(request.durationMs || 0))}</span>
                       <span>TTFT: {formatMs(Number(request.ttftMs || 0))}</span>
                       <span>TPS: {formatTPS(Number(request.tokensPerSec || 0))}</span>
@@ -2179,7 +2193,12 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                     <div className="px-3 py-2 flex items-center justify-between">
                       <span className="text-xs text-text-muted">Cost Today</span>
                       <span className="text-sm font-semibold text-info tabular-nums">
-                        {formatCost(todayMetrics.totalCost, 4)}
+                        {formatCostIn(todayMetrics.totalCost, {
+                          currency,
+                          rate,
+                          symbol,
+                          decimals: 4,
+                        })}
                       </span>
                     </div>
                   </div>
@@ -2295,7 +2314,14 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                           <div className="flex gap-3 mt-0.5 text-[11px] text-text-muted">
                             <span>{row.successRate.toFixed(1)}% ok</span>
                             <span>{formatMs(row.avgLatency)}</span>
-                            <span className="text-info">{formatCost(row.totalCost, 6)}</span>
+                            <span className="text-info">
+                              {formatCostIn(row.totalCost, {
+                                currency,
+                                rate,
+                                symbol,
+                                decimals: 6,
+                              })}
+                            </span>
                           </div>
                         </div>
                       ))
@@ -2874,7 +2900,15 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                                   Number(request.tokensCacheWrite || 0)
                               )}
                             </span>
-                            <span>Cost: {formatCost(Number(request.costTotal || 0), 6)}</span>
+                            <span>
+                              Cost:{' '}
+                              {formatCostIn(Number(request.costTotal || 0), {
+                                currency,
+                                rate,
+                                symbol,
+                                decimals: 6,
+                              })}
+                            </span>
                             <span>Latency: {formatMs(Number(request.durationMs || 0))}</span>
                             <span>TTFT: {formatMs(Number(request.ttftMs || 0))}</span>
                             <span>TPS: {formatTPS(Number(request.tokensPerSec || 0))}</span>

--- a/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
@@ -23,7 +23,8 @@
 import { useEffect, useState } from 'react';
 import { Key, Layers, Boxes, Gauge, Activity, AlertTriangle } from 'lucide-react';
 import { api, type PieChartDataPoint, type QuotaStatusEntry } from '../../../lib/api';
-import { formatNumber, formatTokens, formatCost } from '../../../lib/format';
+import { formatNumber, formatTokens, formatCostIn } from '../../../lib/format';
+import { useCurrency } from '../../../lib/CurrencyContext';
 import { Card } from '../../ui/Card';
 import { QuotaStatusCard } from '../../quota';
 import { TimeRangeSelector } from '../TimeRangeSelector';
@@ -113,6 +114,7 @@ const BreakdownList: React.FC<{
 };
 
 export const OverallTab: React.FC = () => {
+  const { currency, rate, symbol } = useCurrency();
   const [timeRange, setTimeRange] = useState<TimeRange>('day');
   const [info, setInfo] = useState<SelfInfo | null>(null);
   const [summary, setSummary] = useState<SummaryStats | null>(null);
@@ -369,7 +371,7 @@ export const OverallTab: React.FC = () => {
             />
             <Metric
               label="Cost (today)"
-              value={formatCost(summary.todayCost)}
+              value={formatCostIn(summary.todayCost, { currency, rate, symbol, decimals: 4 })}
               sub="attributed to this key"
             />
           </div>

--- a/packages/frontend/src/components/quota/AllowanceMeterRow.tsx
+++ b/packages/frontend/src/components/quota/AllowanceMeterRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { clsx } from 'clsx';
 import type { Meter, MeterStatus } from '../../types/quota';
 import { formatMeterValue } from './MeterValue';
+import { useCurrency } from '../../lib/CurrencyContext';
 
 interface AllowanceMeterRowProps {
   meter: Meter;
@@ -42,12 +43,15 @@ export const AllowanceMeterRow: React.FC<AllowanceMeterRowProps> = ({
   compact,
   onClick,
 }) => {
+  const { currency, rate, symbol } = useCurrency();
   const utilNum = typeof meter.utilizationPercent === 'number' ? meter.utilizationPercent : null;
   const pct = utilNum !== null ? Math.max(0, Math.min(100, utilNum)) : null;
   const period = periodLabel(meter);
 
   const remaining =
-    meter.remaining !== undefined ? formatMeterValue(meter.remaining, meter.unit, true) : undefined;
+    meter.remaining !== undefined
+      ? formatMeterValue(meter.remaining, meter.unit, true, { currency, rate, symbol })
+      : undefined;
 
   if (compact) {
     return (

--- a/packages/frontend/src/components/quota/BalanceMeterRow.tsx
+++ b/packages/frontend/src/components/quota/BalanceMeterRow.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Wallet } from 'lucide-react';
 import type { Meter } from '../../types/quota';
 import { formatMeterValue } from './MeterValue';
+import { useCurrency } from '../../lib/CurrencyContext';
 
 interface BalanceMeterRowProps {
   meter: Meter;
@@ -9,6 +10,7 @@ interface BalanceMeterRowProps {
 }
 
 export const BalanceMeterRow: React.FC<BalanceMeterRowProps> = ({ meter, onClick }) => {
+  const { currency, rate, symbol } = useCurrency();
   const displayValue =
     meter.remaining !== undefined
       ? meter.remaining
@@ -28,7 +30,7 @@ export const BalanceMeterRow: React.FC<BalanceMeterRowProps> = ({ meter, onClick
       </div>
       {displayValue !== undefined ? (
         <span className="text-xs font-semibold text-info tabular-nums flex-shrink-0">
-          {formatMeterValue(displayValue, meter.unit)}
+          {formatMeterValue(displayValue, meter.unit, false, { currency, rate, symbol })}
         </span>
       ) : (
         <span className="text-xs text-text-muted flex-shrink-0">—</span>

--- a/packages/frontend/src/components/quota/CompactBalancesCard.tsx
+++ b/packages/frontend/src/components/quota/CompactBalancesCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { QuotaCheckerInfo } from '../../types/quota';
 import { formatMeterValue } from './MeterValue';
 import { getCheckerDisplayName } from './checker-presentation';
+import { useCurrency } from '../../lib/CurrencyContext';
 
 interface CompactBalancesCardProps {
   balanceQuotas: QuotaCheckerInfo[];
@@ -14,6 +15,7 @@ export const CompactBalancesCard: React.FC<CompactBalancesCardProps> = ({
   displayNameMap,
 }) => {
   const navigate = useNavigate();
+  const { currency, rate, symbol } = useCurrency();
 
   if (balanceQuotas.length === 0) return null;
 
@@ -39,7 +41,9 @@ export const CompactBalancesCard: React.FC<CompactBalancesCardProps> = ({
         const balanceMeter = quota.meters.find((m) => m.kind === 'balance');
         const remaining = balanceMeter?.remaining;
         const formattedBalance =
-          remaining !== undefined ? formatMeterValue(remaining, balanceMeter!.unit) : undefined;
+          remaining !== undefined
+            ? formatMeterValue(remaining, balanceMeter!.unit, false, { currency, rate, symbol })
+            : undefined;
 
         return (
           <div key={quota.checkerId} className="flex items-center justify-between min-w-0">

--- a/packages/frontend/src/components/quota/MeterHistoryModal.tsx
+++ b/packages/frontend/src/components/quota/MeterHistoryModal.tsx
@@ -14,6 +14,7 @@ import { api } from '../../lib/api';
 import { formatMeterValue } from './MeterValue';
 import type { Meter, QuotaCheckerInfo } from '../../types/quota';
 import { Button } from '../ui/Button';
+import { useCurrency } from '../../lib/CurrencyContext';
 
 type TimeRange = '1h' | '3h' | '6h' | '12h' | '24h' | '1w' | '4w';
 
@@ -69,6 +70,7 @@ export const MeterHistoryModal: React.FC<MeterHistoryModalProps> = ({
   meter,
   displayName,
 }) => {
+  const { currency, rate, symbol } = useCurrency();
   const [range, setRange] = useState<TimeRange>('24h');
   const [rawHistory, setRawHistory] = useState<HistoryRow[]>([]);
   const [loading, setLoading] = useState(false);
@@ -151,10 +153,14 @@ export const MeterHistoryModal: React.FC<MeterHistoryModalProps> = ({
   const yLabel = isBalance ? meter.unit : '%';
 
   const formatY = (v: number) =>
-    isBalance ? formatMeterValue(v, meter.unit, true) : `${Math.round(v)}%`;
+    isBalance
+      ? formatMeterValue(v, meter.unit, true, { currency, rate, symbol })
+      : `${Math.round(v)}%`;
 
   const formatTooltip = (v: number) =>
-    isBalance ? formatMeterValue(v, meter.unit) : `${v.toFixed(1)}%`;
+    isBalance
+      ? formatMeterValue(v, meter.unit, false, { currency, rate, symbol })
+      : `${v.toFixed(1)}%`;
 
   if (!isOpen) return null;
 

--- a/packages/frontend/src/components/quota/MeterValue.tsx
+++ b/packages/frontend/src/components/quota/MeterValue.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { formatCost, formatPointsFull } from '../../lib/format';
+import { formatCostIn, formatPointsFull, type FormatCostInOptions } from '../../lib/format';
+import { useCurrency } from '../../lib/CurrencyContext';
+
+type MeterCurrencyOptions = Pick<FormatCostInOptions, 'currency' | 'rate' | 'symbol'>;
+
+const DEFAULT_CURRENCY: MeterCurrencyOptions = {
+  currency: 'USD',
+  rate: 1,
+  symbol: '$',
+};
 
 interface MeterValueProps {
   value: number;
@@ -7,10 +16,15 @@ interface MeterValueProps {
   compact?: boolean;
 }
 
-export function formatMeterValue(value: number, unit: string, compact = false): string {
+export function formatMeterValue(
+  value: number,
+  unit: string,
+  compact = false,
+  currency: MeterCurrencyOptions = DEFAULT_CURRENCY
+): string {
   switch (unit) {
     case 'usd':
-      return formatCost(value);
+      return formatCostIn(value, { ...currency, decimals: 4 });
     case 'percentage':
       return `${Math.round(value)}%`;
     case 'points':
@@ -28,6 +42,16 @@ export function formatMeterValue(value: number, unit: string, compact = false): 
   }
 }
 
-export const MeterValue: React.FC<MeterValueProps> = ({ value, unit, compact }) => (
-  <span>{formatMeterValue(value, unit, compact)}</span>
-);
+export const MeterValue: React.FC<MeterValueProps> = ({ value, unit, compact }) => {
+  const currency = useCurrency();
+
+  return (
+    <span>
+      {formatMeterValue(value, unit, compact, {
+        currency: currency.currency,
+        rate: currency.rate,
+        symbol: currency.symbol,
+      })}
+    </span>
+  );
+};

--- a/packages/frontend/src/components/quota/QuotaStatusCard.tsx
+++ b/packages/frontend/src/components/quota/QuotaStatusCard.tsx
@@ -6,6 +6,7 @@ import { QuotaProgressBar } from './QuotaProgressBar';
 import { QuotaChip, hasScope } from './QuotaChip';
 import { statusForPercent, formatQuotaValue, quotaUsagePercent } from '../../lib/quota';
 import { formatResetsIn } from '../../lib/format';
+import { useCurrency } from '../../lib/CurrencyContext';
 
 export interface QuotaStatusCardProps {
   entry: QuotaStatusEntry;
@@ -45,6 +46,7 @@ export const QuotaStatusCard: React.FC<QuotaStatusCardProps> = ({
   recomputeLeaky = false,
   recomputing = false,
 }) => {
+  const { currency, rate, symbol } = useCurrency();
   const detailed = variant === 'detailed';
   const pct = quotaUsagePercent(entry);
   const resetsLabel =
@@ -127,7 +129,7 @@ export const QuotaStatusCard: React.FC<QuotaStatusCardProps> = ({
         label={detailed && !entry.global ? `${entry.limitType} (scoped)` : entry.limitType}
         value={entry.currentUsage}
         max={entry.limit}
-        displayValue={`${formatQuotaValue(entry.currentUsage, entry.limitType)} / ${formatQuotaValue(entry.limit, entry.limitType)}`}
+        displayValue={`${formatQuotaValue(entry.currentUsage, entry.limitType, { currency, rate, symbol })} / ${formatQuotaValue(entry.limit, entry.limitType, { currency, rate, symbol })}`}
         status={statusForPercent(pct)}
         size="md"
       />
@@ -136,7 +138,7 @@ export const QuotaStatusCard: React.FC<QuotaStatusCardProps> = ({
         <span>
           Remaining:{' '}
           <span className="text-text font-medium">
-            {formatQuotaValue(entry.remaining, entry.limitType)}
+            {formatQuotaValue(entry.remaining, entry.limitType, { currency, rate, symbol })}
           </span>
         </span>
         <span>Resets {resetsLabel}</span>

--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -5,6 +5,7 @@ import type { QuotaCheckerInfo } from '../types/quota';
 import { formatMeterValue } from '../components/quota/MeterValue';
 import { Badge } from '../components/ui/Badge';
 import { useToast } from '../contexts/ToastContext';
+import { useCurrency } from '../lib/CurrencyContext';
 
 const KNOWN_APIS = [
   'chat',
@@ -94,6 +95,7 @@ export interface FetchedModel {
 export function useProviderForm() {
   const toast = useToast();
   const navigate = useNavigate();
+  const { currency, rate, symbol } = useCurrency();
 
   const [providers, setProviders] = useState<Provider[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -833,7 +835,11 @@ export function useProviderForm() {
           className="[&_.connection-dot]:hidden cursor-pointer text-[10px] py-0.5 px-2 bg-bg-subtle border border-border text-text-secondary"
           onClick={handleQuotaClick}
         >
-          {formatMeterValue(balanceMeter.remaining, balanceMeter.unit)}
+          {formatMeterValue(balanceMeter.remaining, balanceMeter.unit, false, {
+            currency,
+            rate,
+            symbol,
+          })}
         </Badge>
       );
     }

--- a/packages/frontend/src/lib/CurrencyContext.tsx
+++ b/packages/frontend/src/lib/CurrencyContext.tsx
@@ -1,0 +1,87 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  DEFAULT_CURRENCY,
+  fetchRates,
+  getCachedRates,
+  getCurrency,
+  getSelectedCurrency,
+  setSelectedCurrency,
+  type CurrencyCode,
+  type CurrencyRates,
+} from './currency';
+
+export type CurrencyContextValue = {
+  currency: CurrencyCode;
+  setCurrency: (currency: CurrencyCode) => void;
+  rate: number;
+  convert: (usd: number) => number;
+  symbol: string;
+  isLoading: boolean;
+  ratesAvailable: boolean;
+};
+
+const CurrencyContext = createContext<CurrencyContextValue | undefined>(undefined);
+
+export const CurrencyProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [currency, setCurrencyState] = useState<CurrencyCode>(getSelectedCurrency);
+  const [rates, setRates] = useState<CurrencyRates | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const cached = getCachedRates();
+
+    if (cached) {
+      setRates({ base: DEFAULT_CURRENCY, date: cached.date, rates: cached.rates });
+    }
+
+    fetchRates()
+      .then((loadedRates) => {
+        if (cancelled) return;
+        setRates(loadedRates);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setCurrency = useCallback((nextCurrency: CurrencyCode) => {
+    setCurrencyState(nextCurrency);
+    setSelectedCurrency(nextCurrency);
+  }, []);
+
+  const activeRate = currency === DEFAULT_CURRENCY ? 1 : (rates?.rates[currency] ?? 1);
+  const ratesAvailable =
+    rates !== null && (currency === DEFAULT_CURRENCY || currency in rates.rates);
+  const symbol = getCurrency(currency).symbol;
+
+  const convert = useCallback((usd: number) => usd * activeRate, [activeRate]);
+
+  const value = useMemo<CurrencyContextValue>(
+    () => ({
+      currency,
+      setCurrency,
+      rate: activeRate,
+      convert,
+      symbol,
+      isLoading,
+      ratesAvailable,
+    }),
+    [activeRate, convert, currency, isLoading, ratesAvailable, setCurrency, symbol]
+  );
+
+  return <CurrencyContext.Provider value={value}>{children}</CurrencyContext.Provider>;
+};
+
+export function useCurrency(): CurrencyContextValue {
+  const context = useContext(CurrencyContext);
+  if (context === undefined) {
+    throw new Error('useCurrency must be used within a CurrencyProvider');
+  }
+  return context;
+}

--- a/packages/frontend/src/lib/__tests__/currency.test.ts
+++ b/packages/frontend/src/lib/__tests__/currency.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerSpy } from '../../../../backend/test/test-utils';
+import {
+  CURRENCY_RATE_CACHE_MAX_AGE_MS,
+  CURRENCY_RATES_STORAGE_KEY,
+  CURRENCY_RATES_URL,
+  DEFAULT_CURRENCY,
+  DISPLAY_CURRENCY_STORAGE_KEY,
+  SUPPORTED_CURRENCIES,
+  fetchRates,
+  getCachedRates,
+  getCurrency,
+  getSelectedCurrency,
+  isCurrencyRateCacheFresh,
+  setSelectedCurrency,
+} from '../currency';
+
+function createStorage(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key) {
+      return values.get(key) ?? null;
+    },
+    key(index) {
+      return [...values.keys()][index] ?? null;
+    },
+    removeItem(key) {
+      values.delete(key);
+    },
+    setItem(key, value) {
+      values.set(key, String(value));
+    },
+  };
+}
+
+const storage = createStorage();
+
+beforeEach(() => {
+  storage.clear();
+  vi.stubGlobal('localStorage', storage);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('currency helpers', () => {
+  it('fetches rates, adds the implicit USD rate, and caches the response', async () => {
+    const now = 1_700_000_000_000;
+    registerSpy(Date, 'now').mockReturnValue(now);
+    const fetchSpy = registerSpy(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ date: '2026-08-01', rates: { EUR: 0.9, GBP: 0.8 } }),
+    });
+
+    await expect(fetchRates()).resolves.toEqual({
+      base: DEFAULT_CURRENCY,
+      date: '2026-08-01',
+      rates: { EUR: 0.9, GBP: 0.8, USD: 1 },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(CURRENCY_RATES_URL);
+    expect(getCachedRates()).toEqual({
+      date: '2026-08-01',
+      fetchedAt: now,
+      rates: { EUR: 0.9, GBP: 0.8, USD: 1 },
+    });
+  });
+
+  it('returns fresh cached rates without fetching again', async () => {
+    const now = 1_700_000_000_000;
+    registerSpy(Date, 'now').mockReturnValue(now);
+    storage.setItem(
+      CURRENCY_RATES_STORAGE_KEY,
+      JSON.stringify({
+        date: '2026-07-31',
+        fetchedAt: now - CURRENCY_RATE_CACHE_MAX_AGE_MS,
+        rates: { EUR: 0.9 },
+      })
+    );
+    const fetchSpy = registerSpy(globalThis, 'fetch');
+
+    await expect(fetchRates()).resolves.toEqual({
+      base: DEFAULT_CURRENCY,
+      date: '2026-07-31',
+      rates: { EUR: 0.9, USD: 1 },
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('identifies fresh and stale cache entries at the twelve-hour boundary', () => {
+    const now = 1_700_000_000_000;
+    const cache = {
+      date: '2026-07-31',
+      fetchedAt: now - CURRENCY_RATE_CACHE_MAX_AGE_MS,
+      rates: { EUR: 0.9, USD: 1 },
+    };
+
+    expect(isCurrencyRateCacheFresh(cache, now)).toBe(true);
+    expect(isCurrencyRateCacheFresh(cache, now + 1)).toBe(false);
+  });
+
+  it('normalizes cached rates and ignores non-numeric entries', () => {
+    storage.setItem(
+      CURRENCY_RATES_STORAGE_KEY,
+      JSON.stringify({
+        date: '2026-07-31',
+        fetchedAt: 1_700_000_000_000,
+        rates: { EUR: 0.9, invalid: 'not-a-rate' },
+      })
+    );
+
+    expect(getCachedRates()).toEqual({
+      date: '2026-07-31',
+      fetchedAt: 1_700_000_000_000,
+      rates: { EUR: 0.9, USD: 1 },
+    });
+  });
+
+  it('falls back to stale cached rates when fetching fails', async () => {
+    const now = 1_700_000_000_000;
+    registerSpy(Date, 'now').mockReturnValue(now);
+    storage.setItem(
+      CURRENCY_RATES_STORAGE_KEY,
+      JSON.stringify({
+        date: '2026-07-30',
+        fetchedAt: now - CURRENCY_RATE_CACHE_MAX_AGE_MS - 1,
+        rates: { EUR: 0.9 },
+      })
+    );
+    registerSpy(globalThis, 'fetch').mockRejectedValue(new Error('network unavailable'));
+
+    await expect(fetchRates()).resolves.toEqual({
+      base: DEFAULT_CURRENCY,
+      date: '2026-07-30',
+      rates: { EUR: 0.9, USD: 1 },
+    });
+  });
+
+  it('returns null when fetching fails and there is no cache', async () => {
+    registerSpy(globalThis, 'fetch').mockRejectedValue(new Error('network unavailable'));
+
+    await expect(fetchRates()).resolves.toBeNull();
+  });
+
+  it('defaults the selected currency to USD and persists changes', () => {
+    expect(getSelectedCurrency()).toBe(DEFAULT_CURRENCY);
+
+    setSelectedCurrency('EUR');
+
+    expect(storage.getItem(DISPLAY_CURRENCY_STORAGE_KEY)).toBe('EUR');
+    expect(getSelectedCurrency()).toBe('EUR');
+  });
+
+  it('falls back to USD for an unsupported selected currency', () => {
+    storage.setItem(DISPLAY_CURRENCY_STORAGE_KEY, 'not-supported');
+
+    expect(getSelectedCurrency()).toBe(DEFAULT_CURRENCY);
+  });
+
+  it('looks up supported currencies and falls back to USD', () => {
+    expect(getCurrency('EUR')).toEqual({ code: 'EUR', symbol: '€', label: 'Euro' });
+    expect(getCurrency('not-supported')).toBe(SUPPORTED_CURRENCIES[0]);
+    expect(SUPPORTED_CURRENCIES[0]).toEqual({ code: 'USD', symbol: '$', label: 'US Dollar' });
+  });
+});

--- a/packages/frontend/src/lib/currency.ts
+++ b/packages/frontend/src/lib/currency.ts
@@ -1,0 +1,203 @@
+export const CURRENCY_RATES_STORAGE_KEY = 'plexus.currencyRates';
+export const DISPLAY_CURRENCY_STORAGE_KEY = 'plexus.displayCurrency';
+export const CURRENCY_RATE_CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+export const DEFAULT_CURRENCY = 'USD';
+export const CURRENCY_RATES_URL = 'https://api.frankfurter.dev/v1/latest?base=USD';
+
+export type Currency = {
+  code: string;
+  symbol: string;
+  label: string;
+};
+
+export const SUPPORTED_CURRENCIES = [
+  { code: 'USD', symbol: '$', label: 'US Dollar' },
+  { code: 'EUR', symbol: '€', label: 'Euro' },
+  { code: 'GBP', symbol: '£', label: 'British Pound' },
+  { code: 'JPY', symbol: '¥', label: 'Japanese Yen' },
+  { code: 'AUD', symbol: 'A$', label: 'Australian Dollar' },
+  { code: 'CAD', symbol: 'C$', label: 'Canadian Dollar' },
+  { code: 'CHF', symbol: 'CHF', label: 'Swiss Franc' },
+  { code: 'CNY', symbol: '¥', label: 'Chinese Yuan' },
+  { code: 'HKD', symbol: 'HK$', label: 'Hong Kong Dollar' },
+  { code: 'NZD', symbol: 'NZ$', label: 'New Zealand Dollar' },
+  { code: 'SEK', symbol: 'kr', label: 'Swedish Krona' },
+  { code: 'KRW', symbol: '₩', label: 'South Korean Won' },
+  { code: 'SGD', symbol: 'S$', label: 'Singapore Dollar' },
+  { code: 'NOK', symbol: 'kr', label: 'Norwegian Krone' },
+  { code: 'MXN', symbol: 'MX$', label: 'Mexican Peso' },
+  { code: 'INR', symbol: '₹', label: 'Indian Rupee' },
+  { code: 'BRL', symbol: 'R$', label: 'Brazilian Real' },
+  { code: 'ZAR', symbol: 'R', label: 'South African Rand' },
+  { code: 'PLN', symbol: 'zł', label: 'Polish Zloty' },
+  { code: 'DKK', symbol: 'kr', label: 'Danish Krone' },
+  { code: 'CZK', symbol: 'Kč', label: 'Czech Koruna' },
+  { code: 'HUF', symbol: 'Ft', label: 'Hungarian Forint' },
+  { code: 'ILS', symbol: '₪', label: 'Israeli New Shekel' },
+  { code: 'PHP', symbol: '₱', label: 'Philippine Peso' },
+  { code: 'MYR', symbol: 'RM', label: 'Malaysian Ringgit' },
+  { code: 'THB', symbol: '฿', label: 'Thai Baht' },
+  { code: 'IDR', symbol: 'Rp', label: 'Indonesian Rupiah' },
+  { code: 'TRY', symbol: '₺', label: 'Turkish Lira' },
+  { code: 'ISK', symbol: 'kr', label: 'Icelandic Krona' },
+  { code: 'RON', symbol: 'lei', label: 'Romanian Leu' },
+  { code: 'BGN', symbol: 'лв', label: 'Bulgarian Lev' },
+] as const satisfies readonly Currency[];
+
+export type CurrencyCode = (typeof SUPPORTED_CURRENCIES)[number]['code'];
+
+export type CurrencyRates = {
+  base: 'USD';
+  date: string;
+  rates: Record<string, number>;
+};
+
+export type CurrencyRateCache = {
+  date: string;
+  fetchedAt: number;
+  rates: Record<string, number>;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function getStorage(): Storage | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeRates(value: unknown): Record<string, number> | null {
+  if (!isRecord(value)) return null;
+
+  const rates: Record<string, number> = {};
+  for (const [code, rate] of Object.entries(value)) {
+    if (typeof rate === 'number' && Number.isFinite(rate)) {
+      rates[code] = rate;
+    }
+  }
+
+  if (Object.keys(rates).length === 0) return null;
+  rates[DEFAULT_CURRENCY] = 1;
+  return rates;
+}
+
+function toCurrencyRates(cache: CurrencyRateCache): CurrencyRates {
+  return {
+    base: DEFAULT_CURRENCY,
+    date: cache.date,
+    rates: cache.rates,
+  };
+}
+
+function writeCachedRates(cache: CurrencyRateCache): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(CURRENCY_RATES_STORAGE_KEY, JSON.stringify(cache));
+  } catch {
+    // Storage can be unavailable or full; the in-memory response remains usable.
+  }
+}
+
+export function getCachedRates(): CurrencyRateCache | null {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(CURRENCY_RATES_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !isRecord(parsed) ||
+      typeof parsed.date !== 'string' ||
+      typeof parsed.fetchedAt !== 'number' ||
+      !Number.isFinite(parsed.fetchedAt)
+    ) {
+      return null;
+    }
+
+    const rates = normalizeRates(parsed.rates);
+    if (!rates) return null;
+
+    return { date: parsed.date, fetchedAt: parsed.fetchedAt, rates };
+  } catch {
+    return null;
+  }
+}
+
+export function isCurrencyRateCacheFresh(
+  cache: CurrencyRateCache,
+  now: number = Date.now()
+): boolean {
+  return now - cache.fetchedAt <= CURRENCY_RATE_CACHE_MAX_AGE_MS;
+}
+
+export async function fetchRates(): Promise<CurrencyRates | null> {
+  const cached = getCachedRates();
+  if (cached && isCurrencyRateCacheFresh(cached)) {
+    return toCurrencyRates(cached);
+  }
+
+  try {
+    const response = await fetch(CURRENCY_RATES_URL);
+    if (!response.ok) throw new Error(`Currency rate request failed: ${response.status}`);
+
+    const data: unknown = await response.json();
+    if (!isRecord(data) || typeof data.date !== 'string') {
+      throw new Error('Currency rate response was invalid');
+    }
+
+    const rates = normalizeRates(data.rates);
+    if (!rates) throw new Error('Currency rate response was invalid');
+
+    const result: CurrencyRates = {
+      base: DEFAULT_CURRENCY,
+      date: data.date,
+      rates,
+    };
+    writeCachedRates({ date: result.date, fetchedAt: Date.now(), rates: result.rates });
+    return result;
+  } catch {
+    return cached ? toCurrencyRates(cached) : null;
+  }
+}
+
+export function getCurrency(code: string): Currency {
+  return SUPPORTED_CURRENCIES.find((currency) => currency.code === code) ?? SUPPORTED_CURRENCIES[0];
+}
+
+export function getSelectedCurrency(): CurrencyCode {
+  const storage = getStorage();
+  if (storage) {
+    try {
+      const stored = storage.getItem(DISPLAY_CURRENCY_STORAGE_KEY);
+      if (stored && SUPPORTED_CURRENCIES.some((currency) => currency.code === stored)) {
+        return stored as CurrencyCode;
+      }
+    } catch {
+      // Use the default when storage is unavailable.
+    }
+  }
+
+  return DEFAULT_CURRENCY;
+}
+
+export function setSelectedCurrency(currency: CurrencyCode): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(DISPLAY_CURRENCY_STORAGE_KEY, currency);
+  } catch {
+    // Storage can be unavailable or full; the in-memory selection remains usable.
+  }
+}

--- a/packages/frontend/src/lib/format.test.ts
+++ b/packages/frontend/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getEstimatedBytesPerToken } from './format';
+import { formatCost, formatCostIn, getEstimatedBytesPerToken } from './format';
 
 describe('getEstimatedBytesPerToken', () => {
   it('returns ~115 B/token for Anthropic messages streaming', () => {
@@ -36,5 +36,30 @@ describe('getEstimatedBytesPerToken', () => {
 
   it('returns ~4.5 B/token for non-streamed responses', () => {
     expect(getEstimatedBytesPerToken({ incomingApiType: 'chat', isStreamed: false })).toBe(4.5);
+  });
+});
+
+describe('formatCostIn', () => {
+  it('matches formatCost for USD at a rate of one', () => {
+    for (const cost of [0, 0.00005, 0.0012, 0.01, 1234.5678]) {
+      expect(formatCostIn(cost, { currency: 'USD', rate: 1 })).toBe(formatCost(cost));
+    }
+  });
+
+  it('scales the USD value by the supplied rate', () => {
+    expect(formatCostIn(2, { currency: 'USD', rate: 0.9 })).toBe('$1.8000');
+  });
+
+  it('uses the small-value threshold marker after conversion', () => {
+    expect(formatCostIn(0.00005, { currency: 'USD', rate: 0.9 })).toBe('$<0.0001');
+  });
+
+  it('formats exactly zero as zero with the currency symbol', () => {
+    expect(formatCostIn(0, { currency: 'USD', rate: 0.9 })).toBe('$0.0000');
+  });
+
+  it('applies a non-USD symbol in the locale currency position', () => {
+    expect(formatCostIn(1.5, { currency: 'EUR', rate: 1, symbol: '€' })).toBe('€1.5000');
+    expect(formatCostIn(1.5, { currency: 'EUR', rate: 1, symbol: 'EUR ' })).toBe('EUR 1.5000');
   });
 });

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -98,6 +98,45 @@ export function formatCost(cost: number, decimals: number = 4): string {
   return `$${cost.toFixed(decimals)}`;
 }
 
+export type FormatCostInOptions = {
+  currency: string;
+  rate: number;
+  symbol?: string;
+  decimals?: number;
+};
+
+export function formatCostIn(costUsd: number, options: FormatCostInOptions): string {
+  const decimals = options.decimals ?? 4;
+  const cost = costUsd * options.rate;
+  const formatter = new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: options.currency,
+    currencyDisplay: 'symbol',
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+
+  const formatValue = (value: number, marker?: string): string => {
+    let integerPartSeen = false;
+    return formatter
+      .formatToParts(value)
+      .map((part) => {
+        if (part.type === 'currency' && options.symbol) return options.symbol;
+        if (marker && !integerPartSeen && part.type === 'integer') {
+          integerPartSeen = true;
+          return `${marker}${part.value}`;
+        }
+        return part.value;
+      })
+      .join('');
+  };
+
+  if (cost === 0) return formatValue(cost);
+  const threshold = Math.pow(10, -decimals);
+  if (cost > 0 && cost < threshold) return formatValue(threshold, '<');
+  return formatValue(cost);
+}
+
 /**
  * Format large point balances with k, M, B suffixes (e.g., 4948499 -> "4.9M", 1500 -> "1k")
  */

--- a/packages/frontend/src/lib/quota.ts
+++ b/packages/frontend/src/lib/quota.ts
@@ -1,6 +1,14 @@
 import type { QuotaStatusEntry } from './api';
-import { formatCost, formatNumber } from './format';
+import { formatCostIn, formatNumber, type FormatCostInOptions } from './format';
 import type { MeterStatus } from '../types/quota';
+
+type CostDisplayOptions = Pick<FormatCostInOptions, 'currency' | 'rate' | 'symbol'>;
+
+const DEFAULT_COST_DISPLAY: CostDisplayOptions = {
+  currency: 'USD',
+  rate: 1,
+  symbol: '$',
+};
 
 /**
  * Map a quota utilization percentage onto the progress-bar status colors
@@ -19,8 +27,14 @@ export function statusForPercent(pct: number): MeterStatus {
  * decimals (quota spend is often fractions of a cent); `tokens` and
  * `requests` reuse the compact number formatter.
  */
-export function formatQuotaValue(value: number, limitType: QuotaStatusEntry['limitType']): string {
-  return limitType === 'cost' ? formatCost(value, 5) : formatNumber(value);
+export function formatQuotaValue(
+  value: number,
+  limitType: QuotaStatusEntry['limitType'],
+  costDisplay: CostDisplayOptions = DEFAULT_COST_DISPLAY
+): string {
+  return limitType === 'cost'
+    ? formatCostIn(value, { ...costDisplay, decimals: 5 })
+    : formatNumber(value);
 }
 
 /** Most-constrained ranking now lives in @plexus/shared so the backend's

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -80,11 +80,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { CurrencyProvider } from './lib/CurrencyContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter basename="/ui">
-      <App />
+      <CurrencyProvider>
+        <App />
+      </CurrencyProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -14,11 +14,14 @@ import {
   Radar,
   Network,
   Trash2,
+  Info,
 } from 'lucide-react';
 import { api } from '../lib/api';
 import type { CompactionSettings } from '../lib/api';
 import { formatMinutesToMinSec } from '@plexus/shared';
 import { useToast } from '../contexts/ToastContext';
+import { useCurrency } from '../lib/CurrencyContext';
+import { SUPPORTED_CURRENCIES } from '../lib/currency';
 import { Card } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
 import { Switch } from '../components/ui/Switch';
@@ -130,6 +133,7 @@ const DEFAULT_COOLDOWN_POLICY: CooldownPolicy = {
 
 export const Config = () => {
   const toast = useToast();
+  const { currency, setCurrency, ratesAvailable } = useCurrency();
   const [config, setConfig] = useState('');
   const [isConfigLoaded, setIsConfigLoaded] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
@@ -928,6 +932,40 @@ export const Config = () => {
 
       <PageContainer>
         <div className="flex flex-col gap-6">
+          <Card title="Display Preferences">
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="displayCurrency"
+                className="font-body text-[12px] font-medium text-text"
+              >
+                Display currency
+              </label>
+              <select
+                id="displayCurrency"
+                value={currency}
+                onChange={(event) => {
+                  const nextCurrency = SUPPORTED_CURRENCIES.find(
+                    ({ code }) => code === event.target.value
+                  );
+                  if (nextCurrency) setCurrency(nextCurrency.code);
+                }}
+                className="w-64 max-w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary"
+              >
+                {SUPPORTED_CURRENCIES.map((option) => (
+                  <option key={option.code} value={option.code}>
+                    {option.label} ({option.code}) — {option.symbol}
+                  </option>
+                ))}
+              </select>
+              {!ratesAvailable && currency !== 'USD' && (
+                <p className="flex items-center gap-1.5 text-[11px] text-text-muted">
+                  <Info size={13} className="text-warning shrink-0" aria-hidden="true" />
+                  <span>Live exchange rates are unavailable; amounts fall back to USD.</span>
+                </p>
+              )}
+            </div>
+          </Card>
+
           {/* ─── Failover Settings ──────────────────────────────────── */}
           <Disclosure
             title="Failover Settings"

--- a/packages/frontend/src/pages/DetailedUsage.tsx
+++ b/packages/frontend/src/pages/DetailedUsage.tsx
@@ -69,7 +69,8 @@ import { Button } from '../components/ui/Button';
 import { PageHeader } from '../components/layout/PageHeader';
 import { TimeRangeSelector } from '../components/dashboard/TimeRangeSelector';
 import { api, type UsageRecord } from '../lib/api';
-import { formatCost, formatMs, formatNumber, formatTokens, formatTimeAgo } from '../lib/format';
+import { useCurrency } from '../lib/CurrencyContext';
+import { formatCostIn, formatMs, formatNumber, formatTokens, formatTimeAgo } from '../lib/format';
 import type { CustomDateRange } from '../lib/date';
 import { parseISODate } from '../lib/date';
 import {
@@ -188,6 +189,12 @@ interface MetricConfig {
   format: (value: number) => string;
 }
 
+interface CostDisplay {
+  currency: string;
+  rate: number;
+  symbol: string;
+}
+
 /**
  * A single data point in the aggregated chart dataset.
  *
@@ -226,7 +233,7 @@ interface SummaryPoint {
  * Count-based metrics (requests, errors) use the left Y-axis;
  * rate/cost/duration metrics use the right Y-axis to avoid scale conflicts.
  */
-const METRICS: MetricConfig[] = [
+const createMetrics = ({ currency, rate, symbol }: CostDisplay): MetricConfig[] => [
   {
     key: 'requests',
     label: 'Requests',
@@ -243,10 +250,10 @@ const METRICS: MetricConfig[] = [
   },
   {
     key: 'cost',
-    label: 'Cost',
+    label: `Cost (${symbol})`,
     color: '#f59e0b',
     yAxisId: 'right',
-    format: (v) => formatCost(v, 4),
+    format: (v) => formatCostIn(v / rate, { currency, rate, symbol, decimals: 4 }),
   },
   {
     key: 'duration',
@@ -681,7 +688,8 @@ const aggregateByGroup = (records: UsageRecord[], groupBy: GroupBy): AggregatedP
 const renderTimeSeriesChart = (
   data: AggregatedPoint[],
   chartType: ChartType,
-  selectedMetrics: string[]
+  selectedMetrics: string[],
+  metrics: MetricConfig[]
 ) => {
   // Select the appropriate Recharts container component based on chart type.
   // ComposedChart is special: it can contain both Bar and Line children.
@@ -696,6 +704,14 @@ const renderTimeSeriesChart = (
   const isComposed = chartType === 'composed';
   // In composed mode, the first 2 metrics are rendered as bars, the rest as lines.
   const barMetrics = selectedMetrics.slice(0, 2);
+  const rightAxisMetrics = metrics.filter(
+    (metric) => metric.yAxisId === 'right' && selectedMetrics.includes(metric.key)
+  );
+  const costMetric = metrics.find((metric) => metric.key === 'cost');
+  const rightAxisTickFormatter =
+    rightAxisMetrics.length === 1 && rightAxisMetrics[0]?.key === 'cost'
+      ? (value: number) => rightAxisMetrics[0].format(value)
+      : undefined;
 
   return (
     <ResponsiveContainer width="100%" height={400}>
@@ -716,6 +732,18 @@ const renderTimeSeriesChart = (
           orientation="right"
           stroke="var(--color-text-secondary)"
           tick={{ fill: 'var(--color-text-secondary)', fontSize: 12 }}
+          tickFormatter={rightAxisTickFormatter}
+          label={
+            selectedMetrics.includes('cost') && costMetric
+              ? {
+                  value: costMetric.label,
+                  angle: 90,
+                  position: 'insideRight',
+                  fill: 'var(--color-text-secondary)',
+                  fontSize: 12,
+                }
+              : undefined
+          }
         />
         <Tooltip
           contentStyle={{
@@ -724,10 +752,17 @@ const renderTimeSeriesChart = (
             borderRadius: '8px',
           }}
           labelStyle={{ color: 'var(--color-text)' }}
+          formatter={(value, name) => {
+            const metric = metrics.find((candidate) => candidate.label === String(name));
+            return [
+              metric ? metric.format(Number(value)) : String(value),
+              metric?.label ?? String(name),
+            ];
+          }}
         />
         <Legend />
         {selectedMetrics.map((metricKey) => {
-          const metric = METRICS.find((m) => m.key === metricKey);
+          const metric = metrics.find((m) => m.key === metricKey);
           if (!metric) return null;
           const isBar = isComposed ? barMetrics.includes(metricKey) : chartType === 'bar';
           const yAxisId = metric.yAxisId || 'left';
@@ -817,7 +852,8 @@ const renderTimeSeriesChart = (
  * @param metricKey - Which metric to use for slice values (e.g., 'requests')
  * @returns JSX element containing the Recharts PieChart
  */
-const renderPieChart = (data: AggregatedPoint[], metricKey: string) => {
+const renderPieChart = (data: AggregatedPoint[], metricKey: string, metrics: MetricConfig[]) => {
+  const metric = metrics.find((candidate) => candidate.key === metricKey);
   const pieData = data
     .map((item, index) => ({
       name: item.name,
@@ -848,6 +884,10 @@ const renderPieChart = (data: AggregatedPoint[], metricKey: string) => {
             border: '1px solid var(--color-border)',
             borderRadius: '8px',
           }}
+          formatter={(value) => [
+            metric ? metric.format(Number(value)) : String(value),
+            metric?.label ?? metricKey,
+          ]}
         />
         <Legend />
       </PieChart>
@@ -869,6 +909,8 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
   initialQueryString,
   onBack,
 }) => {
+  const { currency, rate, symbol, convert } = useCurrency();
+
   // ---------------------------------------------------------------------------
   // Query string resolution: prefer initialQueryString prop (embedded mode),
   // fall back to window.location.search (standalone mode).
@@ -972,7 +1014,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
       if (groupBy === 'time') {
         const [summaryResponse, logsResponse] = await Promise.all([
           api.getSummaryData(timeRange === 'live' ? 'hour' : timeRange, true, startDate, endDate),
-          api.getLogs(100, 0, { startDate, endDate }),
+          api.getLogs(5000, 0, { startDate, endDate }),
         ]);
         // Limit to max 100 points to prevent memory issues
         const limitedData = summaryResponse.slice(0, 100) as SummaryPoint[];
@@ -1031,13 +1073,22 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
       // Use pre-aggregated summary data - minimize object creation
       const isCustom = timeRange === 'custom';
       const customRange = isCustom ? customDateRange : null;
+      const { bucketFn } = getRangeConfig(timeRange, customRange);
+      const costByBucket = new Map<number, number>();
+
+      records.forEach((record) => {
+        const timestampMs = new Date(record.date).getTime();
+        if (Number.isNaN(timestampMs)) return;
+        const bucket = bucketFn(timestampMs);
+        costByBucket.set(bucket, (costByBucket.get(bucket) || 0) + (record.costTotal || 0));
+      });
 
       return summaryData.map((r) => ({
         name: formatBucketLabel(timeRange, Number(r.timestamp), customRange),
         requests: r.requests || 0,
         errors: 0,
         tokens: r.tokens || 0,
-        cost: 0,
+        cost: costByBucket.get(Number(r.timestamp)) || 0,
         duration: 0,
         ttft: 0,
         tps: 0,
@@ -1047,6 +1098,15 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
     // For categorical views, aggregate raw records
     return aggregateByGroup(records, groupBy);
   }, [summaryData, records, groupBy, timeRange, customDateRange]);
+
+  const metrics = useMemo(
+    () => createMetrics({ currency, rate, symbol }),
+    [currency, rate, symbol]
+  );
+  const chartData = useMemo(
+    () => aggregatedData.map((point) => ({ ...point, cost: convert(point.cost) })),
+    [aggregatedData, convert]
+  );
 
   /**
    * Summary statistics computed from all raw records in the current time window.
@@ -1083,13 +1143,17 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
         color: errors > 0 ? 'text-red-500' : '',
       },
       { label: 'Tokens', value: formatTokens(tokens), icon: Database },
-      { label: 'Cost', value: formatCost(cost, 4), icon: DollarSign },
+      {
+        label: 'Cost',
+        value: formatCostIn(cost, { currency, rate, symbol, decimals: 4 }),
+        icon: DollarSign,
+      },
       { label: 'Avg Duration', value: formatMs(avgDuration), icon: Clock },
       { label: 'Avg TTFT', value: formatMs(avgTtft), icon: Clock },
       { label: 'Avg TPS', value: formatNumber(avgTps, 1), icon: TrendingUp },
       { label: 'Success Rate', value: `${successRate.toFixed(1)}%`, icon: TrendingUp },
     ];
-  }, [records]);
+  }, [currency, rate, records, symbol]);
 
   /** Toggle a metric on or off in the chart. Removes it if already selected, adds it otherwise. */
   const toggleMetric = (key: string) =>
@@ -1270,7 +1334,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
             <div className="flex flex-col gap-2">
               <span className="text-xs font-semibold text-text-muted uppercase">Metrics</span>
               <div className="flex gap-2 flex-wrap">
-                {METRICS.map((m) => (
+                {metrics.map((m) => (
                   <button
                     key={m.key}
                     onClick={() => toggleMetric(m.key)}
@@ -1307,9 +1371,9 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
               No data available
             </div>
           ) : chartType === 'pie' ? (
-            renderPieChart(aggregatedData, selectedMetrics[0] || 'requests')
+            renderPieChart(chartData, selectedMetrics[0] || 'requests', metrics)
           ) : (
-            renderTimeSeriesChart(aggregatedData, chartType, selectedMetrics)
+            renderTimeSeriesChart(chartData, chartType, selectedMetrics, metrics)
           )}
         </Card>
       ) : (
@@ -1368,7 +1432,14 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
                   </div>
                   <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
                     <div className="text-[10px] uppercase tracking-wider text-text-muted">Cost</div>
-                    <div className="font-medium text-text">{formatCost(r.costTotal || 0, 4)}</div>
+                    <div className="font-medium text-text">
+                      {formatCostIn(r.costTotal || 0, {
+                        currency,
+                        rate,
+                        symbol,
+                        decimals: 4,
+                      })}
+                    </div>
                   </div>
                   <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
                     <div className="text-[10px] uppercase tracking-wider text-text-muted">
@@ -1447,7 +1518,14 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
                     <td className="py-2 pr-3">
                       {formatTokens((r.tokensInput || 0) + (r.tokensOutput || 0))}
                     </td>
-                    <td className="py-2 pr-3">{formatCost(r.costTotal || 0, 4)}</td>
+                    <td className="py-2 pr-3">
+                      {formatCostIn(r.costTotal || 0, {
+                        currency,
+                        rate,
+                        symbol,
+                        decimals: 4,
+                      })}
+                    </td>
                     <td className="py-2 pr-3">{formatMs(r.durationMs || 0)}</td>
                     <td className="py-2 pr-3">{formatMs(r.ttftMs || 0)}</td>
                     <td className="py-2 pr-3">{formatNumber(r.tokensPerSec || 0, 1)}</td>
@@ -1494,7 +1572,9 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
                   </div>
                   <div className="rounded border border-border-glass bg-bg-glass px-2 py-1.5">
                     <div className="text-[10px] uppercase tracking-wider text-text-muted">Cost</div>
-                    <div className="font-medium text-text">{formatCost(row.cost, 6)}</div>
+                    <div className="font-medium text-text">
+                      {formatCostIn(row.cost, { currency, rate, symbol, decimals: 6 })}
+                    </div>
                   </div>
                 </div>
               </article>
@@ -1532,7 +1612,9 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
                     <td className="py-3 pr-4 text-red-500">{formatNumber(row.errors, 0)}</td>
                     <td className="py-3 pr-4 text-green-500">{row.successRate.toFixed(1)}%</td>
                     <td className="py-3 pr-4">{formatTokens(row.tokens)}</td>
-                    <td className="py-3 pr-4">{formatCost(row.cost, 6)}</td>
+                    <td className="py-3 pr-4">
+                      {formatCostIn(row.cost, { currency, rate, symbol, decimals: 6 })}
+                    </td>
                     <td className="py-3 pr-4">{formatMs(row.duration)}</td>
                     <td className="py-3 pr-4">{formatMs(row.ttft)}</td>
                     <td className="py-3 pr-4">{formatNumber(row.tps, 1)}</td>

--- a/packages/frontend/src/pages/Keys.tsx
+++ b/packages/frontend/src/pages/Keys.tsx
@@ -26,7 +26,8 @@ import {
   ChevronDown,
   Ban,
 } from 'lucide-react';
-import { formatNumber, formatCost } from '../lib/format';
+import { formatNumber, formatCostIn } from '../lib/format';
+import { useCurrency } from '../lib/CurrencyContext';
 import { isClipboardAvailable, copyToClipboard, generateUUID } from '../lib/clipboard';
 import {
   formatQuotaValue,
@@ -70,6 +71,7 @@ function isLeakyRollingDef(def: UserQuota | undefined): boolean {
 
 export const Keys = () => {
   const toast = useToast();
+  const { currency, rate, symbol } = useCurrency();
   const [keys, setKeys] = useState<KeyConfig[]>([]);
   const [quotas, setQuotas] = useState<Record<string, UserQuota>>({});
   const [quotaStatuses, setQuotaStatuses] = useState<Record<string, QuotaStatusResponse>>({});
@@ -629,8 +631,17 @@ export const Keys = () => {
                               <div className="flex items-center justify-between gap-2 text-xs">
                                 <span className="text-text-muted truncate">{primary.name}</span>
                                 <span className="font-medium text-text">
-                                  {formatQuotaValue(primary.currentUsage, primary.limitType)} /{' '}
-                                  {formatQuotaValue(primary.limit, primary.limitType)}
+                                  {formatQuotaValue(primary.currentUsage, primary.limitType, {
+                                    currency,
+                                    rate,
+                                    symbol,
+                                  })}{' '}
+                                  /{' '}
+                                  {formatQuotaValue(primary.limit, primary.limitType, {
+                                    currency,
+                                    rate,
+                                    symbol,
+                                  })}
                                 </span>
                               </div>
                               <div className="h-1.5 overflow-hidden rounded-full bg-bg-hover">
@@ -791,8 +802,17 @@ export const Keys = () => {
                                   }}
                                 />
                                 <span style={{ fontSize: '12px' }}>
-                                  {formatQuotaValue(primary.currentUsage, primary.limitType)} /{' '}
-                                  {formatQuotaValue(primary.limit, primary.limitType)}
+                                  {formatQuotaValue(primary.currentUsage, primary.limitType, {
+                                    currency,
+                                    rate,
+                                    symbol,
+                                  })}{' '}
+                                  /{' '}
+                                  {formatQuotaValue(primary.limit, primary.limitType, {
+                                    currency,
+                                    rate,
+                                    symbol,
+                                  })}
                                 </span>
                                 {status && status.quotas.length > 1 && (
                                   <span className="text-[11px] text-text-muted">
@@ -1004,7 +1024,7 @@ export const Keys = () => {
                             </div>
                             <div className="truncate font-mono text-text">
                               {quota.limitType === 'cost'
-                                ? `${formatCost(quota.limit, 5)} ${quota.limitType}`
+                                ? `${formatCostIn(quota.limit, { currency, rate, symbol, decimals: 5 })} ${quota.limitType}`
                                 : `${formatNumber(quota.limit)} ${quota.limitType}`}
                             </div>
                           </div>
@@ -1081,7 +1101,7 @@ export const Keys = () => {
                           <td className="px-4 py-3 text-left border-b border-border-glass text-text">
                             <span className="font-mono text-xs">
                               {quota.limitType === 'cost'
-                                ? `${formatCost(quota.limit, 5)} ${quota.limitType}`
+                                ? `${formatCostIn(quota.limit, { currency, rate, symbol, decimals: 5 })} ${quota.limitType}`
                                 : `${formatNumber(quota.limit)} ${quota.limitType}`}
                             </span>
                           </td>
@@ -1458,7 +1478,7 @@ export const Keys = () => {
               >
                 <option value="requests">Requests</option>
                 <option value="tokens">Tokens</option>
-                <option value="cost">Cost ($)</option>
+                <option value="cost">Cost ({symbol})</option>
               </select>
             </div>
 
@@ -1473,7 +1493,8 @@ export const Keys = () => {
                 placeholder="1000"
               />
               <p className="text-xs text-text-muted">
-                Maximum {editingQuota.limitType === 'cost' ? 'cost ($)' : editingQuota.limitType}{' '}
+                Maximum{' '}
+                {editingQuota.limitType === 'cost' ? `cost (${symbol})` : editingQuota.limitType}{' '}
                 allowed
               </p>
             </div>

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -18,7 +18,7 @@ import {
 import {
   KWH_PER_SLICE,
   formatBytes,
-  formatCost,
+  formatCostIn,
   formatEnergy,
   formatMs,
   formatSlices,
@@ -78,6 +78,7 @@ import {
 import { clsx } from 'clsx';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { useCurrency } from '../lib/CurrencyContext';
 // @ts-ignore
 import messagesLogo from '../assets/messages.svg';
 // @ts-ignore
@@ -260,6 +261,7 @@ interface DesktopLogRowProps extends LogRowProps {
 }
 
 const MobileLogRow = React.memo(({ log, isNewest, onError, onDebug }: LogRowProps) => {
+  const { currency, rate, symbol } = useCurrency();
   const formatted = formatDateSafely(log.date);
   const totalTokens =
     Number(log.tokensInput || 0) +
@@ -394,7 +396,9 @@ const MobileLogRow = React.memo(({ log, isNewest, onError, onDebug }: LogRowProp
           <div className="min-w-0 rounded bg-bg-subtle px-1.5 py-1">
             <div className="truncate text-text">
               <span className="text-[9px] uppercase text-text-muted">Cost </span>
-              {log.costTotal == null || log.costTotal === 0 ? '-' : formatCost(log.costTotal)}
+              {log.costTotal == null || log.costTotal === 0
+                ? '-'
+                : formatCostIn(log.costTotal, { currency, rate, symbol, decimals: 4 })}
             </div>
           </div>
           <div className="min-w-0 rounded bg-bg-subtle px-1.5 py-1">
@@ -446,6 +450,7 @@ const DesktopLogRow = React.memo(
     onRetryDetails,
     onDelete,
   }: DesktopLogRowProps) => {
+    const { currency, rate, symbol } = useCurrency();
     return (
       <tr
         className={clsx(
@@ -765,12 +770,16 @@ const DesktopLogRow = React.memo(
                 {log.costSource ? (
                   <CostToolTip source={log.costSource} costMetadata={log.costMetadata}>
                     <span style={{ fontWeight: '500', cursor: 'help' }}>
-                      {log.costTotal === 0 ? '-' : formatCost(log.costTotal, 6)}
+                      {log.costTotal === 0
+                        ? '-'
+                        : formatCostIn(log.costTotal, { currency, rate, symbol, decimals: 6 })}
                     </span>
                   </CostToolTip>
                 ) : (
                   <span style={{ fontWeight: '500' }}>
-                    {log.costTotal === 0 ? '-' : formatCost(log.costTotal, 6)}
+                    {log.costTotal === 0
+                      ? '-'
+                      : formatCostIn(log.costTotal, { currency, rate, symbol, decimals: 6 })}
                   </span>
                 )}
               </div>
@@ -792,19 +801,32 @@ const DesktopLogRow = React.memo(
               >
                 <CloudUpload size={10} className="text-blue-400" />
                 <span style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}>
-                  {log.costInput === 0 ? '$-.----' : formatCost(log.costInput || 0)}
+                  {log.costInput === 0
+                    ? `${symbol}-.----`
+                    : formatCostIn(log.costInput || 0, { currency, rate, symbol, decimals: 4 })}
                 </span>
                 <CloudDownload size={10} className="text-green-400" />
                 <span style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}>
-                  {log.costOutput === 0 ? '$-.----' : formatCost(log.costOutput || 0)}
+                  {log.costOutput === 0
+                    ? `${symbol}-.----`
+                    : formatCostIn(log.costOutput || 0, { currency, rate, symbol, decimals: 4 })}
                 </span>
                 <PackageOpen size={10} className="text-orange-400" />
                 <span style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}>
-                  {log.costCached === 0 ? '$-.----' : formatCost(log.costCached || 0)}
+                  {log.costCached === 0
+                    ? `${symbol}-.----`
+                    : formatCostIn(log.costCached || 0, { currency, rate, symbol, decimals: 4 })}
                 </span>
                 <PencilLine size={10} className="text-fuchsia-400" />
                 <span style={{ color: 'var(--color-text-secondary)', fontSize: '0.85em' }}>
-                  {log.costCacheWrite === 0 ? '$-.----' : formatCost(log.costCacheWrite || 0)}
+                  {log.costCacheWrite === 0
+                    ? `${symbol}-.----`
+                    : formatCostIn(log.costCacheWrite || 0, {
+                        currency,
+                        rate,
+                        symbol,
+                        decimals: 4,
+                      })}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Adds an optional display currency for all cost figures in the frontend. Costs remain stored and computed in USD; a user-selected currency is applied purely at render time using live exchange rates. This lets non-USD users read costs in their own currency without any backend or schema changes.

## Why / Context
Every monetary value in the UI was hard-coded to USD via `formatCost`. Users outside the US had to mentally convert costs across Logs, Detailed Usage, dashboards, and quota views. Since costs are an inherently display-side concern, conversion is handled entirely in the frontend with a persisted preference — no database field required.

## Changes
- **Currency core** (`lib/currency.ts`): 31 major currencies, `fetchRates()` against the free, keyless [Frankfurter](https://frankfurter.dev) API, localStorage rate cache with a 12h TTL and stale-cache fallback, and a persisted selected-currency preference (`plexus.displayCurrency`).
- **Context** (`lib/CurrencyContext.tsx`): `CurrencyProvider` + `useCurrency()` exposing `{ currency, setCurrency, rate, convert, symbol, isLoading, ratesAvailable }`; wired into the app root in `main.tsx`.
- **Formatting** (`lib/format.ts`): new `formatCostIn()` that converts USD → selected currency and formats with the right symbol/grouping while preserving the existing sub-cent threshold behavior. Original `formatCost` (USD) is unchanged.
- **Settings** (`pages/Config.tsx`): a "Display Preferences" card with a currency dropdown; shows an inline note (falls back to USD) when live rates are unavailable.
- **Call sites**: cost displays now render in the selected currency across `Logs.tsx`, `DetailedUsage.tsx` (KPIs, tables, chart axes/tooltips), `Keys.tsx`, dashboard `OverallTab`/`LiveTab`, and quota components (`MeterValue`, `QuotaStatusCard`, `BalanceMeterRow`, `AllowanceMeterRow`, `CompactBalancesCard`, `MeterHistoryModal`, `useProviderForm`, `lib/quota.ts`). Token and request counts are intentionally left unconverted.

## Testing
- Added unit tests: `lib/__tests__/currency.test.ts` (fetch, cache freshness/TTL, stale fallback, selected-currency persistence) and new `formatCostIn` cases in `lib/format.test.ts` — 19 tests passing.
- Manually verified in-browser: switching to EUR updates Logs and Detailed Usage (list + chart) values, and the preference persists across reloads via localStorage.

## Notes / Follow-ups
- Display-only: nothing is persisted server-side, and stored USD values are never mutated.
- All localStorage/network access degrades gracefully to USD when storage or the rate API is unavailable.
- Frontend unit tests follow the existing co-located convention and are not part of the backend-only root `test` script.