### PR TITLE
feat(quotas): show reset countdowns on allowance meters

### DIFF
--- a/packages/frontend/src/components/quota/AllowanceMeterRow.tsx
+++ b/packages/frontend/src/components/quota/AllowanceMeterRow.tsx
@@ -3,6 +3,8 @@ import { clsx } from 'clsx';
 import type { Meter, MeterStatus } from '../../types/quota';
 import { formatMeterValue } from './MeterValue';
 import { useCurrency } from '../../lib/CurrencyContext';
+import { countdownTickMs, formatResetCountdown } from '../../lib/format';
+import { useNow } from '../../hooks/useNow';
 
 interface AllowanceMeterRowProps {
   meter: Meter;
@@ -44,6 +46,10 @@ export const AllowanceMeterRow: React.FC<AllowanceMeterRowProps> = ({
   onClick,
 }) => {
   const { currency, rate, symbol } = useCurrency();
+  const resetsAtMs = meter.resetsAt ? new Date(meter.resetsAt).getTime() : NaN;
+  const now = useNow(Number.isFinite(resetsAtMs) ? countdownTickMs(resetsAtMs - Date.now()) : null);
+  const reset = formatResetCountdown(meter.resetsAt, now);
+
   const utilNum = typeof meter.utilizationPercent === 'number' ? meter.utilizationPercent : null;
   const pct = utilNum !== null ? Math.max(0, Math.min(100, utilNum)) : null;
   const period = periodLabel(meter);
@@ -58,9 +64,14 @@ export const AllowanceMeterRow: React.FC<AllowanceMeterRowProps> = ({
       <div className="flex flex-col gap-0.5">
         <div className="flex items-center justify-between gap-1 min-w-0">
           <span className="text-[11px] text-text-secondary truncate flex-1">{meter.label}</span>
-          {pct !== null && (
-            <span className="text-[10px] tabular-nums text-text-muted flex-shrink-0">
-              {Math.round(pct)}%
+          {(pct !== null || reset) && (
+            <span
+              className="text-[10px] tabular-nums text-text-muted flex-shrink-0"
+              title={reset ? `Resets at ${reset.absolute}` : undefined}
+            >
+              {pct !== null && `${Math.round(pct)}%`}
+              {pct !== null && reset && ' · '}
+              {reset?.short}
             </span>
           )}
         </div>
@@ -107,7 +118,7 @@ export const AllowanceMeterRow: React.FC<AllowanceMeterRowProps> = ({
           />
         </div>
       )}
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
         {remaining !== undefined && (
           <span className="text-xs tabular-nums text-text">{remaining} left</span>
         )}
@@ -124,6 +135,19 @@ export const AllowanceMeterRow: React.FC<AllowanceMeterRowProps> = ({
             )}
           >
             {Math.round(pct)}%
+          </span>
+        )}
+        {reset && (
+          <span
+            className={clsx(
+              'text-[10px] tabular-nums',
+              meter.status === 'exhausted' || meter.status === 'critical'
+                ? 'text-text font-medium'
+                : 'text-text-muted'
+            )}
+            title={`Resets at ${reset.absolute}`}
+          >
+            {reset.long}
           </span>
         )}
       </div>

--- a/packages/frontend/src/hooks/useNow.ts
+++ b/packages/frontend/src/hooks/useNow.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a `Date.now()` value that refreshes every `intervalMs`.
+ * Pass `null` to freeze the clock so no timer is registered.
+ */
+export function useNow(intervalMs: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (intervalMs === null) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/packages/frontend/src/lib/__tests__/format.test.ts
+++ b/packages/frontend/src/lib/__tests__/format.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { countdownTickMs, formatResetCountdown } from '../format';
+
+const NOW = Date.parse('2026-08-06T12:00:00.000Z');
+const at = (ms: number) => new Date(NOW + ms).toISOString();
+
+describe('formatResetCountdown', () => {
+  it('returns null when the meter reports no reset time', () => {
+    expect(formatResetCountdown(null, NOW)).toBeNull();
+    expect(formatResetCountdown(undefined, NOW)).toBeNull();
+    expect(formatResetCountdown('not-a-date', NOW)).toBeNull();
+  });
+
+  it('formats hours and minutes for a 5-hour window', () => {
+    const reset = formatResetCountdown(at(3 * 3600_000 + 12 * 60_000), NOW);
+    expect(reset?.short).toBe('3h 12m');
+    expect(reset?.long).toBe('resets in 3h 12m');
+    expect(reset?.remainingMs).toBe(3 * 3600_000 + 12 * 60_000);
+  });
+
+  it('formats days and hours for a weekly window', () => {
+    expect(formatResetCountdown(at(2 * 86400_000 + 4 * 3600_000), NOW)?.short).toBe('2d 4h');
+  });
+
+  it('drops to minutes under an hour and seconds under a minute', () => {
+    expect(formatResetCountdown(at(47 * 60_000), NOW)?.short).toBe('47m');
+    expect(formatResetCountdown(at(41_000), NOW)?.short).toBe('41s');
+  });
+
+  it('rolls over between seconds, minutes and hours at the unit boundaries', () => {
+    expect(formatResetCountdown(at(59_999), NOW)?.short).toBe('59s');
+    expect(formatResetCountdown(at(60_000), NOW)?.short).toBe('1m');
+    expect(formatResetCountdown(at(3599_000), NOW)?.short).toBe('59m');
+    expect(formatResetCountdown(at(3600_000), NOW)?.short).toBe('1h 0m');
+  });
+
+  it('reports a due reset as resetting now', () => {
+    const reset = formatResetCountdown(at(-5_000), NOW);
+    expect(reset?.short).toBe('now');
+    expect(reset?.long).toBe('resetting now');
+    expect(reset?.remainingMs).toBe(-5_000);
+
+    expect(formatResetCountdown(at(0), NOW)?.long).toBe('resetting now');
+  });
+
+  it('still counts down relatively at exactly 7 days', () => {
+    const reset = formatResetCountdown(at(7 * 86400_000), NOW);
+    expect(reset?.short).toBe('7d 0h');
+    expect(reset?.long).toBe('resets in 7d 0h');
+  });
+
+  it('falls back to an absolute date beyond 7 days', () => {
+    const iso = at(9 * 86400_000);
+    const expected = new Date(iso).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+    });
+    const reset = formatResetCountdown(iso, NOW);
+    expect(reset?.short).toBe(expected);
+    expect(reset?.long).toBe(`resets ${expected}`);
+  });
+
+  it('exposes the absolute timestamp for tooltips', () => {
+    const iso = at(3600_000);
+    expect(formatResetCountdown(iso, NOW)?.absolute).toBe(new Date(iso).toLocaleString());
+  });
+});
+
+describe('countdownTickMs', () => {
+  it('ticks every second only while seconds are displayed', () => {
+    expect(countdownTickMs(41_000)).toBe(1_000);
+    expect(countdownTickMs(59_999)).toBe(1_000);
+  });
+
+  it('ticks every 30s for minute-or-coarser precision', () => {
+    expect(countdownTickMs(60_000)).toBe(30_000);
+    expect(countdownTickMs(3 * 3600_000)).toBe(30_000);
+  });
+
+  it('does not tick every second once the reset is overdue', () => {
+    expect(countdownTickMs(0)).toBe(30_000);
+    expect(countdownTickMs(-5_000)).toBe(30_000);
+  });
+});

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -62,6 +62,67 @@ export function formatResetsIn(iso: string | null): string {
   return minutes > 0 ? `in ${minutes}m` : 'in <1m';
 }
 
+export interface ResetCountdown {
+  /** Compact form for tight layouts: "3h 12m", "45s", "now", "Dec 25" */
+  short: string;
+  /** Sentence form: "resets in 3h 12m", "resetting now", "resets Dec 25" */
+  long: string;
+  /** Absolute local timestamp, for tooltips */
+  absolute: string;
+  /** Milliseconds until the reset; <= 0 once due */
+  remainingMs: number;
+}
+
+/**
+ * Build the display forms of a quota reset countdown. Returns null when the
+ * meter reports no reset time (many providers only expose a balance).
+ */
+export function formatResetCountdown(
+  iso: string | null | undefined,
+  nowMs: number = Date.now()
+): ResetCountdown | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  const resetsAtMs = date.getTime();
+  if (!Number.isFinite(resetsAtMs)) return null;
+
+  const absolute = date.toLocaleString();
+  const remainingMs = resetsAtMs - nowMs;
+  if (remainingMs <= 0) {
+    return { short: 'now', long: 'resetting now', absolute, remainingMs };
+  }
+
+  const totalSeconds = Math.floor(remainingMs / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (days > 7) {
+    const short = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return { short, long: `resets ${short}`, absolute, remainingMs };
+  }
+
+  const short =
+    days > 0
+      ? `${days}d ${hours}h`
+      : hours > 0
+        ? `${hours}h ${minutes}m`
+        : minutes > 0
+          ? `${minutes}m`
+          : `${seconds}s`;
+
+  return { short, long: `resets in ${short}`, absolute, remainingMs };
+}
+
+/**
+ * How often a countdown for `remainingMs` needs to re-render to stay accurate:
+ * every second in the final minute (seconds are shown), otherwise every 30s.
+ */
+export function countdownTickMs(remainingMs: number): number {
+  return remainingMs > 0 && remainingMs < 60_000 ? 1_000 : 30_000;
+}
+
 /**
  * Format large numbers with K, M, B suffixes (e.g., "1.3k", "2.5M")
  */


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Add reset-time visibility to quota allowance meters by rendering the existing `Meter.resetsAt` value in both full and compact layouts.

Users can now see whether a quota window is:

- Resetting now
- Resetting in seconds, minutes, hours, or days
- Resetting on a specific calendar date when more than seven days away

Meters without a valid reset time remain unchanged.

## Changes

- Added `formatResetCountdown()` to produce:
  - Compact labels such as `41s`, `47m`, `3h 12m`, and `2d 4h`
  - Full labels such as `resets in 3h 12m` or `resetting now`
  - Absolute local timestamps for tooltips
  - The exact remaining milliseconds for timer scheduling
- Added `countdownTickMs()` to select an update interval:
  - Every second during the final minute
  - Every 30 seconds otherwise, including overdue resets
- Added the `useNow` hook to refresh countdowns while avoiding timers for meters without a reset time.
- Updated `AllowanceMeterRow` to:
  - Append compact reset information beside the percentage
  - Render the full reset message in the meter metadata row
  - Preserve the existing layout when no reset time is available
  - Highlight reset information for critical and exhausted meters
  - Show the absolute reset timestamp on hover
  - Allow the metadata row to wrap in narrow layouts
- Added unit tests covering invalid and missing dates, countdown formatting boundaries, overdue resets, the seven-day cutoff, tooltip timestamps, and timer intervals.

No backend, schema, or persistence changes are included.
<!-- kody-pr-summary:end -->

---

## Why this change

The Quotas UI showed *how much* of each Claude Code window was consumed, but never *when* the window resets — which is the number you actually act on when a limit is tight.

This is a **render-only fix**. `resetsAt` was already collected, persisted and served end-to-end:

| Layer | Location | Status before this PR |
|---|---|---|
| Checker | `claude-code-checker.ts:246,262,288` — reads Anthropic's `resets_at` | Already populated |
| Persistence | `meter_snapshots.resets_at` | Already stored |
| API | `GET /v0/management/quota-checkers` | Already served |
| Frontend type | `types/quota.ts:17` — `resetsAt?: string` | Already declared |
| **UI** | `AllowanceMeterRow.tsx` | **Never read it** |

No backend, schema, migration or API changes.

## Before / after

| Surface | Before | After |
|---|---|---|
| Full row | `67% left · 5h rolling · 33%` | `67% left · 5h rolling · 33% · resets in 3h 59m` |
| Compact sidebar | `5-hour quota · 63%` | `5-hour quota · 63% · 56m` |
| Critical meter | `4% left · 7d rolling · 96%` | `4% left · 7d rolling · 96% · resetting now` |
| Hover | — | `Resets at 8/6/2026, 4:15:00 PM` |

### Quotas page

Identical fixture data in both; the countdown is the only visual delta.

**Before**
![Quotas page before](https://github.com/user-attachments/assets/906238f5-9e96-481f-ab9e-f4a2263ad9bc)

**After**
![Quotas page after](https://github.com/user-attachments/assets/37195aa6-dff0-46fd-a910-e84ba23a075a)

### Sidebar widget + edge cases

Same scroll position. Shows the compact `% · countdown` form, the `resetting now` / `resets Aug 15` variants, and a meter with `resetsAt: null` correctly rendering no countdown at all.

**Before**
![Sidebar and edge cases before](https://github.com/user-attachments/assets/af70abf5-adde-4ecf-96f9-211a221137d5)

**After**
![Sidebar and edge cases after](https://github.com/user-attachments/assets/51ff3672-ca60-4698-971f-c8b8cc047639)

## Applies to every provider, not just Claude Code

The change lives in the shared `AllowanceMeterRow`, so every checker that already reports a reset gains the countdown with no per-provider work: `claude-code`, `openai-codex`, `kimi-code`, `zenmux`, `sakana`, `ollama`, `synthetic`, `nanogpt`, `wafer`, `copilot`, `opencode-go` and others.

Balance-only checkers that report no reset (`naga`, `openrouter`, `kilo`, `poe`, …) are unaffected and render exactly as before.

## Edge cases

| `resetsAt` | Renders | Timer |
|---|---|---|
| absent / `null` / unparseable | nothing | none registered |
| in the past | `resetting now` | 30s |
| < 1 minute | `41s` | 1s |
| < 1 hour | `47m` | 30s |
| < 7 days | `3h 12m`, `2d 4h` | 30s |
| exactly 7 days | `7d 0h` | 30s |
| > 7 days | `resets Aug 15` | 30s |

## Why the tick rate is adaptive

`countdownTickMs()` returns 1s **only** while seconds are actually on screen (the final minute). Everywhere else it is 30s, which is enough to keep minute-precision text honest. A meter with no reset time registers no interval at all — `useNow(null)` skips `setInterval` entirely.

This matters because the Quotas page renders one row per meter per account; a naive 1s tick across every row would re-render the whole grid every second for text that only changes once a minute.

## Layout note

The countdown is placed last in the meta row. Rate-limit cards are at most a quarter of the grid width (`pages/Quotas.tsx:186`), so the row wraps on narrow viewports — trailing position keeps the percentage grouped with `% left` instead of orphaning it on the next line.

## Tests

`packages/frontend/src/lib/__tests__/format.test.ts` — 12 cases covering `formatResetCountdown()` and `countdownTickMs()`: null/undefined/invalid input, the seconds→minutes→hours→days rollovers at their exact boundaries (`59_999`→`59s`, `60_000`→`1m`, `3599s`→`59m`, `3600s`→`1h 0m`), overdue resets including exactly `0ms`, the exact 7-day cutoff, the `>7d` absolute-date fallback, tooltip timestamps, and tick-interval selection.

```
$ cd packages/frontend && bunx vitest run src/lib/__tests__/format.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Follows the existing frontend convention (`src/lib/__tests__/currency.test.ts`): pure-lib vitest only. No new test dependencies, no component-test framework, no CI changes.

## Notes for reviewers

**Pre-existing, out of scope, not introduced here:** frontend tests are not wired into CI. `packages/frontend/package.json` has no `test` script and no vitest config, and `.github/workflows/pr-tests.yml:69` runs only `cd packages/backend && bun run test:force-all`. Both the new `format.test.ts` and the pre-existing `currency.test.ts` therefore run only via `bunx vitest run` from `packages/frontend`. Worth a follow-up PR — deliberately not bundled here to keep this diff to the feature.

Verified manually against a running instance driven through a real browser, using fixture data covering healthy, critical, overdue, >7-day and null-reset meters. Live ticking confirmed across captures (`4h 0m → 3h 59m`, `57m → 56m`).
