### PR TITLE
fix(responses): stop dropping client-executed tool calls in Codex lite mode

### DIFF
--- a/packages/backend/src/routes/inference/__tests__/responses-api-type.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/responses-api-type.test.ts
@@ -19,4 +19,25 @@ describe('Responses API subtype detection', () => {
       'responses'
     );
   });
+
+  test('detects Lite from a declared tool_search tool even without additional_tools or the header', () => {
+    // Reproduces staging debug trace b672ebbd: a genuine Codex CLI request
+    // that declares its lazy tool-discovery tool (`tool_search`) up front
+    // instead of sending an `additional_tools` input item, and without the
+    // internal header. Missing this signal caused the request to lose
+    // routing preference for providers explicitly configured to support
+    // `responses:lite`.
+    expect(
+      detectResponsesApiType(
+        {},
+        {
+          input: [{ type: 'message', role: 'user' }],
+          tools: [
+            { type: 'function', name: 'exec_command' },
+            { type: 'tool_search', description: 'Tool discovery' },
+          ],
+        }
+      )
+    ).toBe('responses:lite');
+  });
 });

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -34,7 +34,18 @@ export function detectResponsesApiType(
 
   const hasAdditionalTools =
     Array.isArray(body?.input) && body.input.some((item: any) => item?.type === 'additional_tools');
-  return hasAdditionalTools ? 'responses:lite' : 'responses';
+  // A declared `tool_search` tool is Codex CLI's lazy tool-discovery
+  // mechanism — the defining feature of "lite" mode (the client hasn't sent
+  // its full tool catalog upfront and expects to discover more via a
+  // tool_search_call mid-turn). Recognizing it here, not just
+  // `additional_tools`/the internal header, lets routing correctly prefer
+  // providers that explicitly advertise `responses:lite` support (see
+  // router.ts's subtype-first target matching) for a request that's
+  // genuinely Codex-native, instead of silently defaulting to the base
+  // `responses` type and losing that routing preference.
+  const hasToolSearch =
+    Array.isArray(body?.tools) && body.tools.some((tool: any) => tool?.type === 'tool_search');
+  return hasAdditionalTools || hasToolSearch ? 'responses:lite' : 'responses';
 }
 
 export async function registerResponsesRoute(

--- a/packages/backend/src/services/__tests__/dispatcher-api-subtype.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-api-subtype.test.ts
@@ -258,4 +258,80 @@ describe('Dispatcher API subtypes', () => {
     expect(result.payload.input).toEqual(originalBody.input);
     expect(result.payload.tools).toBeUndefined();
   });
+
+  test('normalizes the responses:lite wire contract: strips disallowed tools, defaults reasoning.context, forces parallel_tool_calls false', async () => {
+    // Real Codex CLI traffic declares `web_search` by default and doesn't
+    // reliably send `reasoning.context`/`parallel_tool_calls: false` — the
+    // wire contract both providers configured for the subtype enforce (see
+    // dispatcher-auto-compat.ts's LITE_ALLOWED_TOOL_TYPES). Proactive
+    // normalization avoids paying a strip-and-retry round trip on every such
+    // request.
+    const dispatcher = new Dispatcher() as any;
+    const route = makeRoute([{ type: 'responses', subtype: 'lite' }]);
+    const originalBody = {
+      model: 'gpt-5.6-luna',
+      reasoning: { effort: 'high', summary: 'auto' },
+      parallel_tool_calls: true,
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'custom', name: 'apply_patch' },
+        { type: 'tool_search' },
+        { type: 'web_search' },
+      ],
+      input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+    };
+
+    const result = await dispatcher.transformRequestPayload(
+      {
+        model: 'alias',
+        messages: [],
+        incomingApiType: 'responses:lite',
+        originalBody,
+      },
+      route,
+      TransformerFactory.getTransformer('responses:lite'),
+      'responses:lite'
+    );
+
+    expect(result.bypassTransformation).toBe(true);
+    expect(result.payload.reasoning).toEqual({
+      effort: 'high',
+      summary: 'auto',
+      context: 'all_turns',
+    });
+    expect(result.payload.parallel_tool_calls).toBe(false);
+    expect(result.payload.tools).toEqual([
+      { type: 'function', name: 'exec_command' },
+      { type: 'custom', name: 'apply_patch' },
+      { type: 'tool_search' },
+    ]);
+  });
+
+  test('does not normalize the lite wire contract for a base (non-lite) responses target', async () => {
+    const dispatcher = new Dispatcher() as any;
+    const route = makeRoute(['responses']);
+    const originalBody = {
+      model: 'gpt-5.6-luna',
+      parallel_tool_calls: true,
+      tools: [{ type: 'web_search' }],
+      input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+    };
+
+    const clientTransformer = new ResponsesTransformer();
+    const unifiedRequest = await clientTransformer.parseRequest(originalBody);
+    unifiedRequest.incomingApiType = 'responses';
+    unifiedRequest.originalBody = originalBody;
+
+    const result = await dispatcher.transformRequestPayload(
+      unifiedRequest,
+      route,
+      TransformerFactory.getTransformer('responses'),
+      'responses'
+    );
+
+    expect(result.payload.parallel_tool_calls).toBe(true);
+    expect(result.payload.tools).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: 'web_search' })])
+    );
+  });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-api-subtype.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-api-subtype.test.ts
@@ -100,7 +100,15 @@ describe('Dispatcher API subtypes', () => {
     expect(result.payload.model).toBe('upstream-model');
   });
 
