### PR TITLE
fix(responses): strip call_-shaped item ids from replayed function calls

### DIFF
--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -4,6 +4,7 @@ import { Dispatcher } from '../../services/dispatch/dispatcher';
 import {
   ResponsesTransformer,
   normalizeCompositeResponsesCallIds,
+  normalizeResponsesFunctionCallItemIds,
   normalizeResponsesReasoningContent,
 } from '../../transformers/responses';
 import { UsageStorageService } from '../../services/observability/usage-storage';
@@ -176,10 +177,16 @@ export async function registerResponsesRoute(
       // tool call IDs observed in replayed Codex CLI conversations.
       const rawBodyForDebug = JSON.parse(JSON.stringify(body));
       const normalizedCallIds = normalizeCompositeResponsesCallIds(body);
+      const normalizedItemIds = normalizeResponsesFunctionCallItemIds(body);
       const normalizedReasoningItems = normalizeResponsesReasoningContent(body);
       if (normalizedCallIds > 0) {
         logger.warn(
           `Normalized ${normalizedCallIds} composite Responses call_id value(s) for request ${requestId}`
+        );
+      }
+      if (normalizedItemIds > 0) {
+        logger.warn(
+          `Removed call-ID-shaped item id(s) from ${normalizedItemIds} Responses function_call item(s) for request ${requestId}`
         );
       }
       if (normalizedReasoningItems > 0) {

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   ResponsesTransformer,
   normalizeCompositeResponsesCallIds,
+  normalizeResponsesFunctionCallItemIds,
   normalizeResponsesReasoningContent,
 } from '../responses';
 import { OpenAITransformer } from '../openai';
@@ -135,6 +136,103 @@ describe('Responses responses -> responses round-trip preserves native fields', 
         )
         .map((item: any) => item.call_id)
     ).toEqual(['call_enS4L7YycCRyOiWOg31Xpvwm', 'call_enS4L7YycCRyOiWOg31Xpvwm']);
+  });
+
+  it('strips call-ID-shaped item ids from function_call items (strict providers demand fc_...)', () => {
+    const badItem: Record<string, unknown> = {
+      type: 'function_call',
+      id: 'call_913ea4b95c694f4598cdc490',
+      name: 'exec_command',
+      call_id: 'call_913ea4b95c694f4598cdc490',
+      arguments: '{}',
+    };
+    const goodItem: Record<string, unknown> = {
+      type: 'function_call',
+      id: 'fc_0281edd961557cf2016a4b062d87948195968b8fa6c46b8c7a',
+      name: 'exec_command',
+      call_id: 'call_enS4L7YycCRyOiWOg31Xpvwm',
+      arguments: '{}',
+    };
+    const noIdItem: Record<string, unknown> = {
+      type: 'function_call',
+      name: 'exec_command',
+      call_id: 'call_no_item_id',
+      arguments: '{}',
+    };
+    const outputItem: Record<string, unknown> = {
+      type: 'function_call_output',
+      id: 'fco_019fcb3b-b025-7fc3-830a-f61ed2f8142b',
+      call_id: 'call_913ea4b95c694f4598cdc490',
+      output: 'ok',
+    };
+    const body = { input: [badItem, goodItem, noIdItem, outputItem] };
+
+    expect(normalizeResponsesFunctionCallItemIds(body)).toBe(1);
+    expect('id' in badItem).toBe(false);
+    expect(badItem.call_id).toBe('call_913ea4b95c694f4598cdc490');
+    expect(goodItem.id).toBe('fc_0281edd961557cf2016a4b062d87948195968b8fa6c46b8c7a');
+    expect('id' in noIdItem).toBe(false);
+    expect(outputItem.id).toBe('fco_019fcb3b-b025-7fc3-830a-f61ed2f8142b');
+  });
+
+  it('only touches the exact observed bad shape (function_call + call_-prefixed id)', () => {
+    const messageItem: Record<string, unknown> = {
+      type: 'message',
+      id: 'call_not_our_problem',
+      role: 'user',
+      content: [{ type: 'input_text', text: 'hi' }],
+    };
+    // Caller-provided id with another prefix: not rewritten.
+    const customIdItem: Record<string, unknown> = {
+      type: 'function_call',
+      id: 'custom_item_id',
+      name: 'exec_command',
+      call_id: 'call_plain',
+      arguments: '{}',
+    };
+    const body = { input: [messageItem, customIdItem] };
+
+    expect(normalizeResponsesFunctionCallItemIds(body)).toBe(0);
+    expect(messageItem.id).toBe('call_not_our_problem');
+    expect(customIdItem.id).toBe('custom_item_id');
+
+    expect(normalizeResponsesFunctionCallItemIds(null)).toBe(0);
+    expect(normalizeResponsesFunctionCallItemIds({})).toBe(0);
+    expect(normalizeResponsesFunctionCallItemIds({ input: 'not-an-array' })).toBe(0);
+  });
+
+  it('rebuilds a clean request after stripping replayed item ids', async () => {
+    const transformer = new ResponsesTransformer();
+    const body = {
+      model: 'gpt-4o',
+      input: [
+        {
+          type: 'function_call',
+          id: 'call_913ea4b95c694f4598cdc490',
+          name: 'exec_command',
+          call_id: 'call_913ea4b95c694f4598cdc490',
+          arguments: '{}',
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_913ea4b95c694f4598cdc490',
+          output: 'ok',
+        },
+      ],
+    };
+
+    normalizeResponsesFunctionCallItemIds(body);
+    const unified = await transformer.parseRequest(body);
+    const built = await transformer.transformRequest(unified);
+
+    expect(
+      built.input
+        .filter(
+          (item: any) => item.type === 'function_call' || item.type === 'function_call_output'
+        )
+        .map((item: any) => item.call_id)
+    ).toEqual(['call_913ea4b95c694f4598cdc490', 'call_913ea4b95c694f4598cdc490']);
+    expect(built.input.every((item: any) => !String(item.id ?? '').startsWith('call_'))).toBe(true);
   });
 
   it('removes replayed plaintext reasoning content while preserving reasoning metadata', () => {

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -123,6 +123,35 @@ export function normalizeCompositeResponsesCallIds(body: any): number {
   return normalizedCount;
 }
 
+// Some Responses clients (observed: codex_cli_rs replaying rebuilt function
+// call history) send function_call items whose item `id` is the call ID
+// ("call_...") rather than the server-assigned "fc_..." item ID. Strict
+// Responses providers answer that with
+// `Invalid 'input[N].id': 'call_...'. Expected an ID that begins with 'fc'`.
+// The item id is optional on input and `call_id` is what correlates the call
+// with its function_call_output, so drop that exact observed bad shape instead
+// of rewriting arbitrary caller-provided IDs.
+export function normalizeResponsesFunctionCallItemIds(body: any): number {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.input)) {
+    return 0;
+  }
+
+  let normalizedCount = 0;
+  for (const item of body.input) {
+    if (!item || typeof item !== 'object' || item.type !== 'function_call') {
+      continue;
+    }
+    if (typeof item.id !== 'string' || !item.id.startsWith('call_')) {
+      continue;
+    }
+
+    delete item.id;
+    normalizedCount++;
+  }
+
+  return normalizedCount;
+}
+
 // Reasoning items are valid replay context, but some OpenAI-compatible
 // Responses providers reject replayed plaintext reasoning text with
 // "content max length 0". Drop only the optional plaintext content array once


