### PR TITLE
fix(frontend): handle paginated debug and error responses

### DIFF
--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -2260,7 +2260,10 @@ export const api = {
         `${API_BASE}/v0/management/debug/logs?limit=${limit}&offset=${offset}`
       );
       if (!res.ok) throw new Error('Failed to fetch debug logs');
-      return await res.json();
+      const json = (await res.json()) as BackendResponse<
+        { requestId: string; createdAt: number; responseStatus: number | null }[]
+      >;
+      return json.data || [];
     } catch (e) {
       console.error('API Error getDebugLogs', e);
       return [];
@@ -2308,7 +2311,8 @@ export const api = {
         `${API_BASE}/v0/management/errors?limit=${limit}&offset=${offset}`
       );
       if (!res.ok) throw new Error('Failed to fetch error logs');
-      return await res.json();
+      const json = (await res.json()) as BackendResponse<InferenceError[]>;
+      return json.data || [];
     } catch (e) {
       console.error('API Error getErrors', e);
       return [];


### PR DESCRIPTION
## Summary
Prevent the `/ui/debug` and `/ui/errors` pages from crashing when their management endpoints return paginated response envelopes. The pages now receive the arrays they expect and render normally, including empty states.

## Why / Context
The backend returns `{ data, total, limit, offset }`, but the frontend passed the entire object to `.map()`, causing a render-time exception and black screen.

## Changes
- **Frontend API**: unwrap `data` from debug-log responses.
- **Frontend API**: unwrap `data` from inference-error responses.
- **Page contracts**: preserve the existing array return types with empty-array fallbacks.

## Testing
- Manually verified `/ui/debug` and `/ui/errors` in the local dev UI.
- Confirmed both pages render with no browser errors.