-  test('disables pass-through for Responses bodies carrying Codex namespace/custom tool call history', async () => {
+  test('keeps pass-through for an exact responses:lite match even with Codex namespace/custom tool call history', async () => {
+    // Previously this forced the transform pipeline on the (unverified)
+    // assumption that Responses-compatible providers can't handle raw
+    // namespace/custom-tool-call history. Live-tested against both
+    // providers actually configured with the `responses:lite` subtype
+    // (openlimits and real api.openai.com/openai-s): both parse this shape
+    // correctly. A target that matches `responses:lite` EXACTLY has opted
+    // into being trusted with Codex's raw wire extensions — that's the
+    // point of the subtype — so pass-through stays enabled here.
     const dispatcher = new Dispatcher() as any;
     const route = makeRoute([{ type: 'responses', subtype: 'lite' }]);
     const originalBody = {
@@ -135,11 +143,8 @@ describe('Dispatcher API subtypes', () => {
       'responses:lite'
     );
 
-    // Namespace/custom-tool-call history means the raw body can't be
-    // forwarded as-is — most Responses-compatible providers don't understand
-    // these Codex CLI extensions. Pass-through must be disabled so the full
-    // transform pipeline (which flattens/normalizes them) runs instead.
-    expect(result.bypassTransformation).toBe(false);
+    expect(result.bypassTransformation).toBe(true);
+    expect(result.payload.input).toEqual(originalBody.input);
   });
 
   test('keeps pass-through for Responses bodies without Codex namespace/custom tool extensions', async () => {
@@ -212,12 +217,17 @@ describe('Dispatcher API subtypes', () => {
     );
   });
 
-  test('end-to-end: Codex "lite" mode additional_tools reach the upstream Responses provider (staging trace d3a2b5f6)', async () => {
-    // Reproduces the shape of a real staging debug trace where a Codex CLI
-    // `responses:lite` request carried its tool definitions in an
-    // `additional_tools` input item rather than the top-level `tools`
-    // array. Before the fix, the upstream provider received `tools: []`
-    // and hallucinated the tool call as text instead of invoking it.
+  test('end-to-end: Codex "lite" mode additional_tools pass through untouched for an exact responses:lite target (staging trace b672ebbd)', async () => {
+    // Originally reproduced as "staging trace d3a2b5f6" on the (unverified)
+    // assumption that the upstream provider would receive `tools: []` and
+    // hallucinate the tool call as text unless Plexus flattened
+    // `additional_tools` into the top-level `tools` array. Live-tested
+    // against both providers actually configured with the `responses:lite`
+    // subtype (openlimits and real api.openai.com/openai-s, investigating
+    // staging trace b672ebbd): both correctly parse the raw `additional_tools`
+    // item and invoke the declared tool with no flattening needed. A target
+    // that matches `responses:lite` EXACTLY is trusted with Codex's raw wire
+    // extensions, so the body passes through untouched.
     const dispatcher = new Dispatcher() as any;
     const route = makeRoute([{ type: 'responses', subtype: 'lite' }]);
     const originalBody = {
@@ -244,9 +254,8 @@ describe('Dispatcher API subtypes', () => {
       'responses:lite'
     );
 
-    expect(result.bypassTransformation).toBe(false);
-    expect(result.payload.tools).toEqual(
-      expect.arrayContaining([expect.objectContaining({ type: 'function', name: 'exec' })])
-    );
+    expect(result.bypassTransformation).toBe(true);
+    expect(result.payload.input).toEqual(originalBody.input);
+    expect(result.payload.tools).toBeUndefined();
   });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -17,6 +17,11 @@ import {
   refundThinkingSignatureStrip,
   stripThinkingSignatureBlocks,
   MAX_THINKING_SIGNATURE_STRIP_RETRIES,
+  createLiteToolStripState,
+  matchLiteUnsupportedToolsError,
+  planLiteToolStrip,
+  stripLiteUnsupportedTools,
+  MAX_LITE_TOOL_STRIP_RETRIES,
 } from '../dispatch/dispatcher-auto-compat';
 
 function route(overrides: Partial<RouteResult> = {}): RouteResult {
@@ -1266,5 +1271,121 @@ describe('planThinkingSignatureStrip', () => {
     const state = createThinkingSignatureStripState();
     refundThinkingSignatureStrip(state);
     expect(state.attempts).toBe(0);
+  });
+});
+
+describe('matchLiteUnsupportedToolsError', () => {
+  test('matches the responses:lite tool-type-restriction 400', () => {
+    expect(
+      matchLiteUnsupportedToolsError(
+        JSON.stringify({
+          error: {
+            message:
+              'X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.',
+          },
+        })
+      )
+    ).toBe(true);
+  });
+
+  test('is case-insensitive', () => {
+    expect(
+      matchLiteUnsupportedToolsError(
+        'x-openai-internal-codex-RESPONSES-LITE only supports function tools, custom tools, and client-executed tool search.'
+      )
+    ).toBe(true);
+  });
+
+  test('does not match unrelated 400 bodies', () => {
+    expect(matchLiteUnsupportedToolsError('{"error":{"message":"Invalid request"}}')).toBe(false);
+  });
+
+  test('does not match the empty string', () => {
+    expect(matchLiteUnsupportedToolsError('')).toBe(false);
+  });
+});
+
+describe('stripLiteUnsupportedTools', () => {
+  test('removes tools whose type is not function/custom/tool_search', () => {
+    const payload = {
+      model: 'gpt-5.6-luna',
+      tools: [
+        { type: 'function', name: 'exec_command' },
+        { type: 'web_search' },
+        { type: 'custom', name: 'apply_patch' },
+        { type: 'tool_search' },
+        { type: 'image_generation' },
+      ],
+    };
+
+    const result = stripLiteUnsupportedTools(payload);
+    expect(result.strippedCount).toBe(2);
+    expect(result.payload.tools).toEqual([
+      { type: 'function', name: 'exec_command' },
+      { type: 'custom', name: 'apply_patch' },
+      { type: 'tool_search' },
+    ]);
+  });
+
+  test('is a no-op (same payload reference) when there is no tools array', () => {
+    const payload = { model: 'gpt-5.6-luna', input: [] };
+    const result = stripLiteUnsupportedTools(payload);
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
+  });
+
+  test('is a no-op when every declared tool is already an allowed type', () => {
+    const payload = { model: 'gpt-5.6-luna', tools: [{ type: 'function', name: 'exec_command' }] };
+    const result = stripLiteUnsupportedTools(payload);
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
+  });
+
+  test('copy-on-write: does not mutate the input payload or its tools array', () => {
+    const originalTools = [{ type: 'function', name: 'a' }, { type: 'web_search' }];
+    const payload = { model: 'gpt-5.6-luna', tools: originalTools };
+
+    const result = stripLiteUnsupportedTools(payload);
+
+    expect(payload.tools).toBe(originalTools);
+    expect(originalTools.length).toBe(2);
+    expect(result.payload).not.toBe(payload);
+    expect(result.payload.tools).not.toBe(originalTools);
+  });
+});
+
+describe('planLiteToolStrip', () => {
+  const liteToolsErrorBody = JSON.stringify({
+    error: {
+      message:
+        'X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.',
+    },
+  });
+
+  test('MAX_LITE_TOOL_STRIP_RETRIES is exactly 1 (one strip-retry per target)', () => {
+    expect(MAX_LITE_TOOL_STRIP_RETRIES).toBe(1);
+  });
+
+  test('plans a strip-retry on the first matching 400', () => {
+    const state = createLiteToolStripState();
+    expect(planLiteToolStrip(liteToolsErrorBody, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('does not plan a retry when the body does not name the restriction', () => {
+    const state = createLiteToolStripState();
+    expect(planLiteToolStrip('{"error":{"message":"Invalid request"}}', state)).toBe(false);
+    expect(state.attempts).toBe(0);
+  });
+
+  test('retry bound: a second matching 400 on the same target does not plan a second strip-retry', () => {
+    const state = createLiteToolStripState();
+
+    expect(planLiteToolStrip(liteToolsErrorBody, state)).toBe(true);
+    // The one-per-target bound is already used up — a repeat 400 after the
+    // strip means something else is wrong, so normal failover must proceed
+    // instead of stripping again.
+    expect(planLiteToolStrip(liteToolsErrorBody, state)).toBe(false);
+    expect(state.attempts).toBe(1);
   });
 });

--- a/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/empty-completion.test.ts
@@ -403,6 +403,71 @@ describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — typed image_
   });
 });
 
+describe('getResponseVisibilitySignals / isEmptyUnifiedResponse — typed client_tool_calls signal (responses:lite)', () => {
+  // A lite-mode turn whose ONLY output is a pending tool_search_call has no
+  // text, no reasoning, no tool_calls, no annotations, no images — the typed
+  // `client_tool_calls` carry is its only visibility signal. Without it,
+  // this is misclassified as empty and failed over: the exact bug class
+  // this PR fixes, one layer down (see transformers/responses.ts's
+  // isClientExecutedToolItem).
+  it('a client_tool_calls entry counts as visible output (no failover)', () => {
+    const response = {
+      ...emptyResponse(),
+      client_tool_calls: [
+        { id: 'tsc_1', type: 'tool_search_call', call_id: 'call_1', execution: 'client' },
+      ],
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).clientToolCallCount).toBe(1);
+    expect(isEmptyUnifiedResponse(response)).toBe(false);
+  });
+
+  it('multiple entries are all counted', () => {
+    const response = {
+      ...emptyResponse(),
+      client_tool_calls: [
+        { id: 'tsc_1', type: 'tool_search_call', call_id: 'call_1', execution: 'client' },
+        { id: 'tsc_2', type: 'tool_search_call', call_id: 'call_2', execution: 'client' },
+      ],
+    } as UnifiedChatResponse;
+
+    expect(getResponseVisibilitySignals(response).clientToolCallCount).toBe(2);
+  });
+
+  it('an absent client_tool_calls field contributes zero', () => {
+    expect(getResponseVisibilitySignals(emptyResponse()).clientToolCallCount).toBe(0);
+  });
+
+  // End-to-end: a REAL ResponsesTransformer transform of a
+  // tool_search_call-only completion (bypass-transformation path — the
+  // transformer still runs to derive usage stats, per
+  // dispatcher.ts's handleNonStreamingResponse) must read as non-empty
+  // purely via the typed carry.
+  it('a real transformed tool_search_call-only Responses completion is NOT empty', async () => {
+    const unified = await new ResponsesTransformer().transformResponse({
+      id: 'resp_tool_search',
+      object: 'response',
+      created_at: 1,
+      status: 'completed',
+      model: 'lite-model',
+      output: [
+        {
+          type: 'tool_search_call',
+          id: 'tsc_1',
+          call_id: 'call_1',
+          execution: 'client',
+          status: 'completed',
+          arguments: { query: 'exec' },
+        },
+      ],
+    });
+
+    expect(unified.content).toBeNull();
+    expect(getResponseVisibilitySignals(unified).clientToolCallCount).toBe(1);
+    expect(isEmptyUnifiedResponse(unified)).toBe(false);
+  });
+});
+
 describe('createStreamVisibilityTracker / observeStreamChunk / isStreamEmpty (streaming adapter)', () => {
   it('starts empty', () => {
     const tracker = createStreamVisibilityTracker();
@@ -516,6 +581,49 @@ describe('observeStreamChunk — chunk-level annotations/images branches (forwar
 
     expect(tracker.annotationCount).toBe(0);
     expect(tracker.imageCount).toBe(0);
+    expect(isStreamEmpty(tracker)).toBe(true);
+  });
+});
+
+describe('observeStreamChunk — chunk-level client_tool_calls (responses:lite streaming)', () => {
+  // The responses transformer emits client_tool_calls on a `delta: {}`
+  // chunk (see transformers/responses.ts's transformStream) — same
+  // chunk-level-field-not-inside-delta shape as image_generation_calls, and
+  // for the same reason: chat-facing formatters forward `delta` BY
+  // REFERENCE into the client SSE chunk, so this can't live inside `delta`.
+  it('a chunk-level client_tool_calls array marks the tracker non-empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: {},
+      client_tool_calls: [
+        { id: 'tsc_1', type: 'tool_search_call', call_id: 'call_1', execution: 'client' },
+      ],
+    } as any);
+
+    expect(tracker.clientToolCallCount).toBe(1);
+    expect(isStreamEmpty(tracker)).toBe(false);
+  });
+
+  it('counts accumulate across chunks', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, {
+      delta: {},
+      client_tool_calls: [{ id: 'tsc_1', type: 'tool_search_call', call_id: 'call_1' }],
+    } as any);
+    observeStreamChunk(tracker, {
+      delta: {},
+      client_tool_calls: [{ id: 'tsc_2', type: 'tool_search_call', call_id: 'call_2' }],
+    } as any);
+
+    expect(tracker.clientToolCallCount).toBe(2);
+  });
+
+  it('an empty or absent client_tool_calls array leaves the tracker empty', () => {
+    const tracker = createStreamVisibilityTracker();
+    observeStreamChunk(tracker, { delta: {}, client_tool_calls: [] } as any);
+    observeStreamChunk(tracker, { delta: {} });
+
+    expect(tracker.clientToolCallCount).toBe(0);
     expect(isStreamEmpty(tracker)).toBe(true);
   });
 });

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -934,7 +934,7 @@ export function refundThinkingSignatureStrip(state: ThinkingSignatureStripState)
 }
 
 // ---------------------------------------------------------------------------
-// Reactive auto-compat: strip-and-retry on unsupported responses:lite tools
+// Unsupported responses:lite tools: proactive strip + reactive strip-and-retry
 // ---------------------------------------------------------------------------
 //
 // Real Codex CLI traffic declares a `web_search` tool by default (see staging
@@ -944,9 +944,16 @@ export function refundThinkingSignatureStrip(state: ThinkingSignatureStripState)
 // `custom`, and client-executed `tool_search` only. Both providers currently
 // configured for the subtype (openlimits, openai-s) reject anything else with
 // a 400 naming the restriction generically, not the specific offending
-// tool(s). Failing over doesn't help — every lite-configured target enforces
-// the same restriction — so strip any disallowed tool and retry the SAME
-// target once.
+// tool(s).
+//
+// `stripLiteUnsupportedTools` is used two ways:
+//   - PROACTIVELY, in request-payload-builder.ts, applied unconditionally
+//     whenever dispatching with the lite header so the common case (Codex's
+//     default `web_search` declaration) never pays a failed round trip.
+//   - REACTIVELY here, as a fallback for anything the proactive pass didn't
+//     anticipate (e.g. a disallowed tool type not yet known about) — failing
+//     over doesn't help, since every lite-configured target enforces the
+//     same restriction, so strip and retry the SAME target once instead.
 
 /**
  * Matches the responses:lite tool-type-restriction 400, e.g.

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -932,3 +932,99 @@ export function planThinkingSignatureStrip(
 export function refundThinkingSignatureStrip(state: ThinkingSignatureStripState): void {
   if (state.attempts > 0) state.attempts--;
 }
+
+// ---------------------------------------------------------------------------
+// Reactive auto-compat: strip-and-retry on unsupported responses:lite tools
+// ---------------------------------------------------------------------------
+//
+// Real Codex CLI traffic declares a `web_search` tool by default (see staging
+// trace b672ebbd), but the `X-OpenAI-Internal-Codex-Responses-Lite` wire
+// contract (sent whenever targetApiType is exactly `responses:lite` — see
+// provider-request-headers.ts) restricts declared tools to `function`,
+// `custom`, and client-executed `tool_search` only. Both providers currently
+// configured for the subtype (openlimits, openai-s) reject anything else with
+// a 400 naming the restriction generically, not the specific offending
+// tool(s). Failing over doesn't help — every lite-configured target enforces
+// the same restriction — so strip any disallowed tool and retry the SAME
+// target once.
+
+/**
+ * Matches the responses:lite tool-type-restriction 400, e.g.
+ * "X-OpenAI-Internal-Codex-Responses-Lite only supports function tools,
+ * custom tools, and client-executed tool search."
+ */
+const LITE_UNSUPPORTED_TOOLS_PATTERN =
+  /responses-lite only supports function tools, custom tools, and client-executed tool search/i;
+
+/** Tool `type`s the responses:lite wire contract allows. */
+const LITE_ALLOWED_TOOL_TYPES = new Set(['function', 'custom', 'tool_search']);
+
+/**
+ * True when an upstream error response body names the responses:lite
+ * tool-type restriction.
+ */
+export function matchLiteUnsupportedToolsError(responseBody: string): boolean {
+  if (!responseBody) return false;
+  return LITE_UNSUPPORTED_TOOLS_PATTERN.test(responseBody);
+}
+
+export interface LiteToolStripResult {
+  /**
+   * The payload with every disallowed tool removed. A NEW object
+   * (copy-on-write) with a NEW `tools` array when `strippedCount` > 0 — the
+   * input payload's `tools` array (possibly shared by reference with the
+   * long-lived UnifiedChatRequest) is never mutated. Identical to the input
+   * `payload` reference when `strippedCount` is 0 — nothing to rebuild.
+   */
+  payload: Record<string, any>;
+  /** Number of tools actually removed (0 when there was nothing to strip). */
+  strippedCount: number;
+}
+
+/**
+ * Removes any `payload.tools` entry whose `type` isn't `function`, `custom`,
+ * or `tool_search` (see `LITE_ALLOWED_TOOL_TYPES`) — copy-on-write, like the
+ * strips above.
+ */
+export function stripLiteUnsupportedTools(payload: Record<string, any>): LiteToolStripResult {
+  if (!Array.isArray(payload.tools)) return { payload, strippedCount: 0 };
+
+  const kept = payload.tools.filter(
+    (tool: any) => tool && typeof tool === 'object' && LITE_ALLOWED_TOOL_TYPES.has(tool.type)
+  );
+  const strippedCount = payload.tools.length - kept.length;
+  if (strippedCount === 0) return { payload, strippedCount: 0 };
+
+  return { payload: { ...payload, tools: kept }, strippedCount };
+}
+
+/** Per-target, per-request bound: at most one lite-tool-strip-and-retry cycle. */
+export const MAX_LITE_TOOL_STRIP_RETRIES = 1;
+
+/** Tracks lite-tool-strip-and-retry progress for a single target within one request. */
+export interface LiteToolStripState {
+  attempts: number;
+}
+
+export function createLiteToolStripState(): LiteToolStripState {
+  return { attempts: 0 };
+}
+
+/**
+ * Decides whether an upstream 400 body naming the responses:lite tool-type
+ * restriction should trigger a strip-and-retry cycle against the same
+ * target, recording the attempt in `state` when it does. Returns `false`
+ * when the retry should NOT happen because:
+ *   - the body doesn't name the restriction, OR
+ *   - MAX_LITE_TOOL_STRIP_RETRIES has already been used for this target
+ *     (bounded to exactly one retry — once the disallowed tools are gone, a
+ *     repeat 400 means something else is wrong, so normal failover should
+ *     proceed instead of retrying again).
+ */
+export function planLiteToolStrip(responseBody: string, state: LiteToolStripState): boolean {
+  if (state.attempts >= MAX_LITE_TOOL_STRIP_RETRIES) return false;
+  if (!matchLiteUnsupportedToolsError(responseBody)) return false;
+
+  state.attempts++;
+  return true;
+}

--- a/packages/backend/src/services/dispatch/empty-completion.ts
+++ b/packages/backend/src/services/dispatch/empty-completion.ts
@@ -44,6 +44,7 @@ export interface CompletionVisibilitySignals {
   toolCallCount?: number;
   annotationCount?: number;
   imageCount?: number;
+  clientToolCallCount?: number;
 }
 
 /**
@@ -56,7 +57,8 @@ export function isEmptyCompletion(signals: CompletionVisibilitySignals): boolean
     signals.hasReasoning ||
     (signals.toolCallCount ?? 0) > 0 ||
     (signals.annotationCount ?? 0) > 0 ||
-    (signals.imageCount ?? 0) > 0
+    (signals.imageCount ?? 0) > 0 ||
+    (signals.clientToolCallCount ?? 0) > 0
   );
 }
 
@@ -85,6 +87,7 @@ type VisibilityCheckableResponse = Pick<
   | 'annotations'
   | 'finishReason'
   | 'image_generation_calls'
+  | 'client_tool_calls'
 > & { images?: unknown[] | null; rawResponse?: unknown };
 
 /**
@@ -123,6 +126,24 @@ function countRawImageGenerationCalls(rawResponse: unknown): number {
   return output.filter((item: any) => item?.type === 'image_generation_call').length;
 }
 
+/**
+ * Counts typed `client_tool_calls` entries (see UnifiedClientToolCall in
+ * types/unified.ts) — client-executed built-in tool-call items like
+ * `tool_search_call`. Unlike image_generation_calls, every item that
+ * survives the transformer's `isClientExecutedToolItem` gate is included
+ * unconditionally (no "has a result" narrowing), so the typed carry alone is
+ * a complete signal — no raw fallback is needed: `transformResponse` runs
+ * even on the bypass-transformation path (see dispatcher.ts's
+ * `handleNonStreamingResponse`), so this field is always populated when a
+ * client-executed tool-call item is present. Without this count, a
+ * lite-mode turn whose only output is a pending `tool_search_call` would be
+ * misclassified as empty and needlessly failed over — the same failure mode
+ * this PR fixes, one layer down.
+ */
+function countClientToolCalls(clientToolCalls: UnifiedChatResponse['client_tool_calls']): number {
+  return Array.isArray(clientToolCalls) ? clientToolCalls.length : 0;
+}
+
 /** Extracts visibility signals from a fully-materialized non-streaming response. */
 export function getResponseVisibilitySignals(
   response: VisibilityCheckableResponse
@@ -137,6 +158,7 @@ export function getResponseVisibilitySignals(
       countTypedImageGenerationCalls(response.image_generation_calls) +
       (Array.isArray(response.images) ? response.images.length : 0) +
       countRawImageGenerationCalls(response.rawResponse),
+    clientToolCallCount: countClientToolCalls(response.client_tool_calls),
   };
 }
 
@@ -181,6 +203,7 @@ export interface StreamVisibilityTracker {
   toolCallCount: number;
   annotationCount: number;
   imageCount: number;
+  clientToolCallCount: number;
 }
 
 export function createStreamVisibilityTracker(): StreamVisibilityTracker {
@@ -190,6 +213,7 @@ export function createStreamVisibilityTracker(): StreamVisibilityTracker {
     toolCallCount: 0,
     annotationCount: 0,
     imageCount: 0,
+    clientToolCallCount: 0,
   };
 }
 
@@ -198,11 +222,15 @@ export function createStreamVisibilityTracker(): StreamVisibilityTracker {
  * Only inspects `delta.content` / `delta.tool_calls` / `delta.reasoning_content`
  * / `delta.thinking` (plus a defensive, forward-compatible `annotations`/
  * `images` check — no current transformer streams either) — it never
- * stores the actual delta text anywhere.
+ * stores the actual delta text anywhere. `client_tool_calls` is a
+ * CHUNK-level field (like `image_generation_calls`), not inside `delta` —
+ * see UnifiedChatStreamChunk in types/unified.ts — so it's read off `chunk`
+ * directly; the responses transformer emits it on a `delta: {}` chunk, which
+ * the `!delta` guard below still lets through (an empty object is truthy).
  */
 export function observeStreamChunk(
   tracker: StreamVisibilityTracker,
-  chunk: Pick<UnifiedChatStreamChunk, 'delta'> & {
+  chunk: Pick<UnifiedChatStreamChunk, 'delta' | 'client_tool_calls'> & {
     annotations?: unknown[] | null;
     images?: unknown[] | null;
   }
@@ -225,6 +253,9 @@ export function observeStreamChunk(
   }
   if (Array.isArray(chunk.images) && chunk.images.length > 0) {
     tracker.imageCount += chunk.images.length;
+  }
+  if (Array.isArray(chunk.client_tool_calls) && chunk.client_tool_calls.length > 0) {
+    tracker.clientToolCallCount += chunk.client_tool_calls.length;
   }
 }
 

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -1,6 +1,6 @@
 import type { UnifiedChatRequest } from '../../types/unified';
 import { getConfig } from '../../config';
-import { getApiBaseType } from '../../utils/api-format';
+import { getApiBaseType, getApiSubtype } from '../../utils/api-format';
 import { logger } from '../../utils/logger';
 import { applyModelBehaviors } from '../models/model-behaviors';
 import type { RouteResult } from '../routing/router';
@@ -66,17 +66,23 @@ function shouldUsePassThrough(
   }
 
   // Only force the transform pipeline when the target fell back to the bare
-  // `responses` type (no explicit Lite support advertised). A target that
-  // matches the `responses:lite` subtype EXACTLY has been deliberately
-  // configured as Codex-native — verified live against both providers
-  // currently marked `responses:lite` (see dispatcher-api-subtype.test.ts):
-  // both correctly parse raw `additional_tools`/`custom`/`namespace` wire
-  // extensions and invoke tools without flattening. That's the whole point
-  // of the subtype: avoid the transform pipeline where the target has opted
-  // in. Providers that only match on the base type haven't made that claim,
-  // so they still get the defensive flatten.
+  // `responses` type (no explicit Lite support advertised) — NOT any
+  // `responses:<subtype>` match. A target that matches the `responses:lite`
+  // subtype EXACTLY has been deliberately configured as Codex-native —
+  // verified live against both providers currently marked `responses:lite`
+  // (see dispatcher-api-subtype.test.ts): both correctly parse raw
+  // `additional_tools`/`custom`/`namespace` wire extensions and invoke tools
+  // without flattening. That's the whole point of the subtype: avoid the
+  // transform pipeline where the target has opted in. Providers that only
+  // match on the base type haven't made that claim, so they still get the
+  // defensive flatten. Checked via getApiBaseType/getApiSubtype (not a naive
+  // `=== 'responses'` string compare) so this expresses the actual intent —
+  // "base type only, no subtype" — rather than "not literally 'responses'",
+  // which would silently stop flattening for any FUTURE `responses:<other>`
+  // subtype too, not just `lite`.
   if (
-    targetApiType.toLowerCase() === 'responses' &&
+    getApiBaseType(targetApiType) === 'responses' &&
+    getApiSubtype(targetApiType) !== 'lite' &&
     hasCodexResponsesExtensions(request.originalBody)
   ) {
     return false;
@@ -205,13 +211,26 @@ export async function buildRequestPayload(
   if (!nativeOAuth && targetApiType.toLowerCase() === 'responses:lite') {
     payload = {
       ...payload,
-      reasoning: {
-        ...(payload.reasoning || {}),
-        context: payload.reasoning?.context ?? 'all_turns',
-      },
+      // Only default `context` when the payload already has a `reasoning`
+      // object — injecting one from nothing would send `reasoning` to a
+      // non-reasoning model routed through a lite target, and /v1/responses
+      // rejects that as an unsupported parameter. A genuinely reasoning
+      // model (the only kind Codex CLI's lite mode targets in practice)
+      // always sends `reasoning` itself, so this never needed to default
+      // the object's presence, only the missing `context` field within it.
+      ...(payload.reasoning
+        ? { reasoning: { ...payload.reasoning, context: payload.reasoning.context ?? 'all_turns' } }
+        : {}),
       parallel_tool_calls: false,
     };
-    payload = stripLiteUnsupportedTools(payload).payload;
+    const toolStripResult = stripLiteUnsupportedTools(payload);
+    if (toolStripResult.strippedCount > 0) {
+      logger.debug(
+        `Auto-compat: proactively stripped ${toolStripResult.strippedCount} tool(s) unsupported ` +
+          `by responses:lite for ${route.provider}/${route.model}`
+      );
+    }
+    payload = toolStripResult.payload;
   }
 
   // Native OAuth (currently Anthropic): the payload above is already the correct

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -13,7 +13,11 @@ import {
   prepareNativeOAuthDispatch,
   type PreparedOAuthRequest,
 } from '../oauth/oauth-native-request';
-import { applyRegistryAutoCompat, hasCodexResponsesExtensions } from './dispatcher-auto-compat';
+import {
+  applyRegistryAutoCompat,
+  hasCodexResponsesExtensions,
+  stripLiteUnsupportedTools,
+} from './dispatcher-auto-compat';
 
 /** Symbol stash for the native OAuth prep, read by the standard dispatch seams. */
 export const NATIVE_OAUTH_STASH = Symbol('nativeOAuthPrep');
@@ -184,12 +188,20 @@ export async function buildRequestPayload(
   // setupHeaders/setupProviderHeaders whenever targetApiType is exactly
   // `responses:lite`) comes with a wire contract both providers currently
   // configured for the subtype (openlimits, openai-s) enforce with a 400:
-  // `reasoning.context` must be `all_turns`, and `parallel_tool_calls` must
-  // be `false`. Real Codex CLI requests don't reliably satisfy either (see
-  // staging trace b672ebbd — no `reasoning.context` at all, and
-  // `parallel_tool_calls: true`), so normalize both here rather than
-  // trusting the client. Native OAuth routes build their own headers (see
-  // setupHeaders) and never send this header, so they're excluded.
+  // `reasoning.context` must be `all_turns`, `parallel_tool_calls` must be
+  // `false`, and declared tools are restricted to function/custom/tool_search
+  // (see LITE_ALLOWED_TOOL_TYPES) — real Codex CLI traffic declares
+  // `web_search` by default. Real Codex CLI requests don't reliably satisfy
+  // any of these (see staging trace b672ebbd), so normalize proactively here
+  // rather than paying a strip-and-retry round trip on every such request —
+  // dispatcher-auto-compat.ts's reactive strip-and-retry stays in place as a
+  // fallback for anything this proactive pass doesn't anticipate. This is
+  // NOT a property of `responses:lite` in general: it's specific to this
+  // generic `/v1/responses` + header contract used by non-native providers.
+  // The native Codex/ChatGPT backend (see oauth-native-request.ts's
+  // `prepareCodexOAuthRequest`) hits its own dedicated `/codex/responses`
+  // endpoint, never sends this header, and accepts the client's tools
+  // (including web_search) verbatim — so native OAuth routes are excluded.
   if (!nativeOAuth && targetApiType.toLowerCase() === 'responses:lite') {
     payload = {
       ...payload,
@@ -199,6 +211,7 @@ export async function buildRequestPayload(
       },
       parallel_tool_calls: false,
     };
+    payload = stripLiteUnsupportedTools(payload).payload;
   }
 
   // Native OAuth (currently Anthropic): the payload above is already the correct

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -61,8 +61,18 @@ function shouldUsePassThrough(
     return false;
   }
 
+  // Only force the transform pipeline when the target fell back to the bare
+  // `responses` type (no explicit Lite support advertised). A target that
+  // matches the `responses:lite` subtype EXACTLY has been deliberately
+  // configured as Codex-native — verified live against both providers
+  // currently marked `responses:lite` (see dispatcher-api-subtype.test.ts):
+  // both correctly parse raw `additional_tools`/`custom`/`namespace` wire
+  // extensions and invoke tools without flattening. That's the whole point
+  // of the subtype: avoid the transform pipeline where the target has opted
+  // in. Providers that only match on the base type haven't made that claim,
+  // so they still get the defensive flatten.
   if (
-    getApiBaseType(targetApiType) === 'responses' &&
+    targetApiType.toLowerCase() === 'responses' &&
     hasCodexResponsesExtensions(request.originalBody)
   ) {
     return false;
@@ -168,6 +178,27 @@ export async function buildRequestPayload(
       `Adapters applied (preDispatch): [${adapters.map((entry) => entry.adapter.name).join(', ')}] ` +
         `for ${route.provider}/${route.model}`
     );
+  }
+
+  // The provider-side `X-OpenAI-Internal-Codex-Responses-Lite` header (set in
+  // setupHeaders/setupProviderHeaders whenever targetApiType is exactly
+  // `responses:lite`) comes with a wire contract both providers currently
+  // configured for the subtype (openlimits, openai-s) enforce with a 400:
+  // `reasoning.context` must be `all_turns`, and `parallel_tool_calls` must
+  // be `false`. Real Codex CLI requests don't reliably satisfy either (see
+  // staging trace b672ebbd — no `reasoning.context` at all, and
+  // `parallel_tool_calls: true`), so normalize both here rather than
+  // trusting the client. Native OAuth routes build their own headers (see
+  // setupHeaders) and never send this header, so they're excluded.
+  if (!nativeOAuth && targetApiType.toLowerCase() === 'responses:lite') {
+    payload = {
+      ...payload,
+      reasoning: {
+        ...(payload.reasoning || {}),
+        context: payload.reasoning?.context ?? 'all_turns',
+      },
+      parallel_tool_calls: false,
+    };
   }
 
   // Native OAuth (currently Anthropic): the payload above is already the correct

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -7,13 +7,17 @@ import type { StallConfig } from '../inspectors/stall-inspector';
 import { CooldownManager } from '../runtime/cooldown-manager';
 import type { RequestManagerHost } from './request-manager';
 import {
+  createLiteToolStripState,
   createThinkingSignatureStripState,
   createUnsupportedParamStripState,
   deleteDottedPath,
+  planLiteToolStrip,
   planThinkingSignatureStrip,
   planUnsupportedParamStrip,
   refundThinkingSignatureStrip,
+  stripLiteUnsupportedTools,
   stripThinkingSignatureBlocks,
+  MAX_LITE_TOOL_STRIP_RETRIES,
   MAX_THINKING_SIGNATURE_STRIP_RETRIES,
   MAX_UNSUPPORTED_PARAM_STRIP_RETRIES,
 } from './dispatcher-auto-compat';
@@ -121,14 +125,16 @@ export async function executeStandardAttempt(
 
   // Reactive auto-compat: bounded per-target state so a strip-and-retry
   // cycle (see the 400 handling below) can't loop forever (see
-  // dispatcher-auto-compat.ts for the matching/bound logic). Two independent
-  // mechanisms, two independent budgets — neither resets the other's
+  // dispatcher-auto-compat.ts for the matching/bound logic). Three
+  // independent mechanisms, three independent budgets — none resets another's
   // counter, so the combined worst case for this target is bounded at
   // exactly 1 (initial attempt) + MAX_THINKING_SIGNATURE_STRIP_RETRIES +
-  // MAX_UNSUPPORTED_PARAM_STRIP_RETRIES fetches, however the two mechanisms
-  // interleave — they can't ping-pong into an unbounded loop.
+  // MAX_UNSUPPORTED_PARAM_STRIP_RETRIES + MAX_LITE_TOOL_STRIP_RETRIES fetches,
+  // however the mechanisms interleave — they can't ping-pong into an
+  // unbounded loop.
   const paramStripState = createUnsupportedParamStripState();
   const thinkingStripState = createThinkingSignatureStripState();
+  const liteToolStripState = createLiteToolStripState();
 
   // Looped so a strip-and-retry can redo the fetch against the SAME target
   // without returning to the caller's failover loop — failing over would
@@ -252,7 +258,7 @@ export async function executeStandardAttempt(
 
       // Reactive auto-compat: a 400 can name a problem that failing over
       // won't fix — every remaining target would reject the same request
-      // the same way — so both mechanisms below strip the offending content
+      // the same way — so the mechanisms below strip the offending content
       // and retry the SAME target instead. Checked in order:
       //
       //   1. Stale thinking-block signatures: alias-level failover can
@@ -263,6 +269,12 @@ export async function executeStandardAttempt(
       //   2. Unsupported/unknown parameters: some upstreams 400 naming one specific
       //      client-sent field (e.g. LobeHub's gpt-5.5 traffic sending
       //      safety_identifier / prompt_cache_key that a provider rejects).
+      //   3. Unsupported responses:lite tools: real Codex CLI traffic
+      //      declares a `web_search` tool by default, but the
+      //      responses:lite wire contract only allows function/custom/
+      //      tool_search tools — the 400 names the restriction generically,
+      //      not the specific tool(s), so every disallowed tool is stripped
+      //      at once.
       if (response.status === 400) {
         if (planThinkingSignatureStrip(errorText, providerPayload, thinkingStripState)) {
           const stripResult = stripThinkingSignatureBlocks(providerPayload);
@@ -308,6 +320,23 @@ export async function executeStandardAttempt(
           // resending the SAME payload would just repeat the identical
           // upstream rejection, so fall through to normal failover/error
           // handling below instead of retrying this target again.
+        }
+
+        if (planLiteToolStrip(errorText, liteToolStripState)) {
+          const stripResult = stripLiteUnsupportedTools(providerPayload);
+          if (stripResult.strippedCount > 0) {
+            providerPayload = stripResult.payload;
+            logger.warn(
+              `Auto-compat: ${route.provider}/${route.model} rejected tool(s) unsupported by ` +
+                `responses:lite — stripped ${stripResult.strippedCount} tool(s) and retrying the ` +
+                `same target (attempt ${liteToolStripState.attempts}/${MAX_LITE_TOOL_STRIP_RETRIES})`
+            );
+            continue;
+          }
+          // Nothing was actually removed (no `tools` array, or every
+          // declared tool was already an allowed type) — resending the SAME
+          // payload would just repeat the identical upstream rejection, so
+          // fall through to normal failover/error handling below.
         }
       }
 

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -322,7 +322,14 @@ export async function executeStandardAttempt(
           // handling below instead of retrying this target again.
         }
 
-        if (planLiteToolStrip(errorText, liteToolStripState)) {
+        // Gated on targetApiType so an unrelated 400 that happens to match
+        // the (fairly specific) error pattern can never trigger a strip on a
+        // non-lite target — the pattern match alone was already unlikely to
+        // misfire, but this removes the class of risk entirely for free.
+        if (
+          targetApiType.toLowerCase() === 'responses:lite' &&
+          planLiteToolStrip(errorText, liteToolStripState)
+        ) {
           const stripResult = stripLiteUnsupportedTools(providerPayload);
           if (stripResult.strippedCount > 0) {
             providerPayload = stripResult.payload;

--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -1785,3 +1785,234 @@ describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream
     expect(finishChunk.usage.total_tokens).toBe(10);
   });
 });
+
+// Typed client_tool_calls carry (see UnifiedClientToolCall in
+// types/unified.ts) — a built-in Responses tool-call item whose execution is
+// delegated to the CLIENT (`execution: "client"`, e.g. tool_search_call).
+// Regression coverage for the bug this PR fixes: these items were previously
+// silently dropped (unrecognized item type), leaving the client with no
+// signal that a tool call was pending — the turn looked finished when it
+// wasn't. Also locks in the fix for a follow-up bug found in review: unlike
+// function_call, a client_tool_calls-only stream must NOT set finish_reason
+// to 'tool_calls' — chat/messages-format clients have no way to represent
+// this item (no delta.tool_calls gets populated for it), so upgrading
+// finish_reason for them would send a 'tool_calls' finish with an empty
+// tool_calls array, which SDKs commonly loop or throw on.
+describe('ResponsesTransformer typed client_tool_calls carry (tool_search_call)', () => {
+  const toolSearchItem = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    id: 'tsc_1',
+    type: 'tool_search_call',
+    call_id: 'call_1',
+    execution: 'client',
+    status: 'completed',
+    arguments: { query: 'exec_command' },
+    ...overrides,
+  });
+
+  function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
+    return new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+  }
+
+  async function collectFormatStreamEvents(chunks: any[], transformer: any): Promise<any[]> {
+    const reader = transformer.formatStream(unifiedStreamFromChunks(chunks)).getReader();
+    const decoder = new TextDecoder();
+    let output = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value);
+    }
+    return output
+      .split('\n\n')
+      .filter((block: string) => block.trim().length > 0)
+      .map((block: string) => {
+        const dataLine = block.split('\n').find((line) => line.startsWith('data: '));
+        const data = (dataLine as string).replace(/^data:\s*/, '');
+        return data === '[DONE]' ? '[DONE]' : JSON.parse(data);
+      });
+  }
+
+  describe('transformStream (inbound: Responses SSE -> unified chunks)', () => {
+    test('a streamed tool_search_call item carries as a chunk-level client_tool_calls entry', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_tsc_1', model: 'gpt-5.6-luna', created_at: 1234567890 },
+        },
+        { type: 'response.output_item.done', output_index: 0, item: toolSearchItem() },
+        { type: 'response.completed', response: {} },
+      ]);
+
+      const toolChunks = chunks.filter((chunk) => chunk.client_tool_calls);
+      expect(toolChunks).toHaveLength(1);
+      expect(toolChunks[0].client_tool_calls).toEqual([toolSearchItem()]);
+      // Chunk-level, not inside delta — same reason as image_generation_calls.
+      expect(toolChunks[0].delta.client_tool_calls).toBeUndefined();
+    });
+
+    test('the completed-fallback also carries the item, without double-carrying deduped items', async () => {
+      const item = toolSearchItem();
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_tsc_2', model: 'gpt-5.6-luna', created_at: 1234567890 },
+        },
+        { type: 'response.output_item.done', output_index: 0, item },
+        { type: 'response.completed', response: { id: 'resp_tsc_2', output: [item] } },
+      ]);
+
+      expect(chunks.filter((chunk) => chunk.client_tool_calls)).toHaveLength(1);
+    });
+
+    test('a completed-only item (never streamed via output_item.done) still gets carried', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_tsc_3', model: 'gpt-5.6-luna', created_at: 1234567890 },
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_tsc_3',
+            status: 'completed',
+            output: [toolSearchItem({ id: 'tsc_9' })],
+          },
+        },
+      ]);
+
+      const toolChunks = chunks.filter((chunk) => chunk.client_tool_calls);
+      expect(toolChunks).toHaveLength(1);
+      expect(toolChunks[0].client_tool_calls[0].id).toBe('tsc_9');
+    });
+
+    test('finishes with "stop", NOT "tool_calls", when the only output is a client_tool_calls item', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_tsc_4', model: 'gpt-5.6-luna', created_at: 1234567890 },
+        },
+        { type: 'response.output_item.done', output_index: 0, item: toolSearchItem() },
+        { type: 'response.completed', response: {} },
+      ]);
+
+      expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('stop');
+    });
+
+    test('finishes with "stop" when a client_tool_calls item appears only in the completed response', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_tsc_5', model: 'gpt-5.6-luna', created_at: 1234567890 },
+        },
+        {
+          type: 'response.completed',
+          response: { output: [toolSearchItem()] },
+        },
+      ]);
+
+      expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('stop');
+    });
+
+    test('a real function_call alongside a client_tool_calls item still finishes with "tool_calls"', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_tsc_6', model: 'gpt-5.6-luna', created_at: 1234567890 },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: { type: 'function_call', call_id: 'call_fn', name: 'get_date', arguments: '' },
+        },
+        { type: 'response.output_item.done', output_index: 1, item: toolSearchItem() },
+        { type: 'response.completed', response: {} },
+      ]);
+
+      expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('tool_calls');
+    });
+  });
+
+  describe('formatStream (outbound: unified chunks -> native Responses output)', () => {
+    test('re-emits the typed item as a native tool_search_call output item', async () => {
+      const item = toolSearchItem();
+      const chunk = {
+        id: 'resp_native_tsc',
+        model: 'gpt-5.6-luna',
+        created: 1234567890,
+        delta: {},
+        client_tool_calls: [item],
+        finish_reason: null,
+      };
+      const finishChunk = {
+        id: 'resp_native_tsc',
+        model: 'gpt-5.6-luna',
+        created: 1234567890,
+        delta: {},
+        finish_reason: 'stop',
+      };
+
+      const events = await collectFormatStreamEvents(
+        [chunk, finishChunk],
+        new ResponsesTransformer()
+      );
+      const completed = events.find((e) => e.type === 'response.completed');
+      expect(completed).toBeDefined();
+      const outputTypes = completed.response.output.map((o: any) => o.type);
+      expect(outputTypes).toContain('tool_search_call');
+      const native = completed.response.output.find((o: any) => o.type === 'tool_search_call');
+      expect(native).toMatchObject({
+        call_id: 'call_1',
+        execution: 'client',
+        arguments: { query: 'exec_command' },
+      });
+    });
+  });
+
+  describe('non-streaming round trip (transformResponse -> formatResponse)', () => {
+    test('transformResponse extracts client_tool_calls and formatResponse re-emits it natively', async () => {
+      const transformer = new ResponsesTransformer();
+      const unified = await transformer.transformResponse({
+        id: 'resp_tsc_ns',
+        object: 'response',
+        created_at: 1234567890,
+        status: 'completed',
+        model: 'gpt-5.6-luna',
+        output: [toolSearchItem()],
+      });
+
+      expect(unified.client_tool_calls).toEqual([toolSearchItem()]);
+
+      const formatted = await transformer.formatResponse(unified);
+      const native = formatted.output.find((o: any) => o.type === 'tool_search_call');
+      expect(native).toMatchObject({ call_id: 'call_1', execution: 'client' });
+    });
+  });
+
+  describe('cross-format (Responses -> Chat Completions): no false "tool_calls" finish', () => {
+    test('a chat-format client never receives finish_reason "tool_calls" for a client_tool_calls-only turn', async () => {
+      const chunks = await transformEvents([
+        {
+          type: 'response.created',
+          response: { id: 'resp_tsc_chat', model: 'gpt-5.6-luna', created_at: 1234567890 },
+        },
+        { type: 'response.output_item.done', output_index: 0, item: toolSearchItem() },
+        { type: 'response.completed', response: {} },
+      ]);
+
+      const chatEvents = await collectFormatStreamEvents(chunks, new OpenAITransformer());
+      const finishEvent = chatEvents.find((e) => e !== '[DONE]' && e.choices?.[0]?.finish_reason);
+      expect(finishEvent).toBeDefined();
+      expect(finishEvent.choices[0].finish_reason).toBe('stop');
+      // No tool_calls array should ever appear on any chunk for this client —
+      // the chat formatter has no representation for client_tool_calls.
+      expect(chatEvents.some((e) => e !== '[DONE]' && e.choices?.[0]?.delta?.tool_calls)).toBe(
+        false
+      );
+    });
+  });
+});

