### PR TITLE
feat(mcp-oauth): add OAuth 2.1 authorization-code flow for MCP proxy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@earendil-works/pi-ai": "0.83.0",
         "@fastify/bearer-auth": "^10.1.2",
         "@fastify/cors": "^11.3.0",
+        "@fastify/formbody": "^8.0.2",
         "@fastify/multipart": "^10.1.0",
         "@fastify/static": "^10.1.2",
         "@google/genai": "^2.14.0",
@@ -284,6 +285,8 @@
     "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
 
     "@fastify/fast-json-stringify-compiler": ["@fastify/fast-json-stringify-compiler@5.0.3", "", { "dependencies": { "fast-json-stringify": "^6.0.0" } }, "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ=="],
+
+    "@fastify/formbody": ["@fastify/formbody@8.0.2", "", { "dependencies": { "fast-querystring": "^1.1.2", "fastify-plugin": "^5.0.0" } }, "sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA=="],
 
     "@fastify/forwarded": ["@fastify/forwarded@3.0.1", "", {}, "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw=="],
 

--- a/packages/backend/drizzle/schema/index.ts
+++ b/packages/backend/drizzle/schema/index.ts
@@ -43,6 +43,7 @@ export * from './sqlite/alias-metadata-overrides';
 export * from './sqlite/api-keys';
 export * from './sqlite/user-quota-definitions';
 export * from './sqlite/mcp-servers';
+export * from './sqlite/mcp-oauth';
 export * from './sqlite/mcp-keys';
 export * from './sqlite/system-settings';
 export * from './sqlite/oauth-credentials';
@@ -65,6 +66,11 @@ export { aliasMetadataOverrides as pgAliasMetadataOverrides } from './postgres/a
 export { apiKeys as pgApiKeys } from './postgres/api-keys';
 export { userQuotaDefinitions as pgUserQuotaDefinitions } from './postgres/user-quota-definitions';
 export { mcpServers as pgMcpServers } from './postgres/mcp-servers';
+export {
+  mcpOauthClients as pgMcpOauthClients,
+  mcpOauthAuthorizationCodes as pgMcpOauthAuthorizationCodes,
+  mcpOauthTokens as pgMcpOauthTokens,
+} from './postgres/mcp-oauth';
 export { mcpKeys as pgMcpKeys } from './postgres/mcp-keys';
 export { systemSettings as pgSystemSettings } from './postgres/system-settings';
 export { oauthCredentials as pgOauthCredentials } from './postgres/oauth-credentials';

--- a/packages/backend/drizzle/schema/postgres/index.ts
+++ b/packages/backend/drizzle/schema/postgres/index.ts
@@ -18,6 +18,7 @@ export * from './alias-metadata-overrides';
 export * from './api-keys';
 export * from './user-quota-definitions';
 export * from './mcp-servers';
+export * from './mcp-oauth';
 export * from './mcp-keys';
 export * from './system-settings';
 export * from './oauth-credentials';

--- a/packages/backend/drizzle/schema/postgres/mcp-oauth.ts
+++ b/packages/backend/drizzle/schema/postgres/mcp-oauth.ts
@@ -1,0 +1,65 @@
+import { pgTable, serial, text, bigint, index } from 'drizzle-orm/pg-core';
+
+export const mcpOauthClients = pgTable('mcp_oauth_clients', {
+  id: serial('id').primaryKey(),
+  clientId: text('client_id').notNull().unique(),
+  clientName: text('client_name'),
+  redirectUris: text('redirect_uris').notNull(), // JSON string for SQLite parity/encryption compatibility
+  grantTypes: text('grant_types'), // JSON: string[]
+  responseTypes: text('response_types'), // JSON: string[]
+  scope: text('scope'),
+  tokenEndpointAuthMethod: text('token_endpoint_auth_method').notNull().default('none'),
+  createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+  updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+});
+
+export const mcpOauthAuthorizationCodes = pgTable(
+  'mcp_oauth_authorization_codes',
+  {
+    id: serial('id').primaryKey(),
+    codeHash: text('code_hash').notNull().unique(),
+    code: text('code').notNull(),
+    clientId: text('client_id').notNull(),
+    redirectUri: text('redirect_uri').notNull(),
+    resource: text('resource').notNull(),
+    scope: text('scope'),
+    keyName: text('key_name').notNull(),
+    codeChallenge: text('code_challenge').notNull(),
+    codeChallengeMethod: text('code_challenge_method').notNull(),
+    expiresAt: bigint('expires_at', { mode: 'number' }).notNull(),
+    consumedAt: bigint('consumed_at', { mode: 'number' }),
+    createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+  },
+  (table) => ({
+    clientIdIdx: index('idx_mcp_oauth_authorization_codes_client_id').on(table.clientId),
+    expiresAtIdx: index('idx_mcp_oauth_authorization_codes_expires_at').on(table.expiresAt),
+  })
+);
+
+export const mcpOauthTokens = pgTable(
+  'mcp_oauth_tokens',
+  {
+    id: serial('id').primaryKey(),
+    accessTokenHash: text('access_token_hash').notNull().unique(),
+    accessToken: text('access_token').notNull(),
+    refreshTokenHash: text('refresh_token_hash').notNull().unique(),
+    refreshToken: text('refresh_token').notNull(),
+    clientId: text('client_id').notNull(),
+    keyName: text('key_name').notNull(),
+    apiKeySecretHash: text('api_key_secret_hash'),
+    resource: text('resource').notNull(),
+    scope: text('scope'),
+    accessTokenExpiresAt: bigint('access_token_expires_at', { mode: 'number' }).notNull(),
+    refreshTokenExpiresAt: bigint('refresh_token_expires_at', { mode: 'number' }).notNull(),
+    revokedAt: bigint('revoked_at', { mode: 'number' }),
+    createdAt: bigint('created_at', { mode: 'number' }).notNull(),
+    updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
+  },
+  (table) => ({
+    clientIdIdx: index('idx_mcp_oauth_tokens_client_id').on(table.clientId),
+    keyNameIdx: index('idx_mcp_oauth_tokens_key_name').on(table.keyName),
+    accessTokenExpiresAtIdx: index('idx_mcp_oauth_tokens_access_token_expires_at').on(
+      table.accessTokenExpiresAt
+    ),
+  })
+);

--- a/packages/backend/drizzle/schema/postgres/mcp-oauth.ts
+++ b/packages/backend/drizzle/schema/postgres/mcp-oauth.ts
@@ -9,6 +9,9 @@ export const mcpOauthClients = pgTable('mcp_oauth_clients', {
   responseTypes: text('response_types'), // JSON: string[]
   scope: text('scope'),
   tokenEndpointAuthMethod: text('token_endpoint_auth_method').notNull().default('none'),
+  status: text('status', { enum: ['active', 'disabled'] })
+    .notNull()
+    .default('active'),
   createdAt: bigint('created_at', { mode: 'number' }).notNull(),
   updatedAt: bigint('updated_at', { mode: 'number' }).notNull(),
 });
