### PR TITLE
feat(logs): improve live token estimation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,15 +13,12 @@ This file is a **guardrail**, not general documentation.
 - **NEVER** commit, push, or create a PR unless the user explicitly asks.
 - **NEVER** treat earlier permission as ongoing permission. Each individual commit/push needs fresh approval in local/interactive sessions.
 - **NEVER** use `--no-verify` or `LEFTHOOK=0` without user permission.
-- **NEVER** edit existing migration files.
-- **NEVER** manually create SQL migrations.
-- **NEVER** run `drizzle-kit generate` directly.
+- **NEVER** edit or manually create migration files.
 - **NEVER** produce implementation or summary documents unless specifically requested.
-- **NEVER** assume Plexus supports file-based configuration. Providers, models, keys, quotas, and settings are database-backed; manage them through the Admin UI or Management API. Environment variables are only for server-level settings.
 - **DEBUGGING** Plexus instances: read and use the `plexus-cli` skill. The worktree `.env` contains the relevant staging configuration. When the user specifies `staging`, use `PLEXUS_STAGING_URL` for the staging URL and `PLEXUS_ADMIN_KEY` for the admin key.
 - **AVOID** searching library type definitions for documentation. Use context/search skills first when available.
 - **ASK** when requirements are ambiguous.
-- **NEVER** use --delete-branch on gh commands
+- **USE** agents / subtasks aggressively where tools allow for improved cost and performance.
 ## Task triggers
 
 ### If the task changes database schema
@@ -31,21 +28,6 @@ Before editing schema files:
 1. Read the **`db-schema-migrations`** skill.
 2. Update the Drizzle schema.
 3. Generate migrations with:
-
-```bash
-bun run generate-migrations
-bun run generate-migrations --name add_foo
-```
-
-4. Lint migrations with:
-
-```bash
-bun run lint:migrations
-```
-
-Rules:
-- On `main`, `--name` is required.
-- Random migration names like `rare_skullbuster` are rejected by CI.
 
 ### If the task writes or updates tests
 
@@ -71,15 +53,13 @@ Rules:
 - Output: `./dist/main.css`
 - Keep this directive in `globals.css`:
 
-```css
-@source "../src/**/*.{tsx,ts,jsx,js}";
-```
+    ```css
+    @source "../src/**/*.{tsx,ts,jsx,js}";
+    ```
 
 - Put assets in `packages/frontend/src/assets/`.
 - Import assets with ES6 imports only.
 - Do not use dynamic asset paths.
-
-### If the task changes the frontend UI
 
 After editing anything a user sees in the browser (React `.tsx`/`.jsx`, routes, forms,
 Tailwind/CSS, layout, or any file under `packages/frontend/src`), verify it yourself
@@ -89,6 +69,7 @@ instead of handing it back unchecked:
 2. Boot the worktree-safe dev stack, auto-log into the UI, and drive it with a real
    browser to confirm your change renders and behaves correctly.
 
+
 ## Canonical project commands
 
 Use these commands exactly:
@@ -96,8 +77,6 @@ Use these commands exactly:
 - Dev server: `bun run dev`
 - Dev stack for agents (background, worktree-safe): `bun run dev:agent` (or `bun run dev:agent [target]`, e.g. `dev:pglite`, `dev:full`)
 - Stop the agent dev stack: `bun run dev:stop` (or `bun run dev:stop [target]`)
-- Dev port: `PORT=$(bun run dev:get:port)`
-- Dev DB path: `DB_PATH=$(bun run dev:get:db_path)`
 - Tests: `bun run test`
 - Type check: `bun run typecheck`
 - Format: `bun run format`

--- a/packages/backend/src/routes/raw-passthrough.ts
+++ b/packages/backend/src/routes/raw-passthrough.ts
@@ -428,6 +428,7 @@ export async function registerRawPassthroughRoutes(
             DEFAULT_STALL_CONFIG,
             abortController
           );
+          stallInspector.setProgressApiType(observedApiType);
           usageStorage.registerInFlight(
             requestId,
             stallInspector,

--- a/packages/backend/src/services/inspectors/__tests__/stall-inspector.test.ts
+++ b/packages/backend/src/services/inspectors/__tests__/stall-inspector.test.ts
@@ -346,4 +346,44 @@ describe('StallInspector', () => {
       inspector.destroy();
     });
   });
