### PR TITLE
fix(db): use Date timestamps for MCP key migration

### DIFF
--- a/packages/backend/src/db/__tests__/mcp-key-migration.test.ts
+++ b/packages/backend/src/db/__tests__/mcp-key-migration.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
-import { closeDatabase, getDatabase, getSchema, initializeDatabase } from '../client';
+import {
+  closeDatabase,
+  getCurrentDialect,
+  getDatabase,
+  getSchema,
+  initializeDatabase,
+} from '../client';
 import { runMigrations } from '../migrate';
 import { runMcpKeyMigration } from '../mcp-key-migration';
 import { decryptJson, encrypt } from '../../utils/encryption';
@@ -15,6 +21,7 @@ describe('MCP key migration', () => {
     process.env.DATABASE_URL = process.env.PLEXUS_TEST_DB_URL ?? process.env.DATABASE_URL;
     initializeDatabase(process.env.DATABASE_URL);
     await runMigrations();
+    expect(getCurrentDialect()).toBe(process.env.PLEXUS_TEST_DIALECT);
     db = getDatabase();
     schema = getSchema();
     await db.delete(schema.mcpServers);
@@ -40,6 +47,8 @@ describe('MCP key migration', () => {
     const [server] = await db.select().from(schema.mcpServers);
     const [key] = await db.select().from(schema.mcpKeys);
     expect(key).toMatchObject({ mcpServerId: server!.id, key: 'exa-secret' });
+    expect(key!.createdAt).toBeInstanceOf(Date);
+    expect(key!.updatedAt).toBeInstanceOf(Date);
     expect(server!.authScheme).toBe('x-api-key');
     expect(decryptJson(server!.headers)).toEqual({ Accept: 'application/json' });
   });

--- a/packages/backend/src/db/__tests__/target-groups-migration.test.ts
+++ b/packages/backend/src/db/__tests__/target-groups-migration.test.ts
@@ -11,6 +11,10 @@ import { eq } from 'drizzle-orm';
 import { ConfigRepository } from '../config-repository';
 import { toDbBoolean } from '../../utils/normalize';
 
+function parseStoredGroups(value: unknown) {
+  return typeof value === 'string' ? JSON.parse(value) : value;
+}
+
 describe('migrateLegacyTargetGroups', () => {
   let db: ReturnType<typeof getDatabase>;
   let schema: ReturnType<typeof getSchema>;
@@ -99,7 +103,7 @@ describe('migrateLegacyTargetGroups', () => {
     expect(aliasRows).toHaveLength(1);
     const aliasRow = aliasRows[0]!;
     expect(aliasRow.targetGroups).toBeTruthy();
-    const groups = JSON.parse(aliasRow.targetGroups as string);
+    const groups = parseStoredGroups(aliasRow.targetGroups);
     expect(groups).toEqual([{ name: 'default', selector: 'in_order' }]);
 
     // Verify targets now have groupName='default'
@@ -148,7 +152,7 @@ describe('migrateLegacyTargetGroups', () => {
       .select()
       .from(schema.modelAliases)
       .where(eq(schema.modelAliases.slug, 'empty-alias'));
-    const groups = JSON.parse(rows[0]!.targetGroups as string);
+    const groups = parseStoredGroups(rows[0]!.targetGroups);
     expect(groups).toEqual([{ name: 'default', selector: 'random' }]);
   });
 
@@ -240,7 +244,7 @@ describe('migrateLegacyTargetGroups', () => {
       .select()
       .from(schema.modelAliases)
       .where(eq(schema.modelAliases.slug, 'new-alias'));
-    const storedGroups = JSON.parse(rows[0]!.targetGroups as string);
+    const storedGroups = parseStoredGroups(rows[0]!.targetGroups);
     expect(storedGroups).toEqual([
       { name: 'primary', selector: 'random' },
       { name: 'fallback', selector: 'in_order' },

--- a/packages/backend/src/db/mcp-key-migration.ts
+++ b/packages/backend/src/db/mcp-key-migration.ts
@@ -1,7 +1,6 @@
 import { eq } from 'drizzle-orm';
-import { getCurrentDialect, getDatabase, getSchema } from './client';
+import { getDatabase, getSchema } from './client';
 import { decryptJson, encrypt } from '../utils/encryption';
-import { toDbTimestampMs } from '../utils/normalize';
 import { logger } from '../utils/logger';
 
 const AUTH_HEADERS = new Map([
@@ -51,7 +50,7 @@ function extractLegacyCredential(
 export async function runMcpKeyMigration(): Promise<number> {
   const db = getDatabase();
   const schema = getSchema();
-  const timestamp = toDbTimestampMs(Date.now(), getCurrentDialect());
+  const timestamp = new Date();
   let migratedCount = 0;
 
   const servers = await db.select().from(schema.mcpServers);
@@ -73,8 +72,8 @@ export async function runMcpKeyMigration(): Promise<number> {
       await tx.insert(schema.mcpKeys).values({
         mcpServerId: server.id,
         key: encrypt(credential.key),
-        createdAt: timestamp!,
-        updatedAt: timestamp!,
+        createdAt: timestamp,
+        updatedAt: timestamp,
       });
       await tx
         .update(schema.mcpServers)

--- a/packages/backend/src/services/quota/quota-enforcer.ts
+++ b/packages/backend/src/services/quota/quota-enforcer.ts
@@ -401,9 +401,11 @@ export class QuotaEnforcer {
         );
       }
       const leakPerMs = durationMs ? def.limit / durationMs : 0;
+      const leakPerMsSql =
+        this.dialect === 'postgres' ? sql`${leakPerMs}::double precision` : sql`${leakPerMs}`;
 
       const currentUsageExpr = sql`CASE WHEN ${this.schema.quotaState.limitType} != ${limitType} THEN ${usageValue}
-        ELSE ${maxFn}(0, ${this.schema.quotaState.currentUsage} - (${nowMs} - ${this.schema.quotaState.lastUpdated}) * ${leakPerMs}) + ${usageValue}
+        ELSE ${maxFn}(0, ${this.schema.quotaState.currentUsage} - (${nowMs} - ${this.schema.quotaState.lastUpdated}) * ${leakPerMsSql}) + ${usageValue}
         END`;
 
       await this.db

--- a/packages/backend/test/vitest.global-setup.ts
+++ b/packages/backend/test/vitest.global-setup.ts
@@ -17,31 +17,61 @@ function copyDirectory(sourceDir: string, targetDir: string) {
   }
 }
 
-export default async function globalSetup() {
+export type TestDialect = 'sqlite' | 'postgres';
+
+export async function setupTestDatabase(testDialect: TestDialect) {
   const moduleDir = path.dirname(fileURLToPath(import.meta.url));
   const backendRoot = path.resolve(moduleDir, '..');
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'plexus-vitest-'));
-  const testDialect = process.env.PLEXUS_TEST_DIALECT === 'postgres' ? 'postgres' : 'sqlite';
+  const managedEnvKeys = [
+    'PLEXUS_TEST_DB_URL',
+    'PLEXUS_TEST_DB_TMP_ROOT',
+    'PLEXUS_TEST_DIALECT',
+    'PLEXUS_TEST_DB_TEMPLATE_URL',
+    'PLEXUS_TEST_PGLITE_TEMPLATE_DIR',
+    'PLEXUS_TEST_SQLITE_TEMPLATE_URL',
+    'PLEXUS_TEST_SQLITE_TMP_ROOT',
+    'PLEXUS_TEST_POSTGRES_TEMPLATE_DIR',
+    'PLEXUS_TEST_POSTGRES_TMP_ROOT',
+    'PLEXUS_TEST_POSTGRES_DB_URL',
+    'PLEXUS_PGLITE_DATA_DIR',
+    'PLEXUS_POSTGRES_DRIVER',
+    'DATABASE_URL',
+  ];
+  const originalEnv = new Map(managedEnvKeys.map((key) => [key, process.env[key]]));
 
   const sqliteTemplatePath = path.join(tmpRoot, 'vitest-template.sqlite');
   const postgresTemplateDir = path.join(tmpRoot, 'vitest-template.pglite');
+  const configuredDbUrl = process.env.PLEXUS_TEST_DB_URL;
   const defaultDbUrl =
     testDialect === 'postgres'
       ? 'postgres://postgres:postgres@localhost:5432/plexus_test'
       : `sqlite://${sqliteTemplatePath}`;
-  const testDbUrl = process.env.PLEXUS_TEST_DB_URL || defaultDbUrl;
+  const configuredDbMatchesDialect =
+    configuredDbUrl?.startsWith(testDialect === 'postgres' ? 'postgres' : 'sqlite') ?? false;
+  const testDbUrl = configuredDbMatchesDialect ? configuredDbUrl! : defaultDbUrl;
 
   process.env.PLEXUS_TEST_DB_URL = testDbUrl;
   process.env.PLEXUS_TEST_DB_TMP_ROOT = tmpRoot;
   process.env.PLEXUS_TEST_DIALECT = testDialect;
   process.env.DATABASE_URL = testDbUrl;
+  if (testDialect === 'postgres') {
+    process.env.PLEXUS_POSTGRES_DRIVER = 'pglite';
+  } else {
+    delete process.env.PLEXUS_POSTGRES_DRIVER;
+  }
 
   if (testDialect === 'sqlite') {
     process.env.PLEXUS_TEST_DB_TEMPLATE_URL = testDbUrl;
+    process.env.PLEXUS_TEST_SQLITE_TEMPLATE_URL = testDbUrl;
+    process.env.PLEXUS_TEST_SQLITE_TMP_ROOT = tmpRoot;
     delete process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR;
     delete process.env.PLEXUS_PGLITE_DATA_DIR;
   } else {
     process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR = postgresTemplateDir;
+    process.env.PLEXUS_TEST_POSTGRES_TEMPLATE_DIR = postgresTemplateDir;
+    process.env.PLEXUS_TEST_POSTGRES_TMP_ROOT = tmpRoot;
+    process.env.PLEXUS_TEST_POSTGRES_DB_URL = testDbUrl;
     process.env.PLEXUS_PGLITE_DATA_DIR = postgresTemplateDir;
     delete process.env.PLEXUS_TEST_DB_TEMPLATE_URL;
   }
@@ -81,12 +111,12 @@ export default async function globalSetup() {
   await closeDatabase();
 
   if (testDialect === 'postgres') {
-    const finalTemplateDir = process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR!;
+    const finalTemplateDir = postgresTemplateDir;
     if (!fs.existsSync(finalTemplateDir)) {
       fs.mkdirSync(finalTemplateDir, { recursive: true });
     }
     // Ensure the template directory exists even if pglite created it lazily.
-    const currentDir = process.env.PLEXUS_PGLITE_DATA_DIR;
+    const currentDir = postgresTemplateDir;
     if (currentDir && currentDir !== finalTemplateDir && fs.existsSync(currentDir)) {
       copyDirectory(currentDir, finalTemplateDir);
     }
@@ -104,10 +134,18 @@ export default async function globalSetup() {
     } catch {
       // ignore temp cleanup errors
     }
-    delete process.env.PLEXUS_TEST_DB_TEMPLATE_URL;
-    delete process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR;
-    delete process.env.PLEXUS_TEST_DB_URL;
-    delete process.env.PLEXUS_TEST_DB_TMP_ROOT;
-    delete process.env.PLEXUS_PGLITE_DATA_DIR;
+    for (const [key, value] of originalEnv) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
   };
+}
+
+export default async function globalSetup() {
+  const testDialect: TestDialect =
+    process.env.PLEXUS_TEST_DIALECT === 'postgres' ? 'postgres' : 'sqlite';
+  return setupTestDatabase(testDialect);
 }

--- a/packages/backend/test/vitest.postgres.global-setup.ts
+++ b/packages/backend/test/vitest.postgres.global-setup.ts
@@ -1,0 +1,5 @@
+import { setupTestDatabase } from './vitest.global-setup';
+
+export default async function globalSetup() {
+  return setupTestDatabase('postgres');
+}

--- a/packages/backend/test/vitest.setup.ts
+++ b/packages/backend/test/vitest.setup.ts
@@ -18,14 +18,17 @@ function copyDirectory(sourceDir: string, targetDir: string) {
   }
 }
 
-const templateDbUrl = process.env.PLEXUS_TEST_DB_TEMPLATE_URL;
-const pgliteTemplateDir = process.env.PLEXUS_TEST_PGLITE_TEMPLATE_DIR;
-const tmpRoot = process.env.PLEXUS_TEST_DB_TMP_ROOT;
+const testDialect = process.env.PLEXUS_TEST_DIALECT;
+const sqliteTemplateDbUrl = process.env.PLEXUS_TEST_SQLITE_TEMPLATE_URL;
+const sqliteTmpRoot = process.env.PLEXUS_TEST_SQLITE_TMP_ROOT;
+const postgresTemplateDir = process.env.PLEXUS_TEST_POSTGRES_TEMPLATE_DIR;
+const postgresTmpRoot = process.env.PLEXUS_TEST_POSTGRES_TMP_ROOT;
 const workerId = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? '0';
 
-if (templateDbUrl && tmpRoot) {
-  const templateDbPath = sqliteUrlToPath(templateDbUrl);
-  const workerDbPath = path.join(tmpRoot, `vitest-worker-${workerId}.sqlite`);
+if ((testDialect === 'sqlite' || testDialect === 'unit') && sqliteTemplateDbUrl && sqliteTmpRoot) {
+  const templateDbPath = sqliteUrlToPath(sqliteTemplateDbUrl);
+  const workerPrefix = testDialect === 'unit' ? 'vitest-unit-worker' : 'vitest-worker';
+  const workerDbPath = path.join(sqliteTmpRoot, `${workerPrefix}-${workerId}.sqlite`);
 
   if (templateDbPath && !fs.existsSync(workerDbPath)) {
     fs.copyFileSync(templateDbPath, workerDbPath);
@@ -34,15 +37,16 @@ if (templateDbUrl && tmpRoot) {
   const workerDbUrl = `sqlite://${workerDbPath}`;
   process.env.PLEXUS_TEST_DB_URL = workerDbUrl;
   process.env.DATABASE_URL = workerDbUrl;
-} else if (pgliteTemplateDir && tmpRoot) {
-  const workerDataDir = path.join(tmpRoot, `vitest-worker-${workerId}.pglite`);
+} else if (testDialect === 'postgres' && postgresTemplateDir && postgresTmpRoot) {
+  const workerDataDir = path.join(postgresTmpRoot, `vitest-worker-${workerId}.pglite`);
 
   if (!fs.existsSync(workerDataDir)) {
-    copyDirectory(pgliteTemplateDir, workerDataDir);
+    copyDirectory(postgresTemplateDir, workerDataDir);
   }
 
   const workerDbUrl =
-    process.env.PLEXUS_TEST_DB_URL || 'postgres://postgres:postgres@localhost:5432/plexus_test';
+    process.env.PLEXUS_TEST_POSTGRES_DB_URL ||
+    'postgres://postgres:postgres@localhost:5432/plexus_test';
   process.env.PLEXUS_POSTGRES_DRIVER = 'pglite';
   process.env.PLEXUS_PGLITE_DATA_DIR = workerDataDir;
   process.env.PLEXUS_TEST_DB_URL = workerDbUrl;

--- a/packages/backend/test/vitest.sqlite.global-setup.ts
+++ b/packages/backend/test/vitest.sqlite.global-setup.ts
@@ -1,0 +1,5 @@
+import { setupTestDatabase } from './vitest.global-setup';
+
+export default async function globalSetup() {
+  return setupTestDatabase('sqlite');
+}

--- a/packages/backend/vitest.postgres.config.ts
+++ b/packages/backend/vitest.postgres.config.ts
@@ -7,6 +7,7 @@ export default defineProject({
   test: {
     ...baseConfig.test,
     name: 'postgres',
+    globalSetup: ['./test/vitest.postgres.global-setup.ts'],
     include: [...DB_TEST_FILES],
     env: {
       ...baseConfig.test?.env,

--- a/packages/backend/vitest.sqlite.config.ts
+++ b/packages/backend/vitest.sqlite.config.ts
@@ -7,6 +7,7 @@ export default defineProject({
   test: {
     ...baseConfig.test,
     name: 'sqlite',
+    globalSetup: ['./test/vitest.sqlite.global-setup.ts'],
     include: [...DB_TEST_FILES],
     env: {
       ...baseConfig.test?.env,

--- a/packages/backend/vitest.unit.config.ts
+++ b/packages/backend/vitest.unit.config.ts
@@ -10,7 +10,12 @@ export default defineProject({
     // DB tests run in the sqlite and postgres projects; exclude them here so
     // they don't get a redundant third run with no dialect configured.
     exclude: [...(baseConfig.test?.exclude ?? []), ...DB_TEST_FILES],
-    // No database setup needed — all DB access is mocked via vitest.setup.ts.
+    // Unit tests reuse an isolated SQLite worker database when a DB-backed
+    // singleton is exercised, but do not initialize a separate template.
     globalSetup: [],
+    env: {
+      ...baseConfig.test?.env,
+      PLEXUS_TEST_DIALECT: 'unit',
+    },
   },
 });


### PR DESCRIPTION
## Summary
Fixes the PostgreSQL startup failure while migrating legacy MCP credentials. The migration now supplies `Date` values for `mcp_keys` timestamp columns, and the database test projects are guaranteed to exercise their configured dialect.

## Why / Context
The MCP key migration passed epoch numbers through `toDbTimestampMs()` even though PostgreSQL defines `created_at` and `updated_at` as `timestamp` columns. Drizzle consequently called `toISOString()` on a number. PostgreSQL-labeled tests previously initialized SQLite because global setup ran before project-specific environment settings and the worker setup preferred the SQLite template.

## Changes
- **MCP migration**: insert `Date` timestamps compatible with PostgreSQL `timestamp` and SQLite `timestamp_ms` columns.
- **Vitest database setup**: use project-specific global setup and namespaced SQLite/PGlite templates so workers cannot cross dialects.
- **Regression coverage**: assert the active database dialect and timestamp value types in the MCP migration test.
- **PostgreSQL compatibility**: handle JSONB test results and cast quota leak rates to `double precision` when running SQL on PostgreSQL.

## Testing
- Ran the full forced suite: 239 test files / 2662 tests passed.
- Ran the MCP migration tests in both PostgreSQL/PGlite and SQLite projects.
- Typecheck, Biome format, and Biome lint passed.

Fixes #780