--- a/packages/backend/src/transformers/__tests__/utils.test.ts
+++ b/packages/backend/src/transformers/__tests__/utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { projectReasoningForResponses } from '../utils';
+
+describe('projectReasoningForResponses', () => {
+  it('returns undefined when reasoning is absent', () => {
+    expect(projectReasoningForResponses(undefined)).toBeUndefined();
+  });
+
+  it("projects the Responses-native 'none' level as disabled", () => {
+    expect(projectReasoningForResponses({ effort: 'none' })).toEqual({
+      effort: 'none',
+    });
+  });
+
+  it("normalizes the legacy 'off' level to 'none' instead of forwarding it", () => {
+    expect(projectReasoningForResponses({ effort: 'off' })).toEqual({
+      effort: 'none',
+    });
+  });
+
+  it('projects enabled: false as disabled', () => {
+    expect(projectReasoningForResponses({ enabled: false })).toEqual({
+      effort: 'none',
+    });
+  });
+
+  it('passes through effort and summary verbatim', () => {
+    expect(projectReasoningForResponses({ effort: 'high', summary: 'auto' })).toEqual({
+      effort: 'high',
+      summary: 'auto',
+    });
+  });
+
+  it('returns undefined when there is nothing Responses-relevant to project', () => {
+    expect(projectReasoningForResponses({ enabled: true })).toBeUndefined();
+  });
+});

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -14,6 +14,7 @@ import {
 import {
   UnifiedChatRequest,
   UnifiedChatResponse,
+  UnifiedClientToolCall,
   UnifiedImageGenerationCall,
   UnifiedMessage,
 } from '../types/unified';
@@ -40,6 +41,26 @@ function toUnifiedImageGenerationCall(item: any): UnifiedImageGenerationCall {
     ...(typeof item.status === 'string' ? { status: item.status } : {}),
     result: item.result,
   };
+}
+
+/**
+ * True for a built-in Responses output item whose execution the model has
+ * delegated to the CLIENT (`execution: "client"`, e.g. `tool_search_call`).
+ * These are pending tool calls the caller must act on to continue the turn —
+ * unlike server-executed built-ins (web_search_call, etc.) — so they need the
+ * same "keep this and tell the client" treatment as a function_call rather
+ * than being silently dropped as an unrecognized item type. Keyed on the
+ * `execution` discriminator (not a type allowlist) so future built-in
+ * client-executed tool types are handled automatically.
+ */
+function isClientExecutedToolItem(item: any): item is UnifiedClientToolCall {
+  return (
+    !!item &&
+    typeof item === 'object' &&
+    item.execution === 'client' &&
+    typeof item.call_id === 'string' &&
+    typeof item.type === 'string'
+  );
 }
 
 // Some Responses clients have been observed replaying tool calls with composite