### PR DESCRIPTION
## Summary

Observed on staging (trace `174f19cb`): Codex CLI (`codex_cli_rs/0.146.0`, forked subagent thread with `remote_compaction_v2`) replayed conversation history in which locally-rebuilt `function_call` items carried their `call_id` (`call_...`) in the item `id` slot instead of the server-assigned `fc_...` id. Strict Responses providers reject the entire request with a 400: `Invalid 'input[N].id': 'call_...'. Expected an ID that begins with 'fc'.`, and with only one target the request failed hard.

Because the target matched `responses:lite` exactly, the request took the same-format pass-through path, so the bad ids went upstream verbatim (verified: raw vs transformed body differed only in the lite wire-contract fields). This adds a proactive repair at the `/v1/responses` ingress, matching the existing composite-`call_id` (`call_...|fc_...`) and reasoning-content normalizers.

## Changes

- **transformers/responses.ts**: new exported `normalizeResponsesFunctionCallItemIds(body)`. Deletes the `id` field from `function_call` input items whose id starts with `call_` — `id` is optional on input and `call_id` is what correlates a call with its `function_call_output`, so stripping (not rewriting) is sufficient and safe. Deliberately narrow: only the exact observed shape is touched; other item types, `fc_`-prefixed and arbitrary caller-provided ids pass through untouched.
- **routes/inference/responses.ts**: applies the normalizer alongside the existing two (after the debug-capture snapshot, before `parseRequest`), with a warn log when it fires. Covers both the pass-through and transform paths.
- **Tests**: three new cases in `responses-request-roundtrip.test.ts` — strips the bad shape while preserving valid item ids; leaves non-`function_call` items, other id prefixes, and malformed bodies alone; end-to-end parse→rebuild check that no `call_`-prefixed id survives.

## Testing

- Full backend suite passes (2715 tests) via pre-commit hooks, plus targeted responses-transformer runs.
- Verified against the failing staging trace: every offending item in `input` (`call_913ea…`, `call_d520…`, etc.) matches the stripped shape, and the preserved `fco_…` output-item ids confirm the prefix check is correct.
- No live re-fire against a provider; the exact 400 body from the trace is the fixture the tests are modeled on.
