### PR TITLE
fix(oauth): stop double-prefixing mcp__ tools and cover tool_reference blocks in masking renames

### DIFF
--- a/packages/backend/src/transformers/oauth/masking/__tests__/registry.test.ts
+++ b/packages/backend/src/transformers/oauth/masking/__tests__/registry.test.ts
@@ -62,6 +62,37 @@ describe('buildToolRenamePairs', () => {
     });
   });
 
+  it('leaves tools that are already in mcp__<server>__<tool> form untouched', () => {
+    // Real Claude Code already emits this convention. Clustering on the first
+    // underscore reads their literal "mcp" prefix as a server name and
+    // double-prefixes them (mcp__github__get_me ->
+    // mcp__mcp___github__get_me), which desynchronizes tools[].name from the
+    // tool_reference blocks in the message history and makes Anthropic reject
+    // the request with 400 "Tool reference ... not found in available tools".
+    const tools = [
+      tool('mcp__github__get_me'),
+      tool('mcp__github__search_users'),
+      tool('mcp__playwright__browser_click'),
+      tool('mcp__playwright__browser_navigate'),
+      tool('mcp__home-assistant__ha_get_state'),
+    ];
+    expect(buildToolRenamePairs(tools)).toEqual([]);
+  });
+
+  it('still clusters flat server_tool names when CC-shaped MCP tools are present alongside them', () => {
+    const tools = [
+      ...Array.from({ length: 4 }, (_, i) => tool(`mcp__playwright__tool_${i}`)),
+      ...Array.from({ length: 4 }, (_, i) => tool(`github_tool_${i}`)),
+    ];
+    const pairs = buildToolRenamePairs(tools);
+    expect(Object.fromEntries(pairs.map(([from, to]) => [from, to]))).toEqual({
+      github_tool_0: 'mcp__github__tool_0',
+      github_tool_1: 'mcp__github__tool_1',
+      github_tool_2: 'mcp__github__tool_2',
+      github_tool_3: 'mcp__github__tool_3',
+    });
+  });
+
   it('does not cluster prefixes with too few tools (avoids false positives)', () => {
     // Only 3 tools share the "list" prefix — below MIN_CLUSTER_SIZE (4) — so
     // opencode's own list_mcp_resources / list_mcp_resource_templates /

--- a/packages/backend/src/transformers/oauth/masking/__tests__/rename-apply.test.ts
+++ b/packages/backend/src/transformers/oauth/masking/__tests__/rename-apply.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for `applyToolRenames`'s handling of `tool_reference`
+ * blocks (Anthropic advanced tool use / tool search).
+ *
+ * A renamed tool must be renamed everywhere its name appears in the request,
+ * including the `tool_reference.tool_name` blocks a tool-search result leaves
+ * in the message history. If `tools[]` is renamed but those blocks are not,
+ * Anthropic rejects the whole request with
+ * `400 Tool reference '<name>' not found in available tools` — and because
+ * the block is persisted in the client's history, every subsequent turn in
+ * that session fails the same way.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyToolRenames } from '../rename-apply';
+import type { RenamePair } from '../types';
+
+const pairs: RenamePair[] = [['github_search_users', 'mcp__github__search_users']];
+
+describe('applyToolRenames', () => {
+  it('renames a top-level tool_reference block', () => {
+    const body = {
+      tools: [{ name: 'github_search_users' }],
+      messages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_reference', tool_name: 'github_search_users' }],
+        },
+      ],
+    };
+    const result = applyToolRenames(body, pairs);
+    expect(result.messages[0].content[0]).toEqual({
+      type: 'tool_reference',
+      tool_name: 'mcp__github__search_users',
+    });
+    expect(result.tools[0].name).toBe('mcp__github__search_users');
+  });
+
+  it('renames tool_reference blocks nested inside a tool_result (tool-search result shape)', () => {
+    const body = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_01',
+              content: [
+                { type: 'tool_reference', tool_name: 'github_search_users' },
+                { type: 'tool_reference', tool_name: 'unrelated_tool' },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = applyToolRenames(body, pairs);
+    expect(result.messages[0].content[0].content).toEqual([
+      { type: 'tool_reference', tool_name: 'mcp__github__search_users' },
+      { type: 'tool_reference', tool_name: 'unrelated_tool' },
+    ]);
+  });
+
+  it('leaves tool_use renaming and untouched blocks intact', () => {
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'github_search_users' },
+            { type: 'tool_use', id: 'toolu_01', name: 'github_search_users', input: {} },
+          ],
+        },
+      ],
+    };
+    const result = applyToolRenames(body, pairs);
+    expect(result.messages[0].content[0]).toEqual({
+      type: 'text',
+      text: 'github_search_users',
+    });
+    expect(result.messages[0].content[1].name).toBe('mcp__github__search_users');
+  });
+});