+
+  describe('semantic progress accounting', () => {
+    it('excludes Responses lifecycle events from token-estimate bytes', () => {
+      const inspector = new StallInspector(
+        'req-responses-progress',
+        createConfig({ minBytesPerSecond: null }),
+        abortController
+      );
+      inspector.setProgressApiType('responses');
+
+      const lifecycle = 'event: response.created\ndata: {"type":"response.created"}\n\n';
+      const delta =
+        'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hi"}\n\n';
+      inspector.write(Buffer.from(lifecycle + delta.slice(0, 24)));
+      inspector.write(Buffer.from(delta.slice(24)));
+
+      const stats = inspector.getStats();
+      expect(stats.bytesReceived).toBe(Buffer.byteLength(lifecycle + delta));
+      expect(stats.semanticBytesReceived).toBe(Buffer.byteLength(delta));
+
+      inspector.destroy();
+    });
+
+    it('uses all streamed bytes for non-Responses formats', () => {
+      const inspector = new StallInspector(
+        'req-chat-progress',
+        createConfig({ minBytesPerSecond: null }),
+        abortController
+      );
+      inspector.setProgressApiType('chat');
+
+      const chunk = Buffer.from('data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n');
+      inspector.write(chunk);
+
+      const stats = inspector.getStats();
+      expect(stats.semanticBytesReceived).toBe(chunk.length);
+
+      inspector.destroy();
+    });
+  });
 });

--- a/packages/backend/src/services/inspectors/stall-inspector.ts
+++ b/packages/backend/src/services/inspectors/stall-inspector.ts
@@ -1,4 +1,5 @@
 import { PassThrough } from 'stream';
+import { StringDecoder } from 'node:string_decoder';
 import { logger } from '../../utils/logger';
 
 /**
@@ -29,6 +30,8 @@ interface ByteSample {
   timestamp: number;
   /** Cumulative bytes received at this point. */
   cumulativeBytes: number;