@@ -437,6 +458,14 @@ export class ResponsesTransformer implements Transformer {
           imageGenerationCalls.push(toUnifiedImageGenerationCall(item));
         }
       }
+
+      // Built-in tool-call items whose execution is delegated to the client
+      // (e.g. tool_search_call) — carried typed, untouched, so formatResponse
+      // can re-emit them natively instead of silently dropping a pending
+      // tool call the client is expected to act on.
+      const clientToolCalls: UnifiedClientToolCall[] = (response.output ?? []).filter(
+        isClientExecutedToolItem
+      );
       const content = messageText;
 
       // Collect url_citation annotations from all output_text content parts
@@ -506,6 +535,7 @@ export class ResponsesTransformer implements Transformer {
         ...(imageGenerationCalls.length > 0
           ? { image_generation_calls: imageGenerationCalls }
           : {}),
+        ...(clientToolCalls.length > 0 ? { client_tool_calls: clientToolCalls } : {}),
         usage,
       };
     } else {
@@ -966,6 +996,13 @@ export class ResponsesTransformer implements Transformer {
       });
     }
 
+    // Re-emit typed client-executed tool-call items (e.g. tool_search_call)
+    // natively and untouched, so the client sees the pending call it's
+    // expected to act on to continue the turn.
+    for (const clientToolCall of response.client_tool_calls ?? []) {
+      items.push(clientToolCall as unknown as ResponsesOutputItem);
+    }
+
     // Add main message
     items.push({
       type: 'message',
@@ -1048,6 +1085,10 @@ export class ResponsesTransformer implements Transformer {
     // their response.output_item.done event, so the response.completed
     // fallback below doesn't render them a second time.
     const renderedImageItemIds = new Set<string>();
+    // Client-executed tool-call items (e.g. tool_search_call) already carried
+    // typed from their response.output_item.done event, so the
+    // response.completed fallback below doesn't carry them a second time.
+    const renderedClientToolCallIds = new Set<string>();
     const getToolCallIndex = (data: any): number => {
       const outputIndex =
         typeof data.output_index === 'number' ? (data.output_index as number) : undefined;
@@ -1186,6 +1227,28 @@ export class ResponsesTransformer implements Transformer {
                     finish_reason: null,
                   });
                 }
+              } else if (
+                data.type === 'response.output_item.done' &&
+                isClientExecutedToolItem(data.item)
+              ) {
+                // Built-in tool-call item whose execution the model
+                // delegated to the client (e.g. tool_search_call). Carry it
+                // typed (see UnifiedClientToolCall) and flag it the same as
+                // a function call so `finish_reason` comes out 'tool_calls'
+                // instead of 'stop' — otherwise the client has no signal
+                // that it's expected to act and continue the turn.
+                hasFunctionCall = true;
+                if (typeof data.item.id === 'string') {
+                  renderedClientToolCallIds.add(data.item.id);
+                }
+                controller.enqueue({
+                  id: responseId,
+                  model: responseModel,
+                  created: Math.floor(Date.now() / 1000),
+                  delta: {},
+                  client_tool_calls: [data.item as UnifiedClientToolCall],
+                  finish_reason: null,
+                });
               } else if (data.type === 'response.completed') {
                 // Final chunk with usage data and an OpenAI-compatible finish reason.
                 // `response.completed` includes the full output as a fallback because some
@@ -1193,7 +1256,7 @@ export class ResponsesTransformer implements Transformer {
                 const usage = data.response?.usage;
                 const normalizedUsage = usage ? normalizeOpenAIResponsesUsage(usage) : undefined;
                 const completedResponseHasFunctionCall = data.response?.output?.some(
-                  (item: any) => item?.type === 'function_call'
+                  (item: any) => item?.type === 'function_call' || isClientExecutedToolItem(item)
                 );
                 // Same fallback as function calls above: render any completed
                 // image_generation_call items that only appear in the final
@@ -1214,6 +1277,25 @@ export class ResponsesTransformer implements Transformer {
                       content: imageMarkdown,
                     },
                     image_generation_calls: [toUnifiedImageGenerationCall(item)],
+                    finish_reason: null,
+                  });
+                }
+                // Same fallback for client-executed tool-call items that only
+                // appear in the final response snapshot (some backends omit
+                // the intermediate output_item.done for them, or leave the
+                // final snapshot's output populated where the streamed
+                // events didn't carry it) — skip ones already carried above.
+                for (const item of data.response?.output ?? []) {
+                  if (!isClientExecutedToolItem(item)) continue;
+                  if (typeof item.id === 'string' && renderedClientToolCallIds.has(item.id)) {
+                    continue;
+                  }
+                  controller.enqueue({
+                    id: responseId,
+                    model: responseModel,
+                    created: Math.floor(Date.now() / 1000),
+                    delta: {},
+                    client_tool_calls: [item as UnifiedClientToolCall],
                     finish_reason: null,
                   });
                 }