--- a/packages/backend/src/transformers/oauth/masking/__tests__/reverse-rename.test.ts
+++ b/packages/backend/src/transformers/oauth/masking/__tests__/reverse-rename.test.ts
@@ -57,6 +57,18 @@ describe('reverseToolRenames', () => {
     expect(reverseToolRenames(input, pairs)).toBe(input);
   });
 
+  it('reverses a tool_reference.tool_name field (advanced tool use / tool search)', () => {
+    const input = '{"type":"tool_reference","tool_name":"mcp__github__search_users"}';
+    expect(reverseToolRenames(input, pairs)).toBe(
+      '{"type":"tool_reference","tool_name":"github_search_users"}'
+    );
+  });
+
+  it('does NOT rewrite a renamed tool name appearing as an unrelated *_name field value', () => {
+    const input = '{"server_name":"Bash"}';
+    expect(reverseToolRenames(input, pairs)).toBe(input);
+  });
+
   it('is a no-op for text with no rename pairs', () => {
     const input = '{"type":"tool_use","name":"Bash"}';
     expect(reverseToolRenames(input, [])).toBe(input);

--- a/packages/backend/src/transformers/oauth/masking/mcp-shape.ts
+++ b/packages/backend/src/transformers/oauth/masking/mcp-shape.ts
@@ -32,6 +32,18 @@ import type { RenamePair, ToolDescriptor, ToolShape } from './types';
 /** Minimum number of tools sharing a prefix before it's treated as an MCP server name. */
 const MIN_CLUSTER_SIZE = 4;
 
+/**
+ * Tools that are ALREADY in the `mcp__<server>__<tool>` convention — i.e. the
+ * exact shape this module normalizes toward, as real Claude Code emits.
+ * Without this guard the first-underscore clustering below treats their
+ * literal `mcp` prefix as a server name and double-prefixes every one of
+ * them (`mcp__github__get_me` -> `mcp__mcp___github__get_me`),
+ * which desynchronizes `tools[].name` from `tool_reference.tool_name` blocks
+ * in the message history and makes Anthropic reject the request with
+ * `400 Tool reference '<name>' not found in available tools`.
+ */
+const ALREADY_MCP_SHAPED = /^mcp__[^_].*__.+$/;
+
 function firstUnderscoreSplit(name: string): { prefix: string; rest: string } | null {
   const idx = name.indexOf('_');
   if (idx <= 0 || idx === name.length - 1) return null;
@@ -44,6 +56,7 @@ export const mcpShape: ToolShape = {
     const byPrefix = new Map<string, string[]>();
 
     for (const tool of tools) {
+      if (ALREADY_MCP_SHAPED.test(tool.name)) continue;
       const split = firstUnderscoreSplit(tool.name);
       if (!split) continue;
       const list = byPrefix.get(split.prefix) ?? [];

--- a/packages/backend/src/transformers/oauth/masking/rename-apply.ts
+++ b/packages/backend/src/transformers/oauth/masking/rename-apply.ts
@@ -17,6 +17,11 @@
  *   - `tools[].name`
  *   - `tool_choice.name` (when `tool_choice.type === "tool"`)
  *   - assistant message `content[]` blocks with `type === "tool_use"`, `.name`
+ *   - `tool_reference` blocks (advanced tool use / tool search), `.tool_name` —
+ *     both at the top level of a message's `content[]` and nested inside a
+ *     `tool_result`'s `content[]`, which is how tool-search results are
+ *     returned. Anthropic validates these against `tools[]` and rejects a
+ *     mismatch with `400 Tool reference '<name>' not found in available tools`.
  *
  * NOT renamed (verified unaffected):
  *   - `tool_result` blocks correlate to their originating call by
@@ -67,11 +72,34 @@ export function applyToolRenames(body: any, pairs: readonly RenamePair[]): any {
       if (!Array.isArray(msg?.content)) return msg;
       let changed = false;
       const content = msg.content.map((block: any) => {
-        if (block?.type !== 'tool_use') return block;
-        const renamed = renameMap.get(block.name);
-        if (!renamed) return block;
-        changed = true;
-        return { ...block, name: renamed };
+        if (block?.type === 'tool_use') {
+          const renamed = renameMap.get(block.name);
+          if (!renamed) return block;
+          changed = true;
+          return { ...block, name: renamed };
+        }
+        if (block?.type === 'tool_reference') {
+          const renamed = renameMap.get(block.tool_name);
+          if (!renamed) return block;
+          changed = true;
+          return { ...block, tool_name: renamed };
+        }
+        // Tool-search results arrive as `tool_result` blocks whose `content[]`
+        // is a list of `tool_reference` blocks.
+        if (block?.type === 'tool_result' && Array.isArray(block.content)) {
+          let nestedChanged = false;
+          const nested = block.content.map((inner: any) => {
+            if (inner?.type !== 'tool_reference') return inner;
+            const renamed = renameMap.get(inner.tool_name);
+            if (!renamed) return inner;
+            nestedChanged = true;
+            return { ...inner, tool_name: renamed };
+          });
+          if (!nestedChanged) return block;
+          changed = true;
+          return { ...block, content: nested };
+        }
+        return block;
       });
       return changed ? { ...msg, content } : msg;
     });

--- a/packages/backend/src/transformers/oauth/masking/reverse-rename.ts
+++ b/packages/backend/src/transformers/oauth/masking/reverse-rename.ts
@@ -42,11 +42,18 @@ export function reverseToolRenames(text: string, pairs: readonly RenamePair[]): 
   let result = text;
   for (const [orig, renamed] of pairs) {
     const escapedRenamed = escapeForRegex(renamed);
-    result = result.replace(new RegExp(`"name":"${escapedRenamed}"`, 'g'), `"name":"${orig}"`);
-    result = result.replace(
-      new RegExp(`\\\\"name\\\\":\\\\"${escapedRenamed}\\\\"`, 'g'),
-      `\\"name\\":\\"${orig}\\"`
-    );
+    // `name` covers tool_use / function-call blocks; `tool_name` covers the
+    // `tool_reference` blocks emitted by advanced tool use (tool search).
+    for (const key of ['name', 'tool_name']) {
+      result = result.replace(
+        new RegExp(`"${key}":"${escapedRenamed}"`, 'g'),
+        `"${key}":"${orig}"`
+      );
+      result = result.replace(
+        new RegExp(`\\\\"${key}\\\\":\\\\"${escapedRenamed}\\\\"`, 'g'),
+        `\\"${key}\\":\\"${orig}\\"`
+      );
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Summary

With Claude-Code masking active on the Anthropic OAuth path, any Claude Code session that has MCP servers connected fails with a `400` from Anthropic on **every** turn:

```json
{"type":"error","error":{"type":"invalid_request_error","message":"Tool reference 'mcp__linear-server__get_issue' not found in available tools"}}
```

The failure is sticky. The block Anthropic objects to lives in the client's persisted message history, so once the session hits it, every subsequent turn fails identically until the user clears the conversation. We observed 82 such failures in a single day across several different MCP servers before applying this fix.

---

## Root cause

Two independent defects that only produce a visible failure when combined.

### Defect 1 — `mcp-shape` double-prefixes tools already in `mcp__<server>__<tool>` form

`transformers/oauth/masking/mcp-shape.ts` normalizes opencode-style flat `<server>_<tool>` names into Claude Code's `mcp__<server>__<tool>` convention. It detects a "server" by clustering tool names on the substring before their **first** underscore, and renames any cluster with `MIN_CLUSTER_SIZE` (4) or more members.

Names that are *already* in `mcp__<server>__<tool>` form — which is exactly what real Claude Code sends — have `mcp` as their first-underscore prefix. Any real Claude Code session with an MCP server connected has well over four such tools, so the entire set clusters under a phantom server literally named `mcp`, and every tool gets prefixed a second time.

### Defect 2 — renames never reached `tool_reference` blocks

`transformers/oauth/masking/rename-apply.ts` applied renames to `tools[].name`, `tool_choice.name` and `tool_use.name`, but not to `tool_reference` blocks. Those blocks are produced by Anthropic's advanced tool use / tool search feature (the `tool_search_tool_bm25_20251119` / `tool_search_tool_regex_20251119` server tools — this repo already knows about them in `transformers/adapters/strip-unsupported-tool-search.adapter.ts`) and are persisted in the client's message history. `reverse-rename.ts` had the mirror-image gap: it reversed the `"name"` JSON key but not `"tool_name"`.

So `tools[]` was rewritten while the `tool_reference.tool_name` blocks referring to those same tools were not. Anthropic validates the two against each other and rejects the mismatch.

Note this is **v1/v2 parity**, not a new capability: `transformers/oauth/oauth-claude.ts` (the v1 path) already handles `tool_reference` blocks, including ones nested inside `tool_result.content[]` (see the `case 'tool_reference'` and `case 'tool_result'` arms of `applyClaudeOAuthTransform`). The v2 masking pipeline simply never grew the same coverage.

Defect 1 alone would be a fidelity problem; defect 2 alone is latent until something genuinely gets renamed. Together they are a hard failure on the default configuration.

---

## Before / after

Feeding a realistic Claude Code tool list through `buildToolRenamePairs()`:

| Tool name sent by Claude Code | Rename emitted **before** | Rename emitted **after** |
|---|---|---|
| `mcp__linear-server__get_issue` | `mcp__mcp___linear-server__get_issue` | *(none — left alone)* |
| `mcp__playwright__browser_click` | `mcp__mcp___playwright__browser_click` | *(none — left alone)* |
| `mcp__github__get_me` | `mcp__mcp___github__get_me` | *(none — left alone)* |
| `github_search_users` (flat, opencode-style) | `mcp__github__search_users` | `mcp__github__search_users` *(unchanged behaviour)* |

Note the triple underscore in the mangled form: `mcp__` + `mcp` + `___linear-server...`.

The resulting request body is internally inconsistent:

```jsonc
{
  "tools": [ { "name": "mcp__mcp___linear-server__get_issue" } ],   // renamed
  "messages": [
    { "role": "user", "content": [
      { "type": "tool_result", "tool_use_id": "toolu_...", "content": [
        { "type": "tool_reference", "tool_name": "mcp__linear-server__get_issue" }  // NOT renamed
      ]}
    ]}
  ]
}
```

→ `400 Tool reference 'mcp__linear-server__get_issue' not found in available tools`.

---

## Reproduction

Against `main` (no patch), in `packages/backend`:

```ts
import { buildToolRenamePairs } from './src/transformers/oauth/masking/registry';

const names = [
  'mcp__linear-server__get_issue',
  'mcp__linear-server__save_issue',
  'mcp__playwright__browser_click',
  'mcp__playwright__browser_navigate',
];
console.log(buildToolRenamePairs(names.map((name) => ({ name }))));
```

Before this PR, all four are renamed to `mcp__mcp___*`. After, the result is `[]`.

End to end: point a current Claude Code client at a Plexus provider on the Anthropic OAuth path with masking active, connect any MCP server exposing four or more tools, and let tool search fire once. The first turn after the tool-search result lands fails with the 400 above, and so does every turn after it.

---

## What the fix changes

| File | Change |
|---|---|
| `masking/mcp-shape.ts` | Added an `ALREADY_MCP_SHAPED` guard (`/^mcp__[^_].*__.+$/`). Tools already in the target convention are skipped before clustering, so they are never counted toward a cluster nor renamed. Flat `<server>_<tool>` clustering is untouched. |
| `masking/rename-apply.ts` | `applyToolRenames()` now also renames `tool_reference.tool_name`, both at the top level of a message's `content[]` and nested inside a `tool_result`'s `content[]` (the shape tool-search results arrive in). Existing `tool_use` / `tools[]` / `tool_choice` handling is unchanged. |
| `masking/reverse-rename.ts` | `reverseToolRenames()` now reverses the `tool_name` key in addition to `name`, in both the plain and backslash-escaped-quote forms. The key-scoped matching (rather than bare substring) is preserved. |

The change is additive and behaviour-preserving for every input that worked before: flat-prefixed opencode tool sets still cluster and rename exactly as they did.

---

## Test coverage added

All new tests were verified non-vacuous — reverting the three source files to their `main` versions makes **5 of the 26** tests in these files fail.

- `masking/__tests__/registry.test.ts` (+2)
  - CC-shaped `mcp__<server>__<tool>` tools produce no rename pairs at all.
  - Flat `<server>_<tool>` names still cluster and rename correctly when CC-shaped MCP tools are present alongside them (guards against over-correcting).
- `masking/__tests__/rename-apply.test.ts` (new file, 3 tests)
  - A top-level `tool_reference` block is renamed in lockstep with `tools[]`.
  - `tool_reference` blocks nested inside a `tool_result.content[]` are renamed, and unrelated tool names inside the same array are left alone.
  - `tool_use` renaming still works and free-text `text` blocks that happen to contain the tool name are not touched.
- `masking/__tests__/reverse-rename.test.ts` (+2)
  - `tool_reference.tool_name` is reversed on the response path.
  - A renamed name appearing as some *other* `*_name` field's value (e.g. `"server_name":"Bash"`) is still **not** rewritten — the key scoping stays exact.

Verification run on this branch:

- Full backend suite green: **2722 tests / 242 files** (`bun run test:force-all` in `packages/backend`).
- `bun run typecheck`, `biome format`, `biome lint` all clean (the full lefthook pre-commit chain passes).

No schema or migration changes.

---

## Why this matters

Tool search is on by default in recent Claude Code, and MCP servers are the common case rather than an edge case. Any user pointing Claude Code at a Plexus provider on the masked OAuth path therefore hits this on the first turn after tool search fires — and because the offending `tool_reference` block is persisted client-side, the session never recovers on its own. From the user's side it looks like the gateway has simply stopped working, with an error message naming a tool they can see is present in their config.

---

## Related

- [#775](https://github.com/mcowger/plexus/pull/775) (merged) fixed two other defects on this same OAuth path — dropped `anthropic-beta` flags and `description` injection into server-side tools. This is the third defect found in that same investigation; it was masked by those two until they were fixed, since requests were failing earlier in the pipeline. Same area of the code, independent root cause.
- [#723](https://github.com/mcowger/plexus/issues/723) (closed) covers a *different* over-renaming defect in the same masking pipeline — `cc-collision-shape` renaming genuine current-CC tools to `mcp__*` due to a stale reference set. Adjacent symptom, unrelated cause; this PR does not touch `cc-collision-shape`.

I did not find an existing open issue for this specific failure.