+  /** Cumulative bytes from token-producing stream events at this point. */
+  cumulativeSemanticBytes: number;
 }
 
 /**
@@ -68,7 +71,11 @@ export class StallInspector extends PassThrough {
 
   private state: StallState = StallState.DISPATCHED;
   private totalBytes = 0;
+  private semanticBytes = 0;
   private startTime: number;
+  private progressApiType: string | null = null;
+  private responseSseBuffer = '';
+  private readonly responseSseDecoder = new StringDecoder('utf8');
 
   // Ring buffer for sliding window: entries of { timestamp, cumulativeBytes }
   private samples: ByteSample[] = [];
@@ -121,6 +128,14 @@ export class StallInspector extends PassThrough {
     this.requestId = requestId;
   }
 
+  /** Set the client response format used for live token-progress accounting. */
+  setProgressApiType(apiType: string | null | undefined): void {
+    this.progressApiType = apiType?.toLowerCase() ?? null;
+    if (this.totalBytes === 0 && this.isResponsesStream()) {
+      this.semanticBytes = 0;
+    }
+  }
+
   /** Get the current stall config. */
   getConfig(): StallConfig {
     return this.config;
@@ -137,10 +152,19 @@ export class StallInspector extends PassThrough {
       ? chunk.length
       : Buffer.byteLength(chunk, encoding as BufferEncoding);
     this.totalBytes += chunkSize;
+    if (this.isResponsesStream()) {
+      this.consumeResponseChunk(chunk);
+    } else {
+      this.semanticBytes += chunkSize;
+    }
     const now = Date.now();
 
     // Record sample in ring buffer
-    this.samples.push({ timestamp: now, cumulativeBytes: this.totalBytes });
+    this.samples.push({
+      timestamp: now,
+      cumulativeBytes: this.totalBytes,
+      cumulativeSemanticBytes: this.semanticBytes,
+    });
     if (this.samples.length > this.MAX_SAMPLES) {
       this.samples = this.samples.slice(-this.MAX_SAMPLES);
     }
@@ -170,8 +194,61 @@ export class StallInspector extends PassThrough {
   }
 
   override _flush(callback: Function) {
+    if (this.isResponsesStream()) {
+      this.consumeResponseChunk(this.responseSseDecoder.end());
+      this.consumeResponseBlock(this.responseSseBuffer);
+      this.responseSseBuffer = '';
+    }
     this.cleanup();
     callback();
+  }
+
+  private isResponsesStream(): boolean {
+    return this.progressApiType?.includes('responses') ?? false;
+  }
+
+  private consumeResponseChunk(chunk: any): void {
+    const text =
+      typeof chunk === 'string'
+        ? chunk
+        : Buffer.isBuffer(chunk)
+          ? this.responseSseDecoder.write(chunk)
+          : Buffer.from(chunk).toString('utf8');
+    this.responseSseBuffer += text;
+
+    while (true) {
+      const separator = this.responseSseBuffer.match(/\r?\n\r?\n/);
+      if (!separator || separator.index === undefined) return;
+
+      const blockEnd = separator.index + separator[0].length;
+      const block = this.responseSseBuffer.slice(0, blockEnd);
+      this.responseSseBuffer = this.responseSseBuffer.slice(blockEnd);
+      this.consumeResponseBlock(block);
+    }
+  }
+
+  private consumeResponseBlock(block: string): void {
+    if (!block) return;
+
+    const eventName = block.match(/^event:\s*(.+)$/m)?.[1]?.trim();
+    const data = block
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trimStart())
+      .join('\n');
+    let payloadType: string | undefined;
+    if (data) {
+      try {
+        payloadType = JSON.parse(data).type;
+      } catch {
+        // Ignore non-JSON SSE data such as [DONE].
+      }
+    }
+
+    const type = eventName || payloadType;
+    if (type?.endsWith('.delta')) {
+      this.semanticBytes += Buffer.byteLength(block, 'utf8');
+    }
   }
 
   // ─── State transitions ───────────────────────────────────────────
@@ -272,34 +349,42 @@ export class StallInspector extends PassThrough {
     state: 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED';
     bytesReceived: number;
     bytesPerSec: number | null;
+    semanticBytesReceived: number;
+    semanticBytesPerSec: number | null;
     elapsedMs: number;
   } {
     const now = Date.now();
-    let bytesPerSec: number | null = null;
-
-    if (this.samples.length >= 2) {
-      const windowStart = now - this.config.windowMs;
-      // Find oldest sample within the window
-      let oldest = this.samples[0]!;
-      for (let i = 1; i < this.samples.length; i++) {
-        if (this.samples[i]!.timestamp >= windowStart) {
-          oldest = this.samples[i - 1]!;
-          break;
-        }
-      }
-      const bytesInWindow = this.totalBytes - oldest.cumulativeBytes;
-      const timeSpanMs = now - oldest.timestamp;
-      if (timeSpanMs > 0) {
-        bytesPerSec = (bytesInWindow / timeSpanMs) * 1000;
-      }
-    }
+    const bytesPerSec = this.calculateRate(now, (sample) => sample.cumulativeBytes);
+    const semanticBytesPerSec = this.calculateRate(now, (sample) => sample.cumulativeSemanticBytes);
 
     return {
       state: this.state as 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED',
       bytesReceived: this.totalBytes,
       bytesPerSec,
+      semanticBytesReceived: this.semanticBytes,
+      semanticBytesPerSec,
       elapsedMs: now - this.startTime,
     };
+  }
+
+  private calculateRate(
+    now: number,
+    getCumulativeBytes: (sample: ByteSample) => number
+  ): number | null {
+    if (this.samples.length < 2) return null;
+
+    const windowStart = now - this.config.windowMs;
+    let oldest = this.samples[0]!;
+    for (let i = 1; i < this.samples.length; i++) {
+      if (this.samples[i]!.timestamp >= windowStart) {
+        oldest = this.samples[i - 1]!;
+        break;
+      }
+    }
+    const currentBytes = getCumulativeBytes(this.samples[this.samples.length - 1]!);
+    const bytesInWindow = currentBytes - getCumulativeBytes(oldest);
+    const timeSpanMs = now - oldest.timestamp;
+    return timeSpanMs > 0 ? (bytesInWindow / timeSpanMs) * 1000 : null;
   }
 
   // ─── Cleanup ──────────────────────────────────────────────────────

--- a/packages/backend/src/services/observability/usage-storage.ts
+++ b/packages/backend/src/services/observability/usage-storage.ts
@@ -17,6 +17,8 @@ export interface ProgressUpdate {
   isStreamed: boolean;
   bytesReceived: number;
   bytesPerSec: number | null;
+  semanticBytesReceived: number;
+  semanticBytesPerSec: number | null;
   state: 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED';
   elapsedMs: number;
 }

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -413,6 +413,7 @@ export async function handleResponse(
     const stallInspector = stallDetectionResult?.stallInspector ?? null;
     if (stallInspector) {
       stallInspector.setRequestId(usageRecord.requestId!);
+      stallInspector.setProgressApiType(apiType);
       usageStorage.registerInFlight(
         usageRecord.requestId!,
         stallInspector,

--- a/packages/frontend/src/lib/format.test.ts
+++ b/packages/frontend/src/lib/format.test.ts
@@ -2,24 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { formatCost, formatCostIn, getEstimatedBytesPerToken } from './format';
 
 describe('getEstimatedBytesPerToken', () => {
-  it('returns ~115 B/token for Anthropic messages streaming', () => {
-    expect(getEstimatedBytesPerToken({ incomingApiType: 'messages', isStreamed: true })).toBe(115);
+  it('returns ~140 B/token for Anthropic messages streaming', () => {
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'messages', isStreamed: true })).toBe(140);
     expect(
       getEstimatedBytesPerToken({ outgoingApiType: 'anthropic-messages', isStreamed: true })
-    ).toBe(115);
-    expect(getEstimatedBytesPerToken({ incomingApiType: 'oauth', isStreamed: true })).toBe(115);
+    ).toBe(140);
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'oauth', isStreamed: true })).toBe(140);
   });
 
-  it('returns ~160 B/token for OpenAI chat & responses streaming', () => {
-    expect(getEstimatedBytesPerToken({ incomingApiType: 'chat', isStreamed: true })).toBe(160);
+  it('returns ~215 B/token for OpenAI chat streaming', () => {
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'chat', isStreamed: true })).toBe(215);
     expect(
       getEstimatedBytesPerToken({ outgoingApiType: 'openai-completions', isStreamed: true })
-    ).toBe(160);
+    ).toBe(215);
     expect(
       getEstimatedBytesPerToken({ incomingApiType: 'openai-responses', isStreamed: true })
-    ).toBe(160);
+    ).toBe(200);
+    expect(getEstimatedBytesPerToken({ incomingApiType: 'responses', isStreamed: true })).toBe(200);
     expect(getEstimatedBytesPerToken({ incomingApiType: 'antigravity', isStreamed: true })).toBe(
-      160
+      215
     );
   });
 

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -348,8 +348,13 @@ export function getEstimatedBytesPerToken(options: {
   const apiType = (options.incomingApiType || options.outgoingApiType || '').toLowerCase();
 
   if (apiType.includes('anthropic') || apiType.includes('messages') || apiType === 'oauth') {
-    // Anthropic SSE: `event: content_block_delta\ndata: {"type":...}\n\n` (~115 B/token)
-    return 115;
+    // Anthropic Messages streams average about 140 wire bytes per output token.
+    return 140;
+  }
+
+  if (apiType.includes('responses')) {
+    // Responses estimates use only `.delta` events, excluding lifecycle/tool metadata frames.
+    return 200;
   }
 
   if (
@@ -358,8 +363,8 @@ export function getEstimatedBytesPerToken(options: {
     apiType.includes('responses') ||
     apiType.includes('antigravity')
   ) {
-    // OpenAI SSE: `data: {"id":...,"object":"chat.completion.chunk",...}\n\n` (~160 B/token)
-    return 160;
+    // OpenAI Chat streams average about 215 wire bytes per output token.
+    return 215;
   }
 
   if (apiType.includes('gemini') || apiType.includes('google')) {

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -98,6 +98,8 @@ interface ProgressUpdate {
   requestId: string;
   bytesReceived: number;
   bytesPerSec: number | null;
+  semanticBytesReceived?: number;
+  semanticBytesPerSec?: number | null;
   isStreamed: boolean;
   state: 'DISPATCHED' | 'GRACE_PERIOD' | 'MONITORING' | 'THROUGHPUT_STALLED';
   elapsedMs: number;
@@ -861,15 +863,18 @@ const DesktopLogRow = React.memo(
                 ? e2eOutputTokens / (log.durationMs / 1000)
                 : null;
             if (progress) {
+              const semanticBytesReceived =
+                progress.semanticBytesReceived ?? progress.bytesReceived;
+              const semanticBytesPerSec = progress.semanticBytesPerSec ?? progress.bytesPerSec;
               const bytesPerToken = getEstimatedBytesPerToken({
                 ...log,
                 isStreamed: progress.isStreamed,
               });
               const effectiveBytesPerSec =
-                progress.bytesPerSec != null && progress.bytesPerSec > 0
-                  ? progress.bytesPerSec
-                  : progress.elapsedMs > 0 && progress.bytesReceived > 0
-                    ? (progress.bytesReceived / progress.elapsedMs) * 1000
+                semanticBytesPerSec != null && semanticBytesPerSec > 0
+                  ? semanticBytesPerSec
+                  : progress.elapsedMs > 0 && semanticBytesReceived > 0
+                    ? (semanticBytesReceived / progress.elapsedMs) * 1000
                     : null;
               const estTokensPerSec =
                 effectiveBytesPerSec != null &&
@@ -907,6 +912,21 @@ const DesktopLogRow = React.memo(
                       {formatBytes(progress.bytesPerSec)}/s
                     </span>
                   )}
+                  {semanticBytesReceived !== progress.bytesReceived && (
+                    <span
+                      style={{
+                        color: 'var(--color-text-secondary)',
+                        fontSize: '0.85em',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '4px',
+                      }}
+                      title="Bytes from token-producing stream events used for the live token estimate"
+                    >
+                      <Zap size={12} className="text-amber-400" />
+                      {formatBytes(semanticBytesReceived)} token bytes
+                    </span>
+                  )}
                   {estTokensPerSec != null && (
                     <span
                       style={{
@@ -916,7 +936,7 @@ const DesktopLogRow = React.memo(
                         alignItems: 'center',
                         gap: '4px',
                       }}
-                      title={`Estimated tokens/sec (~${Math.round(bytesPerToken)} bytes/token accounting for SSE + JSON framing)`}
+                      title={`Estimated tokens/sec (~${Math.round(bytesPerToken)} bytes/token for this API's streamed token events)`}
                     >
                       <Zap size={12} className="text-amber-400" />
                       <span>~{formatTPS(estTokensPerSec)} tok/s</span>

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -896,7 +896,15 @@ const DesktopLogRow = React.memo(
                     }}
                   >
                     <CloudDownload size={12} className="text-yellow-400" />
-                    <span>{formatBytes(progress.bytesReceived)}</span>
+                    <span>
+                      {formatBytes(progress.bytesReceived)}
+                      {semanticBytesReceived !== progress.bytesReceived && (
+                        <span title="Bytes from token-producing stream events used for the live token estimate">
+                          {' · '}
+                          {formatBytes(semanticBytesReceived)} token bytes
+                        </span>
+                      )}
+                    </span>
                   </span>
                   {progress.bytesPerSec != null && (
                     <span
@@ -910,21 +918,6 @@ const DesktopLogRow = React.memo(
                     >
                       <Gauge size={12} className="text-text-secondary" />
                       {formatBytes(progress.bytesPerSec)}/s
-                    </span>
-                  )}
-                  {semanticBytesReceived !== progress.bytesReceived && (
-                    <span
-                      style={{
-                        color: 'var(--color-text-secondary)',
-                        fontSize: '0.85em',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '4px',
-                      }}
-                      title="Bytes from token-producing stream events used for the live token estimate"
-                    >
-                      <Zap size={12} className="text-amber-400" />
-                      {formatBytes(semanticBytesReceived)} token bytes
                     </span>
                   )}
                   {estTokensPerSec != null && (


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Improve live token estimation in Logs by distinguishing total streamed wire bytes from bytes belonging to token-producing events.

## Changes

- `StallInspector` now tracks total bytes, semantic bytes, and separate rates for both metrics.
- Responses SSE parsing excludes lifecycle and metadata events, counting only events whose type ends in `.delta`.
- SSE parsing handles UTF-8 data split across chunks and flushes buffered data at stream completion.
- Response API types are propagated to both standard response handling and raw passthrough routes.
- Logs uses semantic byte rates for live tokens/sec while continuing to display total bytes; Responses also show token-event bytes separately.
- Added frontend fallbacks for older progress updates without semantic metrics.
- Updated byte-per-token baselines:
  - Anthropic Messages: 140
  - OpenAI Chat: 215
  - OpenAI Responses: 200
- Added tests covering lifecycle exclusion, split SSE chunks, and unchanged accounting for Chat streams.
- Updated `AGENTS.md` workflow guidance.
<!-- kody-pr-summary:end -->