### PR TITLE
fix(mcp): preserve streamable HTTP semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ mise.local.toml
 claude1.txt
 claude2.txt
 claude3.txt
+
+.pi-subagents/

--- a/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
@@ -310,6 +310,55 @@ describe('MCP Routes', () => {
       expect(mockMcpUsageStorage.saveRequest).toHaveBeenCalled();
     });
 
+    test('forwards MCP tool definitions without route-level mutation', async () => {
+      const upstreamResponse = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          tools: [
+            {
+              name: 'github_search_code',
+              description: 'Search GitHub code',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  owner: {
+                    type: 'string',
+                    description: 'Repository owner',
+                    'x-mcp-header': 'owner',
+                  },
+                },
+                required: ['owner'],
+              },
+            },
+          ],
+        },
+      };
+      mockProxyMcpRequest.mockResolvedValueOnce({
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+        body: upstreamResponse,
+      });
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/mcp/test-server',
+        headers: {
+          authorization: 'Bearer sk-valid-key',
+          accept: 'application/json, text/event-stream',
+          'content-type': 'application/json',
+        },
+        payload: {
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          id: 1,
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual(upstreamResponse);
+    });
+
     test('GET /mcp/:name should proxy GET requests', async () => {
       // Clear previous mock calls
       (mockProxyMcpRequest as any).mockClear();
@@ -351,6 +400,67 @@ describe('MCP Routes', () => {
       });
 
       expect(response.statusCode).toBe(405);
+    });
+
+    test('sets portable SSE cache headers without a Connection header', async () => {
+      (mockProxyMcpRequest as any).mockClear();
+      (mockProxyMcpRequest as any).mockResolvedValueOnce({
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('data: ok\n\n'));
+            controller.close();
+          },
+        }),
+      });
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/mcp/test-server',
+        headers: {
+          authorization: 'Bearer sk-valid-key',
+          accept: 'application/json, text/event-stream',
+          'content-type': 'application/json',
+        },
+        payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['cache-control']).toBe('no-cache');
+      expect(response.headers['x-accel-buffering']).toBe('no');
+      expect(response.headers.connection).toBeUndefined();
+    });
+
+    test('preserves an upstream Cache-Control value on SSE responses', async () => {
+      (mockProxyMcpRequest as any).mockClear();
+      (mockProxyMcpRequest as any).mockResolvedValueOnce({
+        status: 200,
+        headers: {
+          'content-type': 'text/event-stream',
+          'cache-control': 'private, max-age=0',
+        },
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('data: ok\n\n'));
+            controller.close();
+          },
+        }),
+      });
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/mcp/test-server',
+        headers: {
+          authorization: 'Bearer sk-valid-key',
+          accept: 'application/json, text/event-stream',
+          'content-type': 'application/json',
+        },
+        payload: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['cache-control']).toBe('private, max-age=0');
     });
 
     test('DELETE /mcp/:name should proxy DELETE requests', async () => {

--- a/packages/backend/src/routes/mcp/index.ts
+++ b/packages/backend/src/routes/mcp/index.ts
@@ -179,8 +179,10 @@ async function streamUpstreamResponse(
   if (!Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')) {
     headers['Content-Type'] = 'text/event-stream';
   }
-  headers['Cache-Control'] = 'no-cache';
-  headers['Connection'] = 'keep-alive';
+  if (!Object.keys(headers).some((key) => key.toLowerCase() === 'cache-control')) {
+    headers['Cache-Control'] = 'no-cache';
+  }
+  headers['X-Accel-Buffering'] = 'no';
 
   // Take over the response lifecycle so Fastify does not also try to send a
   // reply, and write the head directly so it reaches the client immediately
@@ -363,7 +365,6 @@ export async function registerMcpRoutes(
         const body = request.body;
         const jsonrpcMethod = mcpProxyService.extractJsonRpcMethod(body);
         const toolName = mcpProxyService.extractToolName(body);
-        const isStreamed = false;
 
         logger.silly(`POST /mcp/${serverName} - requestId: ${requestId}`);
         logger.silly(`Request body: ${JSON.stringify(body)?.substring(0, 500)}`);
@@ -381,6 +382,7 @@ export async function registerMcpRoutes(
         logger.silly(`Proxy result headers: ${JSON.stringify(result.headers)}`);
 
         const durationMs = Date.now() - startTime;
+        const isStreamed = !!result.stream;
 
         await mcpUsageStorage.saveRequest({
           request_id: requestId,
@@ -460,7 +462,6 @@ export async function registerMcpRoutes(
         const clientHeaders = mcpProxyService.redactSensitiveHeaders(
           request.headers as Record<string, string>
         );
-        const isStreamed = true;
 
         logger.silly(`GET /mcp/${serverName} - requestId: ${requestId}`);
 
@@ -473,6 +474,7 @@ export async function registerMcpRoutes(
         );
 
         const durationMs = Date.now() - startTime;
+        const isStreamed = !!result.stream;
 
         await mcpUsageStorage.saveRequest({
           request_id: requestId,
@@ -544,7 +546,6 @@ export async function registerMcpRoutes(
         const clientHeaders = mcpProxyService.redactSensitiveHeaders(
           request.headers as Record<string, string>
         );
-        const isStreamed = false;
 
         logger.silly(`DELETE /mcp/${serverName} - requestId: ${requestId}`);
 
@@ -555,6 +556,7 @@ export async function registerMcpRoutes(
         );
 
         const durationMs = Date.now() - startTime;
+        const isStreamed = !!result.stream;
 
         await mcpUsageStorage.saveRequest({
           request_id: requestId,

--- a/packages/backend/src/services/mcp-proxy/__tests__/mcp-proxy-service.test.ts
+++ b/packages/backend/src/services/mcp-proxy/__tests__/mcp-proxy-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import {
   getMcpServerConfig,
   validateServerName,
@@ -14,6 +14,8 @@ import {
   injectMcpKeyAuth,
 } from '../mcp-proxy-service';
 import { setConfigForTesting } from '../../../config';
+import { registerSpy } from '../../../../test/test-utils';
+import { mcpProcessManager } from '../../mcp-local/mcp-process-manager';
 
 describe('MCP Proxy Service', () => {
   describe('validateServerName', () => {
@@ -70,23 +72,35 @@ describe('MCP Proxy Service', () => {
       const headers = {
         'Content-Type': 'application/json',
         Connection: 'keep-alive',
+        'MCP-Protocol-Version': '2025-03-26',
+        'Mcp-Method': 'tools/call',
+        'Mcp-Name': 'github_search_code',
+        'Mcp-Param-owner': 'octocat',
       };
 
       const filtered = filterHopByHopHeaders(headers);
 
       expect(filtered['Content-Type']).toBe('application/json');
+      expect(filtered['MCP-Protocol-Version']).toBe('2025-03-26');
+      expect(filtered['Mcp-Method']).toBe('tools/call');
+      expect(filtered['Mcp-Name']).toBe('github_search_code');
+      expect(filtered['Mcp-Param-owner']).toBe('octocat');
       expect(filtered['connection']).toBeUndefined();
     });
 
     test('should handle array values', () => {
       const headers = {
         'x-array-header': ['value1', 'value2'],
+        accept: ['application/json', 'text/event-stream'],
+        cookie: ['a=1', 'b=2'],
         'x-string-header': 'singlevalue',
       };
 
       const filtered = filterHopByHopHeaders(headers);
 
-      expect(filtered['x-array-header']).toBe('value1');
+      expect(filtered['x-array-header']).toBe('value1, value2');
+      expect(filtered.accept).toBe('application/json, text/event-stream');
+      expect(filtered.cookie).toBe('a=1; b=2');
       expect(filtered['x-string-header']).toBe('singlevalue');
     });
 
@@ -352,6 +366,95 @@ describe('MCP Proxy Service', () => {
       const config = getMcpServerConfig('test-server');
 
       expect(config).toBeNull();
+    });
+  });
+
+  describe('upstream response streaming', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    beforeEach(() => {
+      setConfigForTesting({
+        providers: {},
+        models: {},
+        keys: {},
+        failover: {
+          enabled: false,
+          retryableStatusCodes: [429, 500, 502, 503, 504],
+          retryableErrors: ['ECONNREFUSED', 'ETIMEDOUT'],
+        },
+        quotas: [],
+        mcpServers: {
+          'local-server': {
+            mode: 'local_http',
+            enabled: true,
+            launcher: 'bunx',
+            package: '@example/mcp-server',
+            port: 7345,
+            path: '/mcp',
+          },
+        },
+      });
+      registerSpy(mcpProcessManager, 'ensureRunning').mockResolvedValue(undefined);
+    });
+
+    test.each(['text/event-stream', 'TEXT/EVENT-STREAM;charset=utf-8'])(
+      'returns an SSE response body as a stream for %s',
+      async (contentType) => {
+        const fetchMock = vi.fn().mockResolvedValue(
+          new Response('data: {"jsonrpc":"2.0"}\n\n', {
+            status: 200,
+            headers: { 'content-type': contentType },
+          })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await proxyMcpRequest(
+          'local-server',
+          'POST',
+          { accept: 'application/json, text/event-stream' },
+          { jsonrpc: '2.0', method: 'tools/list', id: 1 }
+        );
+
+        expect(result.stream).toBeDefined();
+        expect(result.body).toBeUndefined();
+        await expect(new Response(result.stream).text()).resolves.toContain('jsonrpc');
+      }
+    );
+
+    test('buffers a JSON GET response instead of treating it as SSE', async () => {
+      const body = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          tools: [
+            {
+              name: 'github_search_code',
+              inputSchema: {
+                type: 'object',
+                properties: {
+                  owner: { type: 'string', 'x-mcp-header': 'owner' },
+                },
+              },
+            },
+          ],
+        },
+      };
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await proxyMcpRequest('local-server', 'GET', {
+        accept: 'application/json, text/event-stream',
+      });
+
+      expect(result.stream).toBeUndefined();
+      expect(result.body).toEqual(body);
     });
   });
 });

--- a/packages/backend/src/services/mcp-proxy/mcp-proxy-service.ts
+++ b/packages/backend/src/services/mcp-proxy/mcp-proxy-service.ts
@@ -166,8 +166,8 @@ export function filterHopByHopHeaders(
 
     if (value !== undefined && value !== null) {
       if (Array.isArray(value)) {
-        if (value.length > 0 && value[0] !== undefined) {
-          filtered[key] = value[0] as string;
+        if (value.length > 0) {
+          filtered[key] = value.join(lowerKey === 'cookie' ? '; ' : ', ');
         }
       } else {
         filtered[key] = value;
@@ -395,7 +395,7 @@ export async function proxyMcpRequest(
     const contentType = response.headers.get('content-type');
     logger.silly(`Content-Type: ${contentType}`);
 
-    if (contentType?.includes('text/event-stream') || (method === 'GET' && response.ok)) {
+    if (contentType?.toLowerCase().includes('text/event-stream')) {
       logger.info('[mcp-proxy:' + serverName + '] upstream streaming response detected');
       if (response.body) {
         return {
@@ -410,6 +410,8 @@ export async function proxyMcpRequest(
 
     logger.silly(`Response body (raw): ${responseText.substring(0, 500)}`);
 
+    // MCP JSON-RPC payloads are opaque to the gateway. Preserve tool
+    // inputSchema objects and their protocol extensions exactly as received.
     let parsedBody: unknown;
     try {
       parsedBody = JSON.parse(responseText);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Preserve streamable HTTP and MCP protocol semantics when proxying requests through the gateway. Upstream tool schemas and metadata now pass through unchanged, repeated request headers retain all values, and responses are classified as streamed strictly from their content type.

## Changes

- **Preserve MCP payloads**
  - Keep upstream JSON-RPC responses opaque, including tool `inputSchema` objects and extensions such as `x-mcp-header`.
  - Added route and proxy regression coverage confirming these fields survive the real response path without mutation.

- **Improve request header forwarding**
  - Join repeated header values instead of silently keeping only the first value.
  - Join repeated `Cookie` values with `; `, while using `, ` for other headers such as `Accept`.
  - Continue forwarding MCP-specific metadata headers, including protocol version, method, tool name, and parameter headers.

- **Correct response classification**
  - Treat a response as SSE only when its `Content-Type` contains `text/event-stream`, case-insensitively and with optional parameters.
  - Buffer JSON responses normally, including successful JSON `GET` responses, rather than incorrectly exposing them as streams.

- **Make SSE responses intermediary-safe**
  - Preserve an upstream `Cache-Control` header or default it to `no-cache`.
  - Add `X-Accel-Buffering: no` to prevent buffering by compatible reverse proxies.
  - Stop emitting the hop-by-hop `Connection` header.

- **Correct usage tracking**
  - Set `is_streamed` from whether the proxy result contains an actual stream for `POST`, `GET`, and `DELETE` requests, rather than relying on method-specific defaults.

- **Repository hygiene**
  - Ignore `.pi-subagents/` local workspace artifacts.

## Testing

Added coverage for:

- Standard and mixed-case SSE content types.
- JSON `GET` responses being buffered.
- Preservation of `x-mcp-header` in tool definitions.
- Repeated `Accept`, `Cookie`, and MCP metadata headers.
- Default and upstream-provided SSE cache headers.
- Absence of the `Connection` response header.
<!-- kody-pr-summary:end -->