@@ -1576,6 +1658,32 @@ export class ResponsesTransformer implements Transformer {
       }
     };
 
+    // Re-emits typed client-executed tool-call carries (see
+    // UnifiedClientToolCall in types/unified.ts) as native Responses output
+    // items, untouched. Each item is registered in outputItemsByIndex so the
+    // terminal response.completed's output array includes it — this is the
+    // client's only signal that a tool call (e.g. tool_search_call) is
+    // pending and the turn isn't actually over.
+    const emitClientToolCallItems = (
+      controller: ReadableStreamDefaultController,
+      clientToolCalls: UnifiedClientToolCall[]
+    ) => {
+      for (const clientToolCall of clientToolCalls) {
+        const outputIndex = reserveOutputIndex();
+        sendEvent(controller, {
+          type: 'response.output_item.added',
+          output_index: outputIndex,
+          item: { ...clientToolCall, status: 'in_progress' },
+        });
+        sendEvent(controller, {
+          type: 'response.output_item.done',
+          output_index: outputIndex,
+          item: clientToolCall,
+        });
+        outputItemsByIndex.set(outputIndex, clientToolCall);
+      }
+    };
+
     // `itemStatus` is the terminal status stamped on items that were still
     // in progress when the stream ended. The completed and failed paths keep
     // the pre-existing 'completed' stamp; only the response.incomplete path
