### PR TITLE
fix(quota): trigger cooldown for exhausted meters without reset time

### DIFF
--- a/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
@@ -5,6 +5,7 @@ import {
   executeStandardAttempt,
   type StandardAttemptContext,
 } from '../standard-attempt-request';
+import { isRetryableStatus, isRetryableOAuthError } from '../failover-policy';
 import type { RequestManagerHost } from '../request-manager';
 import type { RouteResult } from '../../routing/router';
 import type { UnifiedChatRequest } from '../../../types/unified';
@@ -317,5 +318,21 @@ describe('executeStandardAttempt — thinking-signature strip-and-retry', () => 
     // ...and the ORIGINAL payload (which can share `messages` with the
     // long-lived request) was never mutated in place.
     expect(providerPayload).toEqual(snapshot);
+  });
+});
+
+describe('failover-policy 402 status code handling', () => {
+  it('treats 402 Payment Required as retryable regardless of configured retryable status codes', () => {
+    expect(isRetryableStatus(402, [])).toBe(true);
+    expect(isRetryableStatus(402, [500, 502])).toBe(true);
+    expect(isRetryableStatus(500, [500])).toBe(true);
+    expect(isRetryableStatus(400, [500])).toBe(false);
+  });
+
+  it('treats 402 Payment Required as retryable for OAuth errors', () => {
+    expect(isRetryableOAuthError({ status: 402, message: 'Low balance' })).toBe(true);
+    expect(isRetryableOAuthError({ statusCode: 402, message: 'Payment required' })).toBe(true);
+    expect(isRetryableOAuthError({ status: 429, message: 'Rate limit' })).toBe(true);
+    expect(isRetryableOAuthError({ status: 401, message: 'Unauthorized' })).toBe(false);
   });
 });

--- a/packages/backend/src/services/dispatch/failover-policy.ts
+++ b/packages/backend/src/services/dispatch/failover-policy.ts
@@ -1,5 +1,5 @@
 export function isRetryableStatus(statusCode: number, retryableStatusCodes: number[]): boolean {
-  return retryableStatusCodes.includes(statusCode);
+  return statusCode === 402 || retryableStatusCodes.includes(statusCode);
 }
 
 /** Determines whether an OAuth failure is safe to retry on another target. */
