### PR TITLE
feat(transformer): support adaptive thinking and reasoning projection

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -237,6 +237,12 @@ describe('matchUnsupportedParameter', () => {
     ).toBe('reasoning.summary');
   });
 
+  test('extracts a dotted-path param from an unknown-parameter error', () => {
+    expect(
+      matchUnsupportedParameter('{"error":{"message":"Unknown parameter: \'reasoning.enabled\'"}}')
+    ).toBe('reasoning.enabled');
+  });
+
   test('extracts a bracket-notation param name, normalized to canonical dotted form', () => {
     // The old `[\w.]+` capture stopped at the `[`, truncating
     // `messages[0].name` to `messages` — and the paired deleteDottedPath call

--- a/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-failover.test.ts
@@ -599,6 +599,32 @@ describe('Dispatcher Failover', () => {
     expect(paramStripWarn).toContain("'safety_identifier'");
   });
 
+  test('same-target retry: strips a named unknown parameter and retries instead of failing over', async () => {
+    setConfigForTesting(makeConfig({ targetCount: 1 }));
+    fetchMock
+      .mockImplementationOnce(async () =>
+        errorResponse(400, "Unknown parameter: 'reasoning.enabled'")
+      )
+      .mockImplementationOnce(async () => successChatResponse('model-1'));
+
+    const dispatcher = new Dispatcher();
+    const response = await dispatcher.dispatch({
+      ...makeChatRequest(),
+      reasoning: { effort: 'high', enabled: false },
+      originalBody: {
+        model: 'test-alias',
+        messages: [{ role: 'user', content: 'hello' }],
+        reasoning: { effort: 'high', enabled: false },
+      },
+    });
+
+    expect((response as any).plexus?.finalAttemptProvider).toBe('p1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const retriedBody = JSON.parse((fetchMock.mock.calls[1] as any[])[1].body as string);
+    expect(retriedBody.reasoning).toEqual({ effort: 'high' });
+  });
+
   test('same-target retry: gives up after the retry bound and fails normally when the upstream keeps naming a NEW unsupported param', async () => {
     setConfigForTesting(makeConfig({ targetCount: 1 }));
     fetchMock

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -6,6 +6,7 @@ import type { GenerationIntent } from '../pi-ai/generation';
 import { normalizeVerbosity } from '../pi-ai/generation';
 import type { ReasoningIntent, ReasoningVisibility } from '../pi-ai/reasoning';
 import { normalizeEffort, normalizeVisibility } from '../pi-ai/reasoning';
+import { projectReasoningForResponses } from '../../transformers/utils';
 
 function hasOwn(value: Record<string, any>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
@@ -61,6 +62,7 @@ function normalizeReasoningFromUnified(
     ...(effort && effort !== 'off' ? { effort } : {}),
     ...(reasoning?.max_tokens != null ? { budgetTokens: reasoning.max_tokens } : {}),
     ...(enabled !== undefined ? { enabled } : {}),
+    ...(reasoning?.adaptive ? { adaptive: true } : {}),
     ...(visibility ? { visibility } : {}),
     ...(reasoning?.summary ? { summaryDetail: reasoning.summary } : {}),
     source: 'client',
@@ -290,17 +292,18 @@ function projectResponsesAutoCompat(
   if (options.textVerbosity !== undefined) {
     next.text = { ...(next.text ?? {}), verbosity: options.textVerbosity };
   }
+  const existingReasoning = projectReasoningForResponses(next.reasoning);
   if (options.reasoningEffort || options.reasoningSummary) {
     next.reasoning = {
-      ...(next.reasoning ?? {}),
+      ...(existingReasoning ?? {}),
       effort: mappedThinkingValue(model, options.reasoningEffort) ?? 'medium',
-      summary: options.reasoningSummary ?? next.reasoning?.summary ?? 'auto',
+      summary: options.reasoningSummary ?? existingReasoning?.summary ?? 'auto',
     };
     next.include = Array.from(
       new Set([...(Array.isArray(next.include) ? next.include : []), 'reasoning.encrypted_content'])
     );
   } else if (options.reasoning === 'off') {
-    next.reasoning = { ...(next.reasoning ?? {}), effort: mappedOffValue(model) ?? 'none' };
+    next.reasoning = { ...(existingReasoning ?? {}), effort: mappedOffValue(model) ?? 'none' };
   }
   return next;
 }
@@ -421,7 +424,7 @@ export function applyRegistryAutoCompat(
 // whole request (e.g. OpenAI-compatible Responses API providers reject a
 // client-sent `safety_identifier` or `prompt_cache_key` with
 // `{"detail":"Unsupported parameter: safety_identifier"}` or
-// `{"error":{"message":"Unsupported parameter: 'foo'"}}`). Failing over to the
+// `{"error":{"message":"Unknown parameter: 'foo'"}}`). Failing over to the
 // next configured target doesn't help when the *client* sent the offending
 // field — every target would reject it the same way. Instead, the dispatch
 // loop (see standard-attempt-request.ts) strips the named field from the
@@ -429,14 +432,15 @@ export function applyRegistryAutoCompat(
 
 /**
  * Matches both `{"detail":"Unsupported parameter: X"}` and
- * `{"error":{"message":"Unsupported parameter: 'X'"}}` shapes. The captured
+ * `{"error":{"message":"Unknown parameter: 'X'"}}` shapes. The captured
  * group also matches dotted paths (e.g. `reasoning.summary`) and
  * bracket-notation paths (e.g. `messages[0].name`), since providers name
  * nested fields both ways. A capture that stopped at `[` would truncate
  * `messages[0].name` to `messages` — and the paired delete would then remove
  * the ENTIRE conversation from the retry payload.
  */
-const UNSUPPORTED_PARAMETER_PATTERN = /unsupported parameter[:\s]+['"]?([\w.[\]]+)['"]?/i;
+const UNSUPPORTED_PARAMETER_PATTERN =
+  /(?:unsupported|unknown) parameter[:\s]+['"]?([\w.[\]]+)['"]?/i;
 
 /**
  * Canonicalizes bracket-notation segments to dotted form

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -260,7 +260,7 @@ export async function executeStandardAttempt(
       //      blocks were signed by a DIFFERENT Claude model/session than
       //      the one we're now targeting, and Anthropic 400s naming the
       //      stale signature specifically.
-      //   2. Unsupported parameters: some upstreams 400 naming one specific
+      //   2. Unsupported/unknown parameters: some upstreams 400 naming one specific
       //      client-sent field (e.g. LobeHub's gpt-5.5 traffic sending
       //      safety_identifier / prompt_cache_key that a provider rejects).
       if (response.status === 400) {

--- a/packages/backend/src/transformers/__tests__/anthropic-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/anthropic-request-roundtrip.test.ts
@@ -124,6 +124,54 @@ describe('Anthropic messages -> messages round-trip preserves native fields', ()
   });
 });
 
+describe('Anthropic reasoning intent normalization', () => {
+  it('treats adaptive thinking as enabled and uses output effort', async () => {
+    const unified = await parseAnthropicRequest({
+      model: 'claude-opus-4-6',
+      messages: [{ role: 'user', content: 'hello' }],
+      thinking: { type: 'adaptive' },
+      output_config: { effort: 'high' },
+    });
+
+    expect(unified.reasoning).toEqual({ effort: 'high', enabled: true, adaptive: true });
+  });
+
+  it('does not invent an effort when adaptive thinking has no budget or output effort', async () => {
+    const unified = await parseAnthropicRequest({
+      model: 'claude-opus-4-6',
+      messages: [{ role: 'user', content: 'hello' }],
+      thinking: { type: 'adaptive' },
+    });
+
+    expect(unified.reasoning).toEqual({ enabled: true, adaptive: true });
+  });
+
+  it('does not retain an effort when thinking is explicitly disabled', async () => {
+    const unified = await parseAnthropicRequest({
+      model: 'claude-opus-4-6',
+      messages: [{ role: 'user', content: 'hello' }],
+      thinking: { type: 'disabled' },
+      output_config: { effort: 'high' },
+    });
+
+    expect(unified.reasoning).toEqual({ enabled: false });
+  });
+
+  it('maps a budgeted thinking request to effort and preserves the budget', async () => {
+    const unified = await parseAnthropicRequest({
+      model: 'claude-opus-4-6',
+      messages: [{ role: 'user', content: 'hello' }],
+      thinking: { type: 'enabled', budget_tokens: 8192 },
+    });
+
+    expect(unified.reasoning).toEqual({
+      effort: 'medium',
+      max_tokens: 8192,
+      enabled: true,
+    });
+  });
+});
+
 describe('Anthropic image block cache_control round-trip', () => {
   it('preserves cache_control on image blocks (Fix #2)', async () => {
     const requestWithImage = {

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeResponsesReasoningContent,
 } from '../responses';
 import { OpenAITransformer } from '../openai';
+import { parseAnthropicRequest } from '../anthropic/request-parser';
 
 /**
  * Round-trip tests for the Responses API transformer.
@@ -286,6 +287,47 @@ describe('Responses responses -> responses round-trip preserves native fields', 
     expect(built.store).toBeUndefined();
     expect(built.service_tier).toBeUndefined();
     expect(built.stream_options).toBeUndefined();
+  });
+});
+
+describe('Anthropic -> Responses reasoning projection', () => {
+  it('omits unified-only reasoning fields from the Responses payload', async () => {
+    const unified = await parseAnthropicRequest({
+      model: 'claude-opus-4-6',
+      messages: [{ role: 'user', content: 'hello' }],
+      thinking: { type: 'adaptive' },
+      output_config: { effort: 'high' },
+    });
+
+    const built = await new ResponsesTransformer().transformRequest(unified);
+
+    expect(built.reasoning).toEqual({ effort: 'high' });
+    expect(built.reasoning).not.toHaveProperty('enabled');
+    expect(built.reasoning).not.toHaveProperty('max_tokens');
+  });
+
+  it('uses the Responses off effort for explicitly disabled thinking', async () => {
+    const unified = await parseAnthropicRequest({
+      model: 'claude-opus-4-6',
+      messages: [{ role: 'user', content: 'hello' }],
+      thinking: { type: 'disabled' },
+    });
+
+    const built = await new ResponsesTransformer().transformRequest(unified);
+
+    expect(built.reasoning).toEqual({ effort: 'none' });
+  });
+
+  it('leaves adaptive magnitude selection to registry auto-compat', async () => {
+    const unified = await parseAnthropicRequest({
+      model: 'claude-opus-4-6',
+      messages: [{ role: 'user', content: 'hello' }],
+      thinking: { type: 'adaptive' },
+    });
+
+    const built = await new ResponsesTransformer().transformRequest(unified);
+
+    expect(built.reasoning).toBeUndefined();
   });
 });
 

--- a/packages/backend/src/transformers/anthropic/request-parser.ts
+++ b/packages/backend/src/transformers/anthropic/request-parser.ts
@@ -1,4 +1,5 @@
 import { UnifiedChatRequest, UnifiedMessage } from '../../types/unified';
+import { normalizeEffort } from '../../services/pi-ai/reasoning';
 import { getThinkLevel } from '../utils';
 import { convertAnthropicContent } from './content-mapper';
 import { convertAnthropicToolsToUnified } from './tool-mapper';
@@ -111,10 +112,24 @@ export async function parseAnthropicRequest(input: any): Promise<UnifiedChatRequ
 
   // Map Thinking/Reasoning Configuration
   if (input.thinking) {
+    const thinkingType = input.thinking.type;
+    const thinkingBudget = input.thinking.budget_tokens;
+    const thinkingEnabled = thinkingType === 'enabled' || thinkingType === 'adaptive';
+    const configuredEffort = normalizeEffort(input.output_config?.effort);
+    const effort = thinkingEnabled
+      ? configuredEffort === 'off'
+        ? 'none'
+        : (configuredEffort ??
+          (typeof thinkingBudget === 'number' ? getThinkLevel(thinkingBudget) : undefined))
+      : undefined;
+
     result.reasoning = {
-      effort: getThinkLevel(input.thinking.budget_tokens),
-      max_tokens: input.thinking.budget_tokens,
-      enabled: input.thinking.type === 'enabled',
+      ...(effort !== undefined ? { effort } : {}),
+      ...(thinkingEnabled && typeof thinkingBudget === 'number'
+        ? { max_tokens: thinkingBudget }
+        : {}),
+      enabled: thinkingEnabled,
+      ...(thinkingType === 'adaptive' ? { adaptive: true } : {}),
     };
   }
 

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -22,6 +22,7 @@ import { encode } from 'eventsource-encoder';
 import { logger } from '../utils/logger';
 import { normalizeOpenAIChatUsage, normalizeOpenAIResponsesUsage } from '../utils/usage-normalizer';
 import { imageGenerationCallMarkdown } from './image-rendering';
+import { projectReasoningForResponses } from './utils';
 
 const OPENAI_RESPONSES_CALL_ID_MAX_LENGTH = 64;
 const OPENAI_RESPONSES_REASONING_CONTENT_MAX_ITEMS = 0;
@@ -336,7 +337,8 @@ export class ResponsesTransformer implements Transformer {
       payload.tool_choice = request.tool_choice;
     }
     if (request.reasoning) {
-      payload.reasoning = request.reasoning;
+      const reasoning = projectReasoningForResponses(request.reasoning);
+      if (reasoning) payload.reasoning = reasoning;
     }
     if (request.include && request.include.length > 0) {
       payload.include = request.include;

--- a/packages/backend/src/transformers/utils.ts
+++ b/packages/backend/src/transformers/utils.ts
@@ -10,7 +10,9 @@ export function projectReasoningForResponses(
     | undefined
 ): { effort?: ThinkLevel; summary?: string } | undefined {
   if (!reasoning) return undefined;
-  if (reasoning.enabled === false) return { effort: 'none' };
+  if (reasoning.enabled === false || reasoning.effort === 'off') {
+    return { effort: 'none' };
+  }
 
   const projected = {
     ...(reasoning.effort !== undefined ? { effort: reasoning.effort } : {}),

--- a/packages/backend/src/transformers/utils.ts
+++ b/packages/backend/src/transformers/utils.ts
@@ -1,5 +1,25 @@
 import { ThinkLevel } from '../types/unified';
 
+export function projectReasoningForResponses(
+  reasoning:
+    | {
+        effort?: ThinkLevel;
+        enabled?: boolean;
+        summary?: string;
+      }
+    | undefined
+): { effort?: ThinkLevel; summary?: string } | undefined {
+  if (!reasoning) return undefined;
+  if (reasoning.enabled === false) return { effort: 'none' };
+
+  const projected = {
+    ...(reasoning.effort !== undefined ? { effort: reasoning.effort } : {}),
+    ...(reasoning.summary !== undefined ? { summary: reasoning.summary } : {}),
+  };
+
+  return Object.keys(projected).length > 0 ? projected : undefined;
+}
+
 /**
  * A more accurate token counter that accounts for common sub-word patterns.
  * No external dependencies.

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -126,6 +126,7 @@ export interface UnifiedChatRequest {
     effort?: ThinkLevel;
     max_tokens?: number;
     enabled?: boolean;
+    adaptive?: boolean;
     summary?: string;
   };
   include?: string[];


### PR DESCRIPTION
## Summary
Fixes Anthropic adaptive-thinking requests routed to OpenAI Responses providers. The gateway now preserves the client’s reasoning intent and emits provider-valid reasoning fields instead of leaking unified-only fields such as `reasoning.enabled`.

## Changes
- Normalize Anthropic adaptive, budgeted, and disabled thinking requests correctly, including `output_config.effort`.
- Preserve adaptive intent through registry auto-compat projection.
- Sanitize Responses reasoning payloads and map explicit disablement to the Responses `none` effort.
- Retry the same target when providers report either `Unsupported parameter` or `Unknown parameter`, including nested paths.
- Add parser, payload-projection, matcher, and same-target retry regression coverage.

## Testing
- Added regression coverage for the captured `reasoning.enabled` failure path and nested unknown-parameter retry behavior.
