### PR TITLE
fix(oauth): proactively refresh provider tokens

### DIFF
--- a/packages/backend/src/services/oauth/__tests__/oauth-auth-manager.test.ts
+++ b/packages/backend/src/services/oauth/__tests__/oauth-auth-manager.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OAuthAuthManager } from '../oauth-auth-manager';
+
+const mocks = vi.hoisted(() => ({
+  configService: {
+    getAllOAuthProviders: vi.fn(),
+    getOAuthCredentials: vi.fn(),
+    setOAuthCredentials: vi.fn(),
+  },
+  getConfigInstance: vi.fn(),
+  getOAuthProviderAuth: vi.fn(),
+  refresh: vi.fn(),
+  toAuth: vi.fn(),
+}));
+
+vi.mock('../../configuration/config-service', () => ({
+  ConfigService: { getInstance: mocks.getConfigInstance },
+}));
+
+vi.mock('../oauth-providers', () => ({
+  getOAuthProviderAuth: mocks.getOAuthProviderAuth,
+}));
+
+const initialCredentials = {
+  accessToken: 'old-access',
+  refreshToken: 'old-refresh',
+  expiresAt: Date.now() + 8 * 60 * 60 * 1000,
+};
+
+const refreshedCredentials = {
+  type: 'oauth' as const,
+  access: 'new-access',
+  refresh: 'new-refresh',
+  expires: Date.now() + 8 * 60 * 60 * 1000,
+};
+
+describe('OAuthAuthManager', () => {
+  beforeEach(() => {
+    OAuthAuthManager.resetForTesting();
+    mocks.getConfigInstance.mockReturnValue(mocks.configService);
+    mocks.configService.getAllOAuthProviders.mockResolvedValue([
+      { providerType: 'anthropic', accountId: 'personal' },
+    ]);
+    mocks.configService.getOAuthCredentials.mockResolvedValue(initialCredentials);
+    mocks.configService.setOAuthCredentials.mockResolvedValue(undefined);
+    mocks.refresh.mockResolvedValue(refreshedCredentials);
+    mocks.toAuth.mockImplementation(async (credentials: { access: string }) => ({
+      apiKey: credentials.access,
+    }));
+    mocks.getOAuthProviderAuth.mockReturnValue({
+      oauth: {
+        refresh: mocks.refresh,
+        toAuth: mocks.toAuth,
+      },
+    });
+  });
+
+  async function createManager(): Promise<OAuthAuthManager> {
+    const manager = OAuthAuthManager.getInstance();
+    await manager.initialize();
+    return manager;
+  }
+
+  it('refreshes proactively at the requested cadence and persists rotated credentials', async () => {
+    const manager = await createManager();
+
+    await expect(
+      manager.getApiKey('anthropic', 'personal', { refreshIfOlderThanMs: 60 * 60 * 1000 })
+    ).resolves.toBe('new-access');
+    await expect(
+      manager.getApiKey('anthropic', 'personal', { refreshIfOlderThanMs: 60 * 60 * 1000 })
+    ).resolves.toBe('new-access');
+
+    expect(mocks.refresh).toHaveBeenCalledTimes(1);
+    expect(mocks.configService.setOAuthCredentials).toHaveBeenCalledWith('anthropic', 'personal', {
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      expiresAt: expect.any(Number),
+    });
+  });
+
+  it('keeps the existing refresh token when a refresh response omits rotation', async () => {
+    mocks.refresh.mockResolvedValueOnce({
+      type: 'oauth',
+      access: 'new-access',
+      expires: Date.now() + 8 * 60 * 60 * 1000,
+    });
+    const manager = await createManager();
+
+    await manager.getApiKey('anthropic', 'personal', { refreshIfOlderThanMs: 0 });
+
+    expect(mocks.configService.setOAuthCredentials).toHaveBeenCalledWith(
+      'anthropic',
+      'personal',
+      expect.objectContaining({ refreshToken: 'old-refresh' })
+    );
+  });
+
+  it('serializes concurrent refreshes for one account', async () => {
+    let resolveRefresh: ((value: typeof refreshedCredentials) => void) | undefined;
+    mocks.refresh.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    const manager = await createManager();
+
+    const first = manager.getApiKey('anthropic', 'personal', { refreshIfOlderThanMs: 0 });
+    const second = manager.getApiKey('anthropic', 'personal', { refreshIfOlderThanMs: 0 });
+
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(1));
+    resolveRefresh?.(refreshedCredentials);
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['new-access', 'new-access']);
+  });
+
+  it('does not proactively refresh without a refresh cadence', async () => {
+    const manager = await createManager();
+
+    await expect(manager.getApiKey('anthropic', 'personal')).resolves.toBe('old-access');
+
+    expect(mocks.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/services/oauth/oauth-auth-manager.ts
+++ b/packages/backend/src/services/oauth/oauth-auth-manager.ts
@@ -1,15 +1,21 @@
 import { logger } from '../../utils/logger';
-import type { OAuthCredential, OAuthCredentials } from '@earendil-works/pi-ai';
+import type { OAuthAuth, OAuthCredential, OAuthCredentials } from '@earendil-works/pi-ai';
 import { ConfigService } from '../configuration/config-service';
 import { getOAuthProviderAuth, type OAuthProvider } from './oauth-providers';
 
 const LEGACY_ACCOUNT_ID = 'legacy';
+
+interface GetApiKeyOptions {
+  refreshIfOlderThanMs?: number;
+}
 
 export class OAuthAuthManager {
   private static instance: OAuthAuthManager;
   // In-memory cache for fast lookups
   private authData: Record<string, { accounts: Record<string, OAuthCredentials> }> = {};
   private initPromise: Promise<void>;
+  private readonly lastRefreshAt = new Map<string, number>();
+  private readonly refreshPromises = new Map<string, Promise<OAuthCredentials>>();
 
   private constructor() {
     this.initPromise = this.loadFromDatabaseAsync();
@@ -143,11 +149,16 @@ export class OAuthAuthManager {
       type: 'oauth',
       ...credentials,
     } as OAuthCredentials;
+    this.lastRefreshAt.set(`${provider}/${accountId}`, Date.now());
 
     await this.saveToDatabase(provider, accountId, credentials);
   }
 
-  async getApiKey(provider: OAuthProvider, accountId?: string | null): Promise<string> {
+  async getApiKey(
+    provider: OAuthProvider,
+    accountId?: string | null,
+    options: GetApiKeyOptions = {}
+  ): Promise<string> {
     const providerRecord = this.authData[provider];
     if (!providerRecord) {
       throw new Error(
@@ -175,17 +186,36 @@ export class OAuthAuthManager {
       throw new Error(`OAuth: provider '${provider}' does not support OAuth login.`);
     }
 
-    // Refresh expired tokens and persist the rotated credentials.
+    const refreshKey = `${provider}/${resolvedAccountId}`;
+    const now = Date.now();
     let current = credentials;
-    if (current.expires <= Date.now()) {
-      const refreshed = await descriptor.oauth.refresh({ ...current, type: 'oauth' });
-      logger.debug(
-        `OAuth: getApiKey for ${provider}/${resolvedAccountId} — token WAS refreshed. ` +
-          `new_refresh=${refreshed.refresh ? `present(${refreshed.refresh.length} chars)` : 'MISSING'}`
-      );
-      current = { ...refreshed };
-      providerRecord.accounts[resolvedAccountId] = current;
-      await this.saveToDatabase(provider, resolvedAccountId, current);
+    const lastRefresh = this.lastRefreshAt.get(refreshKey);
+    const refreshRequested =
+      current.expires <= now ||
+      (options.refreshIfOlderThanMs !== undefined &&
+        (lastRefresh === undefined || now - lastRefresh >= options.refreshIfOlderThanMs));
+
+    if (refreshRequested) {
+      const existingRefresh = this.refreshPromises.get(refreshKey);
+      if (existingRefresh) {
+        current = await existingRefresh;
+      } else {
+        const refreshPromise = this.refreshCredentials(
+          provider,
+          resolvedAccountId,
+          descriptor.oauth.refresh,
+          current,
+          refreshKey
+        );
+        this.refreshPromises.set(refreshKey, refreshPromise);
+        try {
+          current = await refreshPromise;
+        } finally {
+          if (this.refreshPromises.get(refreshKey) === refreshPromise) {
+            this.refreshPromises.delete(refreshKey);
+          }
+        }
+      }
     } else {
       logger.debug(
         `OAuth: getApiKey for ${provider}/${resolvedAccountId} — token was NOT refreshed (not expired).`
@@ -200,6 +230,28 @@ export class OAuthAuthManager {
     }
 
     return auth.apiKey;
+  }
+
+  private async refreshCredentials(
+    provider: OAuthProvider,
+    accountId: string,
+    refresh: OAuthAuth['refresh'],
+    credentials: OAuthCredentials,
+    refreshKey: string
+  ): Promise<OAuthCredentials> {
+    const refreshed = await refresh({ ...credentials, type: 'oauth' } as OAuthCredential);
+    const current = {
+      ...refreshed,
+      refresh: refreshed.refresh || credentials.refresh,
+    } as OAuthCredentials;
+    logger.debug(
+      `OAuth: getApiKey for ${provider}/${accountId} — token WAS refreshed. ` +
+        `new_refresh=${current.refresh ? `present(${current.refresh.length} chars)` : 'MISSING'}`
+    );
+    this.authData[provider]!.accounts[accountId] = current;
+    this.lastRefreshAt.set(refreshKey, Date.now());
+    await this.saveToDatabase(provider, accountId, current);
+    return current;
   }
 
   getCredentials(provider: OAuthProvider, accountId?: string | null): OAuthCredentials | null {
@@ -238,6 +290,9 @@ export class OAuthAuthManager {
     }
 
     delete providerRecord.accounts[accountId];
+    const refreshKey = `${provider}/${accountId}`;
+    this.lastRefreshAt.delete(refreshKey);
+    this.refreshPromises.delete(refreshKey);
     if (Object.keys(providerRecord.accounts).length === 0) {
       delete this.authData[provider];
     }

--- a/packages/backend/src/services/pi-ai/__tests__/catalog.test.ts
+++ b/packages/backend/src/services/pi-ai/__tests__/catalog.test.ts
@@ -141,7 +141,7 @@ describe('createModelCatalog', () => {
     await catalog.refresh();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
 
-    now += REMOTE_CATALOG_REFRESH_INTERVAL_MS + 1;
+    now = Date.now() + REMOTE_CATALOG_REFRESH_INTERVAL_MS + 1;
     await catalog.refresh();
     expect(fetchImpl).toHaveBeenCalledTimes(2);
 

--- a/packages/backend/src/services/quota/checkers/__tests__/openai-codex-checker.test.ts
+++ b/packages/backend/src/services/quota/checkers/__tests__/openai-codex-checker.test.ts
@@ -190,6 +190,8 @@ describe('openai-codex checker', () => {
     const meters = await checkerDef.check(makeCtx());
 
     expect(meters).toHaveLength(1);
-    expect(authManager.getApiKey).toHaveBeenCalledWith('openai-codex');
+    expect(authManager.getApiKey).toHaveBeenCalledWith('openai-codex', undefined, {
+      refreshIfOlderThanMs: 8 * 24 * 60 * 60 * 1000,
+    });
   });
 });

--- a/packages/backend/src/services/quota/checkers/claude-code-checker.ts
+++ b/packages/backend/src/services/quota/checkers/claude-code-checker.ts
@@ -32,6 +32,7 @@ type ClaudeLimit = z.infer<typeof ClaudeLimitSchema>;
 type ClaudeUsageResponse = z.infer<typeof ClaudeUsageResponseSchema>;
 
 const SCOPED_WEEKLY_KIND = 'weekly_scoped';
+const CLAUDE_OAUTH_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 
 interface ScopedLimit {
   dimension: 'model' | 'surface';
@@ -177,17 +178,21 @@ async function resolveApiKey(ctx: {
   const provider = ctx.getOption<string>('oauthProvider', 'anthropic').trim() || 'anthropic';
   const oauthAccountId = ctx.getOption<string>('oauthAccountId', '').trim();
   const authManager = OAuthAuthManager.getInstance();
+  const refreshOptions =
+    provider === 'anthropic'
+      ? { refreshIfOlderThanMs: CLAUDE_OAUTH_REFRESH_INTERVAL_MS }
+      : undefined;
 
   try {
     return oauthAccountId
-      ? await authManager.getApiKey(provider as OAuthProvider, oauthAccountId)
-      : await authManager.getApiKey(provider as OAuthProvider);
+      ? await authManager.getApiKey(provider as OAuthProvider, oauthAccountId, refreshOptions)
+      : await authManager.getApiKey(provider as OAuthProvider, undefined, refreshOptions);
   } catch {
-    authManager.reload();
+    await authManager.reload();
     logger.info(`Reloaded OAuth auth file and retrying for '${provider}'`);
     return oauthAccountId
-      ? await authManager.getApiKey(provider as OAuthProvider, oauthAccountId)
-      : await authManager.getApiKey(provider as OAuthProvider);
+      ? await authManager.getApiKey(provider as OAuthProvider, oauthAccountId, refreshOptions)
+      : await authManager.getApiKey(provider as OAuthProvider, undefined, refreshOptions);
   }
 }
 

--- a/packages/backend/src/services/quota/checkers/openai-codex-checker.ts
+++ b/packages/backend/src/services/quota/checkers/openai-codex-checker.ts
@@ -25,6 +25,8 @@ interface CodexUsageResponse {
   rate_limit?: CodexRateLimitInfo;
 }
 
+const OPENAI_CODEX_OAUTH_REFRESH_INTERVAL_MS = 8 * 24 * 60 * 60 * 1000;
+
 interface OAuthCredentialsBlob {
   access_token?: string;
 }
@@ -121,6 +123,10 @@ export default defineChecker({
         ctx.getOption<string>('oauthProvider', 'openai-codex').trim() || 'openai-codex';
       const oauthAccountId = ctx.getOption<string>('oauthAccountId', '').trim();
       const authManager = OAuthAuthManager.getInstance();
+      const refreshOptions =
+        provider === 'openai-codex'
+          ? { refreshIfOlderThanMs: OPENAI_CODEX_OAUTH_REFRESH_INTERVAL_MS }
+          : undefined;
 
       const rawCreds = (
         oauthAccountId
@@ -132,13 +138,13 @@ export default defineChecker({
       let oauthApiKey: string;
       try {
         oauthApiKey = oauthAccountId
-          ? await authManager.getApiKey(provider as OAuthProvider, oauthAccountId)
-          : await authManager.getApiKey(provider as OAuthProvider);
+          ? await authManager.getApiKey(provider as OAuthProvider, oauthAccountId, refreshOptions)
+          : await authManager.getApiKey(provider as OAuthProvider, undefined, refreshOptions);
       } catch {
-        authManager.reload();
+        await authManager.reload();
         oauthApiKey = oauthAccountId
-          ? await authManager.getApiKey(provider as OAuthProvider, oauthAccountId)
-          : await authManager.getApiKey(provider as OAuthProvider);
+          ? await authManager.getApiKey(provider as OAuthProvider, oauthAccountId, refreshOptions)
+          : await authManager.getApiKey(provider as OAuthProvider, undefined, refreshOptions);
       }
 
       accessToken = parseAccessToken(oauthApiKey);


### PR DESCRIPTION
## Summary
Add proactive OAuth refresh for Claude and Codex quota checks so idle providers rotate credentials before refresh tokens expire.

## Why / Context
The OAuth manager previously refreshed only after an access token expired. Staging showed Claude quota checks running regularly while Anthropic still rejected the eventual refresh with `invalid_grant: Refresh token expired`.

## Changes
- **OAuth manager**: add throttled refresh support, per-account refresh serialization, rotated-token persistence, and refresh-token carry-forward when a response omits rotation.
- **Claude Code quota checker**: proactively refresh Anthropic OAuth credentials hourly.
- **OpenAI Codex quota checker**: proactively refresh Codex OAuth credentials every eight days, matching Codex's stale-session cadence.
- **Retry handling**: await OAuth state reloads before retrying credential resolution.
- **Tests**: cover proactive refresh, token carry-forward, concurrent refresh serialization, and Codex refresh options.

## Testing
- Full suite: 240 test files, 2666 tests passed.
- Pre-commit hooks passed backend tests, typecheck, formatting, and lint.

## Notes
The currently expired staging Claude credential still requires one manual re-authentication; this change prevents future expiry while the quota checker is active.