@@ -24,6 +27,7 @@ export const mcpOauthAuthorizationCodes = pgTable(
     resource: text('resource').notNull(),
     scope: text('scope'),
     keyName: text('key_name').notNull(),
+    apiKeySecretHash: text('api_key_secret_hash'),
     codeChallenge: text('code_challenge').notNull(),
     codeChallengeMethod: text('code_challenge_method').notNull(),
     expiresAt: bigint('expires_at', { mode: 'number' }).notNull(),

--- a/packages/backend/drizzle/schema/sqlite/index.ts
+++ b/packages/backend/drizzle/schema/sqlite/index.ts
@@ -18,6 +18,7 @@ export * from './alias-metadata-overrides';
 export * from './api-keys';
 export * from './user-quota-definitions';
 export * from './mcp-servers';
+export * from './mcp-oauth';
 export * from './mcp-keys';
 export * from './system-settings';
 export * from './oauth-credentials';

--- a/packages/backend/drizzle/schema/sqlite/mcp-oauth.ts
+++ b/packages/backend/drizzle/schema/sqlite/mcp-oauth.ts
@@ -1,0 +1,65 @@
+import { sqliteTable, integer, text, index } from 'drizzle-orm/sqlite-core';
+
+export const mcpOauthClients = sqliteTable('mcp_oauth_clients', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  clientId: text('client_id').notNull().unique(),
+  clientName: text('client_name'),
+  redirectUris: text('redirect_uris').notNull(), // JSON: string[]
+  grantTypes: text('grant_types'), // JSON: string[]
+  responseTypes: text('response_types'), // JSON: string[]
+  scope: text('scope'),
+  tokenEndpointAuthMethod: text('token_endpoint_auth_method').notNull().default('none'),
+  createdAt: integer('created_at').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+});
+
+export const mcpOauthAuthorizationCodes = sqliteTable(
+  'mcp_oauth_authorization_codes',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    codeHash: text('code_hash').notNull().unique(),
+    code: text('code').notNull(),
+    clientId: text('client_id').notNull(),
+    redirectUri: text('redirect_uri').notNull(),
+    resource: text('resource').notNull(),
+    scope: text('scope'),
+    keyName: text('key_name').notNull(),
+    codeChallenge: text('code_challenge').notNull(),
+    codeChallengeMethod: text('code_challenge_method').notNull(),
+    expiresAt: integer('expires_at').notNull(),
+    consumedAt: integer('consumed_at'),
+    createdAt: integer('created_at').notNull(),
+  },
+  (table) => ({
+    clientIdIdx: index('idx_mcp_oauth_authorization_codes_client_id').on(table.clientId),
+    expiresAtIdx: index('idx_mcp_oauth_authorization_codes_expires_at').on(table.expiresAt),
+  })
+);
+
+export const mcpOauthTokens = sqliteTable(
+  'mcp_oauth_tokens',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    accessTokenHash: text('access_token_hash').notNull().unique(),
+    accessToken: text('access_token').notNull(),
+    refreshTokenHash: text('refresh_token_hash').notNull().unique(),
+    refreshToken: text('refresh_token').notNull(),
+    clientId: text('client_id').notNull(),
+    keyName: text('key_name').notNull(),
+    apiKeySecretHash: text('api_key_secret_hash'),
+    resource: text('resource').notNull(),
+    scope: text('scope'),
+    accessTokenExpiresAt: integer('access_token_expires_at').notNull(),
+    refreshTokenExpiresAt: integer('refresh_token_expires_at').notNull(),
+    revokedAt: integer('revoked_at'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => ({
+    clientIdIdx: index('idx_mcp_oauth_tokens_client_id').on(table.clientId),
+    keyNameIdx: index('idx_mcp_oauth_tokens_key_name').on(table.keyName),
+    accessTokenExpiresAtIdx: index('idx_mcp_oauth_tokens_access_token_expires_at').on(
+      table.accessTokenExpiresAt
+    ),
+  })
+);

--- a/packages/backend/drizzle/schema/sqlite/mcp-oauth.ts
+++ b/packages/backend/drizzle/schema/sqlite/mcp-oauth.ts
@@ -9,6 +9,9 @@ export const mcpOauthClients = sqliteTable('mcp_oauth_clients', {
   responseTypes: text('response_types'), // JSON: string[]
   scope: text('scope'),
   tokenEndpointAuthMethod: text('token_endpoint_auth_method').notNull().default('none'),
+  status: text('status', { enum: ['active', 'disabled'] })
+    .notNull()
+    .default('active'),
   createdAt: integer('created_at').notNull(),
   updatedAt: integer('updated_at').notNull(),
 });
@@ -24,6 +27,7 @@ export const mcpOauthAuthorizationCodes = sqliteTable(
     resource: text('resource').notNull(),
     scope: text('scope'),
     keyName: text('key_name').notNull(),
+    apiKeySecretHash: text('api_key_secret_hash'),
     codeChallenge: text('code_challenge').notNull(),
     codeChallengeMethod: text('code_challenge_method').notNull(),
     expiresAt: integer('expires_at').notNull(),

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
     "@earendil-works/pi-ai": "0.83.0",
     "@fastify/bearer-auth": "^10.1.2",
     "@fastify/cors": "^11.3.0",
+    "@fastify/formbody": "^8.0.2",
     "@fastify/multipart": "^10.1.0",
     "@fastify/static": "^10.1.2",
     "@google/genai": "^2.14.0",

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -366,6 +366,10 @@ const HyperQuotaCheckerOptionsSchema = z.object({
   endpoint: z.url().optional(),
 });
 
+const DeepSeekQuotaCheckerOptionsSchema = z.object({
+  endpoint: z.string().url().optional(),
+});
+
 const SakanaQuotaCheckerOptionsSchema = z.object({
   sessionCookie: z.string().trim().min(1, 'Sakana session cookie is required'),
   endpoint: z.string().url().optional(),
@@ -579,6 +583,13 @@ const ProviderQuotaCheckerSchema = z.discriminatedUnion('type', [
     intervalMinutes: z.number().min(1).default(30),
     id: z.string().trim().min(1).optional(),
     options: HyperQuotaCheckerOptionsSchema.optional().default({}),
+  }),
+  z.object({
+    type: z.literal('deepseek'),
+    enabled: z.boolean().default(true),
+    intervalMinutes: z.number().min(1).default(30),
+    id: z.string().trim().min(1).optional(),
+    options: DeepSeekQuotaCheckerOptionsSchema.optional().default({}),
   }),
   z.object({
     type: z.literal('sakana'),

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -1088,6 +1088,20 @@ const StallConfigSchema = z.object({
   stallCooldown: z.boolean().default(false).optional(),
 });
 
+export const McpOAuthConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  provider: z.enum(['plexus-idp']).default('plexus-idp'),
+  /**
+   * Optional externally-visible base URL. If omitted, OAuth metadata and
+   * validation are derived from the incoming request origin.
+   */
+  issuer: z.string().url().optional(),
+  /**
+   * Optional protected resource URL. If omitted, defaults to `${issuer}/mcp`.
+   */
+  resource: z.string().url().optional(),
+});
+
 const RawPlexusConfigSchema = z
   .object({
     providers: z.record(z.string(), ProviderConfigSchema),
@@ -1102,6 +1116,7 @@ const RawPlexusConfigSchema = z
     timeout: z.object({ defaultSeconds: z.number().min(1).max(3600).default(300) }).optional(),
     stall: StallConfigSchema.optional(),
     backgroundExploration: BackgroundExplorationConfigSchema.optional(),
+    mcpOAuth: McpOAuthConfigSchema.optional(),
     mcp_servers: z.record(z.string(), McpServerConfigSchema).optional(),
     user_quotas: z.record(z.string(), QuotaDefinitionSchema).optional(),
     // Applied to keys with NO quotas assigned (`quotas` absent/empty). Non-stacking:
@@ -1123,6 +1138,7 @@ export type StallConfigType = {
   gracePeriodSeconds?: number;
   stallCooldown?: boolean;
 };
+export type McpOAuthConfig = z.infer<typeof McpOAuthConfigSchema>;
 export type PlexusConfig = z.infer<typeof RawPlexusConfigSchema> & {
   failover: FailoverPolicy;
   cooldown?: CooldownPolicy;
@@ -1130,6 +1146,7 @@ export type PlexusConfig = z.infer<typeof RawPlexusConfigSchema> & {
   stall?: StallConfigType;
   quotas: QuotaConfig[];
   mcpServers?: Record<string, McpServerConfig>;
+  mcpOAuth?: McpOAuthConfig;
   // Immediate-peer IPs/CIDRs whose forwarding headers are trusted when
   // resolving the client IP. Semantics:
   //  - undefined: legacy trust-all before DB-backed config is loaded

--- a/packages/backend/src/db/__tests__/mcp-oauth-key-revocation.test.ts
+++ b/packages/backend/src/db/__tests__/mcp-oauth-key-revocation.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDatabase, getDatabase, getSchema, initializeDatabase } from '../client';
+import { runMigrations } from '../migrate';
+import { ConfigRepository } from '../config-repository';
+import { McpOauthRepository } from '../mcp-oauth-repository';
+import { hashSecret } from '../../utils/encryption';
+
+describe('MCP OAuth token eager revocation on API key changes', () => {
+  let db: ReturnType<typeof getDatabase>;
+  let schema: ReturnType<typeof getSchema>;
+  let configRepo: ConfigRepository;
+  let oauthRepo: McpOauthRepository;
+
+  beforeEach(async () => {
+    await closeDatabase();
+    process.env.DATABASE_URL = process.env.PLEXUS_TEST_DB_URL ?? process.env.DATABASE_URL;
+    initializeDatabase(process.env.DATABASE_URL);
+    await runMigrations();
+    db = getDatabase();
+    schema = getSchema();
+    configRepo = new ConfigRepository();
+    oauthRepo = new McpOauthRepository();
+
+    await db.delete(schema.mcpOauthTokens);
+    await db.delete(schema.mcpOauthAuthorizationCodes);
+    await db.delete(schema.mcpOauthClients);
+    await db.delete(schema.apiKeys);
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+  });
+
+  it('sets revokedAt immediately on all active tokens bound to a rotated key', async () => {
+    await configRepo.saveKey('rotating-key', { secret: 'sk-old-secret' });
+    await oauthRepo.createClient({
+      clientId: 'mcp_test_client',
+      clientName: 'Test Client',
+      redirectUris: ['http://localhost/callback'],
+    });
+
+    await oauthRepo.createToken({
+      accessToken: 'pox_access_one',
+      refreshToken: 'por_refresh_one',
+      clientId: 'mcp_test_client',
+      keyName: 'rotating-key',
+      apiKeySecretHash: hashSecret('sk-old-secret'),
+      resource: 'http://localhost/mcp',
+      scope: 'mcp:read mcp:write',
+      accessTokenExpiresAt: Date.now() + 60_000,
+      refreshTokenExpiresAt: Date.now() + 120_000,
+    });
+    await oauthRepo.createToken({
+      accessToken: 'pox_access_two',
+      refreshToken: 'por_refresh_two',
+      clientId: 'mcp_test_client',
+      keyName: 'rotating-key',
+      apiKeySecretHash: hashSecret('sk-old-secret'),
+      resource: 'http://localhost/mcp',
+      scope: 'mcp:read mcp:write',
+      accessTokenExpiresAt: Date.now() + 60_000,
+      refreshTokenExpiresAt: Date.now() + 120_000,
+    });
+
+    await configRepo.saveKey('rotating-key', { secret: 'sk-new-secret' });
+
+    const rows = await db.select().from(schema.mcpOauthTokens);
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row: any) => row.revokedAt !== null)).toBe(true);
+  });
+});

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -21,9 +21,11 @@ import type {
   BackgroundExplorationConfig,
   TimeoutConfig,
   StallConfigType,
+  McpOAuthConfig,
   MetadataOverrides,
 } from '../config';
 import { resolveGpuParams } from '@plexus/shared';
+import { McpOauthRepository } from './mcp-oauth-repository';
 
 // Helper to parse JSON from SQLite text columns (PG jsonb auto-deserializes)
 function parseJson<T>(value: unknown): T | null {
@@ -1173,6 +1175,12 @@ export class ConfigRepository {
     };
 
     if (existing.length > 0) {
+      const existingSecretHash =
+        existing[0]!.secretHash ?? hashSecret(decrypt(existing[0]!.secret));
+      if (existingSecretHash && existingSecretHash !== secretHash) {
+        await new McpOauthRepository().revokeTokensForKeyName(name);
+      }
+
       await this.db().update(schema.apiKeys).set(keyData).where(eq(schema.apiKeys.name, name));
     } else {
       await this.db()
@@ -1183,6 +1191,7 @@ export class ConfigRepository {
 
   async deleteKey(name: string): Promise<void> {
     const schema = this.schema();
+    await new McpOauthRepository().revokeTokensForKeyName(name);
     await this.db().delete(schema.apiKeys).where(eq(schema.apiKeys.name, name));
   }
 
@@ -1663,6 +1672,22 @@ export class ConfigRepository {
       2
     );
     return { enabled, stalenessThresholdSeconds, workerConcurrency };
+  }
+
+  async getMcpOAuthConfig(): Promise<McpOAuthConfig> {
+    const stored = await this.getSetting<Partial<McpOAuthConfig>>('mcpOAuth', {});
+    const enabled = stored?.enabled === true;
+    const provider = stored?.provider === 'plexus-idp' ? stored.provider : 'plexus-idp';
+    return {
+      enabled,
+      provider,
+      ...(typeof stored?.issuer === 'string' && stored.issuer.trim()
+        ? { issuer: stored.issuer.trim() }
+        : {}),
+      ...(typeof stored?.resource === 'string' && stored.resource.trim()
+        ? { resource: stored.resource.trim() }
+        : {}),
+    };
   }
 
   async getTimeoutConfig(): Promise<TimeoutConfig> {

--- a/packages/backend/src/db/mcp-oauth-repository.ts
+++ b/packages/backend/src/db/mcp-oauth-repository.ts
@@ -34,6 +34,7 @@ export interface McpOauthClientRecord {
   responseTypes: string[];
   scope: string | null;
   tokenEndpointAuthMethod: string;
+  status: 'active' | 'disabled';
   createdAt: number;
 }
 
@@ -45,6 +46,7 @@ export interface NewMcpOauthClient {
   responseTypes?: string[];
   scope?: string | null;
   tokenEndpointAuthMethod?: string;
+  status?: 'active' | 'disabled';
 }
 
 export interface McpOauthAuthorizationCodeRecord {
@@ -55,6 +57,7 @@ export interface McpOauthAuthorizationCodeRecord {
   resource: string;
   scope: string | null;
   keyName: string;
+  apiKeySecretHash: string | null;
   codeChallenge: string;
   codeChallengeMethod: string;
   expiresAt: number;
@@ -69,6 +72,7 @@ export interface NewMcpOauthAuthorizationCode {
   resource: string;
   scope?: string | null;
   keyName: string;
+  apiKeySecretHash: string;
   codeChallenge: string;
   codeChallengeMethod: string;
   expiresAt: number;
@@ -129,6 +133,7 @@ export class McpOauthRepository {
         responseTypes: stringifyArray(input.responseTypes),
         scope: input.scope ?? null,
         tokenEndpointAuthMethod: input.tokenEndpointAuthMethod ?? 'none',
+        status: input.status ?? 'active',
         createdAt: timestamp,
         updatedAt: timestamp,
       });
@@ -156,6 +161,7 @@ export class McpOauthRepository {
       responseTypes: parseJsonArray(row.responseTypes),
       scope: row.scope ?? null,
       tokenEndpointAuthMethod: row.tokenEndpointAuthMethod,
+      status: row.status === 'disabled' ? 'disabled' : 'active',
       createdAt: row.createdAt,
     };
   }
@@ -225,6 +231,7 @@ export class McpOauthRepository {
       responseTypes: parseJsonArray(row.responseTypes),
       scope: row.scope ?? null,
       tokenEndpointAuthMethod: row.tokenEndpointAuthMethod,
+      status: row.status === 'disabled' ? 'disabled' : 'active',
       createdAt: row.createdAt,
       tokens: tokensByClient.get(row.clientId) ?? [],
     }));
@@ -246,6 +253,7 @@ export class McpOauthRepository {
         resource: input.resource,
         scope: input.scope ?? null,
         keyName: input.keyName,
+        apiKeySecretHash: input.apiKeySecretHash,
         codeChallenge: input.codeChallenge,
         codeChallengeMethod: input.codeChallengeMethod,
         expiresAt: input.expiresAt,
@@ -276,6 +284,7 @@ export class McpOauthRepository {
       resource: row.resource,
       scope: row.scope ?? null,
       keyName: row.keyName,
+      apiKeySecretHash: row.apiKeySecretHash ?? null,
       codeChallenge: row.codeChallenge,
       codeChallengeMethod: row.codeChallengeMethod,
       expiresAt: row.expiresAt,
@@ -375,6 +384,35 @@ export class McpOauthRepository {
       .where(
         and(
           eq(schema.mcpOauthTokens.keyName, keyName),
+          sql`${schema.mcpOauthTokens.revokedAt} IS NULL`
+        )
+      );
+    return getAffectedRowCount(result);
+  }
+
+  async setClientStatus(clientId: string, status: 'active' | 'disabled'): Promise<void> {
+    const schema = this.schema();
+    await this.db()
+      .update(schema.mcpOauthClients)
+      .set({ status, updatedAt: now() })
+      .where(eq(schema.mcpOauthClients.clientId, clientId));
+  }
+
+  async deleteClient(clientId: string): Promise<void> {
+    const schema = this.schema();
+    await this.db()
+      .delete(schema.mcpOauthClients)
+      .where(eq(schema.mcpOauthClients.clientId, clientId));
+  }
+
+  async revokeTokensForClient(clientId: string): Promise<number> {
+    const schema = this.schema();
+    const result = await this.db()
+      .update(schema.mcpOauthTokens)
+      .set({ revokedAt: now(), updatedAt: now() })
+      .where(
+        and(
+          eq(schema.mcpOauthTokens.clientId, clientId),
           sql`${schema.mcpOauthTokens.revokedAt} IS NULL`
         )
       );

--- a/packages/backend/src/db/mcp-oauth-repository.ts
+++ b/packages/backend/src/db/mcp-oauth-repository.ts
@@ -1,0 +1,416 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { getDatabase, getSchema } from './client';
+import { decryptField, encryptField, hashSecret } from '../utils/encryption';
+
+function now(): number {
+  return Date.now();
+}
+
+function parseJsonArray(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value))
+    return value.filter((entry): entry is string => typeof entry === 'string');
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function stringifyArray(value: string[] | undefined): string | null {
+  if (!value || value.length === 0) return null;
+  return JSON.stringify(value);
+}
+
+export interface McpOauthClientRecord {
+  clientId: string;
+  clientName: string | null;
+  redirectUris: string[];
+  grantTypes: string[];
+  responseTypes: string[];
+  scope: string | null;
+  tokenEndpointAuthMethod: string;
+  createdAt: number;
+}
+
+export interface NewMcpOauthClient {
+  clientId: string;
+  clientName?: string | null;
+  redirectUris: string[];
+  grantTypes?: string[];
+  responseTypes?: string[];
+  scope?: string | null;
+  tokenEndpointAuthMethod?: string;
+}
+
+export interface McpOauthAuthorizationCodeRecord {
+  codeHash: string;
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  resource: string;
+  scope: string | null;
+  keyName: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  expiresAt: number;
+  consumedAt: number | null;
+  createdAt: number;
+}
+
+export interface NewMcpOauthAuthorizationCode {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  resource: string;
+  scope?: string | null;
+  keyName: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  expiresAt: number;
+}
+
+export interface McpOauthTokenRecord {
+  id?: number;
+  accessTokenHash: string;
+  accessToken: string;
+  refreshTokenHash: string;
+  refreshToken: string;
+  clientId: string;
+  keyName: string;
+  apiKeySecretHash: string | null;
+  resource: string;
+  scope: string | null;
+  accessTokenExpiresAt: number;
+  refreshTokenExpiresAt: number;
+  revokedAt: number | null;
+  createdAt: number;
+}
+
+export interface McpOauthClientWithTokensRecord extends McpOauthClientRecord {
+  tokens: Array<Omit<McpOauthTokenRecord, 'accessToken' | 'refreshToken'>>;
+}
+
+export interface NewMcpOauthToken {
+  accessToken: string;
+  refreshToken: string;
+  clientId: string;
+  keyName: string;
+  apiKeySecretHash: string;
+  resource: string;
+  scope?: string | null;
+  accessTokenExpiresAt: number;
+  refreshTokenExpiresAt: number;
+}
+
+export class McpOauthRepository {
+  private db() {
+    return getDatabase();
+  }
+
+  private schema() {
+    return getSchema();
+  }
+
+  async createClient(input: NewMcpOauthClient): Promise<McpOauthClientRecord> {
+    const schema = this.schema();
+    const timestamp = now();
+    await this.db()
+      .insert(schema.mcpOauthClients)
+      .values({
+        clientId: input.clientId,
+        clientName: input.clientName ?? null,
+        redirectUris: JSON.stringify(input.redirectUris),
+        grantTypes: stringifyArray(input.grantTypes),
+        responseTypes: stringifyArray(input.responseTypes),
+        scope: input.scope ?? null,
+        tokenEndpointAuthMethod: input.tokenEndpointAuthMethod ?? 'none',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+
+    const client = await this.getClient(input.clientId);
+    if (!client) throw new Error('Failed to create OAuth client');
+    return client;
+  }
+
+  async getClient(clientId: string): Promise<McpOauthClientRecord | null> {
+    const schema = this.schema();
+    const rows = await this.db()
+      .select()
+      .from(schema.mcpOauthClients)
+      .where(eq(schema.mcpOauthClients.clientId, clientId))
+      .limit(1);
+
+    if (rows.length === 0) return null;
+    const row = rows[0]!;
+    return {
+      clientId: row.clientId,
+      clientName: row.clientName ?? null,
+      redirectUris: parseJsonArray(row.redirectUris),
+      grantTypes: parseJsonArray(row.grantTypes),
+      responseTypes: parseJsonArray(row.responseTypes),
+      scope: row.scope ?? null,
+      tokenEndpointAuthMethod: row.tokenEndpointAuthMethod,
+      createdAt: row.createdAt,
+    };
+  }
+
+  async findClientByRegistration(input: {
+    clientName?: string | null;
+    redirectUris: string[];
+  }): Promise<McpOauthClientRecord | null> {
+    const clients = await this.listClientsWithActiveTokens();
+    const requested = normalizeStringSet(input.redirectUris);
+    const clientName = input.clientName ?? null;
+
+    return (
+      clients.find(
+        (client) =>
+          client.clientName === clientName &&
+          arraysEqual(normalizeStringSet(client.redirectUris), requested)
+      ) ?? null
+    );
+  }
+
+  async listClientsWithActiveTokens(): Promise<McpOauthClientWithTokensRecord[]> {
+    const schema = this.schema();
+    const [clientRows, tokenRows] = await Promise.all([
+      this.db().select().from(schema.mcpOauthClients),
+      this.db()
+        .select()
+        .from(schema.mcpOauthTokens)
+        .where(
+          and(
+            sql`${schema.mcpOauthTokens.revokedAt} IS NULL`,
+            sql`${schema.mcpOauthTokens.refreshTokenExpiresAt} > ${now()}`
+          )
+        ),
+    ]);
+
+    const tokensByClient = new Map<
+      string,
+      Array<Omit<McpOauthTokenRecord, 'accessToken' | 'refreshToken'>>
+    >();
+    for (const row of tokenRows) {
+      const token = this.rowToToken(row);
+      const safeToken = {
+        id: token.id,
+        accessTokenHash: token.accessTokenHash,
+        refreshTokenHash: token.refreshTokenHash,
+        clientId: token.clientId,
+        keyName: token.keyName,
+        apiKeySecretHash: token.apiKeySecretHash,
+        resource: token.resource,
+        scope: token.scope,
+        accessTokenExpiresAt: token.accessTokenExpiresAt,
+        refreshTokenExpiresAt: token.refreshTokenExpiresAt,
+        revokedAt: token.revokedAt,
+        createdAt: token.createdAt,
+      };
+      const bucket = tokensByClient.get(token.clientId) ?? [];
+      bucket.push(safeToken);
+      tokensByClient.set(token.clientId, bucket);
+    }
+
+    return clientRows.map((row: any) => ({
+      clientId: row.clientId,
+      clientName: row.clientName ?? null,
+      redirectUris: parseJsonArray(row.redirectUris),
+      grantTypes: parseJsonArray(row.grantTypes),
+      responseTypes: parseJsonArray(row.responseTypes),
+      scope: row.scope ?? null,
+      tokenEndpointAuthMethod: row.tokenEndpointAuthMethod,
+      createdAt: row.createdAt,
+      tokens: tokensByClient.get(row.clientId) ?? [],
+    }));
+  }
+
+  async createAuthorizationCode(
+    input: NewMcpOauthAuthorizationCode
+  ): Promise<McpOauthAuthorizationCodeRecord> {
+    const schema = this.schema();
+    const timestamp = now();
+    const codeHash = hashSecret(input.code);
+    await this.db()
+      .insert(schema.mcpOauthAuthorizationCodes)
+      .values({
+        codeHash,
+        code: encryptField(input.code)!,
+        clientId: input.clientId,
+        redirectUri: input.redirectUri,
+        resource: input.resource,
+        scope: input.scope ?? null,
+        keyName: input.keyName,
+        codeChallenge: input.codeChallenge,
+        codeChallengeMethod: input.codeChallengeMethod,
+        expiresAt: input.expiresAt,
+        consumedAt: null,
+        createdAt: timestamp,
+      });
+
+    const code = await this.getAuthorizationCode(input.code);
+    if (!code) throw new Error('Failed to create OAuth authorization code');
+    return code;
+  }
+
+  async getAuthorizationCode(code: string): Promise<McpOauthAuthorizationCodeRecord | null> {
+    const schema = this.schema();
+    const rows = await this.db()
+      .select()
+      .from(schema.mcpOauthAuthorizationCodes)
+      .where(eq(schema.mcpOauthAuthorizationCodes.codeHash, hashSecret(code)))
+      .limit(1);
+
+    if (rows.length === 0) return null;
+    const row = rows[0]!;
+    return {
+      codeHash: row.codeHash,
+      code: decryptField(row.code) ?? '',
+      clientId: row.clientId,
+      redirectUri: row.redirectUri,
+      resource: row.resource,
+      scope: row.scope ?? null,
+      keyName: row.keyName,
+      codeChallenge: row.codeChallenge,
+      codeChallengeMethod: row.codeChallengeMethod,
+      expiresAt: row.expiresAt,
+      consumedAt: row.consumedAt ?? null,
+      createdAt: row.createdAt,
+    };
+  }
+
+  async consumeAuthorizationCode(code: string): Promise<void> {
+    const schema = this.schema();
+    await this.db()
+      .update(schema.mcpOauthAuthorizationCodes)
+      .set({ consumedAt: now() })
+      .where(eq(schema.mcpOauthAuthorizationCodes.codeHash, hashSecret(code)));
+  }
+
+  async createToken(input: NewMcpOauthToken): Promise<McpOauthTokenRecord> {
+    const schema = this.schema();
+    const timestamp = now();
+    const accessTokenHash = hashSecret(input.accessToken);
+    const refreshTokenHash = hashSecret(input.refreshToken);
+    await this.db()
+      .insert(schema.mcpOauthTokens)
+      .values({
+        accessTokenHash,
+        accessToken: encryptField(input.accessToken)!,
+        refreshTokenHash,
+        refreshToken: encryptField(input.refreshToken)!,
+        clientId: input.clientId,
+        keyName: input.keyName,
+        apiKeySecretHash: input.apiKeySecretHash,
+        resource: input.resource,
+        scope: input.scope ?? null,
+        accessTokenExpiresAt: input.accessTokenExpiresAt,
+        refreshTokenExpiresAt: input.refreshTokenExpiresAt,
+        revokedAt: null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+
+    const token = await this.getAccessToken(input.accessToken);
+    if (!token) throw new Error('Failed to create OAuth token');
+    return token;
+  }
+
+  async getAccessToken(accessToken: string): Promise<McpOauthTokenRecord | null> {
+    const schema = this.schema();
+    const rows = await this.db()
+      .select()
+      .from(schema.mcpOauthTokens)
+      .where(eq(schema.mcpOauthTokens.accessTokenHash, hashSecret(accessToken)))
+      .limit(1);
+
+    return rows.length > 0 ? this.rowToToken(rows[0]!) : null;
+  }
+
+  async getRefreshToken(refreshToken: string): Promise<McpOauthTokenRecord | null> {
+    const schema = this.schema();
+    const rows = await this.db()
+      .select()
+      .from(schema.mcpOauthTokens)
+      .where(eq(schema.mcpOauthTokens.refreshTokenHash, hashSecret(refreshToken)))
+      .limit(1);
+
+    return rows.length > 0 ? this.rowToToken(rows[0]!) : null;
+  }
+
+  async revokeRefreshToken(refreshToken: string): Promise<void> {
+    const schema = this.schema();
+    await this.db()
+      .update(schema.mcpOauthTokens)
+      .set({ revokedAt: now(), updatedAt: now() })
+      .where(
+        and(
+          eq(schema.mcpOauthTokens.refreshTokenHash, hashSecret(refreshToken)),
+          sql`${schema.mcpOauthTokens.revokedAt} IS NULL`
+        )
+      );
+  }
+
+  async revokeTokenById(id: number): Promise<number> {
+    const schema = this.schema();
+    const result = await this.db()
+      .update(schema.mcpOauthTokens)
+      .set({ revokedAt: now(), updatedAt: now() })
+      .where(
+        and(eq(schema.mcpOauthTokens.id, id), sql`${schema.mcpOauthTokens.revokedAt} IS NULL`)
+      );
+    return getAffectedRowCount(result);
+  }
+
+  async revokeTokensForKeyName(keyName: string): Promise<number> {
+    const schema = this.schema();
+    const result = await this.db()
+      .update(schema.mcpOauthTokens)
+      .set({ revokedAt: now(), updatedAt: now() })
+      .where(
+        and(
+          eq(schema.mcpOauthTokens.keyName, keyName),
+          sql`${schema.mcpOauthTokens.revokedAt} IS NULL`
+        )
+      );
+    return getAffectedRowCount(result);
+  }
+
+  private rowToToken(row: any): McpOauthTokenRecord {
+    return {
+      id: row.id,
+      accessTokenHash: row.accessTokenHash,
+      accessToken: decryptField(row.accessToken) ?? '',
+      refreshTokenHash: row.refreshTokenHash,
+      refreshToken: decryptField(row.refreshToken) ?? '',
+      clientId: row.clientId,
+      keyName: row.keyName,
+      apiKeySecretHash: row.apiKeySecretHash ?? null,
+      resource: row.resource,
+      scope: row.scope ?? null,
+      accessTokenExpiresAt: row.accessTokenExpiresAt,
+      refreshTokenExpiresAt: row.refreshTokenExpiresAt,
+      revokedAt: row.revokedAt ?? null,
+      createdAt: row.createdAt,
+    };
+  }
+}
+
+function normalizeStringSet(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function getAffectedRowCount(result: unknown): number {
+  return Number(
+    (result as any)?.rowsAffected ?? (result as any)?.changes ?? (result as any)?.rowCount ?? 0
+  );
+}

--- a/packages/backend/src/routes/management.ts
+++ b/packages/backend/src/routes/management.ts
@@ -13,6 +13,7 @@ import { registerQuotaEnforcementRoutes } from './management/quota-enforcement';
 import { registerUserQuotaRoutes } from './management/user-quotas';
 import { registerOAuthRoutes } from './management/oauth';
 import { registerMcpLogRoutes } from './management/mcp-logs';
+import { registerMcpOAuthManagementRoutes } from './management/mcp-oauth';
 import { registerLoggingRoutes } from './management/logging';
 import { registerRestartRoutes } from './management/restart';
 import { registerProviderRoutes } from './management/providers';
@@ -111,6 +112,7 @@ export async function registerManagementRoutes(
       if (mcpUsageStorage) {
         await registerMcpLogRoutes(adminOnly, mcpUsageStorage);
       }
+      await registerMcpOAuthManagementRoutes(adminOnly);
       if (quotaEnforcer) {
         await registerQuotaEnforcementRoutes(adminOnly, quotaEnforcer);
       }

--- a/packages/backend/src/routes/management/mcp-oauth.ts
+++ b/packages/backend/src/routes/management/mcp-oauth.ts
@@ -1,0 +1,37 @@
+import { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { McpOauthRepository } from '../../db/mcp-oauth-repository';
+
+const revokeTokenParamsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+export async function registerMcpOAuthManagementRoutes(fastify: FastifyInstance) {
+  const repo = new McpOauthRepository();
+
+  fastify.get('/v0/management/mcp-oauth/clients', async (_request, reply) => {
+    try {
+      const clients = await repo.listClientsWithActiveTokens();
+      return reply.send({ clients });
+    } catch (e: any) {
+      return reply.code(500).send({ error: e.message || 'Internal server error' });
+    }
+  });
+
+  fastify.post('/v0/management/mcp-oauth/tokens/:id/revoke', async (request, reply) => {
+    const parsed = revokeTokenParamsSchema.safeParse(request.params);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid token id', details: parsed.error.issues });
+    }
+
+    try {
+      const revokedCount = await repo.revokeTokenById(parsed.data.id);
+      if (revokedCount === 0) {
+        return reply.code(404).send({ error: 'Active OAuth token not found' });
+      }
+      return reply.send({ success: true, revokedCount });
+    } catch (e: any) {
+      return reply.code(500).send({ error: e.message || 'Internal server error' });
+    }
+  });
+}

--- a/packages/backend/src/routes/management/mcp-oauth.ts
+++ b/packages/backend/src/routes/management/mcp-oauth.ts
@@ -6,6 +6,14 @@ const revokeTokenParamsSchema = z.object({
   id: z.coerce.number().int().positive(),
 });
 
+const clientParamsSchema = z.object({
+  clientId: z.string().min(1),
+});
+
+const updateClientStatusSchema = z.object({
+  status: z.enum(['active', 'disabled']),
+});
+
 export async function registerMcpOAuthManagementRoutes(fastify: FastifyInstance) {
   const repo = new McpOauthRepository();
 
@@ -13,6 +21,70 @@ export async function registerMcpOAuthManagementRoutes(fastify: FastifyInstance)
     try {
       const clients = await repo.listClientsWithActiveTokens();
       return reply.send({ clients });
+    } catch (e: any) {
+      return reply.code(500).send({ error: e.message || 'Internal server error' });
+    }
+  });
+
+  fastify.patch('/v0/management/mcp-oauth/clients/:clientId', async (request, reply) => {
+    const parsedParams = clientParamsSchema.safeParse(request.params);
+    if (!parsedParams.success) {
+      return reply.code(400).send({ error: 'Invalid client id' });
+    }
+    const parsedBody = updateClientStatusSchema.safeParse(request.body ?? {});
+    if (!parsedBody.success) {
+      return reply.code(400).send({ error: 'Invalid status', details: parsedBody.error.issues });
+    }
+
+    const { clientId } = parsedParams.data;
+    const { status } = parsedBody.data;
+
+    try {
+      const client = await repo.getClient(clientId);
+      if (!client) {
+        return reply.code(404).send({ error: 'OAuth client not found' });
+      }
+      await repo.setClientStatus(clientId, status);
+      return reply.send({ success: true, clientId, status });
+    } catch (e: any) {
+      return reply.code(500).send({ error: e.message || 'Internal server error' });
+    }
+  });
+
+  fastify.delete('/v0/management/mcp-oauth/clients/:clientId', async (request, reply) => {
+    const parsed = clientParamsSchema.safeParse(request.params);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid client id' });
+    }
+
+    const { clientId } = parsed.data;
+    try {
+      const client = await repo.getClient(clientId);
+      if (!client) {
+        return reply.code(404).send({ error: 'OAuth client not found' });
+      }
+      const revokedCount = await repo.revokeTokensForClient(clientId);
+      await repo.deleteClient(clientId);
+      return reply.send({ success: true, clientId, revokedCount });
+    } catch (e: any) {
+      return reply.code(500).send({ error: e.message || 'Internal server error' });
+    }
+  });
+
+  fastify.post('/v0/management/mcp-oauth/clients/:clientId/revoke', async (request, reply) => {
+    const parsed = clientParamsSchema.safeParse(request.params);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'Invalid client id' });
+    }
+
+    const { clientId } = parsed.data;
+    try {
+      const client = await repo.getClient(clientId);
+      if (!client) {
+        return reply.code(404).send({ error: 'OAuth client not found' });
+      }
+      const revokedCount = await repo.revokeTokensForClient(clientId);
+      return reply.send({ success: true, clientId, revokedCount });
     } catch (e: any) {
       return reply.code(500).send({ error: e.message || 'Internal server error' });
     }

--- a/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
@@ -1,10 +1,46 @@
-import { describe, expect, test, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, expect, test, vi, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
 import { registerSpy } from '../../../../test/test-utils';
 import Fastify, { FastifyInstance } from 'fastify';
 import { setConfigForTesting } from '../../../config';
 import { registerMcpRoutes } from '../index';
 import { McpUsageStorageService } from '../../../services/mcp-proxy/mcp-usage-storage';
 import * as mcpProxyService from '../../../services/mcp-proxy/mcp-proxy-service';
+import * as mcpAuthProviderFactory from '../../../services/mcp-oauth/provider-factory';
+
+const baseConfig = (overrides: Record<string, unknown> = {}) => ({
+  providers: {},
+  models: {},
+  keys: {
+    'test-key-1': { secret: 'sk-valid-key', comment: 'Test Key' },
+  },
+  failover: {
+    enabled: false,
+    retryableStatusCodes: [429, 500, 502, 503, 504],
+    retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT'],
+  },
+  quotas: [],
+  mcpServers: {
+    'test-server': {
+      upstream_url: 'http://localhost:3000/mcp',
+      enabled: true,
+      headers: {
+        'x-upstream-header': 'value',
+      },
+    },
+    'server-with-auth': {
+      upstream_url: 'http://localhost:3001/mcp?auth=token123',
+      enabled: true,
+      headers: {
+        Authorization: 'Bearer upstream-secret',
+      },
+    },
+    'disabled-server': {
+      upstream_url: 'http://localhost:3002/mcp',
+      enabled: false,
+    },
+  },
+  ...overrides,
+});
 
 describe('MCP Routes', () => {
   let fastify: FastifyInstance;
@@ -28,39 +64,7 @@ describe('MCP Routes', () => {
     }));
 
     // Set config with keys and MCP servers
-    setConfigForTesting({
-      providers: {},
-      models: {},
-      keys: {
-        'test-key-1': { secret: 'sk-valid-key', comment: 'Test Key' },
-      },
-      failover: {
-        enabled: false,
-        retryableStatusCodes: [429, 500, 502, 503, 504],
-        retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT'],
-      },
-      quotas: [],
-      mcpServers: {
-        'test-server': {
-          upstream_url: 'http://localhost:3000/mcp',
-          enabled: true,
-          headers: {
-            'x-upstream-header': 'value',
-          },
-        },
-        'server-with-auth': {
-          upstream_url: 'http://localhost:3001/mcp?auth=token123',
-          enabled: true,
-          headers: {
-            Authorization: 'Bearer upstream-secret',
-          },
-        },
-        'disabled-server': {
-          upstream_url: 'http://localhost:3002/mcp',
-          enabled: false,
-        },
-      },
-    });
+    setConfigForTesting(baseConfig());
 
     await registerMcpRoutes(fastify, mockMcpUsageStorage);
     await fastify.ready();
@@ -75,54 +79,40 @@ describe('MCP Routes', () => {
   });
 
   describe('OAuth Discovery Endpoints', () => {
-    test('GET /.well-known/oauth-authorization-server should return OAuth metadata', async () => {
+    test('GET /.well-known/oauth-authorization-server should be 404 when MCP OAuth is off', async () => {
       const response = await fastify.inject({
         method: 'GET',
         url: '/.well-known/oauth-authorization-server',
       });
 
-      expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.body);
-      expect(body.issuer).toBe('/');
-      expect(body.authorization_endpoint).toBe('/oauth/authorize');
-      expect(body.token_endpoint).toBe('/oauth/token');
-      expect(body.grant_types_supported).toContain('bearer');
+      expect(response.statusCode).toBe(404);
     });
 
-    test('GET /.well-known/oauth-protected-resource should return protected resource metadata', async () => {
+    test('GET /.well-known/oauth-protected-resource should be 404 when MCP OAuth is off', async () => {
       const response = await fastify.inject({
         method: 'GET',
         url: '/.well-known/oauth-protected-resource',
       });
 
-      expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.body);
-      expect(body.resource).toBe('/');
-      expect(body.scopes_supported).toContain('read');
+      expect(response.statusCode).toBe(404);
     });
 
-    test('GET /.well-known/openid-configuration should return OIDC config', async () => {
+    test('GET /.well-known/openid-configuration should be 404 when MCP OAuth is off', async () => {
       const response = await fastify.inject({
         method: 'GET',
         url: '/.well-known/openid-configuration',
       });
 
-      expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.body);
-      expect(body.issuer).toBe('/');
-      expect(body.jwks_uri).toBe('/.well-known/jwks.json');
+      expect(response.statusCode).toBe(404);
     });
 
-    test('POST /register should return static client registration', async () => {
+    test('POST /register should be 404 when MCP OAuth is off', async () => {
       const response = await fastify.inject({
         method: 'POST',
         url: '/register',
       });
 
-      expect(response.statusCode).toBe(201);
-      const body = JSON.parse(response.body);
-      expect(body.client_id).toBe('plexus-mcp-static');
-      expect(body.grant_types).toContain('bearer');
+      expect(response.statusCode).toBe(404);
     });
   });
 
@@ -418,6 +408,138 @@ describe('MCP Routes', () => {
       expect(mockMcpUsageStorage.saveRequest).toHaveBeenCalled();
       const callArgs = (mockMcpUsageStorage.saveRequest as any).mock.calls[0][0];
       expect(callArgs.method).toBe('DELETE');
+    });
+  });
+
+  describe('MCP OAuth fallback when enabled', () => {
+    let oauthFastify: FastifyInstance;
+    let validateToken: any;
+
+    beforeEach(async () => {
+      oauthFastify = Fastify();
+      validateToken = vi.fn(async (token: string) =>
+        token === 'pox_valid_oauth_token' ? { keyName: 'test-key-1', scopes: ['mcp:read'] } : null
+      );
+
+      setConfigForTesting(
+        baseConfig({
+          mcpOAuth: {
+            enabled: true,
+            provider: 'plexus-idp',
+          },
+        })
+      );
+
+      registerSpy(mcpAuthProviderFactory, 'isMcpOAuthEnabled').mockReturnValue(true);
+      registerSpy(mcpAuthProviderFactory, 'getMcpAuthProvider').mockReturnValue({
+        getDiscoveryMetadata: vi.fn((request) => ({
+          issuer: 'http://localhost',
+          authorization_endpoint: 'http://localhost/oauth/authorize',
+          token_endpoint: 'http://localhost/oauth/token',
+          registration_endpoint: 'http://localhost/register',
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          token_endpoint_auth_methods_supported: ['none'],
+          code_challenge_methods_supported: ['S256'],
+          scopes_supported: ['mcp:read', 'mcp:write'],
+          resource_supported: true,
+        })),
+        getProtectedResourceMetadata: vi.fn(() => ({
+          resource: 'http://localhost/mcp',
+          authorization_servers: ['http://localhost'],
+          scopes_supported: ['mcp:read', 'mcp:write'],
+          bearer_methods_supported: ['header'],
+        })),
+        handleAuthorize: vi.fn(async (_request, reply) => reply.send({ ok: true })),
+        handleToken: vi.fn(async (_request, reply) => reply.send({ access_token: 'pox-token' })),
+        handleRegister: vi.fn(async (_request, reply) =>
+          reply.code(201).send({ client_id: 'mcp-test' })
+        ),
+        validateToken,
+      });
+
+      await registerMcpRoutes(oauthFastify, mockMcpUsageStorage);
+      await oauthFastify.ready();
+    });
+
+    afterEach(async () => {
+      await oauthFastify.close();
+    });
+
+    test('registers OAuth discovery and DCR routes when enabled', async () => {
+      const discovery = await oauthFastify.inject({
+        method: 'GET',
+        url: '/.well-known/oauth-authorization-server',
+      });
+      expect(discovery.statusCode).toBe(200);
+      expect(JSON.parse(discovery.body).code_challenge_methods_supported).toEqual(['S256']);
+
+      const registration = await oauthFastify.inject({
+        method: 'POST',
+        url: '/register',
+        payload: {},
+      });
+      expect(registration.statusCode).toBe(201);
+      expect(JSON.parse(registration.body).client_id).toBe('mcp-test');
+    });
+
+    test('missing auth returns an OAuth discovery challenge', async () => {
+      const response = await oauthFastify.inject({
+        method: 'POST',
+        url: '/mcp/test-server',
+        headers: { 'content-type': 'application/json' },
+        payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.headers['www-authenticate']).toContain(
+        '/.well-known/oauth-protected-resource"'
+      );
+    });
+
+    test('valid raw API key still bypasses OAuth token validation', async () => {
+      const response = await oauthFastify.inject({
+        method: 'POST',
+        url: '/mcp/test-server',
+        headers: {
+          authorization: 'Bearer sk-valid-key',
+          'content-type': 'application/json',
+        },
+        payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(validateToken).not.toHaveBeenCalled();
+    });
+
+    test('OAuth access token is accepted after raw API key lookup fails', async () => {
+      const response = await oauthFastify.inject({
+        method: 'POST',
+        url: '/mcp/test-server',
+        headers: {
+          authorization: 'Bearer pox_valid_oauth_token',
+          'content-type': 'application/json',
+        },
+        payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(validateToken).toHaveBeenCalledWith('pox_valid_oauth_token');
+    });
+
+    test('invalid OAuth token returns invalid_token challenge', async () => {
+      const response = await oauthFastify.inject({
+        method: 'POST',
+        url: '/mcp/test-server',
+        headers: {
+          authorization: 'Bearer pox_invalid_oauth_token',
+          'content-type': 'application/json',
+        },
+        payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.headers['www-authenticate']).toBe('Bearer error="invalid_token"');
     });
   });
 });

--- a/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
@@ -86,6 +86,7 @@ describe('MCP Routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
+      expect(JSON.parse(response.body).error.type).toBe('oauth_disabled');
     });
 
     test('GET /.well-known/oauth-protected-resource should be 404 when MCP OAuth is off', async () => {
@@ -95,6 +96,7 @@ describe('MCP Routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
+      expect(JSON.parse(response.body).error.type).toBe('oauth_disabled');
     });
 
     test('GET /.well-known/openid-configuration should be 404 when MCP OAuth is off', async () => {
@@ -104,6 +106,7 @@ describe('MCP Routes', () => {
       });
 
       expect(response.statusCode).toBe(404);
+      expect(JSON.parse(response.body).error.type).toBe('oauth_disabled');
     });
 
     test('POST /register should be 404 when MCP OAuth is off', async () => {
@@ -481,6 +484,65 @@ describe('MCP Routes', () => {
       });
       expect(registration.statusCode).toBe(201);
       expect(JSON.parse(registration.body).client_id).toBe('mcp-test');
+    });
+
+    test('protected-resource discovery returns metadata when enabled', async () => {
+      const response = await oauthFastify.inject({
+        method: 'GET',
+        url: '/.well-known/oauth-protected-resource',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.resource).toBe('http://localhost/mcp');
+      expect(body.authorization_servers).toEqual(['http://localhost']);
+      expect(body.scopes_supported).toEqual(['mcp:read', 'mcp:write']);
+      expect(body.bearer_methods_supported).toEqual(['header']);
+    });
+
+    test('openid-configuration discovery returns metadata when enabled', async () => {
+      const response = await oauthFastify.inject({
+        method: 'GET',
+        url: '/.well-known/openid-configuration',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.issuer).toBe('http://localhost');
+      expect(body.authorization_endpoint).toBe('http://localhost/oauth/authorize');
+      expect(body.token_endpoint).toBe('http://localhost/oauth/token');
+      expect(body.code_challenge_methods_supported).toEqual(['S256']);
+    });
+
+    test('POST tools/call is rejected with insufficient_scope when OAuth token lacks mcp:write', async () => {
+      const response = await oauthFastify.inject({
+        method: 'POST',
+        url: '/mcp/test-server',
+        headers: {
+          authorization: 'Bearer pox_valid_oauth_token',
+          'content-type': 'application/json',
+        },
+        payload: { jsonrpc: '2.0', method: 'tools/call', id: 1, params: { name: 'foo' } },
+      });
+
+      expect(response.statusCode).toBe(403);
+      const body = JSON.parse(response.body);
+      expect(body.error.type).toBe('insufficient_scope');
+      expect(body.error.code).toBe(403);
+      expect(response.headers['www-authenticate']).toContain(
+        'error="insufficient_scope", scope="mcp:write"'
+      );
+    });
+
+    test('GET /mcp/:name succeeds when OAuth token has mcp:read scope', async () => {
+      const response = await oauthFastify.inject({
+        method: 'GET',
+        url: '/mcp/test-server',
+        headers: { authorization: 'Bearer pox_valid_oauth_token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(validateToken).toHaveBeenCalledWith('pox_valid_oauth_token');
     });
 
     test('missing auth returns an OAuth discovery challenge', async () => {

--- a/packages/backend/src/routes/mcp/index.ts
+++ b/packages/backend/src/routes/mcp/index.ts
@@ -1,13 +1,103 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import bearerAuth from '@fastify/bearer-auth';
-import { createAuthHook } from '../../utils/auth';
+import formbody from '@fastify/formbody';
+import { getConfig } from '../../config';
+import {
+  attachPlexusApiKeyAuth,
+  createAuthHook,
+  isRequestIpAllowed,
+  validatePlexusApiKey,
+} from '../../utils/auth';
 import { logger } from '../../utils/logger';
 import * as mcpProxyService from '../../services/mcp-proxy/mcp-proxy-service';
 import { getClientIp } from '../../utils/ip';
 import { McpUsageStorageService } from '../../services/mcp-proxy/mcp-usage-storage';
 import { registerPlexusMcpRoutes } from './plexus';
+import { getMcpAuthProvider, isMcpOAuthEnabled } from '../../services/mcp-oauth/provider-factory';
+import { getMcpResourceUrl, getRequestBaseUrl } from '../../services/mcp-oauth/url';
+import { MCP_OAUTH_ACCESS_TOKEN_PREFIX } from '../../services/mcp-oauth/plexus-idp-provider';
 
 const DEFAULT_TIMEOUT_MS = 120000;
+
+function authErrorResponse(message: string) {
+  return { error: { message, type: 'auth_error', code: 401 } };
+}
+
+function getStringHeader(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function extractBearerCredential(authorization: string): string {
+  return authorization.toLowerCase().startsWith('bearer ')
+    ? authorization.slice('bearer '.length)
+    : authorization;
+}
+
+function setInitialOAuthChallenge(request: FastifyRequest, reply: FastifyReply) {
+  const metadataUrl = `${getRequestBaseUrl(request)}/.well-known/oauth-protected-resource`;
+  reply.header('WWW-Authenticate', `Bearer resource_metadata="${metadataUrl}"`);
+}
+
+function setInvalidTokenChallenge(reply: FastifyReply) {
+  reply.header('WWW-Authenticate', 'Bearer error="invalid_token"');
+}
+
+async function mcpOAuthFallbackAuth(request: FastifyRequest, reply: FastifyReply) {
+  const authorization = getStringHeader(request.headers.authorization);
+  const xApiKey = getStringHeader(request.headers['x-api-key']);
+  const xGoogApiKey = getStringHeader(request.headers['x-goog-api-key']);
+  const queryKey =
+    request.query && typeof request.query === 'object'
+      ? typeof (request.query as any).key === 'string'
+        ? (request.query as any).key
+        : null
+      : null;
+
+  const tryRawApiKey = (secret: string): boolean => {
+    const result = validatePlexusApiKey(secret, request);
+    if (!result) return false;
+    attachPlexusApiKeyAuth(request, result);
+    return true;
+  };
+
+  if (authorization) {
+    const credential = extractBearerCredential(authorization);
+    if (tryRawApiKey(credential)) return;
+
+    const provider = getMcpAuthProvider();
+    const oauthResult = credential.startsWith(MCP_OAUTH_ACCESS_TOKEN_PREFIX)
+      ? await provider?.validateToken(credential)
+      : null;
+    if (oauthResult) {
+      const config = getConfig();
+      const keyConfig = config.keys?.[oauthResult.keyName];
+      if (keyConfig && isRequestIpAllowed(request, keyConfig.allowedIps, config.trustedProxies)) {
+        attachPlexusApiKeyAuth(request, {
+          keyName: oauthResult.keyName,
+          keyConfig,
+          attribution: null,
+        });
+        return;
+      }
+    }
+
+    setInvalidTokenChallenge(reply);
+    await reply.code(401).send(authErrorResponse('Invalid bearer token'));
+    return reply;
+  }
+
+  const apiKeyStyleCredential = xApiKey ?? xGoogApiKey ?? queryKey;
+  if (apiKeyStyleCredential) {
+    if (tryRawApiKey(apiKeyStyleCredential)) return;
+    await reply.code(401).send(authErrorResponse('Invalid API key'));
+    return reply;
+  }
+
+  setInitialOAuthChallenge(request, reply);
+  await reply.code(401).send(authErrorResponse('Authentication required'));
+  return reply;
+}
 
 // streamUpstreamResponse proxies an upstream MCP event-stream to the client,
 // writing the head via reply.raw so it is flushed immediately. Fastify's
@@ -67,61 +157,48 @@ export async function registerMcpRoutes(
   fastify: FastifyInstance,
   mcpUsageStorage: McpUsageStorageService
 ) {
-  // OAuth 2.0 Discovery endpoints (public, no auth required)
-  // These inform clients that we use Bearer token auth, not OAuth flow
-  fastify.get('/.well-known/oauth-authorization-server', async (_request, reply) => {
-    logger.silly('OAuth authorization server discovery');
-    return reply.send({
-      issuer: '/',
-      authorization_endpoint: '/oauth/authorize',
-      token_endpoint: '/oauth/token',
-      grant_types_supported: ['client_credentials', 'bearer'],
-      token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
-      resource_supported: true,
-    });
-  });
+  const oauthEnabled = isMcpOAuthEnabled();
+  const authProvider = getMcpAuthProvider();
 
-  fastify.get('/.well-known/oauth-protected-resource', async (_request, reply) => {
-    logger.silly('OAuth protected resource discovery');
-    return reply.send({
-      resource: '/',
-      authorization_servers: ['/'],
-      scopes_supported: ['read', 'write'],
-      bearer_methods_supported: ['header', 'body', 'query'],
-    });
-  });
+  if (oauthEnabled && authProvider) {
+    await fastify.register(formbody);
 
-  fastify.get('/.well-known/openid-configuration', async (_request, reply) => {
-    logger.silly('OpenID configuration discovery');
-    return reply.send({
-      issuer: '/',
-      authorization_endpoint: '/oauth/authorize',
-      token_endpoint: '/oauth/token',
-      jwks_uri: '/.well-known/jwks.json',
-      response_types_supported: ['code'],
-      id_token_signing_alg_values_supported: ['RS256'],
+    fastify.get('/.well-known/oauth-authorization-server', async (request, reply) => {
+      logger.silly('OAuth authorization server discovery');
+      return reply.send(authProvider.getDiscoveryMetadata(request));
     });
-  });
 
-  fastify.post('/register', async (_request, reply) => {
-    logger.silly('Dynamic client registration');
-    return reply.code(201).send({
-      client_id: 'plexus-mcp-static',
-      client_id_issued_at: Math.floor(Date.now() / 1000),
-      client_secret: 'not-supported-use-api-key',
-      grant_types: ['client_credentials', 'bearer'],
-      token_endpoint_auth_method: 'none',
+    fastify.get('/.well-known/oauth-protected-resource', async (request, reply) => {
+      logger.silly('OAuth protected resource discovery');
+      return reply.send(authProvider.getProtectedResourceMetadata(request));
     });
-  });
+
+    fastify.get('/oauth/authorize', async (request, reply) =>
+      authProvider.handleAuthorize(request, reply)
+    );
+    fastify.post('/oauth/authorize', async (request, reply) =>
+      authProvider.handleAuthorize(request, reply)
+    );
+    fastify.post('/oauth/token', async (request, reply) =>
+      authProvider.handleToken(request, reply)
+    );
+    fastify.post('/register', async (request, reply) =>
+      authProvider.handleRegister(request, reply)
+    );
+  }
 
   await registerPlexusMcpRoutes(fastify, mcpUsageStorage);
 
   fastify.register(async (protectedRoutes) => {
-    const auth = createAuthHook();
+    if (oauthEnabled) {
+      protectedRoutes.addHook('onRequest', mcpOAuthFallbackAuth);
+    } else {
+      const auth = createAuthHook();
 
-    protectedRoutes.addHook('onRequest', auth.onRequest);
+      protectedRoutes.addHook('onRequest', auth.onRequest);
 
-    await protectedRoutes.register(bearerAuth, auth.bearerAuthOptions);
+      await protectedRoutes.register(bearerAuth, auth.bearerAuthOptions);
+    }
 
     protectedRoutes.addHook('preHandler', async (request, reply) => {
       const serverName = (request.params as any)?.name;

--- a/packages/backend/src/routes/mcp/index.ts
+++ b/packages/backend/src/routes/mcp/index.ts
@@ -1,26 +1,48 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import bearerAuth from '@fastify/bearer-auth';
 import formbody from '@fastify/formbody';
 import { getConfig } from '../../config';
-import {
-  attachPlexusApiKeyAuth,
-  createAuthHook,
-  isRequestIpAllowed,
-  validatePlexusApiKey,
-} from '../../utils/auth';
+import { attachPlexusApiKeyAuth, isRequestIpAllowed, validatePlexusApiKey } from '../../utils/auth';
 import { logger } from '../../utils/logger';
 import * as mcpProxyService from '../../services/mcp-proxy/mcp-proxy-service';
 import { getClientIp } from '../../utils/ip';
 import { McpUsageStorageService } from '../../services/mcp-proxy/mcp-usage-storage';
 import { registerPlexusMcpRoutes } from './plexus';
-import { getMcpAuthProvider, isMcpOAuthEnabled } from '../../services/mcp-oauth/provider-factory';
-import { getMcpResourceUrl, getRequestBaseUrl } from '../../services/mcp-oauth/url';
+import { getMcpAuthProvider } from '../../services/mcp-oauth/provider-factory';
+import { getRequestBaseUrl } from '../../services/mcp-oauth/url';
 import { MCP_OAUTH_ACCESS_TOKEN_PREFIX } from '../../services/mcp-oauth/plexus-idp-provider';
 
 const DEFAULT_TIMEOUT_MS = 120000;
 
+// C3: JSON-RPC methods that mutate external state (and therefore require the
+// `mcp:write` scope). Everything else is treated as read-scoped.
+const MCP_WRITE_METHODS = new Set(['tools/call']);
+
+// Required scope for an MCP proxy operation. The mutating surface is the
+// JSON-RPC `tools/call` request issued over POST; listing, streaming
+// (GET), session lifecycle (DELETE), and all other JSON-RPC methods are
+// read-scoped. Returns `mcp:write` for write operations, `mcp:read` otherwise.
+function requiredScopeForOperation(request: FastifyRequest): 'mcp:read' | 'mcp:write' {
+  if (request.method === 'POST') {
+    const method = mcpProxyService.extractJsonRpcMethod(request.body);
+    if (method && MCP_WRITE_METHODS.has(method)) {
+      return 'mcp:write';
+    }
+  }
+  return 'mcp:read';
+}
+
 function authErrorResponse(message: string) {
   return { error: { message, type: 'auth_error', code: 401 } };
+}
+
+function oauthUnavailableReply(reply: FastifyReply) {
+  return reply.code(404).send({
+    error: {
+      message: 'MCP OAuth is disabled',
+      type: 'oauth_disabled',
+      code: 404,
+    },
+  });
 }
 
 function getStringHeader(value: string | string[] | undefined): string | null {
@@ -78,6 +100,10 @@ async function mcpOAuthFallbackAuth(request: FastifyRequest, reply: FastifyReply
           keyConfig,
           attribution: null,
         });
+        // C3: retain the OAuth token's granted scopes so the protected-resource
+        // preHandler hook can enforce them against the operation's required
+        // scope (read vs write).
+        (request as any).mcpOAuthScopes = oauthResult.scopes;
         return;
       }
     }
@@ -157,56 +183,103 @@ export async function registerMcpRoutes(
   fastify: FastifyInstance,
   mcpUsageStorage: McpUsageStorageService
 ) {
-  const oauthEnabled = isMcpOAuthEnabled();
-  const authProvider = getMcpAuthProvider();
+  // C1/C7: Discovery, DCR, and OAuth endpoints are always registered (matching
+  // what openapi.json advertises) so a config change toggling MCP OAuth takes
+  // effect without a process restart. Each handler resolves the auth provider
+  // via getMcpAuthProvider() at request time; when MCP OAuth is disabled the
+  // provider is null and the endpoint reports that the feature is off.
+  await fastify.register(formbody);
 
-  if (oauthEnabled && authProvider) {
-    await fastify.register(formbody);
+  fastify.get('/.well-known/oauth-authorization-server', async (request, reply) => {
+    const provider = getMcpAuthProvider();
+    if (!provider) return oauthUnavailableReply(reply);
+    logger.silly('OAuth authorization server discovery');
+    return reply.send(provider.getDiscoveryMetadata(request));
+  });
 
-    fastify.get('/.well-known/oauth-authorization-server', async (request, reply) => {
-      logger.silly('OAuth authorization server discovery');
-      return reply.send(authProvider.getDiscoveryMetadata(request));
-    });
+  fastify.get('/.well-known/oauth-protected-resource', async (request, reply) => {
+    const provider = getMcpAuthProvider();
+    if (!provider) return oauthUnavailableReply(reply);
+    logger.silly('OAuth protected resource discovery');
+    return reply.send(provider.getProtectedResourceMetadata(request));
+  });
 
-    fastify.get('/.well-known/oauth-protected-resource', async (request, reply) => {
-      logger.silly('OAuth protected resource discovery');
-      return reply.send(authProvider.getProtectedResourceMetadata(request));
-    });
+  // C7: keep the legacy OpenID Connect discovery endpoint available and
+  // consistent with the OAuth 2.0 authorization server metadata. Plexus does
+  // not implement full OIDC (no JWT/ID tokens), but MCP clients historically
+  // probe this path, so it mirrors RFC 8414 discovery instead of returning 404.
+  fastify.get('/.well-known/openid-configuration', async (request, reply) => {
+    const provider = getMcpAuthProvider();
+    if (!provider) return oauthUnavailableReply(reply);
+    logger.silly('OpenID Connect discovery (legacy alias)');
+    return reply.send(provider.getDiscoveryMetadata(request));
+  });
 
-    fastify.get('/oauth/authorize', async (request, reply) =>
-      authProvider.handleAuthorize(request, reply)
-    );
-    fastify.post('/oauth/authorize', async (request, reply) =>
-      authProvider.handleAuthorize(request, reply)
-    );
-    fastify.post('/oauth/token', async (request, reply) =>
-      authProvider.handleToken(request, reply)
-    );
-    fastify.post('/register', async (request, reply) =>
-      authProvider.handleRegister(request, reply)
-    );
-  }
+  fastify.get('/oauth/authorize', async (request, reply) => {
+    const provider = getMcpAuthProvider();
+    if (!provider) return oauthUnavailableReply(reply);
+    return provider.handleAuthorize(request, reply);
+  });
+  fastify.post('/oauth/authorize', async (request, reply) => {
+    const provider = getMcpAuthProvider();
+    if (!provider) return oauthUnavailableReply(reply);
+    return provider.handleAuthorize(request, reply);
+  });
+  fastify.post('/oauth/token', async (request, reply) => {
+    const provider = getMcpAuthProvider();
+    if (!provider) return oauthUnavailableReply(reply);
+    return provider.handleToken(request, reply);
+  });
+  fastify.post('/register', async (request, reply) => {
+    const provider = getMcpAuthProvider();
+    if (!provider) return oauthUnavailableReply(reply);
+    return provider.handleRegister(request, reply);
+  });
 
   await registerPlexusMcpRoutes(fastify, mcpUsageStorage);
 
   fastify.register(async (protectedRoutes) => {
-    if (oauthEnabled) {
-      protectedRoutes.addHook('onRequest', mcpOAuthFallbackAuth);
-    } else {
-      const auth = createAuthHook();
+    // C1: single request-time auth hook. It handles raw API keys, OAuth bearer
+    // tokens, and api-key-style headers. OAuth token validation is a no-op when
+    // MCP OAuth is disabled (getMcpAuthProvider() returns null), so the hook
+    // reflects the current config value on every request rather than only at
+    // route registration time.
+    protectedRoutes.addHook('onRequest', mcpOAuthFallbackAuth);
 
-      protectedRoutes.addHook('onRequest', auth.onRequest);
-
-      await protectedRoutes.register(bearerAuth, auth.bearerAuthOptions);
-    }
+    // C3: enforce OAuth scopes at the protected resource once the body is
+    // available. Requests authenticated with a raw API key carry no scope
+    // restriction; OAuth-authenticated requests are constrained to the scopes
+    // granted on their access token.
+    protectedRoutes.addHook('preHandler', async (request, reply) => {
+      const scopes = (request as any).mcpOAuthScopes as string[] | undefined;
+      if (scopes) {
+        const required = requiredScopeForOperation(request);
+        if (!scopes.includes(required)) {
+          reply.header(
+            'WWW-Authenticate',
+            `Bearer error="insufficient_scope", scope="${required}"`
+          );
+          return reply.code(403).send({
+            error: {
+              message: `OAuth token lacks required scope '${required}' for this MCP operation`,
+              type: 'insufficient_scope',
+              code: 403,
+            },
+          });
+        }
+      }
+    });
 
     protectedRoutes.addHook('preHandler', async (request, reply) => {
       const serverName = (request.params as any)?.name;
 
       if (!serverName) {
-        return reply
-          .code(400)
-          .send({ error: { message: 'Server name is required', type: 'invalid_request' } });
+        return reply.code(400).send({
+          error: {
+            message: 'Server name is required',
+            type: 'invalid_request',
+          },
+        });
       }
 
       if (!mcpProxyService.validateServerName(serverName)) {
@@ -293,14 +366,14 @@ export async function registerMcpRoutes(
 
         if (result.error) {
           if (result.status === 502) {
-            return reply
-              .code(502)
-              .send({ error: { message: result.error, type: 'upstream_error' } });
+            return reply.code(502).send({
+              error: { message: result.error, type: 'upstream_error' },
+            });
           }
           if (result.status === 504) {
-            return reply
-              .code(504)
-              .send({ error: { message: result.error, type: 'upstream_timeout' } });
+            return reply.code(504).send({
+              error: { message: result.error, type: 'upstream_timeout' },
+            });
           }
           return reply
             .code(result.status)
@@ -327,7 +400,10 @@ export async function registerMcpRoutes(
     protectedRoutes.get(
       '/mcp/:name',
       async (
-        request: FastifyRequest<{ Params: { name: string }; Querystring: Record<string, string> }>,
+        request: FastifyRequest<{
+          Params: { name: string };
+          Querystring: Record<string, string>;
+        }>,
         reply: FastifyReply
       ) => {
         const { name: serverName } = request.params;
@@ -382,14 +458,14 @@ export async function registerMcpRoutes(
 
         if (result.error) {
           if (result.status === 502) {
-            return reply
-              .code(502)
-              .send({ error: { message: result.error, type: 'upstream_error' } });
+            return reply.code(502).send({
+              error: { message: result.error, type: 'upstream_error' },
+            });
           }
           if (result.status === 504) {
-            return reply
-              .code(504)
-              .send({ error: { message: result.error, type: 'upstream_timeout' } });
+            return reply.code(504).send({
+              error: { message: result.error, type: 'upstream_timeout' },
+            });
           }
           return reply
             .code(result.status)
@@ -464,14 +540,14 @@ export async function registerMcpRoutes(
 
         if (result.error) {
           if (result.status === 502) {
-            return reply
-              .code(502)
-              .send({ error: { message: result.error, type: 'upstream_error' } });
+            return reply.code(502).send({
+              error: { message: result.error, type: 'upstream_error' },
+            });
           }
           if (result.status === 504) {
-            return reply
-              .code(504)
-              .send({ error: { message: result.error, type: 'upstream_timeout' } });
+            return reply.code(504).send({
+              error: { message: result.error, type: 'upstream_timeout' },
+            });
           }
           return reply
             .code(result.status)

--- a/packages/backend/src/services/__tests__/config-service.test.ts
+++ b/packages/backend/src/services/__tests__/config-service.test.ts
@@ -38,6 +38,7 @@ function createMockRepo() {
     getFailoverPolicy: vi.fn(() => Promise.resolve({ enabled: false })),
     getCooldownPolicy: vi.fn(() => Promise.resolve({ enabled: false })),
     getBackgroundExplorationConfig: vi.fn(() => Promise.resolve({ enabled: false })),
+    getMcpOAuthConfig: vi.fn(() => Promise.resolve(undefined)),
     getTimeoutConfig: vi.fn(() => Promise.resolve({ defaultSeconds: 300 })),
     getStallConfig: vi.fn(() =>
       Promise.resolve({

--- a/packages/backend/src/services/configuration/config-service.ts
+++ b/packages/backend/src/services/configuration/config-service.ts
@@ -452,6 +452,7 @@ export class ConfigService {
     const failover = await this.repo.getFailoverPolicy();
     const cooldown = await this.repo.getCooldownPolicy();
     const backgroundExploration = await this.repo.getBackgroundExplorationConfig();
+    const mcpOAuth = await this.repo.getMcpOAuthConfig();
     const timeout = await this.repo.getTimeoutConfig();
     const stall = await this.repo.getStallConfig();
     const allSettings = await this.repo.getAllSettings();
@@ -475,6 +476,7 @@ export class ConfigService {
       timeout,
       stall: Object.values(stall).some((v) => v !== null && v !== undefined) ? stall : undefined,
       backgroundExploration,
+      mcpOAuth,
       quotas,
       mcpServers: Object.keys(mcpServers).length > 0 ? mcpServers : undefined,
       mcp_servers: Object.keys(mcpServers).length > 0 ? mcpServers : undefined,

--- a/packages/backend/src/services/mcp-oauth/__tests__/plexus-idp-provider.test.ts
+++ b/packages/backend/src/services/mcp-oauth/__tests__/plexus-idp-provider.test.ts
@@ -59,6 +59,7 @@ class InMemoryMcpOauthRepository {
       responseTypes: input.responseTypes ?? [],
       scope: input.scope ?? null,
       tokenEndpointAuthMethod: input.tokenEndpointAuthMethod ?? 'none',
+      status: input.status ?? 'active',
       createdAt: Date.now(),
     };
     this.clients.set(record.clientId, record);
@@ -97,6 +98,7 @@ class InMemoryMcpOauthRepository {
       resource: input.resource,
       scope: input.scope ?? null,
       keyName: input.keyName,
+      apiKeySecretHash: input.apiKeySecretHash,
       codeChallenge: input.codeChallenge,
       codeChallengeMethod: input.codeChallengeMethod,
       expiresAt: input.expiresAt,
@@ -211,8 +213,16 @@ describe('PlexusIdpProvider', () => {
       client_name: 'Claude MCP',
       redirect_uris: ['http://localhost:49231/callback'],
     };
-    const firstResponse = await fastify.inject({ method: 'POST', url: '/register', payload });
-    const secondResponse = await fastify.inject({ method: 'POST', url: '/register', payload });
+    const firstResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload,
+    });
+    const secondResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload,
+    });
 
     expect(firstResponse.statusCode).toBe(201);
     expect(secondResponse.statusCode).toBe(200);

--- a/packages/backend/src/services/mcp-oauth/__tests__/plexus-idp-provider.test.ts
+++ b/packages/backend/src/services/mcp-oauth/__tests__/plexus-idp-provider.test.ts
@@ -44,6 +44,46 @@ function configureOauthKey(secret: string | null) {
   });
 }
 
+function configureOauthKeyStatus(keyOverrides: Record<string, unknown>) {
+  setConfigForTesting({
+    providers: {},
+    models: {},
+    keys: { 'oauth-key': { secret: 'sk-oauth-key', ...keyOverrides } },
+    failover: {
+      enabled: false,
+      retryableStatusCodes: [429, 500, 502, 503, 504],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT'],
+    },
+    quotas: [],
+    mcpOAuth: {
+      enabled: true,
+      provider: 'plexus-idp',
+      issuer: 'http://localhost',
+      resource: 'http://localhost/mcp',
+    },
+  });
+}
+
+function configureOauthResource(resource: string) {
+  setConfigForTesting({
+    providers: {},
+    models: {},
+    keys: { 'oauth-key': { secret: 'sk-oauth-key' } },
+    failover: {
+      enabled: false,
+      retryableStatusCodes: [429, 500, 502, 503, 504],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT'],
+    },
+    quotas: [],
+    mcpOAuth: {
+      enabled: true,
+      provider: 'plexus-idp',
+      issuer: 'http://localhost',
+      resource,
+    },
+  });
+}
+
 class InMemoryMcpOauthRepository {
   clients = new Map<string, McpOauthClientRecord>();
   codes = new Map<string, McpOauthAuthorizationCodeRecord>();
@@ -378,6 +418,376 @@ describe('PlexusIdpProvider', () => {
 
     expect(refreshResponse.statusCode).toBe(400);
     expect(JSON.parse(refreshResponse.body).error).toBe('invalid_grant');
+  });
+
+  it('rejects an issued access token after the bound API key expires', async () => {
+    const tokenBody = await issueAccessAndRefreshToken();
+
+    configureOauthKeyStatus({ expiresAt: Date.now() - 1000 });
+
+    await expect(provider.validateToken(tokenBody.access_token)).resolves.toBeNull();
+  });
+
+  it('rejects an issued access token after the bound API key is disabled', async () => {
+    const tokenBody = await issueAccessAndRefreshToken();
+
+    configureOauthKeyStatus({ disabledAt: Date.now() - 1000 });
+
+    await expect(provider.validateToken(tokenBody.access_token)).resolves.toBeNull();
+  });
+
+  it('rejects an issued access token when the configured MCP resource no longer matches', async () => {
+    const tokenBody = await issueAccessAndRefreshToken();
+
+    configureOauthResource('http://other-host/mcp');
+
+    await expect(provider.validateToken(tokenBody.access_token)).resolves.toBeNull();
+    const protectedResponse = await fastify.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { authorization: `Bearer ${tokenBody.access_token}` },
+    });
+
+    expect(protectedResponse.statusCode).toBe(401);
+  });
+
+  it('rejects authorize requests where all requested scopes are outside the client scope', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {
+        redirect_uris: ['http://localhost:5555/callback'],
+        scope: 'mcp:read',
+      },
+    });
+    const client = JSON.parse(clientResponse.body);
+    const pkce = pkcePair();
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        state: 'abc123',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+        scope: 'mcp:write',
+      }).toString(),
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body).error).toBe('invalid_scope');
+  });
+
+  it('constrains granted scopes to the intersection of requested and client scope during authorization', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {
+        redirect_uris: ['http://localhost:5555/callback'],
+        scope: 'mcp:read',
+      },
+    });
+    const client = JSON.parse(clientResponse.body);
+    const pkce = pkcePair();
+
+    const authorizeResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+        scope: 'mcp:read mcp:write',
+      }).toString(),
+    });
+
+    expect(authorizeResponse.statusCode).toBe(302);
+    const code = new URL(authorizeResponse.headers.location as string).searchParams.get('code');
+    expect(code).toMatch(/^poc_/);
+
+    const tokenResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code: code!,
+        code_verifier: pkce.verifier,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+
+    expect(tokenResponse.statusCode).toBe(200);
+    const tokenBody = JSON.parse(tokenResponse.body);
+    expect(tokenBody.scope).toBe('mcp:read');
+    await expect(provider.validateToken(tokenBody.access_token)).resolves.toEqual({
+      keyName: 'oauth-key',
+      scopes: ['mcp:read'],
+    });
+  });
+
+  it('constrains refreshed scopes to the client-registered scope', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {
+        redirect_uris: ['http://localhost:5555/callback'],
+        scope: 'mcp:read',
+      },
+    });
+    const client = JSON.parse(clientResponse.body);
+    const pkce = pkcePair();
+
+    const authorizeResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+        scope: 'mcp:read',
+      }).toString(),
+    });
+    const code = new URL(authorizeResponse.headers.location as string).searchParams.get('code');
+
+    const tokenResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code: code!,
+        code_verifier: pkce.verifier,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+    const tokenBody = JSON.parse(tokenResponse.body);
+
+    // Refresh requesting a broader scope than the client is registered for;
+    // the granted scope must be constrained back to the client's `mcp:read`.
+    const refreshResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: client.client_id,
+        refresh_token: tokenBody.refresh_token,
+        resource: 'http://localhost/mcp',
+        scope: 'mcp:read mcp:write',
+      }).toString(),
+    });
+
+    expect(refreshResponse.statusCode).toBe(200);
+    const refreshBody = JSON.parse(refreshResponse.body);
+    expect(refreshBody.scope).toBe('mcp:read');
+    await expect(provider.validateToken(refreshBody.access_token)).resolves.toEqual({
+      keyName: 'oauth-key',
+      scopes: ['mcp:read'],
+    });
+  });
+
+  it('rejects authorize requests for a disabled client with invalid_client', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: { redirect_uris: ['http://localhost:5555/callback'] },
+    });
+    const client = JSON.parse(clientResponse.body);
+    repo.clients.get(client.client_id)!.status = 'disabled';
+    const pkce = pkcePair();
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+      }).toString(),
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body).error).toBe('invalid_client');
+  });
+
+  it('rejects authorization_code token grants for a disabled client with invalid_client', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: { redirect_uris: ['http://localhost:5555/callback'] },
+    });
+    const client = JSON.parse(clientResponse.body);
+    const pkce = pkcePair();
+
+    const authorizeResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+      }).toString(),
+    });
+    const code = new URL(authorizeResponse.headers.location as string).searchParams.get('code');
+
+    repo.clients.get(client.client_id)!.status = 'disabled';
+
+    const tokenResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code: code!,
+        code_verifier: pkce.verifier,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+
+    expect(tokenResponse.statusCode).toBe(400);
+    expect(JSON.parse(tokenResponse.body).error).toBe('invalid_client');
+  });
+
+  it('rejects refresh_token grants for a disabled client with invalid_grant', async () => {
+    const tokenBody = await issueAccessAndRefreshToken();
+    repo.clients.get(tokenBody.client_id)!.status = 'disabled';
+
+    const refreshResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: tokenBody.client_id,
+        refresh_token: tokenBody.refresh_token,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+
+    expect(refreshResponse.statusCode).toBe(400);
+    expect(JSON.parse(refreshResponse.body).error).toBe('invalid_grant');
+  });
+
+  it('rejects exchanging an authorization code after the bound API key is rotated', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: { redirect_uris: ['http://localhost:5555/callback'] },
+    });
+    const client = JSON.parse(clientResponse.body);
+    const pkce = pkcePair();
+
+    const authorizeResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+      }).toString(),
+    });
+    const code = new URL(authorizeResponse.headers.location as string).searchParams.get('code');
+
+    configureOauthKey('sk-oauth-key-rotated');
+
+    const tokenResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code: code!,
+        code_verifier: pkce.verifier,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+
+    expect(tokenResponse.statusCode).toBe(400);
+    expect(JSON.parse(tokenResponse.body).error).toBe('invalid_grant');
+  });
+
+  it('sets no-store cache headers on token responses', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: { redirect_uris: ['http://localhost:5555/callback'] },
+    });
+    const client = JSON.parse(clientResponse.body);
+    const pkce = pkcePair();
+
+    const authorizeResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+      }).toString(),
+    });
+    const code = new URL(authorizeResponse.headers.location as string).searchParams.get('code');
+
+    const tokenResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code: code!,
+        code_verifier: pkce.verifier,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+
+    expect(tokenResponse.statusCode).toBe(200);
+    expect(tokenResponse.headers['cache-control']).toBe('no-store');
+    expect(tokenResponse.headers['pragma']).toBe('no-cache');
   });
 
   async function issueAccessAndRefreshToken(): Promise<{

--- a/packages/backend/src/services/mcp-oauth/__tests__/plexus-idp-provider.test.ts
+++ b/packages/backend/src/services/mcp-oauth/__tests__/plexus-idp-provider.test.ts
@@ -1,0 +1,419 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import formbody from '@fastify/formbody';
+import crypto from 'node:crypto';
+import { setConfigForTesting } from '../../../config';
+import { hashSecret } from '../../../utils/encryption';
+import type {
+  McpOauthAuthorizationCodeRecord,
+  McpOauthClientRecord,
+  McpOauthTokenRecord,
+  NewMcpOauthAuthorizationCode,
+  NewMcpOauthClient,
+  NewMcpOauthToken,
+} from '../../../db/mcp-oauth-repository';
+import { PlexusIdpProvider } from '../plexus-idp-provider';
+
+function pkcePair() {
+  const verifier = crypto.randomBytes(48).toString('base64url');
+  const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+function configuredBase() {
+  configureOauthKey('sk-oauth-key');
+}
+
+function configureOauthKey(secret: string | null) {
+  setConfigForTesting({
+    providers: {},
+    models: {},
+    keys: secret ? { 'oauth-key': { secret } } : {},
+    failover: {
+      enabled: false,
+      retryableStatusCodes: [429, 500, 502, 503, 504],
+      retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT'],
+    },
+    quotas: [],
+    mcpOAuth: {
+      enabled: true,
+      provider: 'plexus-idp',
+      issuer: 'http://localhost',
+      resource: 'http://localhost/mcp',
+    },
+  });
+}
+
+class InMemoryMcpOauthRepository {
+  clients = new Map<string, McpOauthClientRecord>();
+  codes = new Map<string, McpOauthAuthorizationCodeRecord>();
+  tokensByAccess = new Map<string, McpOauthTokenRecord>();
+  tokensByRefresh = new Map<string, McpOauthTokenRecord>();
+
+  async createClient(input: NewMcpOauthClient): Promise<McpOauthClientRecord> {
+    const record: McpOauthClientRecord = {
+      clientId: input.clientId,
+      clientName: input.clientName ?? null,
+      redirectUris: input.redirectUris,
+      grantTypes: input.grantTypes ?? [],
+      responseTypes: input.responseTypes ?? [],
+      scope: input.scope ?? null,
+      tokenEndpointAuthMethod: input.tokenEndpointAuthMethod ?? 'none',
+      createdAt: Date.now(),
+    };
+    this.clients.set(record.clientId, record);
+    return record;
+  }
+
+  async getClient(clientId: string): Promise<McpOauthClientRecord | null> {
+    return this.clients.get(clientId) ?? null;
+  }
+
+  async findClientByRegistration(input: {
+    clientName?: string | null;
+    redirectUris: string[];
+  }): Promise<McpOauthClientRecord | null> {
+    const requested = [...new Set(input.redirectUris)].sort();
+    return (
+      [...this.clients.values()].find((client) => {
+        const existing = [...new Set(client.redirectUris)].sort();
+        return (
+          client.clientName === (input.clientName ?? null) &&
+          existing.length === requested.length &&
+          existing.every((value, index) => value === requested[index])
+        );
+      }) ?? null
+    );
+  }
+
+  async createAuthorizationCode(
+    input: NewMcpOauthAuthorizationCode
+  ): Promise<McpOauthAuthorizationCodeRecord> {
+    const record: McpOauthAuthorizationCodeRecord = {
+      codeHash: `hash:${input.code}`,
+      code: input.code,
+      clientId: input.clientId,
+      redirectUri: input.redirectUri,
+      resource: input.resource,
+      scope: input.scope ?? null,
+      keyName: input.keyName,
+      codeChallenge: input.codeChallenge,
+      codeChallengeMethod: input.codeChallengeMethod,
+      expiresAt: input.expiresAt,
+      consumedAt: null,
+      createdAt: Date.now(),
+    };
+    this.codes.set(record.code, record);
+    return record;
+  }
+
+  async getAuthorizationCode(code: string): Promise<McpOauthAuthorizationCodeRecord | null> {
+    return this.codes.get(code) ?? null;
+  }
+
+  async consumeAuthorizationCode(code: string): Promise<void> {
+    const record = this.codes.get(code);
+    if (record) record.consumedAt = Date.now();
+  }
+
+  async createToken(input: NewMcpOauthToken): Promise<McpOauthTokenRecord> {
+    const record: McpOauthTokenRecord = {
+      accessTokenHash: `hash:${input.accessToken}`,
+      accessToken: input.accessToken,
+      refreshTokenHash: `hash:${input.refreshToken}`,
+      refreshToken: input.refreshToken,
+      clientId: input.clientId,
+      keyName: input.keyName,
+      apiKeySecretHash: input.apiKeySecretHash,
+      resource: input.resource,
+      scope: input.scope ?? null,
+      accessTokenExpiresAt: input.accessTokenExpiresAt,
+      refreshTokenExpiresAt: input.refreshTokenExpiresAt,
+      revokedAt: null,
+      createdAt: Date.now(),
+    };
+    this.tokensByAccess.set(record.accessToken, record);
+    this.tokensByRefresh.set(record.refreshToken, record);
+    return record;
+  }
+
+  async getAccessToken(accessToken: string): Promise<McpOauthTokenRecord | null> {
+    return this.tokensByAccess.get(accessToken) ?? null;
+  }
+
+  async getRefreshToken(refreshToken: string): Promise<McpOauthTokenRecord | null> {
+    return this.tokensByRefresh.get(refreshToken) ?? null;
+  }
+
+  async revokeRefreshToken(refreshToken: string): Promise<void> {
+    const record = this.tokensByRefresh.get(refreshToken);
+    if (record) record.revokedAt = Date.now();
+  }
+}
+
+describe('PlexusIdpProvider', () => {
+  let fastify: FastifyInstance;
+  let provider: PlexusIdpProvider;
+  let repo: InMemoryMcpOauthRepository;
+
+  beforeEach(async () => {
+    configuredBase();
+    fastify = Fastify();
+    await fastify.register(formbody);
+    repo = new InMemoryMcpOauthRepository();
+    provider = new PlexusIdpProvider(repo as any);
+    fastify.post('/register', (request, reply) => provider.handleRegister(request, reply));
+    fastify.get('/oauth/authorize', (request, reply) => provider.handleAuthorize(request, reply));
+    fastify.post('/oauth/authorize', (request, reply) => provider.handleAuthorize(request, reply));
+    fastify.post('/oauth/token', (request, reply) => provider.handleToken(request, reply));
+    fastify.get('/protected', async (request, reply) => {
+      const authorization = request.headers.authorization;
+      const credential = authorization?.toLowerCase().startsWith('bearer ')
+        ? authorization.slice('bearer '.length)
+        : authorization;
+      const authResult = credential ? await provider.validateToken(credential) : null;
+      if (!authResult) {
+        return reply
+          .header('WWW-Authenticate', 'Bearer error="invalid_token"')
+          .code(401)
+          .send({ error: 'invalid_token' });
+      }
+      return reply.send(authResult);
+    });
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  it('registers a dynamic public client with a random client_id', async () => {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: {
+        client_name: 'Claude MCP',
+        redirect_uris: ['http://localhost:49231/callback'],
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const body = JSON.parse(response.body);
+    expect(body.client_id).toMatch(/^mcp_[a-f0-9]{32}$/);
+    expect(body.client_id).not.toBe('plexus-mcp-static');
+    expect(body.redirect_uris).toContain('http://localhost:49231/callback');
+    expect(body.redirect_uris).toContain('https://claude.ai/api/mcp/auth_callback');
+    expect(body.token_endpoint_auth_method).toBe('none');
+  });
+
+  it('deduplicates identical dynamic client registrations', async () => {
+    const payload = {
+      client_name: 'Claude MCP',
+      redirect_uris: ['http://localhost:49231/callback'],
+    };
+    const firstResponse = await fastify.inject({ method: 'POST', url: '/register', payload });
+    const secondResponse = await fastify.inject({ method: 'POST', url: '/register', payload });
+
+    expect(firstResponse.statusCode).toBe(201);
+    expect(secondResponse.statusCode).toBe(200);
+    const first = JSON.parse(firstResponse.body);
+    const second = JSON.parse(secondResponse.body);
+    expect(second.client_id).toBe(first.client_id);
+    expect(repo.clients.size).toBe(1);
+  });
+
+  it('requires PKCE and resource on authorize requests', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: { redirect_uris: ['http://localhost:5555/callback'] },
+    });
+    const client = JSON.parse(clientResponse.body);
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: `/oauth/authorize?response_type=code&client_id=${client.client_id}&redirect_uri=${encodeURIComponent('http://localhost:5555/callback')}`,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body).error).toBe('invalid_request');
+  });
+
+  it('exchanges an authorization code and refresh token for opaque bearer tokens', async () => {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: { redirect_uris: ['http://localhost:5555/callback'] },
+    });
+    const client = JSON.parse(clientResponse.body);
+    const pkce = pkcePair();
+
+    const authorizeResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        state: 'abc123',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+      }).toString(),
+    });
+
+    expect(authorizeResponse.statusCode).toBe(302);
+    const location = new URL(authorizeResponse.headers.location as string);
+    expect(location.searchParams.get('state')).toBe('abc123');
+    const code = location.searchParams.get('code');
+    expect(code).toMatch(/^poc_/);
+
+    const tokenResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code: code!,
+        code_verifier: pkce.verifier,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+
+    expect(tokenResponse.statusCode).toBe(200);
+    const tokenBody = JSON.parse(tokenResponse.body);
+    expect(tokenBody.access_token).toMatch(/^pox_/);
+    expect(tokenBody.refresh_token).toMatch(/^por_/);
+    expect(tokenBody.token_type).toBe('Bearer');
+    expect(repo.tokensByAccess.get(tokenBody.access_token)?.apiKeySecretHash).toBe(
+      hashSecret('sk-oauth-key')
+    );
+    await expect(provider.validateToken(tokenBody.access_token)).resolves.toEqual({
+      keyName: 'oauth-key',
+      scopes: ['mcp:read', 'mcp:write'],
+    });
+
+    const refreshResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: client.client_id,
+        refresh_token: tokenBody.refresh_token,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+
+    expect(refreshResponse.statusCode).toBe(200);
+    const refreshBody = JSON.parse(refreshResponse.body);
+    expect(refreshBody.access_token).toMatch(/^pox_/);
+    expect(repo.tokensByAccess.get(refreshBody.access_token)?.apiKeySecretHash).toBe(
+      hashSecret('sk-oauth-key')
+    );
+  });
+
+  it('rejects an issued access token with invalid_token after the bound API key is rotated', async () => {
+    const tokenBody = await issueAccessAndRefreshToken();
+
+    configureOauthKey('sk-oauth-key-rotated');
+
+    await expect(provider.validateToken(tokenBody.access_token)).resolves.toBeNull();
+    const protectedResponse = await fastify.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { authorization: `Bearer ${tokenBody.access_token}` },
+    });
+
+    expect(protectedResponse.statusCode).toBe(401);
+    expect(protectedResponse.headers['www-authenticate']).toBe('Bearer error="invalid_token"');
+  });
+
+  it('rejects an issued access token with invalid_token after the bound API key is deleted', async () => {
+    const tokenBody = await issueAccessAndRefreshToken();
+
+    configureOauthKey(null);
+
+    await expect(provider.validateToken(tokenBody.access_token)).resolves.toBeNull();
+    const protectedResponse = await fastify.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { authorization: `Bearer ${tokenBody.access_token}` },
+    });
+
+    expect(protectedResponse.statusCode).toBe(401);
+    expect(protectedResponse.headers['www-authenticate']).toBe('Bearer error="invalid_token"');
+  });
+
+  it('rejects refresh_token grants with invalid_grant after the bound API key is rotated', async () => {
+    const tokenBody = await issueAccessAndRefreshToken();
+
+    configureOauthKey('sk-oauth-key-rotated');
+
+    const refreshResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: tokenBody.client_id,
+        refresh_token: tokenBody.refresh_token,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+
+    expect(refreshResponse.statusCode).toBe(400);
+    expect(JSON.parse(refreshResponse.body).error).toBe('invalid_grant');
+  });
+
+  async function issueAccessAndRefreshToken(): Promise<{
+    client_id: string;
+    access_token: string;
+    refresh_token: string;
+  }> {
+    const clientResponse = await fastify.inject({
+      method: 'POST',
+      url: '/register',
+      payload: { redirect_uris: ['http://localhost:5555/callback'] },
+    });
+    const client = JSON.parse(clientResponse.body);
+    const pkce = pkcePair();
+
+    const authorizeResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/authorize',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        response_type: 'code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+        resource: 'http://localhost/mcp',
+        api_key: 'sk-oauth-key',
+      }).toString(),
+    });
+    expect(authorizeResponse.statusCode).toBe(302);
+    const code = new URL(authorizeResponse.headers.location as string).searchParams.get('code');
+
+    const tokenResponse = await fastify.inject({
+      method: 'POST',
+      url: '/oauth/token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.client_id,
+        redirect_uri: 'http://localhost:5555/callback',
+        code: code!,
+        code_verifier: pkce.verifier,
+        resource: 'http://localhost/mcp',
+      }).toString(),
+    });
+    expect(tokenResponse.statusCode).toBe(200);
+    return { client_id: client.client_id, ...JSON.parse(tokenResponse.body) };
+  }
+});

