### PR TITLE
fix(dispatch): handle structured UNKNOWN_FIELD errors in strip-and-retry

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -255,6 +255,56 @@ describe('matchUnsupportedParameter', () => {
   test('returns undefined for an empty body', () => {
     expect(matchUnsupportedParameter('')).toBeUndefined();
   });
+
+  // Structured unknown-field errors (e.g. Alibaba Cloud DashScope) name the
+  // offending field in a machine-readable `data.field` member with a
+  // localized message and a `code` of UNKNOWN_FIELD, instead of the English
+  // "Unsupported parameter: X" text. See issue #783.
+  test('extracts the field from a structured UNKNOWN_FIELD body (#783)', () => {
+    const body = JSON.stringify({
+      code: 'UNKNOWN_FIELD',
+      message: '未知请求字段：reasoning.effort',
+      data: { field: 'reasoning.effort' },
+      traceId: 'trace_92b98af4-b0f9-4742-b50b-31f3ac25e824',
+    });
+    expect(matchUnsupportedParameter(body)).toBe('reasoning.effort');
+  });
+
+  test('extracts the field from a structured UNKNOWN_FIELD body with a dotted path', () => {
+    expect(
+      matchUnsupportedParameter(
+        '{"code":"UNKNOWN_FIELD","message":"unknown field","data":{"field":"text.verbosity"}}'
+      )
+    ).toBe('text.verbosity');
+  });
+
+  test('normalizes bracket notation in a structured UNKNOWN_FIELD field', () => {
+    expect(
+      matchUnsupportedParameter('{"code":"UNKNOWN_FIELD","data":{"field":"messages[0].name"}}')
+    ).toBe('messages.0.name');
+  });
+
+  test('accepts data.field_path as an alternative key', () => {
+    expect(
+      matchUnsupportedParameter('{"code":"UNKNOWN_FIELD","data":{"field_path":"reasoning.effort"}}')
+    ).toBe('reasoning.effort');
+  });
+
+  test('returns undefined for a structured body without the unknown-field code', () => {
+    expect(
+      matchUnsupportedParameter('{"code":"RATE_LIMITED","data":{"field":"reasoning.effort"}}')
+    ).toBeUndefined();
+  });
+
+  test('returns undefined for a structured body without a data.field', () => {
+    expect(
+      matchUnsupportedParameter('{"code":"UNKNOWN_FIELD","message":"bad request"}')
+    ).toBeUndefined();
+  });
+
+  test('returns undefined for a non-JSON body', () => {
+    expect(matchUnsupportedParameter('not json at all')).toBeUndefined();
+  });
 });
 
 describe('deleteDottedPath', () => {
@@ -596,6 +646,18 @@ describe('planUnsupportedParamStrip', () => {
       planUnsupportedParamStrip('{"error":{"message":"Invalid request"}}', state)
     ).toBeUndefined();
     expect(state.attempts).toBe(0);
+  });
+
+  test('strips a field named by a structured UNKNOWN_FIELD body (#783)', () => {
+    const state = createUnsupportedParamStripState();
+    const body = JSON.stringify({
+      code: 'UNKNOWN_FIELD',
+      message: '未知请求字段：reasoning.effort',
+      data: { field: 'reasoning.effort' },
+    });
+    expect(planUnsupportedParamStrip(body, state)).toBe('reasoning.effort');
+    expect(state.attempts).toBe(1);
+    expect(state.strippedParams.has('reasoning.effort')).toBe(true);
   });
 
   test('structural guard: refuses to strip the whole messages/input/model field, consuming no budget', () => {

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -456,8 +456,51 @@ function normalizeBracketSegments(path: string): string {
  */
 export function matchUnsupportedParameter(responseBody: string): string | undefined {
   if (!responseBody) return undefined;
+
+  // Structured error formats that name an unsupported/unknown field in a
+  // machine-readable location rather than a free-text "Unsupported
+  // parameter: X" message. Example (Alibaba Cloud DashScope):
+  //   {"code":"UNKNOWN_FIELD","message":"未知请求字段：reasoning.effort","data":{"field":"reasoning.effort"}}
+  // Without this, a provider returning a localized/structured unknown-field
+  // error bypasses the strip-and-retry loop and the request fails outright.
+  const structured = matchStructuredUnknownField(responseBody);
+  if (structured) return structured;
+
   const paramName = UNSUPPORTED_PARAMETER_PATTERN.exec(responseBody)?.[1];
   return paramName === undefined ? undefined : normalizeBracketSegments(paramName);
+}
+
+/**
+ * Matches structured upstream error bodies that report an unknown/unrecognized
+ * request field via a `data.field` (or `data.field_path`) member rather than an
+ * English "Unsupported parameter" message. Covers Alibaba Cloud DashScope
+ * ({"code":"UNKNOWN_FIELD",...,"data":{"field":"reasoning.effort"}}),
+ * which is the shape reported in #783.
+ *
+ * Returns the canonical (dotted) field path, or `undefined` when the body is
+ * not one of these structured shapes.
+ */
+function matchStructuredUnknownField(responseBody: string): string | undefined {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(responseBody);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+
+  // DashScope-style: { "code": "UNKNOWN_FIELD", "data": { "field": "..." } }
+  const code = typeof parsed.code === 'string' ? parsed.code.toUpperCase() : undefined;
+  const isUnknownField =
+    code === 'UNKNOWN_FIELD' || code === 'INVALID_PARAMETER' || code === 'UNEXPECTED_PARAMETER';
+  if (!isUnknownField) return undefined;
+
+  const data = parsed.data;
+  if (!data || typeof data !== 'object') return undefined;
+  const raw = data.field ?? data.field_path ?? data.fieldPath;
+  if (typeof raw !== 'string' || !raw) return undefined;
+
+  return normalizeBracketSegments(raw);
 }
 
 /** Segment names that must never be traversed — see `deleteDottedPath`. */


### PR DESCRIPTION
## Summary

Fixes #783 - `UNKNOWN_FIELD` error for `reasoning.effort` when routing to providers that reject unknown fields with a structured error body.

## Problem

Some upstream providers (e.g. Alibaba Cloud DashScope) reject an unrecognized request field with a **structured** error body instead of the English free-text `Unsupported parameter: X` message that Plexus's reactive auto-compat loop matches on:

```json
{
  "code": "UNKNOWN_FIELD",
  "message": "??????:reasoning.effort",
  "data": { "field": "reasoning.effort" },
  "traceId": "trace_92b98af4-b0f9-4742-b50b-31f3ac25e824"
}
```

Because `matchUnsupportedParameter` only recognized the `"Unsupported parameter: X"` phrasing, these structured unknown-field 400s **bypassed the strip-and-retry mechanism entirely**. Instead of dropping the offending field and retrying the same target, the request failed outright.

This is what a Claude Code (or any OpenAI/Anthropic-compatible client) user hitting Plexus sees when the routed provider doesn't understand `reasoning.effort`.

## Fix

Extend `matchUnsupportedParameter` (`packages/backend/src/services/dispatch/dispatcher-auto-compat.ts`) to also parse structured error bodies that carry an unknown/unexpected-field code (`UNKNOWN_FIELD`, `INVALID_PARAMETER`, `UNEXPECTED_PARAMETER`) with the offending path in `data.field` / `data.field_path` / `data.fieldPath`. It returns the canonical dotted path so the existing `deleteDottedPath` + strip-and-retry flow handles them **identically** to the text-based errors - no new retry budget, no new code path.

The structured check runs before the regex so a localized message (e.g. Chinese `??????`) never fails to match, and a non-JSON body still falls through to the existing regex unchanged.

## Testing

Added unit tests in `packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts`:
- Extracts the field from a structured `UNKNOWN_FIELD` body (#783 exact shape, including the localized message)
- Extracts dotted-path fields (`text.verbosity`)
- Normalizes bracket notation (`messages[0].name` ? `messages.0.name`)
- Accepts `data.field_path` as an alternative key
- Returns `undefined` for a non-unknown-field code, a body without `data.field`, and a non-JSON body
- `planUnsupportedParamStrip` end-to-end: a structured `UNKNOWN_FIELD` body triggers a strip and consumes one attempt

All existing tests continue to pass (85 in this file; 653 across services; 274 across transformers). CI on the fork branch is green (PR Tests ?).

## Notes

- This is a **reactive** fix (strip-and-retry on the named field), consistent with how Plexus already handles the English `"Unsupported parameter"` shape. A proactive normalize of `reasoning.effort` ? `reasoning_effort` across API dialects is a larger change intentionally left out of scope.
- The strip leaves an empty `reasoning: {}` parent object (existing `deleteDottedPath` behavior is documented as non-pruning). If a provider then rejects the empty object too, the bounded strip-and-retry loop will strip `reasoning` wholesale on the next 400 - the existing 2-retry budget covers this cascade.