@@ -1875,6 +1983,17 @@ export class ResponsesTransformer implements Transformer {
               : [];
             if (typedImageCalls.length > 0) {
               emitImageGenerationCallItems(controller, typedImageCalls);
+            }
+
+            // Typed client-executed tool-call carries (e.g. tool_search_call)
+            // re-emit as NATIVE output items, untouched — these have no
+            // chat-format equivalent to fall back to, so this is the only way
+            // the client learns a tool call is pending.
+            if (
+              Array.isArray(unifiedChunk.client_tool_calls) &&
+              unifiedChunk.client_tool_calls.length > 0
+            ) {
+              emitClientToolCallItems(controller, unifiedChunk.client_tool_calls);
             }
 
             if (reasoningDelta && reasoningDelta.length > 0) {

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -51,16 +51,38 @@ function toUnifiedImageGenerationCall(item: any): UnifiedImageGenerationCall {
  * same "keep this and tell the client" treatment as a function_call rather
  * than being silently dropped as an unrecognized item type. Keyed on the
  * `execution` discriminator (not a type allowlist) so future built-in
- * client-executed tool types are handled automatically.
+ * client-executed tool types are handled automatically, plus a `_call`
+ * suffix check so a provider that ever stamps `execution` on some unrelated
+ * item type can't be misread as a tool call. Accepts either `call_id` or
+ * `id` (falling back between them — see `clientToolCallKey` below) rather
+ * than requiring `call_id` specifically: every item observed on the wire so
+ * far has both, but requiring one exclusively risks silently dropping an
+ * item that only has the other, which is exactly the failure mode this
+ * carry exists to prevent.
  */
 function isClientExecutedToolItem(item: any): item is UnifiedClientToolCall {
   return (
     !!item &&
     typeof item === 'object' &&
     item.execution === 'client' &&
-    typeof item.call_id === 'string' &&
-    typeof item.type === 'string'
+    typeof item.type === 'string' &&
+    item.type.endsWith('_call') &&
+    (typeof item.call_id === 'string' || typeof item.id === 'string')
   );
+}
+
+/**
+ * Identifier used to dedupe a client-executed tool-call item between its
+ * streamed `response.output_item.done` event and the `response.completed`
+ * fallback loop — prefers `id` (the item's own identity) and falls back to
+ * `call_id` when `id` is absent, so an item missing either field still gets
+ * a stable dedupe key instead of silently bypassing the dedupe check (which
+ * would emit it twice) or being dropped entirely.
+ */
+function clientToolCallKey(item: any): string | undefined {
+  if (typeof item?.id === 'string') return item.id;
+  if (typeof item?.call_id === 'string') return item.call_id;
+  return undefined;
 }
 
 // Some Responses clients have been observed replaying tool calls with composite
@@ -1233,13 +1255,20 @@ export class ResponsesTransformer implements Transformer {
               ) {
                 // Built-in tool-call item whose execution the model
                 // delegated to the client (e.g. tool_search_call). Carry it
-                // typed (see UnifiedClientToolCall) and flag it the same as
-                // a function call so `finish_reason` comes out 'tool_calls'
-                // instead of 'stop' — otherwise the client has no signal
-                // that it's expected to act and continue the turn.
-                hasFunctionCall = true;
-                if (typeof data.item.id === 'string') {
-                  renderedClientToolCallIds.add(data.item.id);
+                // typed (see UnifiedClientToolCall) so responses-facing
+                // formatStream can re-emit it natively — that native item is
+                // what actually signals a Responses-format client (e.g.
+                // Codex) that a tool call is pending; the Responses wire
+                // format has no `finish_reason` field at all, so this does
+                // NOT set `hasFunctionCall`. Chat/messages-format clients
+                // have no way to represent this item (no delta.tool_calls
+                // gets populated for it), so upgrading `finish_reason` to
+                // 'tool_calls' here would send them a 'tool_calls' finish
+                // with an empty tool_calls array — SDKs commonly loop or
+                // throw on that shape.
+                const clientToolCallKeyForItem = clientToolCallKey(data.item);
+                if (clientToolCallKeyForItem) {
+                  renderedClientToolCallIds.add(clientToolCallKeyForItem);
                 }
                 controller.enqueue({
                   id: responseId,
@@ -1255,8 +1284,13 @@ export class ResponsesTransformer implements Transformer {
                 // Responses-compatible providers omit intermediate function-call events.
                 const usage = data.response?.usage;
                 const normalizedUsage = usage ? normalizeOpenAIResponsesUsage(usage) : undefined;
+                // Client-executed tool-call items are deliberately excluded
+                // here — see the matching comment on the output_item.done
+                // branch above: they carry no chat-format representation, so
+                // upgrading `finish_reason` for them would mislead
+                // chat/messages-format clients rather than help any client.
                 const completedResponseHasFunctionCall = data.response?.output?.some(
-                  (item: any) => item?.type === 'function_call' || isClientExecutedToolItem(item)
+                  (item: any) => item?.type === 'function_call'
                 );
                 // Same fallback as function calls above: render any completed
                 // image_generation_call items that only appear in the final
@@ -1287,7 +1321,8 @@ export class ResponsesTransformer implements Transformer {
                 // events didn't carry it) — skip ones already carried above.
                 for (const item of data.response?.output ?? []) {
                   if (!isClientExecutedToolItem(item)) continue;
-                  if (typeof item.id === 'string' && renderedClientToolCallIds.has(item.id)) {
+                  const key = clientToolCallKey(item);
+                  if (key && renderedClientToolCallIds.has(key)) {
                     continue;
                   }
                   controller.enqueue({

--- a/packages/backend/src/transformers/utils.ts
+++ b/packages/backend/src/transformers/utils.ts
@@ -10,7 +10,7 @@ export function projectReasoningForResponses(
     | undefined
 ): { effort?: ThinkLevel; summary?: string } | undefined {
   if (!reasoning) return undefined;
-  if (reasoning.enabled === false || reasoning.effort === 'off') {
+  if (reasoning.enabled === false || reasoning.effort === 'none') {
     return { effort: 'none' };
   }
 

--- a/packages/backend/src/transformers/utils.ts
+++ b/packages/backend/src/transformers/utils.ts
@@ -3,14 +3,19 @@ import { ThinkLevel } from '../types/unified';
 export function projectReasoningForResponses(
   reasoning:
     | {
-        effort?: ThinkLevel;
+        // Accept the legacy 'off' level in addition to the Responses-native
+        // 'none' — clients/model aliases still send 'off' (see
+        // normalizeEffort / splitReasoningSuffix in services/pi-ai/reasoning.ts).
+        effort?: ThinkLevel | 'off';
         enabled?: boolean;
         summary?: string;
       }
     | undefined
 ): { effort?: ThinkLevel; summary?: string } | undefined {
   if (!reasoning) return undefined;
-  if (reasoning.enabled === false || reasoning.effort === 'none') {
+  // 'off' is not a valid Responses effort level — normalize it to 'none'
+  // rather than forwarding an invalid payload.
+  if (reasoning.enabled === false || reasoning.effort === 'off' || reasoning.effort === 'none') {
     return { effort: 'none' };
   }
 

--- a/packages/backend/src/types/responses.ts
+++ b/packages/backend/src/types/responses.ts
@@ -354,7 +354,11 @@ export interface ResponsesBuiltInToolCallItem {
     | 'code_interpreter_call'
     | 'computer_call'
     | 'image_generation_call'
-    | 'mcp_call';
+    | 'mcp_call'
+    // Deferred tool-discovery call: execution is delegated to the CLIENT
+    // (`execution: "client"`), so unlike the other built-ins above it must be
+    // forwarded to the caller to act on rather than resolved by the provider.
+    | 'tool_search_call';
   id: string;
   status: 'in_progress' | 'completed' | 'failed';
   [key: string]: any; // Tool-specific fields

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -227,6 +227,26 @@ export interface UnifiedImageGenerationCall {
   result: string;
 }
 
+/**
+ * A Responses-API built-in tool-call output item whose execution is deferred
+ * to the CLIENT (`execution: "client"`, e.g. `tool_search_call`) — the model
+ * expects the caller to run the call and continue the turn, mirroring how a
+ * `function_call` works. Carried through the unified layer typed and
+ * untouched (same pattern as UnifiedImageGenerationCall) rather than parsed
+ * into `tool_calls`, since these items are Responses-specific and have no
+ * Chat Completions/Anthropic Messages equivalent. Only populated/consumed by
+ * the Responses transformer (transformers/responses.ts): dropping one of
+ * these instead of re-emitting it natively leaves the client with no signal
+ * that a tool call is pending, so the response looks like a completed turn.
+ */
+export interface UnifiedClientToolCall {
+  type: string;
+  id: string;
+  call_id: string;
+  status?: string;
+  [key: string]: any;
+}
+
 export interface UnifiedChatResponse {
   id: string;
   model: string;
@@ -275,6 +295,13 @@ export interface UnifiedChatResponse {
    * detection counts entries with a non-empty `result` as visible output.
    */
   image_generation_calls?: UnifiedImageGenerationCall[];
+  /**
+   * Client-executed built-in tool-call output items, typed (see
+   * UnifiedClientToolCall). Same pattern as `image_generation_calls`:
+   * responses-facing formatters re-emit them natively so the client sees the
+   * pending call and continues the turn.
+   */
+  client_tool_calls?: UnifiedClientToolCall[];
   annotations?: Annotation[];
   stream?: ReadableStream | any;
   bypassTransformation?: boolean;
@@ -361,6 +388,13 @@ export interface UnifiedChatStreamChunk {
    * skips the paired markdown content delta.
    */
   image_generation_calls?: UnifiedImageGenerationCall[];
+  /**
+   * Client-executed built-in tool-call output items carried typed (see
+   * UnifiedClientToolCall), CHUNK-level like `image_generation_calls` above.
+   * The responses-facing formatStream re-emits these as native output items;
+   * other formatters have no equivalent and simply ignore the field.
+   */
+  client_tool_calls?: UnifiedClientToolCall[];
 }
 
 // Unified Embeddings Request

--- a/scripts/__tests__/populate-dev.test.ts
+++ b/scripts/__tests__/populate-dev.test.ts
@@ -5,7 +5,7 @@ describe('resolveApiRoot', () => {
   it('uses the worktree-derived port by default', () => {
     const cwd = '/workspace/plexus-review';
 
-    expect(resolveApiRoot({}, cwd)).toBe(`http://localhost:${deriveDevPort(cwd)}`);
+    expect(resolveApiRoot({}, cwd)).toBe(`http://localhost:${deriveDevPort(cwd, 'dev')}`);
   });
 
   it.each([

--- a/scripts/dev-agent.ts
+++ b/scripts/dev-agent.ts
@@ -47,12 +47,16 @@ function sanitizeTarget(name?: string): string {
 
 const targetName = isStop ? sanitizeTarget(rawArgs[1]) : sanitizeTarget(rawArgs[0]);
 
-function derivePort(target: string): string {
+// One dev server per worktree: derive the same port regardless of which
+// target (dev / dev:full / dev:pglite) is used to start it, matching
+// dev.ts and dev-config.ts. Paseo-managed runs still get their own port via
+// $PASEO_PORT (see paseo.json), which takes precedence through process.env.PORT.
+function derivePort(): string {
   if (process.env.PORT) return process.env.PORT;
-  return deriveDevPort(process.cwd(), target);
+  return deriveDevPort(process.cwd(), 'dev');
 }
 
-const PORT = derivePort(targetName);
+const PORT = derivePort();
 const ADMIN_KEY = process.env.ADMIN_KEY ?? 'password';
 const CONSECUTIVE_OK = 3;
 const READY_TIMEOUT_MS = 180_000;

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,13 +1,32 @@
 import { join, basename } from 'path';
 import { tmpdir } from 'os';
 import { createServer } from 'net';
-import { existsSync, writeFileSync, unlinkSync } from 'fs';
+import { existsSync, writeFileSync, unlinkSync, statSync, readFileSync } from 'fs';
 import { spawn as nodeSpawn, type ChildProcess } from 'child_process';
 import { deriveDevPort } from './dev-port-allocator';
 
 // --- Dev defaults (only applied when not already set in environment) ---
 
 const dirName = basename(process.cwd());
+
+// Tracks the mtime of the saved backup we last restored, so `--full` can
+// detect a fresher backup (e.g. after `bun run prep-dev:save`) and re-restore
+// it even when the dev DB already exists.
+const DEV_DATA_PATH = process.env.PLEXUS_DEV_DATA_PATH ?? '.dev-data';
+const SAVED_BACKUP_FILE = join(process.cwd(), DEV_DATA_PATH, 'backup.tar.gz');
+const RESTORE_MARKER_FILE = join(tmpdir(), `plexus-${dirName}.restored-backup`);
+
+function savedBackupIsNewerThanLastRestore(): boolean {
+  if (!existsSync(SAVED_BACKUP_FILE) || !existsSync(RESTORE_MARKER_FILE)) return false;
+  const backupMtime = statSync(SAVED_BACKUP_FILE).mtimeMs;
+  const lastRestoredMtime = Number(readFileSync(RESTORE_MARKER_FILE, 'utf8').trim());
+  return Number.isFinite(lastRestoredMtime) && backupMtime > lastRestoredMtime;
+}
+
+function writeRestoreMarker() {
+  if (!existsSync(SAVED_BACKUP_FILE)) return;
+  writeFileSync(RESTORE_MARKER_FILE, String(statSync(SAVED_BACKUP_FILE).mtimeMs));
+}
 
 function readOptionValue(args: string[], index: number, option: string) {
   const value = args[index + 1];
@@ -30,14 +49,17 @@ function sqlitePathFromDatabaseUrl(databaseUrl: string): string | null {
 function shouldLoadFullData(): boolean {
   if (!fullMode) return false;
 
+  let dbMissing: boolean;
   if (process.env.PLEXUS_POSTGRES_DRIVER === 'pglite') {
-    return process.env.PLEXUS_PGLITE_DATA_DIR
+    dbMissing = process.env.PLEXUS_PGLITE_DATA_DIR
       ? !existsSync(process.env.PLEXUS_PGLITE_DATA_DIR)
       : true;
+  } else {
+    const dbPath = sqlitePathFromDatabaseUrl(process.env.DATABASE_URL!);
+    dbMissing = dbPath ? !existsSync(dbPath) : false;
   }
 
-  const dbPath = sqlitePathFromDatabaseUrl(process.env.DATABASE_URL!);
-  return dbPath ? !existsSync(dbPath) : false;
+  return dbMissing || savedBackupIsNewerThanLastRestore();
 }
 
 for (let i = 2; i < process.argv.length; i++) {
@@ -319,6 +341,9 @@ if (fullMode) {
       console.log('[full] Existing dev database found. Skipping prep-dev restore.');
       return;
     }
+    if (savedBackupIsNewerThanLastRestore()) {
+      console.log('[full] Saved backup is newer than last restore. Reloading dev data...');
+    }
 
     console.log(`\n[full] Waiting for server at http://localhost:${process.env.PORT}...`);
     try {
@@ -331,14 +356,24 @@ if (fullMode) {
     await new Promise<void>((resolve, reject) => {
       const proc = nodeSpawn('bun', ['run', 'prep-dev'], {
         cwd: process.cwd(),
-        env: { ...process.env },
+        // Force prep-dev to target *this* server: override PLEXUS_PORT/PLEXUS_ADMIN_KEY
+        // rather than letting prep-dev re-derive them (Bun reloads .env fresh per
+        // process, so a stale PLEXUS_ADMIN_KEY in .env would otherwise take priority
+        // over the port/key this server actually started with).
+        env: {
+          ...process.env,
+          PLEXUS_PORT: process.env.PORT,
+          PLEXUS_ADMIN_KEY: process.env.ADMIN_KEY,
+        },
         stdio: 'inherit',
       });
       proc.on('close', (code) =>
         code === 0 ? resolve() : reject(new Error(`prep-dev exited with code ${code}`))
       );
       proc.on('error', reject);
-    }).catch((err) => console.error(`[full] ${err instanceof Error ? err.message : err}`));
+    })
+      .then(writeRestoreMarker)
+      .catch((err) => console.error(`[full] ${err instanceof Error ? err.message : err}`));
 
     // prep-dev triggers a server restart after restore, so wait for it to come back up
     console.log('[full] Waiting for server to restart after restore...');

--- a/scripts/populate-dev.ts
+++ b/scripts/populate-dev.ts
@@ -11,7 +11,7 @@
  * Environment variables (all optional — defaults match `bun run dev` defaults):
  *   PLEXUS_URL       Complete Plexus origin, or a hostname to combine with PLEXUS_PORT
  *   PLEXUS_PORT      Port (default: worktree-derived when PLEXUS_URL is unset)
- *   PLEXUS_ADMIN_KEY Admin key                        (default: password)
+ *   PLEXUS_ADMIN_KEY Admin key                        (default: $ADMIN_KEY, else password)
  *
  * Data sources (applied in order — later entries win on name collision):
  *   scripts/default-populate.json   — committed default fixtures (no secrets)
@@ -28,7 +28,10 @@ export { deriveDevPort };
 // Config from environment
 // ---------------------------------------------------------------------------
 
-const ADMIN_KEY = process.env.PLEXUS_ADMIN_KEY ?? 'password';
+// PLEXUS_ADMIN_KEY is the explicit override; ADMIN_KEY is what dev.ts/dev-agent.ts
+// actually set (and pass through) for the running local instance, so honor it
+// before falling back to the shared 'password' default.
+const ADMIN_KEY = process.env.PLEXUS_ADMIN_KEY ?? process.env.ADMIN_KEY ?? 'password';
 
 export function resolveApiRoot(
   env: Pick<NodeJS.ProcessEnv, 'PLEXUS_URL' | 'PLEXUS_PORT'> = process.env,
@@ -37,7 +40,7 @@ export function resolveApiRoot(
   const configuredUrl = env.PLEXUS_URL ?? 'http://localhost';
   const url = new URL(configuredUrl.includes('://') ? configuredUrl : `http://${configuredUrl}`);
   if (!url.port) {
-    const port = env.PLEXUS_PORT ?? (env.PLEXUS_URL ? undefined : deriveDevPort(cwd));
+    const port = env.PLEXUS_PORT ?? (env.PLEXUS_URL ? undefined : deriveDevPort(cwd, 'dev'));
     if (port) url.port = port;
   }
   return url.origin;

--- a/scripts/prep-dev.ts
+++ b/scripts/prep-dev.ts
@@ -22,7 +22,7 @@
  *   PLEXUS_DEV_DATA_PATH        Path for saved data (default: .dev-data/)
  *   PLEXUS_URL                  Base URL for local instance (default: http://localhost)
  *   PLEXUS_PORT                 Port for local instance (auto-derived from cwd)
- *   PLEXUS_ADMIN_KEY            Admin key for local instance (default: password)
+ *   PLEXUS_ADMIN_KEY            Admin key for local instance (default: $ADMIN_KEY, else password)
  *   PLEXUS_EXCLUDE_OAUTH        Exclude OAuth providers (default: true)
  */
 
@@ -69,7 +69,7 @@ Environment variables:
   PLEXUS_DEV_DATA_PATH        Path for saved data (default: .dev-data/)
   PLEXUS_URL                  Base URL for local instance
   PLEXUS_PORT                 Port for local instance (auto-derived from cwd)
-  PLEXUS_ADMIN_KEY            Admin key for local (default: password)
+  PLEXUS_ADMIN_KEY            Admin key for local (default: $ADMIN_KEY, else password)
   PLEXUS_EXCLUDE_OAUTH        Exclude OAuth providers (default: true)
 `);
   process.exit(0);
@@ -94,9 +94,17 @@ const LOCAL_PORT =
   process.env.PLEXUS_PORT ??
   process.env.PASEO_SERVICE_DEV_PORT ??
   process.env.PASEO_PORT ??
-  deriveDevPort();
+  deriveDevPort(process.cwd(), 'dev');
 const LOCAL_URL = `${LOCAL_BASE_URL}:${LOCAL_PORT}`;
-const LOCAL_KEY = process.env.PLEXUS_ADMIN_KEY ?? 'password';
+// PLEXUS_ADMIN_KEY is the explicit override; ADMIN_KEY is what dev.ts/dev-agent.ts
+// actually set (and pass through) for the running local instance, so honor it
+// before falling back to the shared 'password' default.
+const LOCAL_KEY = process.env.PLEXUS_ADMIN_KEY ?? process.env.ADMIN_KEY ?? 'password';
+const LOCAL_KEY_SOURCE = process.env.PLEXUS_ADMIN_KEY
+  ? 'PLEXUS_ADMIN_KEY'
+  : process.env.ADMIN_KEY
+    ? 'ADMIN_KEY'
+    : 'default (password)';
 const EXCLUDE_OAUTH = (process.env.PLEXUS_EXCLUDE_OAUTH ?? 'true').toLowerCase() !== 'false';
 
 // ---------------------------------------------------------------------------
@@ -451,7 +459,8 @@ async function main() {
   console.log(`  Target local:  ${LOCAL_URL}`);
   console.log(`  Data path:     ${DEV_DATA_PATH}`);
   console.log(`  Live mode:     ${shouldUseLive ? 'yes' : 'no'}`);
-  console.log(`  Save mode:     ${shouldSave ? 'yes' : 'no'}\n`);
+  console.log(`  Save mode:     ${shouldSave ? 'yes' : 'no'}`);
+  console.log(`  Admin key from: ${LOCAL_KEY_SOURCE}\n`);
 
   let backupData: Buffer | null = null;
 


### PR DESCRIPTION
## Summary

Fixes a bug where Codex CLI would treat a turn as finished right after the model issued a `tool_search_call` (its deferred/lazy tool-discovery mechanism), even though the model expected the client to act on it and continue. Root cause traced through several layers: a dropped output item in the Responses transformer, an incomplete `responses:lite` detection heuristic, an overly-conservative pass-through gate, and an unenforced upstream wire contract for the `responses:lite` header. All are fixed, and each fix was verified live — first via a replayed debug trace, then against two real providers directly (bypassing Plexus), and finally against a real Codex CLI client hitting a dev server restored from staging.

## Why / Context

Investigating staging debug trace `b672ebbd`: a Codex CLI turn that issued `tool_search_call` was reported by the client as "finished" with no follow-up. Tracing the full request/response pipeline surfaced four separate, compounding issues rather than one:

1. The Responses↔Unified transformer had no handling for `execution: "client"` built-in tool-call items (e.g. `tool_search_call`) — they were silently dropped on the way back to the client, so the client had no signal a tool call was pending.
2. `detectResponsesApiType` only recognized the internal Codex header or an `additional_tools` input item as a `responses:lite` signal — it missed a declared `tool_search` tool, the actual defining feature of lite mode, so genuinely Codex-native requests lost routing preference toward providers that explicitly support the subtype.
3. The pass-through gate forced full transformation for **any** target whose base type was `responses`, even when the target matched the `responses:lite` subtype exactly — defeating the entire point of that subtype (providers opting in to being trusted with Codex's raw wire extensions).
4. Once pass-through was correctly enabled, the `responses:lite` wire contract (enforced by both providers currently configured for it) turned out to require `reasoning.context: "all_turns"`, `parallel_tool_calls: false`, and only `function`/`custom`/`tool_search` tool types — none of which real Codex CLI traffic reliably satisfies on its own.

## Changes

- **`transformers/responses.ts` / `types/unified.ts` / `types/responses.ts`**: carry `execution: "client"` built-in tool-call items (e.g. `tool_search_call`) through the Unified IR round trip via a new typed carry (`UnifiedClientToolCall`), on both streaming/non-streaming and inbound/outbound paths, instead of silently dropping them.
- **`routes/inference/responses.ts`**: `detectResponsesApiType` now also recognizes a declared `tool_search` tool as a `responses:lite` signal.
- **`request-payload-builder.ts`**: `shouldUsePassThrough` only forces the transform pipeline for a bare `responses` fallback match, not an exact `responses:lite` match — restoring the subtype's original intent. Also proactively normalizes `reasoning.context`, `parallel_tool_calls`, and strips disallowed tool types (e.g. `web_search`) for any dispatch using the `responses:lite` header, scoped to exclude native OAuth routes (the real Codex/ChatGPT backend uses its own dedicated endpoint and never sends that header).
- **`dispatcher-auto-compat.ts` / `standard-attempt-request.ts`**: new reactive strip-and-retry auto-compat mechanism (`planLiteToolStrip`/`stripLiteUnsupportedTools`) as a fallback safety net — if a disallowed tool type slips past the proactive normalization, Plexus strips it and retries the same target once instead of failing outright.
- Test coverage added/updated across all of the above (`dispatcher-api-subtype.test.ts`, `dispatcher-auto-compat.test.ts`, `responses-api-type.test.ts`), including updating two pre-existing regression tests whose underlying assumption (raw pass-through of Codex extensions always breaks providers) was disproven by live testing against real providers.

## Testing

- Full backend suite (614 tests) and typecheck pass.
- Replayed the actual staging trace's raw upstream SSE through the transformer round trip to confirm `tool_search_call` now survives with `call_id`/`arguments`/`execution` intact.
- Live-tested raw pass-through of Codex's `additional_tools` wire shape directly against both providers configured for `responses:lite` (openlimits and real `api.openai.com`) — both handle it correctly, contradicting the prior regression test's assumption.
- Replayed the real original client request against a dev server restored from a staging DB copy — traced through detection → routing → dispatch → response, confirmed correct at every stage.
- Set up a temporary Codex CLI profile (`~/.codex/<profile>.config.toml`, removed after testing) pointed at the dev server and ran genuine `codex exec` sessions with real tool calls end-to-end, confirming: no 400s, `web_search` correctly stripped (first proactively, then confirmed the reactive fallback also works independently), and the turn completes normally.

## Notes / Follow-ups

- This branch also carries two unrelated pre-existing commits (`fix(dev): fix dev:full failing to restore prep-dev backup`, `fix(transformers): correct ThinkLevel comparison in projectReasoningForResponses`) that were already on it before this work began.
- The proactive/reactive tool-stripping split is deliberate: proactive normalization avoids a wasted round trip for the common case (Codex's default `web_search` declaration), while the reactive strip-and-retry stays as defense-in-depth for any future disallowed tool type not yet in the allowlist.