@@ -9,7 +9,12 @@ export function isRetryableOAuthError(error: any): boolean {
   const errorMessage = error.message?.toLowerCase() || '';
   const statusCode = error.status || error.statusCode;
 
-  if (!statusCode || (statusCode >= 500 && statusCode < 600) || statusCode === 429) {
+  if (
+    !statusCode ||
+    (statusCode >= 500 && statusCode < 600) ||
+    statusCode === 429 ||
+    statusCode === 402
+  ) {
     return true;
   }
 

--- a/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
@@ -17,13 +17,16 @@ import { registerSpy } from '../../../../test/test-utils';
 const CHECKER_ID = 'quota-persistence-checker';
 
 const makeConfig = (
-  overrides: Partial<{ maxUtilizationPercent: number }> & { id?: string; provider?: string } = {}
+  overrides: Partial<{ maxUtilizationPercent: number; intervalMinutes: number }> & {
+    id?: string;
+    provider?: string;
+  } = {}
 ): QuotaConfig => ({
   id: overrides.id ?? CHECKER_ID,
   provider: overrides.provider ?? 'test-provider',
   type: 'synthetic',
   enabled: true,
-  intervalMinutes: 60,
+  intervalMinutes: overrides.intervalMinutes ?? 60,
   options: {
     ...(overrides.maxUtilizationPercent !== undefined
       ? { maxUtilizationPercent: overrides.maxUtilizationPercent }
@@ -440,6 +443,88 @@ describe('QuotaScheduler maxUtilizationPercent', () => {
       lenientConfig
     );
     isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(false);
+  });
+
+  it('triggers provider cooldown when a balance meter without resetsAt is exhausted', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+    const config = makeConfig({ provider: PROVIDER, intervalMinutes: 10 });
+    scheduler.configs.set('balance-checker', config);
+
+    const balanceResult: MeterCheckResult = {
+      checkerId: 'balance-checker',
+      checkerType: 'kilo',
+      provider: PROVIDER,
+      checkedAt: new Date().toISOString(),
+      success: true,
+      meters: [
+        {
+          key: 'balance',
+          label: 'Account balance',
+          kind: 'balance',
+          unit: 'usd',
+          remaining: -0.168363,
+          utilizationPercent: 100,
+          status: 'exhausted',
+        },
+      ],
+    };
+
+    await scheduler.applyCooldownsFromResult(balanceResult, config);
+
+    const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
+    expect(isHealthy).toBe(false);
+
+    // When balance recovers to positive, applying a healthy result clears cooldown
+    const recoveredResult: MeterCheckResult = {
+      ...balanceResult,
+      meters: [
+        {
+          key: 'balance',
+          label: 'Account balance',
+          kind: 'balance',
+          unit: 'usd',
+          remaining: 10.0,
+          utilizationPercent: 'not_applicable',
+          status: 'ok',
+        },
+      ],
+    };
+
+    await scheduler.applyCooldownsFromResult(recoveredResult, config);
+    const isHealthyAfterRecovery = await CooldownManager.getInstance().isProviderHealthy(
+      PROVIDER,
+      ''
+    );
+    expect(isHealthyAfterRecovery).toBe(true);
+  });
+
+  it('triggers provider cooldown when allowance meter without resetsAt is exhausted', async () => {
+    const scheduler = QuotaScheduler.getInstance() as any;
+    const config = makeConfig({ provider: PROVIDER, intervalMinutes: 5 });
+    scheduler.configs.set('allowance-checker', config);
+
+    const result: MeterCheckResult = {
+      checkerId: 'allowance-checker',
+      checkerType: 'synthetic',
+      provider: PROVIDER,
+      checkedAt: new Date().toISOString(),
+      success: true,
+      meters: [
+        {
+          key: 'quota',
+          label: 'Usage quota',
+          kind: 'allowance',
+          unit: 'requests',
+          utilizationPercent: 100,
+          status: 'exhausted',
+        },
+      ],
+    };
+
+    await scheduler.applyCooldownsFromResult(result, config);
+
+    const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
     expect(isHealthy).toBe(false);
   });
 });

--- a/packages/backend/src/services/quota/quota-scheduler.ts
+++ b/packages/backend/src/services/quota/quota-scheduler.ts
@@ -140,12 +140,20 @@ export class QuotaScheduler {
     const cooldownManager = CooldownManager.getInstance();
     const provider = result.provider;
 
+    let isExhausted = false;
     let latestResetMs: number | null = null;
     let exhaustedMeterLabel: string | null = null;
 
     for (const meter of result.meters) {
       const util = meter.utilizationPercent;
-      if (typeof util === 'number' && util >= exhaustionThreshold) {
+      const utilExhausted = typeof util === 'number' && util >= exhaustionThreshold;
+      const statusExhausted = meter.status === 'exhausted';
+
+      if (utilExhausted || statusExhausted) {
+        isExhausted = true;
+        if (!exhaustedMeterLabel) {
+          exhaustedMeterLabel = meter.label;
+        }
         const resetMs = meter.resetsAt ? new Date(meter.resetsAt).getTime() : null;
         if (resetMs !== null && resetMs > Date.now()) {
           if (latestResetMs === null || resetMs > latestResetMs) {
@@ -156,8 +164,12 @@ export class QuotaScheduler {
       }
     }
 
-    if (latestResetMs !== null) {
-      const durationMs = Math.max(0, latestResetMs - Date.now());
+    if (isExhausted) {
+      const intervalMs = (config.intervalMinutes ?? 10) * 60 * 1000;
+      const fallbackMs = Math.max(60_000, intervalMs);
+      const durationMs =
+        latestResetMs !== null ? Math.max(0, latestResetMs - Date.now()) : fallbackMs;
+
       logger.info(
         `Provider '${provider}' quota exhausted` +
           ` (meter: ${exhaustedMeterLabel}, threshold: ${exhaustionThreshold}%, checker: ${result.checkerId}).` +


### PR DESCRIPTION
## Summary
Fixes an issue where exhausted quota meters without a `resetsAt` timestamp (such as Kilo credit balance or allowance meters with no reset date) failed to trigger provider cooldowns and were instead clearing active cooldowns, and ensures HTTP 402 (Payment Required / Low Credit) is always an internally retryable status code for failover.

## Why / Context
1. When a provider quota checker detected a negative or zero balance (status: `exhausted`), `QuotaScheduler.applyCooldownsFromResult()` required `resetMs !== null` (`meter.resetsAt`) to inject a provider cooldown. Because balance meters omit `resetsAt`, the scheduler evaluated `latestResetMs` as `null` and fell through to the `else` branch, calling `cooldownManager.markProviderSuccess()` and clearing any existing provider cooldown.
2. In failover policy evaluation, HTTP 402 status codes were not guaranteed to be retryable across all failover policy paths and OAuth checks, preventing automatic retry to the next provider candidate when an upstream ran out of credits.

## Changes
- **Quota Scheduler**: Updated `QuotaScheduler.applyCooldownsFromResult()` to track `isExhausted` based on `meter.status === 'exhausted'` or `utilizationPercent >= threshold`.
- **Fallback Cooldown**: When `isExhausted` is true and `resetsAt` is missing or not in the future, injects a fallback cooldown based on `config.intervalMinutes` (minimum 60 seconds).
- **Failover Policy**: Updated `isRetryableStatus()` and `isRetryableOAuthError()` in `failover-policy.ts` to explicitly include HTTP 402 as a retryable status code.
- **Testing**: Added unit test coverage for balance meters without `resetsAt` when exhausted/recovered, as well as 402 retryability tests in failover policy.

## Testing
- Ran unit tests (`bun run test`).
- Ran type checks (`bun run typecheck`).
- Ran format checks (`bun run format:check`).


<!-- kody-pr-summary:start -->
## Summary

- Treat HTTP `402 Payment Required` responses as retryable during provider failover, including OAuth errors, regardless of configured retryable status codes.
- Update quota scheduling to trigger provider cooldowns when a meter reports `status: "exhausted"`, even when no `resetsAt` timestamp is provided.
- Use the configured quota-check interval as the cooldown fallback when an exhausted meter has no reset time, with a minimum cooldown of one minute.
- Preserve reset-time-based cooldowns when a future `resetsAt` value is available.
- Add coverage for exhausted balance and allowance meters, cooldown recovery, and `402` retry behavior.
<!-- kody-pr-summary:end -->