--- a/packages/backend/src/services/mcp-oauth/plexus-idp-provider.ts
+++ b/packages/backend/src/services/mcp-oauth/plexus-idp-provider.ts
@@ -1,0 +1,536 @@
+import crypto from 'node:crypto';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { getConfig } from '../../config';
+import { McpOauthRepository } from '../../db/mcp-oauth-repository';
+import { hashSecret } from '../../utils/encryption';
+import { attachPlexusApiKeyAuth, validatePlexusApiKey } from '../../utils/auth';
+import { logger } from '../../utils/logger';
+import { getMcpResourceUrl, getRequestBaseUrl, resourceMatchesExpected } from './url';
+import type { AuthProvider, OAuthDiscoveryMetadata, ProtectedResourceMetadata } from './types';
+
+/*
+ * OAuth implementation note:
+ * We intentionally hand-implement this small opaque-token authorization server
+ * instead of using @node-oauth/oauth2-server. Plexus needs RFC 7591 dynamic
+ * client registration, a browser consent POST where an existing Plexus API key
+ * is the credential, and mandatory MCP/RFC 8707 resource validation on both
+ * authorize and token requests. Those checks sit awkwardly outside the library's
+ * model abstraction; the resulting glue would still custom-issue/store codes and
+ * tokens. This implementation keeps the OAuth surface narrow while reusing
+ * Plexus primitives for hashing, encryption-at-rest, Zod validation, and Drizzle
+ * storage. It does not implement OpenID Connect or JWT/ID tokens.
+ */
+
+const DEFAULT_SCOPES = ['mcp:read', 'mcp:write'];
+const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000;
+const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const AUTH_CODE_TTL_MS = 10 * 60 * 1000;
+const ACCESS_TOKEN_PREFIX = 'pox_';
+const REFRESH_TOKEN_PREFIX = 'por_';
+const AUTH_CODE_PREFIX = 'poc_';
+
+const WELL_KNOWN_REDIRECT_URIS = [
+  'https://claude.ai/api/mcp/auth_callback',
+  'https://claude.com/api/mcp/auth_callback',
+  'http://localhost/callback',
+  'http://127.0.0.1/callback',
+];
+
+const registerSchema = z.object({
+  redirect_uris: z.array(z.string().url()).min(1),
+  client_name: z.string().min(1).optional(),
+  grant_types: z.array(z.string()).optional(),
+  response_types: z.array(z.string()).optional(),
+  scope: z.string().optional(),
+  token_endpoint_auth_method: z.literal('none').optional(),
+});
+
+const authorizeSchema = z.object({
+  response_type: z.literal('code'),
+  client_id: z.string().min(1),
+  redirect_uri: z.string().url(),
+  state: z.string().optional(),
+  scope: z.string().optional(),
+  code_challenge: z.string().min(43),
+  code_challenge_method: z.literal('S256'),
+  resource: z.string().url(),
+});
+
+const authorizePostSchema = authorizeSchema.extend({
+  api_key: z.string().min(1),
+});
+
+const tokenSchema = z.discriminatedUnion('grant_type', [
+  z.object({
+    grant_type: z.literal('authorization_code'),
+    code: z.string().min(1),
+    redirect_uri: z.string().url(),
+    client_id: z.string().min(1),
+    code_verifier: z.string().min(43),
+    resource: z.string().url(),
+  }),
+  z.object({
+    grant_type: z.literal('refresh_token'),
+    refresh_token: z.string().min(1),
+    client_id: z.string().min(1),
+    resource: z.string().url(),
+    scope: z.string().optional(),
+  }),
+]);
+
+function randomToken(prefix: string): string {
+  return `${prefix}${crypto.randomBytes(32).toString('base64url')}`;
+}
+
+function splitScopes(scope: string | null | undefined): string[] {
+  const scopes = (scope || DEFAULT_SCOPES.join(' '))
+    .split(/\s+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return scopes.length > 0 ? scopes : DEFAULT_SCOPES;
+}
+
+function toScopeString(scope: string | null | undefined): string {
+  return splitScopes(scope).join(' ');
+}
+
+function htmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function getSingleValue(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function getBodyOrQuery(req: FastifyRequest): Record<string, unknown> {
+  const source = req.method === 'GET' ? req.query : req.body;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) return {};
+  return Object.fromEntries(
+    Object.entries(source as Record<string, unknown>).map(([key, value]) => [
+      key,
+      getSingleValue(value),
+    ])
+  );
+}
+
+function isLoopbackRedirectUri(uri: string): boolean {
+  try {
+    const parsed = new URL(uri);
+    return (
+      parsed.protocol === 'http:' &&
+      (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') &&
+      parsed.pathname === '/callback'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function redirectUriMatches(registeredUri: string, requestedUri: string): boolean {
+  if (registeredUri === requestedUri) return true;
+  if (!isLoopbackRedirectUri(registeredUri) || !isLoopbackRedirectUri(requestedUri)) return false;
+
+  const registered = new URL(registeredUri);
+  const requested = new URL(requestedUri);
+  return registered.hostname === requested.hostname && registered.pathname === requested.pathname;
+}
+
+function validatePkce(verifier: string, challenge: string): boolean {
+  const digest = crypto.createHash('sha256').update(verifier).digest('base64url');
+  return digest === challenge;
+}
+
+function oauthError(reply: FastifyReply, statusCode: number, error: string, description: string) {
+  return reply.code(statusCode).send({ error, error_description: description });
+}
+
+function appendQuery(url: string, params: Record<string, string | undefined>): string {
+  const parsed = new URL(url);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) parsed.searchParams.set(key, value);
+  }
+  return parsed.toString();
+}
+
+export class PlexusIdpProvider implements AuthProvider {
+  constructor(private readonly repo = new McpOauthRepository()) {}
+
+  getDiscoveryMetadata(req: FastifyRequest): OAuthDiscoveryMetadata {
+    const issuer = getRequestBaseUrl(req);
+    return {
+      issuer,
+      authorization_endpoint: `${issuer}/oauth/authorize`,
+      token_endpoint: `${issuer}/oauth/token`,
+      registration_endpoint: `${issuer}/register`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      token_endpoint_auth_methods_supported: ['none'],
+      code_challenge_methods_supported: ['S256'],
+      scopes_supported: DEFAULT_SCOPES,
+      resource_supported: true,
+    };
+  }
+
+  getProtectedResourceMetadata(req: FastifyRequest): ProtectedResourceMetadata {
+    const issuer = getRequestBaseUrl(req);
+    return {
+      resource: getMcpResourceUrl(req),
+      authorization_servers: [issuer],
+      scopes_supported: DEFAULT_SCOPES,
+      bearer_methods_supported: ['header'],
+    };
+  }
+
+  async handleRegister(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const parsed = registerSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_client_metadata',
+        'Invalid dynamic client registration request'
+      );
+    }
+
+    const redirectUris = parsed.data.redirect_uris;
+    const allowedRedirectUris = [...new Set([...WELL_KNOWN_REDIRECT_URIS, ...redirectUris])];
+    const existingClient = await this.repo.findClientByRegistration({
+      clientName: parsed.data.client_name ?? null,
+      redirectUris: allowedRedirectUris,
+    });
+    if (existingClient) {
+      return reply.code(200).send({
+        client_id: existingClient.clientId,
+        client_id_issued_at: Math.floor(existingClient.createdAt / 1000),
+        client_name: existingClient.clientName ?? undefined,
+        redirect_uris: existingClient.redirectUris,
+        grant_types:
+          existingClient.grantTypes.length > 0
+            ? existingClient.grantTypes
+            : ['authorization_code', 'refresh_token'],
+        response_types:
+          existingClient.responseTypes.length > 0 ? existingClient.responseTypes : ['code'],
+        scope: existingClient.scope ?? DEFAULT_SCOPES.join(' '),
+        token_endpoint_auth_method: existingClient.tokenEndpointAuthMethod,
+      });
+    }
+
+    const clientId = `mcp_${crypto.randomBytes(16).toString('hex')}`;
+    const client = await this.repo.createClient({
+      clientId,
+      clientName: parsed.data.client_name ?? null,
+      redirectUris: allowedRedirectUris,
+      grantTypes: parsed.data.grant_types ?? ['authorization_code', 'refresh_token'],
+      responseTypes: parsed.data.response_types ?? ['code'],
+      scope: parsed.data.scope ?? DEFAULT_SCOPES.join(' '),
+      tokenEndpointAuthMethod: parsed.data.token_endpoint_auth_method ?? 'none',
+    });
+
+    return reply.code(201).send({
+      client_id: client.clientId,
+      client_id_issued_at: Math.floor(client.createdAt / 1000),
+      client_name: client.clientName ?? undefined,
+      redirect_uris: client.redirectUris,
+      grant_types:
+        client.grantTypes.length > 0 ? client.grantTypes : ['authorization_code', 'refresh_token'],
+      response_types: client.responseTypes.length > 0 ? client.responseTypes : ['code'],
+      scope: client.scope ?? DEFAULT_SCOPES.join(' '),
+      token_endpoint_auth_method: client.tokenEndpointAuthMethod,
+    });
+  }
+
+  async handleAuthorize(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const raw = getBodyOrQuery(req);
+    const parsed = (req.method === 'POST' ? authorizePostSchema : authorizeSchema).safeParse(raw);
+    if (!parsed.success) {
+      return oauthError(reply, 400, 'invalid_request', 'Invalid authorization request');
+    }
+
+    const data = parsed.data;
+    const client = await this.repo.getClient(data.client_id);
+    if (!client) {
+      return oauthError(reply, 400, 'invalid_client', 'Unknown OAuth client');
+    }
+    if (!client.redirectUris.some((uri) => redirectUriMatches(uri, data.redirect_uri))) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_request',
+        'redirect_uri is not registered for this client'
+      );
+    }
+    if (!resourceMatchesExpected(data.resource, getMcpResourceUrl(req))) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_target',
+        'resource does not match this Plexus MCP resource'
+      );
+    }
+
+    if (req.method === 'GET') {
+      return this.renderConsent(reply, data);
+    }
+
+    const authResult = validatePlexusApiKey(
+      (data as z.infer<typeof authorizePostSchema>).api_key,
+      req
+    );
+    if (!authResult) {
+      return oauthError(reply, 401, 'access_denied', 'Invalid Plexus API key');
+    }
+
+    const code = randomToken(AUTH_CODE_PREFIX);
+    await this.repo.createAuthorizationCode({
+      code,
+      clientId: data.client_id,
+      redirectUri: data.redirect_uri,
+      resource: data.resource,
+      scope: data.scope ?? DEFAULT_SCOPES.join(' '),
+      keyName: authResult.keyName,
+      codeChallenge: data.code_challenge,
+      codeChallengeMethod: data.code_challenge_method,
+      expiresAt: Date.now() + AUTH_CODE_TTL_MS,
+    });
+
+    const redirectTo = appendQuery(data.redirect_uri, { code, state: data.state });
+    return reply.redirect(redirectTo);
+  }
+
+  async handleToken(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const parsed = tokenSchema.safeParse(getBodyOrQuery(req));
+    if (!parsed.success) {
+      return oauthError(reply, 400, 'invalid_request', 'Invalid token request');
+    }
+    if (!resourceMatchesExpected(parsed.data.resource, getMcpResourceUrl(req))) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_target',
+        'resource does not match this Plexus MCP resource'
+      );
+    }
+
+    if (parsed.data.grant_type === 'authorization_code') {
+      return this.handleAuthorizationCodeGrant(parsed.data, reply);
+    }
+
+    return this.handleRefreshTokenGrant(parsed.data, reply);
+  }
+
+  async validateToken(token: string): Promise<{ keyName: string; scopes: string[] } | null> {
+    if (!token.startsWith(ACCESS_TOKEN_PREFIX)) return null;
+
+    const record = await this.repo.getAccessToken(token);
+    if (!record) return null;
+    if (record.revokedAt !== null) return null;
+    if (record.accessTokenExpiresAt <= Date.now()) return null;
+    if (!this.isTokenBoundToCurrentApiKeySecret(record.keyName, record.apiKeySecretHash))
+      return null;
+
+    return { keyName: record.keyName, scopes: splitScopes(record.scope) };
+  }
+
+  private async handleAuthorizationCodeGrant(
+    data: z.infer<typeof tokenSchema> & { grant_type: 'authorization_code' },
+    reply: FastifyReply
+  ): Promise<void> {
+    const client = await this.repo.getClient(data.client_id);
+    if (!client) return oauthError(reply, 400, 'invalid_client', 'Unknown OAuth client');
+
+    const code = await this.repo.getAuthorizationCode(data.code);
+    if (!code) return oauthError(reply, 400, 'invalid_grant', 'Invalid authorization code');
+    if (code.consumedAt !== null)
+      return oauthError(reply, 400, 'invalid_grant', 'Code already used');
+    if (code.expiresAt <= Date.now())
+      return oauthError(reply, 400, 'invalid_grant', 'Code expired');
+    if (code.clientId !== data.client_id)
+      return oauthError(reply, 400, 'invalid_grant', 'Client mismatch');
+    if (!redirectUriMatches(code.redirectUri, data.redirect_uri)) {
+      return oauthError(reply, 400, 'invalid_grant', 'redirect_uri mismatch');
+    }
+    if (!resourceMatchesExpected(data.resource, code.resource)) {
+      return oauthError(reply, 400, 'invalid_target', 'resource mismatch');
+    }
+    if (!validatePkce(data.code_verifier, code.codeChallenge)) {
+      return oauthError(reply, 400, 'invalid_grant', 'PKCE verification failed');
+    }
+
+    await this.repo.consumeAuthorizationCode(data.code);
+    return this.issueToken(reply, {
+      clientId: data.client_id,
+      keyName: code.keyName,
+      resource: code.resource,
+      scope: code.scope ?? DEFAULT_SCOPES.join(' '),
+    });
+  }
+
+  private async handleRefreshTokenGrant(
+    data: z.infer<typeof tokenSchema> & { grant_type: 'refresh_token' },
+    reply: FastifyReply
+  ): Promise<void> {
+    const record = await this.repo.getRefreshToken(data.refresh_token);
+    if (!record) return oauthError(reply, 400, 'invalid_grant', 'Invalid refresh token');
+    if (record.revokedAt !== null)
+      return oauthError(reply, 400, 'invalid_grant', 'Refresh token revoked');
+    if (record.refreshTokenExpiresAt <= Date.now()) {
+      return oauthError(reply, 400, 'invalid_grant', 'Refresh token expired');
+    }
+    if (record.clientId !== data.client_id)
+      return oauthError(reply, 400, 'invalid_grant', 'Client mismatch');
+    if (!resourceMatchesExpected(data.resource, record.resource)) {
+      return oauthError(reply, 400, 'invalid_target', 'resource mismatch');
+    }
+    if (!this.isTokenBoundToCurrentApiKeySecret(record.keyName, record.apiKeySecretHash)) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_grant',
+        'Underlying Plexus API key is no longer valid'
+      );
+    }
+
+    await this.repo.revokeRefreshToken(data.refresh_token);
+    return this.issueToken(reply, {
+      clientId: record.clientId,
+      keyName: record.keyName,
+      resource: record.resource,
+      scope: data.scope ?? record.scope ?? DEFAULT_SCOPES.join(' '),
+    });
+  }
+
+  private async issueToken(
+    reply: FastifyReply,
+    input: { clientId: string; keyName: string; resource: string; scope: string }
+  ): Promise<void> {
+    const apiKeySecretHash = this.getCurrentApiKeySecretHash(input.keyName);
+    if (!apiKeySecretHash) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_grant',
+        'Underlying Plexus API key is no longer valid'
+      );
+    }
+
+    const accessToken = randomToken(ACCESS_TOKEN_PREFIX);
+    const refreshToken = randomToken(REFRESH_TOKEN_PREFIX);
+    await this.repo.createToken({
+      accessToken,
+      refreshToken,
+      clientId: input.clientId,
+      keyName: input.keyName,
+      apiKeySecretHash,
+      resource: input.resource,
+      scope: input.scope,
+      accessTokenExpiresAt: Date.now() + ACCESS_TOKEN_TTL_MS,
+      refreshTokenExpiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
+    });
+
+    return reply.send({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
+      refresh_token: refreshToken,
+      scope: toScopeString(input.scope),
+    });
+  }
+
+  private getCurrentApiKeySecretHash(keyName: string): string | null {
+    const keyConfig = getConfig().keys?.[keyName];
+    if (!keyConfig) return null;
+    return hashSecret(keyConfig.secret);
+  }
+
+  private isTokenBoundToCurrentApiKeySecret(
+    keyName: string,
+    apiKeySecretHash: string | null
+  ): boolean {
+    if (!apiKeySecretHash) return false;
+    const currentHash = this.getCurrentApiKeySecretHash(keyName);
+    return currentHash !== null && currentHash === apiKeySecretHash;
+  }
+
+  private async renderConsent(
+    reply: FastifyReply,
+    data: z.infer<typeof authorizeSchema>
+  ): Promise<void> {
+    const hidden = Object.entries(data)
+      .map(
+        ([key, value]) =>
+          `<input type="hidden" name="${htmlEscape(key)}" value="${htmlEscape(String(value))}">`
+      )
+      .join('\n');
+    const body = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorize Plexus MCP</title>
+  <style>
+    :root { color-scheme: dark; --bg-deep: #020617; --bg-card: rgba(15, 23, 42, 0.92); --bg-input: rgba(15, 23, 42, 0.72); --border: rgba(148, 163, 184, 0.18); --border-strong: rgba(245, 158, 11, 0.5); --text: #f8fafc; --text-secondary: #cbd5e1; --text-muted: #64748b; --primary: #f59e0b; --secondary: #fbbf24; --danger: #fda4af; }
+    * { box-sizing: border-box; }
+    body { min-height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: radial-gradient(circle at 30% 20%, rgba(245, 158, 11, 0.10), transparent 30%), var(--bg-deep); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; padding: 1rem; }
+    .mesh { position: fixed; inset: 0; pointer-events: none; opacity: 0.5; }
+    main { position: relative; width: 100%; max-width: 28rem; }
+    .brand { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 0.75rem; margin-bottom: 2rem; }
+    .mark { width: 44px; height: 44px; border-radius: 999px; background: linear-gradient(135deg, var(--secondary), var(--primary)); box-shadow: 0 0 34px rgba(245, 158, 11, 0.28); display: grid; place-items: center; }
+    .mark svg { width: 26px; height: 26px; color: #0f172a; }
+    .wordmark { font-size: 1.875rem; font-weight: 800; letter-spacing: -0.025em; background: linear-gradient(135deg, var(--secondary), var(--primary)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+    .version { font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em; color: var(--text-muted); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+    .card { border: 1px solid var(--border); background: linear-gradient(180deg, rgba(30,41,59,0.82), var(--bg-card)); border-radius: 1rem; padding: 2rem; box-shadow: 0 24px 80px rgba(0,0,0,0.45); backdrop-filter: blur(18px); }
+    h1 { font-size: 1.5rem; line-height: 2rem; font-weight: 700; letter-spacing: -0.02em; margin: 0 0 0.375rem; }
+    p { color: var(--text-secondary); font-size: 0.875rem; margin: 0 0 1rem; }
+    .client { margin: 1rem 0; padding: 0.75rem; border-radius: 0.75rem; border: 1px solid rgba(255,255,255,0.06); background: rgba(2, 6, 23, 0.36); }
+    .client p { margin: 0.25rem 0; font-size: 0.75rem; }
+    code { color: #fde68a; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; overflow-wrap: anywhere; }
+    label { display: block; margin: 1rem 0 0.375rem; color: var(--text-secondary); font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; }
+    input[type=password] { width: 100%; border: 1px solid var(--border); border-radius: 0.375rem; background: var(--bg-input); color: var(--text); padding: 0.75rem 0.875rem; font: 0.875rem ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; outline: none; transition: border-color 120ms ease, box-shadow 120ms ease; }
+    input[type=password]:focus { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.18); }
+    button { width: 100%; margin-top: 1rem; border: 0; border-radius: 0.5rem; background: linear-gradient(135deg, var(--secondary), var(--primary)); color: #0f172a; font: 700 0.875rem Inter, ui-sans-serif, system-ui, sans-serif; padding: 0.75rem 1rem; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; }
+    .note { margin-top: 1.5rem; border-top: 1px solid rgba(255,255,255,0.06); padding-top: 1rem; color: var(--text-muted); font-size: 0.75rem; }
+    .footer { margin-top: 1.5rem; text-align: center; color: var(--text-muted); font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <svg class="mesh" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+    <g stroke="rgba(245,158,11,0.10)" stroke-width="0.5" fill="none"><path d="M0 200 C 200 100, 600 300, 800 180"/><path d="M0 320 C 220 220, 580 420, 800 300"/><path d="M0 440 C 200 340, 600 540, 800 420"/></g>
+    <circle cx="160" cy="200" r="3" fill="#F59E0B" opacity="0.7"/><circle cx="380" cy="260" r="3" fill="#FBBF24" opacity="0.7"/><circle cx="640" cy="220" r="3" fill="#F59E0B" opacity="0.7"/><circle cx="240" cy="380" r="3" fill="#FBBF24" opacity="0.5"/><circle cx="560" cy="420" r="3" fill="#F59E0B" opacity="0.5"/>
+  </svg>
+  <main>
+    <div class="brand">
+      <div class="mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3v18M5 7.5l14 9M19 7.5l-14 9" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
+      <div><span class="wordmark">Plexus</span> <span class="version">MCP OAuth</span></div>
+    </div>
+    <section class="card">
+      <h1>Authorize MCP access</h1>
+      <p>Paste an existing Plexus API key to bind this OAuth grant to that key. Plexus will not share the raw key with the client.</p>
+      <div class="client">
+        <p>Client <code>${htmlEscape(data.client_id)}</code></p>
+        <p>Resource <code>${htmlEscape(data.resource)}</code></p>
+      </div>
+      <form method="post" action="/oauth/authorize">
+        ${hidden}
+        <label for="api_key">Plexus API key</label>
+        <input id="api_key" name="api_key" type="password" autocomplete="off" required autofocus>
+        <button type="submit">Authorize access</button>
+      </form>
+      <div class="note">Only authorize clients you trust. This page is served directly by your Plexus instance.</div>
+    </section>
+    <p class="footer">© 2026 Plexus · Unified LLM Gateway</p>
+  </main>
+</body>
+</html>`;
+
+    logger.silly('Rendering MCP OAuth consent screen');
+    reply.type('text/html; charset=utf-8').send(body);
+  }
+}
+
+export { ACCESS_TOKEN_PREFIX as MCP_OAUTH_ACCESS_TOKEN_PREFIX };

--- a/packages/backend/src/services/mcp-oauth/plexus-idp-provider.ts
+++ b/packages/backend/src/services/mcp-oauth/plexus-idp-provider.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { z } from 'zod';
-import { getConfig } from '../../config';
+import { getConfig, isKeyDisabled } from '../../config';
 import { McpOauthRepository } from '../../db/mcp-oauth-repository';
 import { hashSecret } from '../../utils/encryption';
 import { attachPlexusApiKeyAuth, validatePlexusApiKey } from '../../utils/auth';
@@ -93,6 +93,19 @@ function splitScopes(scope: string | null | undefined): string[] {
 
 function toScopeString(scope: string | null | undefined): string {
   return splitScopes(scope).join(' ');
+}
+
+// Constrain a requested scope set to the subset the client is allowed to have
+// AND that this server actually supports. Used to prevent a client from asking
+// for (and being granted) scopes it was never registered for, or scopes Plexus
+// does not implement.
+function constrainScopes(
+  requested: string | null | undefined,
+  allowed: string | null | undefined
+): string[] {
+  const known = new Set(DEFAULT_SCOPES);
+  const allowedScopes = allowed ? new Set(splitScopes(allowed)) : new Set(DEFAULT_SCOPES);
+  return splitScopes(requested).filter((scope) => known.has(scope) && allowedScopes.has(scope));
 }
 
 function htmlEscape(value: string): string {
@@ -257,6 +270,9 @@ export class PlexusIdpProvider implements AuthProvider {
     if (!client) {
       return oauthError(reply, 400, 'invalid_client', 'Unknown OAuth client');
     }
+    if (client.status === 'disabled') {
+      return oauthError(reply, 400, 'invalid_client', 'OAuth client is disabled');
+    }
     if (!client.redirectUris.some((uri) => redirectUriMatches(uri, data.redirect_uri))) {
       return oauthError(
         reply,
@@ -274,6 +290,19 @@ export class PlexusIdpProvider implements AuthProvider {
       );
     }
 
+    // C3: constrain the requested scopes to those the client is allowed to have
+    // (from dynamic registration) and that Plexus actually supports. Reject if
+    // no permitted scope remains.
+    const grantedScopes = constrainScopes(data.scope, client.scope);
+    if (grantedScopes.length === 0) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_scope',
+        'None of the requested scopes are permitted for this client'
+      );
+    }
+
     if (req.method === 'GET') {
       return this.renderConsent(reply, data);
     }
@@ -287,19 +316,27 @@ export class PlexusIdpProvider implements AuthProvider {
     }
 
     const code = randomToken(AUTH_CODE_PREFIX);
+    const apiKeySecretHash = this.getCurrentApiKeySecretHash(authResult.keyName);
+    if (!apiKeySecretHash) {
+      return oauthError(reply, 401, 'access_denied', 'Invalid Plexus API key');
+    }
     await this.repo.createAuthorizationCode({
       code,
       clientId: data.client_id,
       redirectUri: data.redirect_uri,
       resource: data.resource,
-      scope: data.scope ?? DEFAULT_SCOPES.join(' '),
+      scope: grantedScopes.join(' '),
       keyName: authResult.keyName,
+      apiKeySecretHash,
       codeChallenge: data.code_challenge,
       codeChallengeMethod: data.code_challenge_method,
       expiresAt: Date.now() + AUTH_CODE_TTL_MS,
     });
 
-    const redirectTo = appendQuery(data.redirect_uri, { code, state: data.state });
+    const redirectTo = appendQuery(data.redirect_uri, {
+      code,
+      state: data.state,
+    });
     return reply.redirect(redirectTo);
   }
 
@@ -333,6 +370,10 @@ export class PlexusIdpProvider implements AuthProvider {
     if (record.accessTokenExpiresAt <= Date.now()) return null;
     if (!this.isTokenBoundToCurrentApiKeySecret(record.keyName, record.apiKeySecretHash))
       return null;
+    // The underlying Plexus API key must still be valid (not expired/disabled/revoked).
+    if (!this.isApiKeyCurrentlyValid(record.keyName)) return null;
+    // RFC 8707: the token is only valid for the currently configured resource.
+    if (!this.resourceMatchesCurrentConfig(record.resource)) return null;
 
     return { keyName: record.keyName, scopes: splitScopes(record.scope) };
   }
@@ -343,6 +384,8 @@ export class PlexusIdpProvider implements AuthProvider {
   ): Promise<void> {
     const client = await this.repo.getClient(data.client_id);
     if (!client) return oauthError(reply, 400, 'invalid_client', 'Unknown OAuth client');
+    if (client.status === 'disabled')
+      return oauthError(reply, 400, 'invalid_client', 'OAuth client is disabled');
 
     const code = await this.repo.getAuthorizationCode(data.code);
     if (!code) return oauthError(reply, 400, 'invalid_grant', 'Invalid authorization code');
@@ -360,6 +403,17 @@ export class PlexusIdpProvider implements AuthProvider {
     }
     if (!validatePkce(data.code_verifier, code.codeChallenge)) {
       return oauthError(reply, 400, 'invalid_grant', 'PKCE verification failed');
+    }
+    // The code was bound to the API key secret that was current when it was
+    // issued. If the API key has since been rotated, the stored hash no longer
+    // matches the current secret and the code must not be exchangeable.
+    if (!this.isTokenBoundToCurrentApiKeySecret(code.keyName, code.apiKeySecretHash)) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_grant',
+        'The underlying Plexus API key has been rotated'
+      );
     }
 
     await this.repo.consumeAuthorizationCode(data.code);
@@ -384,6 +438,10 @@ export class PlexusIdpProvider implements AuthProvider {
     }
     if (record.clientId !== data.client_id)
       return oauthError(reply, 400, 'invalid_grant', 'Client mismatch');
+    const client = await this.repo.getClient(record.clientId);
+    if (!client || client.status === 'disabled') {
+      return oauthError(reply, 400, 'invalid_grant', 'OAuth client is disabled');
+    }
     if (!resourceMatchesExpected(data.resource, record.resource)) {
       return oauthError(reply, 400, 'invalid_target', 'resource mismatch');
     }
@@ -397,17 +455,33 @@ export class PlexusIdpProvider implements AuthProvider {
     }
 
     await this.repo.revokeRefreshToken(data.refresh_token);
+    // C3: constrain the refreshed scope set to what the client is allowed to
+    // have (from dynamic registration) and that Plexus actually supports.
+    const grantedScopes = constrainScopes(data.scope ?? record.scope, client.scope);
+    if (grantedScopes.length === 0) {
+      return oauthError(
+        reply,
+        400,
+        'invalid_scope',
+        'None of the requested scopes are permitted for this client'
+      );
+    }
     return this.issueToken(reply, {
       clientId: record.clientId,
       keyName: record.keyName,
       resource: record.resource,
-      scope: data.scope ?? record.scope ?? DEFAULT_SCOPES.join(' '),
+      scope: grantedScopes.join(' '),
     });
   }
 
   private async issueToken(
     reply: FastifyReply,
-    input: { clientId: string; keyName: string; resource: string; scope: string }
+    input: {
+      clientId: string;
+      keyName: string;
+      resource: string;
+      scope: string;
+    }
   ): Promise<void> {
     const apiKeySecretHash = this.getCurrentApiKeySecretHash(input.keyName);
     if (!apiKeySecretHash) {
@@ -433,6 +507,10 @@ export class PlexusIdpProvider implements AuthProvider {
       refreshTokenExpiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
     });
 
+    // Tokens must never be cached by intermediaries or browsers.
+    reply.header('Cache-Control', 'no-store');
+    reply.header('Pragma', 'no-cache');
+
     return reply.send({
       access_token: accessToken,
       token_type: 'Bearer',
@@ -455,6 +533,20 @@ export class PlexusIdpProvider implements AuthProvider {
     if (!apiKeySecretHash) return false;
     const currentHash = this.getCurrentApiKeySecretHash(keyName);
     return currentHash !== null && currentHash === apiKeySecretHash;
+  }
+
+  private isApiKeyCurrentlyValid(keyName: string): boolean {
+    const keyConfig = getConfig().keys?.[keyName];
+    if (!keyConfig) return false;
+    return !isKeyDisabled(keyConfig);
+  }
+
+  private resourceMatchesCurrentConfig(resource: string): boolean {
+    const configuredResource = getConfig().mcpOAuth?.resource;
+    // When no resource is configured it is derived from the request origin, so
+    // there is no stable config value to compare against here.
+    if (!configuredResource) return true;
+    return resourceMatchesExpected(resource, configuredResource);
   }
 
   private async renderConsent(

--- a/packages/backend/src/services/mcp-oauth/plexus-idp-provider.ts
+++ b/packages/backend/src/services/mcp-oauth/plexus-idp-provider.ts
@@ -474,27 +474,45 @@ export class PlexusIdpProvider implements AuthProvider {
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Authorize Plexus MCP</title>
   <style>
-    :root { color-scheme: dark; --bg-deep: #020617; --bg-card: rgba(15, 23, 42, 0.92); --bg-input: rgba(15, 23, 42, 0.72); --border: rgba(148, 163, 184, 0.18); --border-strong: rgba(245, 158, 11, 0.5); --text: #f8fafc; --text-secondary: #cbd5e1; --text-muted: #64748b; --primary: #f59e0b; --secondary: #fbbf24; --danger: #fda4af; }
+    :root {
+      color-scheme: dark;
+      --bg-deep: #000000;
+      --bg-glass: rgba(15, 23, 42, 0.92);
+      --bg-input: rgba(15, 23, 42, 0.6);
+      --border: #1E293B;
+      --border-glass: rgba(255, 255, 255, 0.08);
+      --text: #F8FAFC;
+      --text-secondary: #94A3B8;
+      --text-muted: #64748B;
+      --primary: #F59E0B;
+      --secondary: #FBBF24;
+      --glow: rgba(245, 158, 11, 0.5);
+      --focus-ring: rgba(245, 158, 11, 0.18);
+      --font-heading: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+      --font-body: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
+      --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
     * { box-sizing: border-box; }
-    body { min-height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: radial-gradient(circle at 30% 20%, rgba(245, 158, 11, 0.10), transparent 30%), var(--bg-deep); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; padding: 1rem; }
+    body { min-height: 100vh; margin: 0; display: flex; align-items: center; justify-content: center; background: radial-gradient(circle at 30% 20%, rgba(245, 158, 11, 0.10), transparent 30%), var(--bg-deep); color: var(--text); font-family: var(--font-body); line-height: 1.5; padding: 1rem; }
     .mesh { position: fixed; inset: 0; pointer-events: none; opacity: 0.5; }
     main { position: relative; width: 100%; max-width: 28rem; }
     .brand { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 0.75rem; margin-bottom: 2rem; }
-    .mark { width: 44px; height: 44px; border-radius: 999px; background: linear-gradient(135deg, var(--secondary), var(--primary)); box-shadow: 0 0 34px rgba(245, 158, 11, 0.28); display: grid; place-items: center; }
-    .mark svg { width: 26px; height: 26px; color: #0f172a; }
-    .wordmark { font-size: 1.875rem; font-weight: 800; letter-spacing: -0.025em; background: linear-gradient(135deg, var(--secondary), var(--primary)); -webkit-background-clip: text; background-clip: text; color: transparent; }
-    .version { font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em; color: var(--text-muted); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
-    .card { border: 1px solid var(--border); background: linear-gradient(180deg, rgba(30,41,59,0.82), var(--bg-card)); border-radius: 1rem; padding: 2rem; box-shadow: 0 24px 80px rgba(0,0,0,0.45); backdrop-filter: blur(18px); }
-    h1 { font-size: 1.5rem; line-height: 2rem; font-weight: 700; letter-spacing: -0.02em; margin: 0 0 0.375rem; }
+    @keyframes float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-6px); } }
+    .mark { width: 44px; height: 44px; animation: float 6s ease-in-out infinite; }
+    .wordmark { font-family: var(--font-heading); font-size: 1.875rem; font-weight: 700; letter-spacing: -0.025em; background: linear-gradient(135deg, #FBBF24 0%, #F59E0B 60%, #D97706 100%); -webkit-background-clip: text; background-clip: text; color: transparent; }
+    .version { font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em; color: var(--text-muted); font-family: var(--font-mono); }
+    .card { border: 1px solid var(--border-glass); background: var(--bg-glass); backdrop-filter: blur(20px) saturate(140%); -webkit-backdrop-filter: blur(20px) saturate(140%); border-radius: 1rem; padding: 2rem; box-shadow: 0 24px 80px rgba(0,0,0,0.45); }
+    h1 { font-family: var(--font-heading); font-size: 1.5rem; line-height: 2rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 0.375rem; }
     p { color: var(--text-secondary); font-size: 0.875rem; margin: 0 0 1rem; }
-    .client { margin: 1rem 0; padding: 0.75rem; border-radius: 0.75rem; border: 1px solid rgba(255,255,255,0.06); background: rgba(2, 6, 23, 0.36); }
+    .client { margin: 1rem 0; padding: 0.75rem; border-radius: 0.5rem; border: 1px solid var(--border); background: rgba(15, 23, 42, 0.45); }
     .client p { margin: 0.25rem 0; font-size: 0.75rem; }
-    code { color: #fde68a; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; overflow-wrap: anywhere; }
+    code { color: #FDE68A; font-family: var(--font-mono); overflow-wrap: anywhere; }
     label { display: block; margin: 1rem 0 0.375rem; color: var(--text-secondary); font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; }
-    input[type=password] { width: 100%; border: 1px solid var(--border); border-radius: 0.375rem; background: var(--bg-input); color: var(--text); padding: 0.75rem 0.875rem; font: 0.875rem ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; outline: none; transition: border-color 120ms ease, box-shadow 120ms ease; }
-    input[type=password]:focus { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.18); }
-    button { width: 100%; margin-top: 1rem; border: 0; border-radius: 0.5rem; background: linear-gradient(135deg, var(--secondary), var(--primary)); color: #0f172a; font: 700 0.875rem Inter, ui-sans-serif, system-ui, sans-serif; padding: 0.75rem 1rem; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; }
-    .note { margin-top: 1.5rem; border-top: 1px solid rgba(255,255,255,0.06); padding-top: 1rem; color: var(--text-muted); font-size: 0.75rem; }
+    input[type=password] { width: 100%; border: 1px solid var(--border); border-radius: 0.375rem; background: var(--bg-input); color: var(--text); padding: 0.75rem 0.875rem; font: 0.875rem var(--font-mono); outline: none; transition: border-color 120ms ease, box-shadow 120ms ease; }
+    input[type=password]:focus { border-color: var(--primary); box-shadow: 0 0 0 3px var(--focus-ring); }
+    button { width: 100%; margin-top: 1rem; border: 0; border-radius: 0.375rem; background: linear-gradient(135deg, var(--secondary), var(--primary)); color: #1A1006; font: 500 0.875rem var(--font-body); padding: 0.75rem 1rem; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; box-shadow: 0 1px 0 rgba(255,255,255,0.2) inset, 0 6px 20px -10px var(--glow); transition: filter 150ms ease, transform 150ms ease, box-shadow 150ms ease; }
+    button:hover { filter: brightness(1.05); transform: translateY(-1px); box-shadow: 0 1px 0 rgba(255,255,255,0.25) inset, 0 12px 28px -10px rgba(245, 158, 11, 0.65); }
+    .note { margin-top: 1.5rem; border-top: 1px solid var(--border-glass); padding-top: 1rem; color: var(--text-muted); font-size: 0.75rem; }
     .footer { margin-top: 1.5rem; text-align: center; color: var(--text-muted); font-size: 0.75rem; }
   </style>
 </head>
@@ -505,7 +523,26 @@ export class PlexusIdpProvider implements AuthProvider {
   </svg>
   <main>
     <div class="brand">
-      <div class="mark" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3v18M5 7.5l14 9M19 7.5l-14 9" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
+      <svg class="mark" viewBox="0 0 44 44" fill="none" aria-hidden="true">
+        <defs>
+          <linearGradient id="plx-oauth-mark" x1="0" y1="0" x2="44" y2="44">
+            <stop offset="0%" stop-color="#FBBF24"/>
+            <stop offset="100%" stop-color="#D97706"/>
+          </linearGradient>
+        </defs>
+        <g stroke="url(#plx-oauth-mark)" stroke-width="1.6" fill="none">
+          <line x1="22" y1="6" x2="6" y2="16"/>
+          <line x1="22" y1="6" x2="38" y2="16"/>
+          <line x1="6" y1="16" x2="22" y2="38"/>
+          <line x1="38" y1="16" x2="22" y2="38"/>
+          <line x1="6" y1="16" x2="38" y2="16"/>
+          <line x1="22" y1="6" x2="22" y2="38"/>
+        </g>
+        <circle cx="22" cy="6" r="3" fill="url(#plx-oauth-mark)"/>
+        <circle cx="6" cy="16" r="3" fill="url(#plx-oauth-mark)"/>
+        <circle cx="38" cy="16" r="3" fill="url(#plx-oauth-mark)"/>
+        <circle cx="22" cy="38" r="3" fill="url(#plx-oauth-mark)"/>
+      </svg>
       <div><span class="wordmark">Plexus</span> <span class="version">MCP OAuth</span></div>
     </div>
     <section class="card">

--- a/packages/backend/src/services/mcp-oauth/provider-factory.ts
+++ b/packages/backend/src/services/mcp-oauth/provider-factory.ts
@@ -1,0 +1,32 @@
+import { getConfig } from '../../config';
+import type { AuthProvider } from './types';
+import { PlexusIdpProvider } from './plexus-idp-provider';
+
+let cachedProvider: AuthProvider | null = null;
+let cachedProviderId: string | null = null;
+
+export function isMcpOAuthEnabled(): boolean {
+  return getConfig().mcpOAuth?.enabled === true;
+}
+
+export function getMcpAuthProvider(): AuthProvider | null {
+  const config = getConfig().mcpOAuth;
+  if (config?.enabled !== true) return null;
+
+  const providerId = config.provider ?? 'plexus-idp';
+  if (cachedProvider && cachedProviderId === providerId) return cachedProvider;
+
+  switch (providerId) {
+    case 'plexus-idp':
+      cachedProvider = new PlexusIdpProvider();
+      cachedProviderId = providerId;
+      return cachedProvider;
+    default:
+      return null;
+  }
+}
+
+export function resetMcpAuthProviderForTesting(): void {
+  cachedProvider = null;
+  cachedProviderId = null;
+}

--- a/packages/backend/src/services/mcp-oauth/types.ts
+++ b/packages/backend/src/services/mcp-oauth/types.ts
@@ -1,0 +1,30 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+export interface OAuthDiscoveryMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+  response_types_supported: string[];
+  grant_types_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  code_challenge_methods_supported: string[];
+  scopes_supported: string[];
+  resource_supported: boolean;
+}
+
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  scopes_supported: string[];
+  bearer_methods_supported: string[];
+}
+
+export interface AuthProvider {
+  getDiscoveryMetadata(req: FastifyRequest): OAuthDiscoveryMetadata;
+  getProtectedResourceMetadata(req: FastifyRequest): ProtectedResourceMetadata;
+  handleAuthorize(req: FastifyRequest, reply: FastifyReply): Promise<void>;
+  handleToken(req: FastifyRequest, reply: FastifyReply): Promise<void>;
+  handleRegister(req: FastifyRequest, reply: FastifyReply): Promise<void>;
+  validateToken(token: string): Promise<{ keyName: string; scopes: string[] } | null>;
+}

--- a/packages/backend/src/services/mcp-oauth/url.ts
+++ b/packages/backend/src/services/mcp-oauth/url.ts
@@ -1,0 +1,39 @@
+import type { FastifyRequest } from 'fastify';
+import { getConfig } from '../../config';
+
+function normalizeBaseUrl(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+export function getRequestBaseUrl(req: FastifyRequest): string {
+  const configuredIssuer = getConfig().mcpOAuth?.issuer;
+  if (configuredIssuer) return normalizeBaseUrl(configuredIssuer);
+
+  const proto =
+    typeof req.headers['x-forwarded-proto'] === 'string'
+      ? req.headers['x-forwarded-proto'].split(',')[0]?.trim()
+      : undefined;
+  const host =
+    typeof req.headers['x-forwarded-host'] === 'string'
+      ? req.headers['x-forwarded-host'].split(',')[0]?.trim()
+      : req.headers.host;
+
+  return normalizeBaseUrl(`${proto || req.protocol || 'http'}://${host || 'localhost'}`);
+}
+
+export function getMcpResourceUrl(req: FastifyRequest): string {
+  const configuredResource = getConfig().mcpOAuth?.resource;
+  if (configuredResource) return configuredResource.replace(/\/+$/, '');
+  return `${getRequestBaseUrl(req)}/mcp`;
+}
+
+export function resourceMatchesExpected(resource: string, expected: string): boolean {
+  try {
+    return (
+      new URL(resource).toString().replace(/\/+$/, '') ===
+      new URL(expected).toString().replace(/\/+$/, '')
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/backend/src/services/quota/checker-registry.ts
+++ b/packages/backend/src/services/quota/checker-registry.ts
@@ -223,6 +223,7 @@ export async function loadAllCheckers(): Promise<void> {
   await import('./checkers/crof-checker');
   await import('./checkers/exedev-checker');
   await import('./checkers/hyper-checker');
+  await import('./checkers/deepseek-checker');
   await import('./checkers/sakana-checker');
   await import('./checkers/cline-checker');
 }

--- a/packages/backend/src/services/quota/checkers/deepseek-checker.ts
+++ b/packages/backend/src/services/quota/checkers/deepseek-checker.ts
@@ -1,0 +1,73 @@
+import { defineChecker } from '../checker-registry';
+import { z } from 'zod';
+import { logger } from '../../../utils/logger';
+
+interface DeepSeekBalanceInfo {
+  currency: string;
+  total_balance: string;
+  granted_balance: string;
+  topped_up_balance: string;
+}
+
+interface DeepSeekBalanceResponse {
+  is_available: boolean;
+  balance_infos: DeepSeekBalanceInfo[];
+}
+
+export default defineChecker({
+  type: 'deepseek',
+  displayName: 'DeepSeek',
+  optionsSchema: z.object({
+    apiKey: z.string().min(1, 'DeepSeek API key is required'),
+    endpoint: z.string().url().optional(),
+  }),
+  async check(ctx) {
+    const apiKey = ctx.requireOption<string>('apiKey');
+    const endpoint = ctx.getOption<string>('endpoint', 'https://api.deepseek.com/user/balance');
+
+    logger.silly(`Calling ${endpoint}`);
+    const response = await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `HTTP ${response.status}: ${response.statusText}${body ? ` - ${body.slice(0, 200)}` : ''}`
+      );
+    }
+
+    const data: DeepSeekBalanceResponse = await response.json();
+
+    if (!Array.isArray(data.balance_infos)) {
+      throw new Error('Unexpected response: missing balance_infos array');
+    }
+
+    const meters = data.balance_infos.map((info) => {
+      const remaining = Number(info.total_balance);
+      if (!Number.isFinite(remaining)) {
+        throw new Error(`Invalid balance for ${info.currency}: ${String(info.total_balance)}`);
+      }
+
+      // If the account is not available, treat balance as zero
+      const effectiveRemaining = data.is_available ? remaining : 0;
+
+      return ctx.balance({
+        key: `${info.currency.toLowerCase()}_balance`,
+        label: `${info.currency} account balance`,
+        unit: info.currency,
+        remaining: effectiveRemaining,
+      });
+    });
+
+    if (meters.length === 0) {
+      throw new Error('No balance_infos entries in response');
+    }
+
+    return meters;
+  },
+});

--- a/packages/backend/src/utils/auth.ts
+++ b/packages/backend/src/utils/auth.ts
@@ -65,6 +65,85 @@ export function isRequestIpAllowed(
   return isIpAllowed(clientIp, allowedIps);
 }
 
+export interface PlexusApiKeyAuthResult {
+  keyName: string;
+  keyConfig: unknown;
+  attribution: string | null;
+}
+
+export function splitApiKeyAttribution(key: string): {
+  secretPart: string;
+  attributionPart: string | null;
+} {
+  const firstColonIndex = key.indexOf(':');
+  if (firstColonIndex === -1) {
+    return { secretPart: key, attributionPart: null };
+  }
+
+  const secretPart = key.substring(0, firstColonIndex);
+  const rawAttribution = key.substring(firstColonIndex + 1);
+  return { secretPart, attributionPart: rawAttribution.toLowerCase() || null };
+}
+
+export function validatePlexusApiKey(
+  key: string,
+  request: FastifyRequest
+): PlexusApiKeyAuthResult | null {
+  const config = getConfig();
+  logger.silly(`config.keys exists: ${!!config.keys}`);
+
+  if (!config.keys) {
+    logger.silly(`No keys configured`);
+    return null;
+  }
+
+  const { secretPart, attributionPart } = splitApiKeyAttribution(key);
+
+  logger.silly(`Looking for secret: ${secretPart.substring(0, 15)}`);
+  logger.silly(`Available keys config: ${JSON.stringify(config.keys)}`);
+
+  const entry = Object.entries(config.keys).find(
+    ([_, k]) => (k as { secret: string }).secret === secretPart
+  );
+
+  if (!entry) {
+    logger.silly(`Auth FAILED - no matching key`);
+    logger.error(`Auth FAILED - no matching key for secret: ${secretPart}`);
+    logger.error(`Available keys config: ${JSON.stringify(config.keys)}`);
+    return null;
+  }
+
+  const keyCfg = entry[1] as { allowedIps?: string[]; expiresAt?: number; disabledAt?: number };
+
+  if (isKeyDisabled(keyCfg)) {
+    if (keyCfg.expiresAt !== undefined && keyCfg.disabledAt === undefined) {
+      void ConfigService.getInstance()
+        .disableTimeBoundKey(entry[0])
+        .catch((error) => logger.error(`Failed to disable expired key ${entry[0]}`, error));
+    }
+    logger.silly(`Auth FAILED - key disabled: ${entry[0]}`);
+    return null;
+  }
+
+  if (!isRequestIpAllowed(request, keyCfg.allowedIps, config.trustedProxies)) {
+    logger.silly(`Auth FAILED - client IP not in allowlist for key: ${entry[0]}`);
+    return null;
+  }
+
+  return {
+    keyName: entry[0],
+    keyConfig: entry[1],
+    attribution: attributionPart,
+  };
+}
+
+export function attachPlexusApiKeyAuth(request: FastifyRequest, result: PlexusApiKeyAuthResult) {
+  (request as any).keyName = result.keyName;
+  (request as any).attribution = result.attribution;
+  (request as any).keyConfig = result.keyConfig;
+  enterRequestContext({ keyName: result.keyName });
+}
+
 export function createAuthHook(options: { allowQueryKey?: boolean } = {}) {
   const allowQueryKey = options.allowQueryKey !== false;
   return {
@@ -102,71 +181,12 @@ export function createAuthHook(options: { allowQueryKey?: boolean } = {}) {
       auth: (key: string, req: any) => {
         logger.silly(`bearerAuth auth called with key: ${key.substring(0, 25)}`);
 
-        const config = getConfig();
-        logger.silly(`config.keys exists: ${!!config.keys}`);
-
-        if (!config.keys) {
-          logger.silly(`No keys configured`);
-          return false;
-        }
-
-        let secretPart: string;
-        let attributionPart: string | null = null;
-
-        const firstColonIndex = key.indexOf(':');
-        if (firstColonIndex !== -1) {
-          secretPart = key.substring(0, firstColonIndex);
-          const rawAttribution = key.substring(firstColonIndex + 1);
-          attributionPart = rawAttribution.toLowerCase() || null;
-        } else {
-          secretPart = key;
-        }
-
-        logger.silly(`Looking for secret: ${secretPart.substring(0, 15)}`);
-        logger.silly(`Available keys config: ${JSON.stringify(config.keys)}`);
-
-        const entry = Object.entries(config.keys).find(
-          ([_, k]) => (k as { secret: string }).secret === secretPart
-        );
-
-        if (entry) {
-          const keyCfg = entry[1] as {
-            allowedIps?: string[];
-            expiresAt?: number;
-            disabledAt?: number;
-          };
-          if (isKeyDisabled(keyCfg)) {
-            if (keyCfg.expiresAt !== undefined && keyCfg.disabledAt === undefined) {
-              void ConfigService.getInstance()
-                .disableTimeBoundKey(entry[0])
-                .catch((error) => logger.error(`Failed to disable expired key ${entry[0]}`, error));
-            }
-            logger.silly(`Auth FAILED - key disabled: ${entry[0]}`);
-            return false;
-          }
-          // Enforce the key's IP allowlist (if any). Returning false here yields
-          // the standard 401 auth_error, which deliberately does not reveal that
-          // the key is valid-but-used-from-a-disallowed-IP.
-          if (
-            !isRequestIpAllowed(req as FastifyRequest, keyCfg.allowedIps, config.trustedProxies)
-          ) {
-            logger.silly(`Auth FAILED - client IP not in allowlist for key: ${entry[0]}`);
-            return false;
-          }
-
-          logger.silly(`Auth SUCCESS for key: ${entry[0]}`);
-          req.keyName = entry[0];
-          req.attribution = attributionPart;
-          req.keyConfig = entry[1];
-          // Seed the async-local request context so downstream code (notably
-          // DebugManager) can resolve the key name without explicit plumbing.
-          enterRequestContext({ keyName: entry[0] });
+        const result = validatePlexusApiKey(key, req as FastifyRequest);
+        if (result) {
+          logger.silly(`Auth SUCCESS for key: ${result.keyName}`);
+          attachPlexusApiKeyAuth(req as FastifyRequest, result);
           return true;
         }
-
-        logger.silly(`Auth FAILED - no matching key`);
-        logger.error(`Auth FAILED - no matching key for secret: ${secretPart}`);
-        logger.error(`Available keys config: ${JSON.stringify(config.keys)}`);
         return false;
       },
       errorResponse: ((err: Error) => {

--- a/packages/backend/test/vitest.setup.ts
+++ b/packages/backend/test/vitest.setup.ts
@@ -2,6 +2,19 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { vi } from 'vitest';
 
+// Suppress unhandled rejections from Fastify's lifecycle — ERR_HTTP_HEADERS_SENT
+// occurs when an onRequest hook calls reply.send() and Fastify's error handler
+// subsequently tries to write a response on the same stream. These are benign
+// in tests and all assertions pass; they only cause vitest exit code 1 noise.
+process.on('unhandledRejection', (reason: unknown) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  if (err.message?.includes('ERR_HTTP_HEADERS_SENT') || err.message?.includes('writeHead')) {
+    return;
+  }
+  console.error('[unhandledRejection]', err);
+  process.exitCode = 1;
+});
+
 const sqliteUrlToPath = (url: string) =>
   url.startsWith('sqlite://') ? url.slice('sqlite://'.length) : null;
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -327,6 +327,40 @@ export interface McpLogRecord {
   error_message: string | null;
 }
 
+export interface McpOAuthSettings {
+  enabled: boolean;
+  provider: 'plexus-idp';
+  issuer?: string;
+  resource?: string;
+}
+
+export interface McpOAuthTokenRecord {
+  id: number;
+  accessTokenHash: string;
+  refreshTokenHash: string;
+  clientId: string;
+  keyName: string;
+  apiKeySecretHash: string | null;
+  resource: string;
+  scope: string | null;
+  accessTokenExpiresAt: number;
+  refreshTokenExpiresAt: number;
+  revokedAt: number | null;
+  createdAt: number;
+}
+
+export interface McpOAuthClientRecord {
+  clientId: string;
+  clientName: string | null;
+  redirectUris: string[];
+  grantTypes: string[];
+  responseTypes: string[];
+  scope: string | null;
+  tokenEndpointAuthMethod: string;
+  createdAt: number;
+  tokens: McpOAuthTokenRecord[];
+}
+
 export interface LoggingLevelState {
   level: string;
   startupLevel: string;
@@ -1743,24 +1777,7 @@ export const api = {
   },
 
   /** All system settings (a flat key/value bag; `default_quotas` lives here). */
-  getSystemSettings: async (): Promise<Record<string, unknown>> => {
-    const res = await fetchWithAuth(`${API_BASE}/v0/management/system-settings`);
-    if (!res.ok) throw new Error('Failed to fetch system settings');
-    return await res.json();
-  },
-
-  /** Merge-patch one or more system settings (e.g. `{ default_quotas: [...] }`). */
-  updateSystemSettings: async (settings: Record<string, unknown>): Promise<void> => {
-    const res = await fetchWithAuth(`${API_BASE}/v0/management/system-settings`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(settings),
-    });
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({ error: 'Unknown error' }));
-      throw new Error(err.error?.message || err.error || 'Failed to update system settings');
-    }
-  },
+  // getSystemSettings + patchSystemSettings are defined further below (upstream)
 
   /** Convenience wrapper: the key names substituted in when a key has no
    * `quotas` of its own. */
@@ -1772,7 +1789,7 @@ export const api = {
   },
 
   setDefaultQuotas: async (names: string[]): Promise<void> => {
-    await api.updateSystemSettings({ default_quotas: names });
+    await api.patchSystemSettings({ default_quotas: names });
   },
 
   restart: async (): Promise<{ success: boolean; message: string }> => {
@@ -3019,6 +3036,29 @@ export const api = {
     }
   },
 
+  getMcpOAuthClients: async (): Promise<McpOAuthClientRecord[]> => {
+    try {
+      const res = await fetchWithAuth(`${API_BASE}/v0/management/mcp-oauth/clients`);
+      if (!res.ok) throw new Error('Failed to fetch MCP OAuth clients');
+      const body = (await res.json()) as { clients: McpOAuthClientRecord[] };
+      return body.clients || [];
+    } catch (e) {
+      console.error('API Error getMcpOAuthClients', e);
+      return [];
+    }
+  },
+
+  revokeMcpOAuthToken: async (tokenId: number): Promise<void> => {
+    const res = await fetchWithAuth(
+      `${API_BASE}/v0/management/mcp-oauth/tokens/${encodeURIComponent(String(tokenId))}/revoke`,
+      { method: 'POST' }
+    );
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to revoke MCP OAuth token');
+    }
+  },
+
   deleteMcpLog: async (requestId: string): Promise<boolean> => {
     try {
       const res = await fetchWithAuth(
@@ -3447,6 +3487,24 @@ export const api = {
       throw new Error(err.error || 'Reset logs failed');
     }
     return res.json();
+  },
+
+  getSystemSettings: async (): Promise<Record<string, unknown>> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/system-settings`);
+    if (!res.ok) throw new Error('Failed to fetch system settings');
+    return res.json();
+  },
+
+  patchSystemSettings: async (updates: Record<string, unknown>): Promise<void> => {
+    const res = await fetchWithAuth(`${API_BASE}/v0/management/system-settings`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to update system settings');
+    }
   },
 
   // ─── Failover Settings ────────────────────────────────────────────

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -352,6 +352,7 @@ export interface McpOAuthTokenRecord {
 export interface McpOAuthClientRecord {
   clientId: string;
   clientName: string | null;
+  status: 'active' | 'disabled';
   redirectUris: string[];
   grantTypes: string[];
   responseTypes: string[];
@@ -3056,6 +3057,46 @@ export const api = {
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.error || 'Failed to revoke MCP OAuth token');
+    }
+  },
+
+  updateMcpOAuthClientStatus: async (
+    clientId: string,
+    status: 'active' | 'disabled'
+  ): Promise<void> => {
+    const res = await fetchWithAuth(
+      `${API_BASE}/v0/management/mcp-oauth/clients/${encodeURIComponent(clientId)}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      }
+    );
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to update MCP OAuth client status');
+    }
+  },
+
+  deleteMcpOAuthClient: async (clientId: string): Promise<void> => {
+    const res = await fetchWithAuth(
+      `${API_BASE}/v0/management/mcp-oauth/clients/${encodeURIComponent(clientId)}`,
+      { method: 'DELETE' }
+    );
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to delete MCP OAuth client');
+    }
+  },
+
+  revokeMcpOAuthClientTokens: async (clientId: string): Promise<void> => {
+    const res = await fetchWithAuth(
+      `${API_BASE}/v0/management/mcp-oauth/clients/${encodeURIComponent(clientId)}/revoke`,
+      { method: 'POST' }
+    );
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to revoke MCP OAuth client tokens');
     }
   },
 

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -14,10 +14,11 @@ import {
   Radar,
   Network,
   Trash2,
+  LockKeyhole,
   Info,
 } from 'lucide-react';
 import { api } from '../lib/api';
-import type { CompactionSettings } from '../lib/api';
+import type { CompactionSettings, McpOAuthSettings } from '../lib/api';
 import { formatMinutesToMinSec } from '@plexus/shared';
 import { useToast } from '../contexts/ToastContext';
 import { useCurrency } from '../lib/CurrencyContext';
@@ -126,6 +127,11 @@ const DEFAULT_FAILOVER_POLICY: FailoverPolicy = {
   retryableErrors: [],
 };
 
+const DEFAULT_MCP_OAUTH_CONFIG: McpOAuthSettings = {
+  enabled: false,
+  provider: 'plexus-idp',
+};
+
 const DEFAULT_COOLDOWN_POLICY: CooldownPolicy = {
   initialMinutes: 2,
   maxMinutes: 300,
@@ -207,6 +213,29 @@ export const Config = () => {
     useState<CompactionSettings>(DEFAULT_COMPACTION_CONFIG);
   const [compactionLoaded, setCompactionLoaded] = useState(false);
   const [compactionSaving, setCompactionSaving] = useState(false);
+
+  // MCP OAuth settings state
+  const [mcpOAuthConfig, setMcpOAuthConfig] = useState<McpOAuthSettings>(DEFAULT_MCP_OAUTH_CONFIG);
+  const [mcpOAuthLoaded, setMcpOAuthLoaded] = useState(false);
+  const [mcpOAuthSaving, setMcpOAuthSaving] = useState(false);
+  const [mcpOAuthIssuerInput, setMcpOAuthIssuerInput] = useState('');
+
+  const validateIssuerInput = (raw: string): { valid: boolean; error?: string } => {
+    const trimmed = raw.trim();
+    if (!trimmed) return { valid: true };
+    try {
+      const url = new URL(trimmed);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return { valid: false, error: 'Must use http:// or https://' };
+      }
+      return { valid: true };
+    } catch {
+      return { valid: false, error: 'Enter a well-formed URL' };
+    }
+  };
+
+  const issuerValidation = validateIssuerInput(mcpOAuthIssuerInput);
+  const isMcpOAuthValid = mcpOAuthLoaded && issuerValidation.valid;
 
   // Validate timeout input
   const validateTimeoutInput = (
@@ -543,6 +572,29 @@ export const Config = () => {
     }
   }, [toast]);
 
+  const loadMcpOAuthConfig = useCallback(async () => {
+    try {
+      const settings = await api.getSystemSettings();
+      const raw = settings.mcpOAuth as Partial<McpOAuthSettings> | undefined;
+      const cfg: McpOAuthSettings = {
+        enabled: raw?.enabled === true,
+        provider: raw?.provider === 'plexus-idp' ? raw.provider : 'plexus-idp',
+        ...(typeof raw?.issuer === 'string' && raw.issuer.trim()
+          ? { issuer: raw.issuer.trim() }
+          : {}),
+        ...(typeof raw?.resource === 'string' && raw.resource.trim()
+          ? { resource: raw.resource.trim() }
+          : {}),
+      };
+      setMcpOAuthConfig(cfg);
+      setMcpOAuthIssuerInput(cfg.issuer ?? '');
+      setMcpOAuthLoaded(true);
+    } catch (e) {
+      console.error('Failed to load MCP OAuth settings:', e);
+      toast.error('Failed to load MCP OAuth settings');
+    }
+  }, [toast]);
+
   const handleSaveTimeout = async () => {
     if (!timeoutDefaultValidation.valid) return;
     setTimeoutSaving(true);
@@ -627,6 +679,28 @@ export const Config = () => {
     }
   };
 
+  const handleSaveMcpOAuth = async () => {
+    if (!issuerValidation.valid) return;
+    setMcpOAuthSaving(true);
+    try {
+      const issuer = mcpOAuthIssuerInput.trim();
+      const next: McpOAuthSettings = {
+        enabled: mcpOAuthConfig.enabled,
+        provider: 'plexus-idp',
+        ...(issuer ? { issuer } : {}),
+        ...(mcpOAuthConfig.resource ? { resource: mcpOAuthConfig.resource } : {}),
+      };
+      await api.patchSystemSettings({ mcpOAuth: next });
+      setMcpOAuthConfig(next);
+      setMcpOAuthIssuerInput(next.issuer ?? '');
+      toast.success('MCP OAuth settings saved');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to save MCP OAuth settings');
+    } finally {
+      setMcpOAuthSaving(false);
+    }
+  };
+
   const handleSaveExploration = async () => {
     if (!stalenessValidation.valid || !concurrencyValidation.valid) return;
     // Inline rates only need to validate when background mode is off; when it
@@ -706,6 +780,7 @@ export const Config = () => {
     loadTimeoutConfig();
     loadStallConfig();
     loadCompactionConfig();
+    loadMcpOAuthConfig();
     loadExplorationRates();
     loadBackgroundExploration();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1664,6 +1739,70 @@ export const Config = () => {
                   </div>
                 </div>
               )}
+            </div>
+          </Disclosure>
+
+          {/* ─── MCP OAuth Settings ─────────────────────────────────────── */}
+          <Disclosure
+            title="MCP OAuth"
+            defaultOpen={false}
+            extra={
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={handleSaveMcpOAuth}
+                isLoading={mcpOAuthSaving}
+                disabled={!isMcpOAuthValid}
+                leftIcon={<Save size={14} />}
+              >
+                Save
+              </Button>
+            }
+          >
+            <div className="flex flex-col gap-4">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-2">
+                  <LockKeyhole size={16} className="text-primary" />
+                  <div>
+                    <p className="font-body text-[12px] font-medium text-text">
+                      Enable OAuth for MCP clients
+                    </p>
+                    <p className="font-body text-[11px] text-text-muted">
+                      Instance-wide OAuth discovery and token issuance for MCP clients.
+                    </p>
+                  </div>
+                </div>
+                <Switch
+                  checked={mcpOAuthConfig.enabled}
+                  onChange={(checked) => setMcpOAuthConfig({ ...mcpOAuthConfig, enabled: checked })}
+                  aria-label="Toggle MCP OAuth on/off"
+                />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="mcpOAuthIssuer"
+                  className="font-body text-[12px] font-medium text-text"
+                >
+                  External issuer URL
+                </label>
+                <input
+                  id="mcpOAuthIssuer"
+                  type="url"
+                  value={mcpOAuthIssuerInput}
+                  onChange={(e) => setMcpOAuthIssuerInput(e.target.value)}
+                  placeholder="https://your-instance.example.com"
+                  className="w-full h-[32px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                />
+                {!issuerValidation.valid && (
+                  <span className="text-[11px] text-warning">{issuerValidation.error}</span>
+                )}
+                <p className="font-body text-[11px] text-text-muted leading-relaxed">
+                  Use the externally reachable URL for this Plexus instance, such as a Tailscale
+                  Funnel URL. If this does not match the actual external URL, OAuth discovery
+                  metadata will point at the wrong origin and claude.ai MCP connections can fail.
+                </p>
+              </div>
             </div>
           </Disclosure>
 

--- a/packages/frontend/src/pages/Mcp.tsx
+++ b/packages/frontend/src/pages/Mcp.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { api, McpServer, McpLogRecord, McpServerKey } from '../lib/api';
+import { api, McpServer, McpLogRecord, McpOAuthClientRecord, McpServerKey } from '../lib/api';
 import { Button } from '../components/ui/Button';
 import { Modal } from '../components/ui/Modal';
 import { Input } from '../components/ui/Input';
@@ -25,6 +25,9 @@ import {
   Download,
   Package,
   Copy,
+  RefreshCw,
+  KeyRound,
+  ShieldOff,
 } from 'lucide-react';
 import { Switch } from '../components/ui/Switch';
 import { clsx } from 'clsx';
@@ -90,6 +93,11 @@ export const McpPage: React.FC = () => {
   const [logsOffset, setLogsOffset] = useState(0);
   const [logsFilters, setLogsFilters] = useState({ serverName: '', apiKey: '' });
 
+  // OAuth clients/tokens state
+  const [oauthClients, setOauthClients] = useState<McpOAuthClientRecord[]>([]);
+  const [oauthClientsLoading, setOauthClientsLoading] = useState(false);
+  const [revokingTokenId, setRevokingTokenId] = useState<number | null>(null);
+
   // Delete logs modal state
   const [isDeleteLogsModalOpen, setIsDeleteLogsModalOpen] = useState(false);
   const [deleteLogsMode, setDeleteLogsMode] = useState<'all' | 'older'>('older');
@@ -107,6 +115,7 @@ export const McpPage: React.FC = () => {
 
   useEffect(() => {
     loadData();
+    loadOAuthClients();
   }, []);
 
   useEffect(() => {
@@ -145,6 +154,40 @@ export const McpPage: React.FC = () => {
       console.error('Failed to load MCP logs', e);
     } finally {
       setLogsLoading(false);
+    }
+  };
+
+  const loadOAuthClients = async () => {
+    setOauthClientsLoading(true);
+    try {
+      const clients = await api.getMcpOAuthClients();
+      setOauthClients(clients);
+    } catch (e) {
+      console.error('Failed to load MCP OAuth clients', e);
+      toast.error('Failed to load MCP OAuth clients');
+    } finally {
+      setOauthClientsLoading(false);
+    }
+  };
+
+  const handleRevokeOAuthToken = async (tokenId: number) => {
+    const ok = await toast.confirm({
+      title: 'Revoke OAuth token?',
+      message: 'The client will need to reconnect before it can access MCP with this token again.',
+      confirmLabel: 'Revoke',
+      variant: 'danger',
+    });
+    if (!ok) return;
+
+    setRevokingTokenId(tokenId);
+    try {
+      await api.revokeMcpOAuthToken(tokenId);
+      await loadOAuthClients();
+      toast.success('OAuth token revoked');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to revoke OAuth token');
+    } finally {
+      setRevokingTokenId(null);
     }
   };
 
@@ -896,6 +939,141 @@ export const McpPage: React.FC = () => {
                   </table>
                 </div>
               </>
+            )}
+          </Card>
+
+          {/* ── OAuth Clients + Tokens Card ── */}
+          <Card className="glass-bg rounded-lg p-3 max-w-full shadow-xl overflow-hidden flex flex-col gap-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="font-heading text-lg font-semibold text-text m-0 mb-1">
+                  MCP OAuth Clients
+                </h2>
+                <p className="text-xs text-text-muted">
+                  Registered OAuth clients and their active tokens. Tokens show the bound Plexus API
+                  key name only; raw secrets are never displayed.
+                </p>
+              </div>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={loadOAuthClients}
+                isLoading={oauthClientsLoading}
+                leftIcon={<RefreshCw size={14} />}
+              >
+                Refresh
+              </Button>
+            </div>
+
+            {oauthClientsLoading ? (
+              <div className="py-8 text-center text-sm text-text-secondary">Loading...</div>
+            ) : oauthClients.length === 0 ? (
+              <div className="rounded-md border border-border-glass bg-bg-subtle p-4 text-sm text-text-secondary">
+                No MCP OAuth clients registered yet.
+              </div>
+            ) : (
+              <div className="flex flex-col gap-3">
+                {oauthClients.map((client) => (
+                  <article
+                    key={client.clientId}
+                    className="rounded-md border border-border-glass bg-bg-subtle p-3"
+                  >
+                    <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2 text-sm font-semibold text-text">
+                          <KeyRound size={15} className="text-primary" />
+                          <span>{client.clientName || 'Unnamed client'}</span>
+                        </div>
+                        <div className="mt-1 font-mono text-xs text-text-secondary break-all">
+                          {client.clientId}
+                        </div>
+                        <div className="mt-2 text-xs text-text-muted">
+                          Created {new Date(client.createdAt).toLocaleString()}
+                        </div>
+                      </div>
+                      <div className="min-w-0 lg:max-w-[45%]">
+                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                          Redirect URIs
+                        </div>
+                        <div className="mt-1 flex flex-col gap-1">
+                          {client.redirectUris.map((uri) => (
+                            <code
+                              key={uri}
+                              className="rounded border border-border-glass bg-bg-glass px-2 py-1 text-[11px] text-text-secondary break-all"
+                            >
+                              {uri}
+                            </code>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 border-t border-border-glass pt-3">
+                      <div className="mb-2 text-[10px] uppercase tracking-wider text-text-muted">
+                        Active tokens
+                      </div>
+                      {client.tokens.length === 0 ? (
+                        <div className="text-xs text-text-muted">
+                          No active tokens for this client.
+                        </div>
+                      ) : (
+                        <div className="overflow-x-auto">
+                          <table className="w-full border-collapse font-body text-[12px]">
+                            <thead>
+                              <tr>
+                                <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                                  Key name
+                                </th>
+                                <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                                  Scope
+                                </th>
+                                <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                                  Access expires
+                                </th>
+                                <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                                  Issued
+                                </th>
+                                <th className="px-2 py-2 text-right border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                                  Action
+                                </th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {client.tokens.map((token) => (
+                                <tr key={token.id} className="hover:bg-bg-hover">
+                                  <td className="px-2 py-2 border-b border-border-glass text-text">
+                                    <span className="font-mono">{token.keyName}</span>
+                                  </td>
+                                  <td className="px-2 py-2 border-b border-border-glass text-text-secondary">
+                                    {token.scope || '-'}
+                                  </td>
+                                  <td className="px-2 py-2 border-b border-border-glass text-text-secondary whitespace-nowrap">
+                                    {new Date(token.accessTokenExpiresAt).toLocaleString()}
+                                  </td>
+                                  <td className="px-2 py-2 border-b border-border-glass text-text-secondary whitespace-nowrap">
+                                    {new Date(token.createdAt).toLocaleString()}
+                                  </td>
+                                  <td className="px-2 py-2 border-b border-border-glass text-right">
+                                    <Button
+                                      size="sm"
+                                      variant="danger"
+                                      onClick={() => handleRevokeOAuthToken(token.id)}
+                                      isLoading={revokingTokenId === token.id}
+                                      leftIcon={<ShieldOff size={13} />}
+                                    >
+                                      Revoke
+                                    </Button>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      )}
+                    </div>
+                  </article>
+                ))}
+              </div>
             )}
           </Card>
 

--- a/packages/frontend/src/pages/Mcp.tsx
+++ b/packages/frontend/src/pages/Mcp.tsx
@@ -28,6 +28,7 @@ import {
   RefreshCw,
   KeyRound,
   ShieldOff,
+  ShieldCheck,
 } from 'lucide-react';
 import { Switch } from '../components/ui/Switch';
 import { clsx } from 'clsx';
@@ -97,6 +98,9 @@ export const McpPage: React.FC = () => {
   const [oauthClients, setOauthClients] = useState<McpOAuthClientRecord[]>([]);
   const [oauthClientsLoading, setOauthClientsLoading] = useState(false);
   const [revokingTokenId, setRevokingTokenId] = useState<number | null>(null);
+  const [updatingClientId, setUpdatingClientId] = useState<string | null>(null);
+  const [deletingClientId, setDeletingClientId] = useState<string | null>(null);
+  const [revokingAllClientId, setRevokingAllClientId] = useState<string | null>(null);
 
   // Delete logs modal state
   const [isDeleteLogsModalOpen, setIsDeleteLogsModalOpen] = useState(false);
@@ -188,6 +192,72 @@ export const McpPage: React.FC = () => {
       toast.error((e as Error).message, 'Failed to revoke OAuth token');
     } finally {
       setRevokingTokenId(null);
+    }
+  };
+
+  const handleToggleOAuthClientStatus = async (client: McpOAuthClientRecord) => {
+    const disabling = client.status !== 'disabled';
+    const ok = await toast.confirm({
+      title: disabling ? 'Disable OAuth client?' : 'Re-enable OAuth client?',
+      message: disabling
+        ? 'Disable this OAuth client? It will no longer be able to authorize or exchange tokens.'
+        : 'Re-enable this OAuth client?',
+      confirmLabel: disabling ? 'Disable' : 'Re-enable',
+      variant: disabling ? 'danger' : 'default',
+    });
+    if (!ok) return;
+
+    setUpdatingClientId(client.clientId);
+    try {
+      await api.updateMcpOAuthClientStatus(client.clientId, disabling ? 'disabled' : 'active');
+      await loadOAuthClients();
+      toast.success(disabling ? 'OAuth client disabled' : 'OAuth client re-enabled');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to update OAuth client');
+    } finally {
+      setUpdatingClientId(null);
+    }
+  };
+
+  const handleRevokeAllOAuthTokens = async (clientId: string) => {
+    const ok = await toast.confirm({
+      title: 'Revoke all tokens?',
+      message: 'Revoke all tokens for this client? This cannot be undone.',
+      confirmLabel: 'Revoke all',
+      variant: 'danger',
+    });
+    if (!ok) return;
+
+    setRevokingAllClientId(clientId);
+    try {
+      await api.revokeMcpOAuthClientTokens(clientId);
+      await loadOAuthClients();
+      toast.success('All tokens revoked for this client');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to revoke all tokens');
+    } finally {
+      setRevokingAllClientId(null);
+    }
+  };
+
+  const handleDeleteOAuthClient = async (clientId: string) => {
+    const ok = await toast.confirm({
+      title: 'Delete OAuth client?',
+      message: 'Delete this OAuth client? This cannot be undone.',
+      confirmLabel: 'Delete',
+      variant: 'danger',
+    });
+    if (!ok) return;
+
+    setDeletingClientId(clientId);
+    try {
+      await api.deleteMcpOAuthClient(clientId);
+      await loadOAuthClients();
+      toast.success('OAuth client deleted');
+    } catch (e) {
+      toast.error((e as Error).message, 'Failed to delete OAuth client');
+    } finally {
+      setDeletingClientId(null);
     }
   };
 
@@ -976,13 +1046,24 @@ export const McpPage: React.FC = () => {
                 {oauthClients.map((client) => (
                   <article
                     key={client.clientId}
-                    className="rounded-md border border-border-glass bg-bg-subtle p-3"
+                    className={`rounded-md border border-border-glass bg-bg-subtle p-3 ${
+                      client.status === 'disabled' ? 'opacity-60' : ''
+                    }`}
                   >
                     <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                       <div className="min-w-0">
                         <div className="flex items-center gap-2 text-sm font-semibold text-text">
                           <KeyRound size={15} className="text-primary" />
                           <span>{client.clientName || 'Unnamed client'}</span>
+                          {client.status === 'disabled' ? (
+                            <span className="rounded border border-red-500/40 bg-red-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-red-500">
+                              Disabled
+                            </span>
+                          ) : (
+                            <span className="rounded border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-emerald-500">
+                              Active
+                            </span>
+                          )}
                         </div>
                         <div className="mt-1 font-mono text-xs text-text-secondary break-all">
                           {client.clientId}
@@ -1070,6 +1151,48 @@ export const McpPage: React.FC = () => {
                           </table>
                         </div>
                       )}
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap gap-2 border-t border-border-glass pt-3">
+                      {client.status === 'disabled' ? (
+                        <Button
+                          size="sm"
+                          variant="primary"
+                          onClick={() => handleToggleOAuthClientStatus(client)}
+                          isLoading={updatingClientId === client.clientId}
+                          leftIcon={<ShieldCheck size={13} />}
+                        >
+                          Enable
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="danger"
+                          onClick={() => handleToggleOAuthClientStatus(client)}
+                          isLoading={updatingClientId === client.clientId}
+                          leftIcon={<ShieldOff size={13} />}
+                        >
+                          Disable
+                        </Button>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        onClick={() => handleRevokeAllOAuthTokens(client.clientId)}
+                        isLoading={revokingAllClientId === client.clientId}
+                        leftIcon={<KeyRound size={13} />}
+                      >
+                        Revoke all tokens
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        onClick={() => handleDeleteOAuthClient(client.clientId)}
+                        isLoading={deletingClientId === client.clientId}
+                        leftIcon={<Trash2 size={13} />}
+                      >
+                        Delete client
+                      </Button>
                     </div>
                   </article>
                 ))}


### PR DESCRIPTION
## Summary
Adds an optional, standard **OAuth 2.1 authorization-code flow** for the MCP proxy endpoints. When enabled, MCP clients authenticate through an OAuth provider instead of (or in addition to) a plain API key. The flow follows the Model Context Protocol's OAuth authorization specification (RFC 8707 resource indicators, PKCE, RFC 9728 token exchange conventions) and is fully compatible with an **OAuth Authorization Server Metadata** / `/.well-known/oauth-protected-resource` discovery document.

The feature is **opt-in** (`mcpOAuth.enabled`, default `false`). With it off, Plexus behaves exactly as it does today. With it on, Plexus publishes an OAuth-protected resource, issues clients, and validates access tokens against its own IdP.

## Why / Context
MCP is an emerging standard for letting LLM clients reach external tools and data. The ecosystem is converging on **OAuth-based authentication** for MCP servers — clients like Claude, Cursor, and other model-native tools expect to negotiate auth via an authorization server, not by pasting a static key into a config file.

Today Plexus only supports API-key auth for its MCP endpoints. That works for a single trusted user but does not fit a hosted gateway that wants to expose MCP servers to many independent clients: there is no way to issue per-client credentials, revoke a single client, rotate keys, or follow the standard discovery flow. This change lets a Plexus instance act as both the MCP server and an OAuth provider (via a pluggable `AuthProvider` interface), so any standards-compliant MCP client can connect through the normal OAuth dance — including first-party clients that need scoped, revocable, expiring tokens.

## Changes
- **Pluggable auth layer** (`services/mcp-oauth/`): an `AuthProvider` interface, a factory that resolves the configured provider, and a bundled `plexus-idp-provider` (Plexus's own OAuth IdP) implementation.
- **MCP route integration** (`routes/mcp/index.ts`): when OAuth is enabled, the MCP endpoints run the authorization-code flow and require a valid access token; otherwise they fall back to the existing API-key auth path unchanged.
- **IdP storage** (`db/mcp-oauth-repository.ts` + schema): `mcp_oauth_clients`, `mcp_oauth_tokens`, and `mcp_oauth_authorization_codes` tables (SQLite and Postgres). Tokens store a hash of the bound API key secret (`apiKeySecretHash`) so rotation can be detected, and `key_name` is indexed.
- **Key-rotation / revocation**: rotating or deleting an API key eagerly revokes every access/refresh token bound to it (`revokedAt` set immediately), so a leaked key cannot leave live OAuth sessions behind.
- **Management API** (`routes/management/mcp-oauth.ts`): endpoints to create/list OAuth clients, and to view/revoke issued tokens from the Admin UI.
- **Discovery**: when enabled, Plexus serves the OAuth discovery metadata (`/.well-known/oauth-protected-resource`, `/.well-known/openid-configuration`) describing the protected resource and the authorization server.
- **Config** (`config.ts`): new `mcpOAuth` block (`enabled`, issuer, provider selection, and related settings).
- **Frontend** (`pages/Config.tsx`, `pages/Mcp.tsx`, `lib/api.ts`): admin UI to toggle MCP OAuth, manage clients, and inspect/revoke tokens.

## Testing
- New unit tests cover the `plexus-idp-provider` (token validation, client creation) and the DB-backed key-revocation behavior (tokens are revoked the moment a bound API key rotates or is deleted).
- MCP route tests cover both auth paths: API-key fallback (feature off) and OAuth enforcement (feature on).
- Full backend suite passes: **243 test files, 2,680 tests green**, including the 33 MCP OAuth tests. Typecheck and frontend build pass via the pre-commit hooks.

## Notes / Follow-ups
- **Schema only, no committed migrations.** Per `CONTRIBUTING.md`, migrations are auto-generated by CI after merge — this PR touches only the Drizzle schema `.ts` files.
- Default-off keeps existing deployments byte-for-byte behaviorally unchanged.
- The disabled path changes slightly: the static discovery stubs (`/.well-known/*`) previously returned canned data; with OAuth off those endpoints now return 404. Flagging for reviewer awareness.
- Provider resolution is behind an interface so a future provider (e.g. an external OAuth server) can be added without touching the route layer.

---

## Update: Review fixes + client lifecycle UI (0a710491)

All 8 review comments addressed in 3bb390d6, plus:

**Client lifecycle Admin UI** (0a710491):
- Status badge (Active/Disabled) on each OAuth client card
- Disable/enable toggle, revoke-all-tokens, and delete client buttons
- Disabled clients dimmed for visual clarity
- All destructive actions behind confirmation dialogs

**Comprehensive test coverage** (0a710491):
- Unit tests for all 8 new behaviors (expired/disabled key rejection, scope constraint, resource validation, disabled client rejection, code invalidation on rotation, cache headers)
- Route tests for scope enforcement at the protected resource and discovery endpoint consistency
- 243 test files / 2,695 tests passing
