### PR TITLE
fix(quota): maintain indefinite provider cooldown until balance is positive

### DIFF
--- a/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-scheduler.test.ts
@@ -446,7 +446,7 @@ describe('QuotaScheduler maxUtilizationPercent', () => {
     expect(isHealthy).toBe(false);
   });
 
-  it('triggers provider cooldown when a balance meter without resetsAt is exhausted', async () => {
+  it('triggers provider indefinite cooldown when a balance meter without resetsAt is exhausted', async () => {
     const scheduler = QuotaScheduler.getInstance() as any;
     const config = makeConfig({ provider: PROVIDER, intervalMinutes: 10 });
     scheduler.configs.set('balance-checker', config);
@@ -474,6 +474,12 @@ describe('QuotaScheduler maxUtilizationPercent', () => {
 
     const isHealthy = await CooldownManager.getInstance().isProviderHealthy(PROVIDER, '');
     expect(isHealthy).toBe(false);
+
+    // Verify cooldown is indefinite (remaining time is > 30 days)
+    const cooldowns = CooldownManager.getInstance().getCooldowns();
+    const kiloCooldown = cooldowns.find((c) => c.provider === PROVIDER);
+    expect(kiloCooldown).toBeDefined();
+    expect(kiloCooldown!.timeRemainingMs).toBeGreaterThan(30 * 24 * 60 * 60 * 1000);
 
     // When balance recovers to positive, applying a healthy result clears cooldown
     const recoveredResult: MeterCheckResult = {

--- a/packages/backend/src/services/quota/quota-scheduler.ts
+++ b/packages/backend/src/services/quota/quota-scheduler.ts
@@ -6,6 +6,7 @@ import type { MeterCheckResult, Meter } from '../../types/meter';
 import { toDbTimestampMs } from '../../utils/normalize';
 import { eq, desc, gte, and } from 'drizzle-orm';
 import { CooldownManager } from '../runtime/cooldown-manager';
+import { INDEFINITE_COOLDOWN_MS } from '@plexus/shared';
 
 const DEFAULT_EXHAUSTION_THRESHOLD = 99;
 
@@ -165,15 +166,15 @@ export class QuotaScheduler {
     }
 
     if (isExhausted) {
-      const intervalMs = (config.intervalMinutes ?? 10) * 60 * 1000;
-      const fallbackMs = Math.max(60_000, intervalMs);
       const durationMs =
-        latestResetMs !== null ? Math.max(0, latestResetMs - Date.now()) : fallbackMs;
+        latestResetMs !== null ? Math.max(0, latestResetMs - Date.now()) : INDEFINITE_COOLDOWN_MS;
 
       logger.info(
         `Provider '${provider}' quota exhausted` +
           ` (meter: ${exhaustedMeterLabel}, threshold: ${exhaustionThreshold}%, checker: ${result.checkerId}).` +
-          ` Injecting provider-wide cooldown for ${Math.round(durationMs / 1000)}s.`
+          (latestResetMs !== null
+            ? ` Injecting provider-wide cooldown for ${Math.round(durationMs / 1000)}s.`
+            : ` Injecting provider-wide indefinite cooldown until reset/balance recovery.`)
       );
       await cooldownManager.markProviderFailure(
         provider,

--- a/packages/frontend/src/components/dashboard/ServiceAlertsCard.tsx
+++ b/packages/frontend/src/components/dashboard/ServiceAlertsCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Card } from '../ui/Card';
 import { AlertTriangle } from 'lucide-react';
 import type { Cooldown } from '../../lib/api';
-import { formatMsToMinSec } from '@plexus/shared';
+import { formatMsToMinSec, INDEFINITE_COOLDOWN_THRESHOLD_MS } from '@plexus/shared';
 
 interface ServiceAlertsCardProps {
   cooldowns: Cooldown[];
@@ -47,17 +47,22 @@ export const ServiceAlertsCard: React.FC<ServiceAlertsCardProps> = ({ cooldowns,
           const [provider, model] = key.split(':');
           const hasAccountId = modelCooldowns.some((c) => c.accountId);
           const maxTime = Math.max(...modelCooldowns.map((c) => c.timeRemainingMs));
-          const timeDisplay = formatMsToMinSec(maxTime);
+          const representative = modelCooldowns.reduce((a, b) =>
+            a.timeRemainingMs >= b.timeRemainingMs ? a : b
+          );
+          const timeDisplay = formatMsToMinSec(maxTime, representative.lastError);
+          const isIndefinite = maxTime >= INDEFINITE_COOLDOWN_THRESHOLD_MS;
+          const prep = isIndefinite ? ' ' : ' for ';
 
           let statusText: string;
           const modelDisplay = model || 'all models';
 
           if (hasAccountId && modelCooldowns.length > 1) {
-            statusText = `${modelDisplay} has ${modelCooldowns.length} accounts on cooldown for up to ${timeDisplay}`;
+            statusText = `${modelDisplay} has ${modelCooldowns.length} accounts on cooldown${prep}up to ${timeDisplay}`;
           } else if (hasAccountId && modelCooldowns.length === 1) {
-            statusText = `${modelDisplay} has 1 account on cooldown for ${timeDisplay}`;
+            statusText = `${modelDisplay} has 1 account on cooldown${prep}${timeDisplay}`;
           } else {
-            statusText = `${modelDisplay} is on cooldown for ${timeDisplay}`;
+            statusText = `${modelDisplay} is on cooldown${prep}${timeDisplay}`;
           }
 
           return (

--- a/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/LiveTab.tsx
@@ -118,7 +118,7 @@ import {
   formatTokens,
   formatTPS,
 } from '../../../lib/format';
-import { formatMsToMinSec } from '@plexus/shared';
+import { formatMsToMinSec, INDEFINITE_COOLDOWN_THRESHOLD_MS } from '@plexus/shared';
 import { clsx } from 'clsx';
 import { useAuth } from '../../../contexts/AuthContext';
 import { useToast } from '../../../contexts/ToastContext';
@@ -2281,7 +2281,18 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                         const representative = modelCooldowns.reduce((a, b) =>
                           a.timeRemainingMs >= b.timeRemainingMs ? a : b
                         );
-                        const timeDisplay = formatMsToMinSec(maxTime);
+                        const timeDisplay = formatMsToMinSec(maxTime, representative.lastError);
+                        const isIndefinite =
+                          representative.timeRemainingMs >= INDEFINITE_COOLDOWN_THRESHOLD_MS;
+                        const lastErr = representative.lastError?.toLowerCase() ?? '';
+                        const expiryStr = isIndefinite
+                          ? lastErr.includes('balance') ||
+                            lastErr.includes('credit') ||
+                            lastErr.includes('payment') ||
+                            lastErr.includes('account')
+                            ? 'Until positive balance'
+                            : 'Until reset'
+                          : new Date(representative.expiry).toLocaleString();
                         return (
                           <CooldownRow
                             key={key}
@@ -2290,7 +2301,7 @@ export const LiveTab: React.FC<LiveTabProps> = ({
                             timeDisplay={timeDisplay}
                             consecutiveFailures={representative.consecutiveFailures}
                             lastError={representative.lastError}
-                            expiryStr={new Date(representative.expiry).toLocaleString()}
+                            expiryStr={expiryStr}
                             onClear={() => handleClearSingleCooldown(provider, model)}
                           />
                         );

--- a/packages/frontend/src/components/models/AliasMobileCard.tsx
+++ b/packages/frontend/src/components/models/AliasMobileCard.tsx
@@ -8,6 +8,7 @@ import { ModelTypeBadge } from './ModelTypeBadge';
 import type { Alias, Provider, Cooldown } from '../../lib/api';
 import { getAliasProviderLabels, getAliasTargetCount } from '../../lib/modelList';
 import { dedupeStrings } from '../../lib/modelOptions';
+import { formatMsToMinSec } from '@plexus/shared';
 
 interface Props {
   alias: Alias;
@@ -154,7 +155,9 @@ export const AliasMobileCard: React.FC<Props> = ({
                 const cooldown = cooldowns.find(
                   (c) => c.provider === t.provider && c.model === t.model && !c.accountId
                 );
-                const cooldownMinutes = cooldown ? Math.ceil(cooldown.timeRemainingMs / 60000) : 0;
+                const cooldownText = cooldown
+                  ? formatMsToMinSec(cooldown.timeRemainingMs, cooldown.lastError)
+                  : '';
 
                 return (
                   <div
@@ -178,7 +181,7 @@ export const AliasMobileCard: React.FC<Props> = ({
                         )}
                         {cooldown && (
                           <div className="mt-1 text-[11px] font-medium text-warning">
-                            Cooldown {cooldownMinutes}m
+                            Cooldown ({cooldownText})
                           </div>
                         )}
                         {testState?.showResult && testState.message && (

--- a/packages/frontend/src/components/models/AliasTableRow.tsx
+++ b/packages/frontend/src/components/models/AliasTableRow.tsx
@@ -4,7 +4,7 @@ import { CopyButton } from '../ui/CopyButton';
 import { Badge } from '../ui/Badge';
 import { Switch } from '../ui/Switch';
 import { Alias, Provider, Cooldown } from '../../lib/api';
-import { formatMsToMinSec } from '@plexus/shared';
+import { formatMsToMinSec, INDEFINITE_COOLDOWN_THRESHOLD_MS } from '@plexus/shared';
 import { SELECTOR_LABELS } from '../../lib/selectors';
 import { getAliasProviderLabels, getAliasTargetCount } from '../../lib/modelList';
 import { dedupeStrings } from '../../lib/modelOptions';
@@ -161,8 +161,11 @@ export const AliasTableRow: React.FC<AliasTableRowProps> = ({
                   );
                   const isCoolingDown = !!cooldown;
                   const cooldownDisplay = cooldown
-                    ? formatMsToMinSec(cooldown.timeRemainingMs)
+                    ? formatMsToMinSec(cooldown.timeRemainingMs, cooldown.lastError)
                     : '';
+                  const isIndefinite =
+                    cooldown && cooldown.timeRemainingMs >= INDEFINITE_COOLDOWN_THRESHOLD_MS;
+                  const titlePrefix = isIndefinite ? 'On cooldown ' : 'On cooldown for ';
 
                   return (
                     <React.Fragment key={`${t.provider}-${t.model}-${targetIdx}`}>
@@ -174,7 +177,7 @@ export const AliasTableRow: React.FC<AliasTableRowProps> = ({
                         {isCoolingDown && (
                           <div
                             className="flex items-center gap-1 text-warning font-medium text-[11px]"
-                            title={`On cooldown for ${cooldownDisplay}`}
+                            title={`${titlePrefix}${cooldownDisplay}`}
                           >
                             <Clock size={12} />
                             <span>{cooldownDisplay}</span>

--- a/packages/shared/src/format-time.ts
+++ b/packages/shared/src/format-time.ts
@@ -1,3 +1,6 @@
+export const INDEFINITE_COOLDOWN_MS = 100 * 365 * 24 * 60 * 60 * 1000;
+export const INDEFINITE_COOLDOWN_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000;
+
 /**
  * Format a fractional number of minutes into a human-readable "min:sec" string.
  *
@@ -39,11 +42,25 @@ export function formatMinutesToMinSec(minutes: number): string {
  *   90000   → "1m 30s"
  *
  * @param ms - The duration in milliseconds
- * @returns A formatted string like "2m", "30s", or "1m 30s"
+ * @param lastError - Optional error message to specialize indefinite cooldown label
+ * @returns A formatted string like "2m", "30s", "1m 30s", or "until positive balance"
  */
-export function formatMsToMinSec(ms: number): string {
+export function formatMsToMinSec(ms: number, lastError?: string): string {
   if (!Number.isFinite(ms) || ms <= 0) {
     return '0s';
+  }
+
+  if (ms >= INDEFINITE_COOLDOWN_THRESHOLD_MS) {
+    const err = lastError?.toLowerCase() ?? '';
+    if (
+      err.includes('balance') ||
+      err.includes('credit') ||
+      err.includes('payment') ||
+      err.includes('account')
+    ) {
+      return 'until positive balance';
+    }
+    return 'until reset';
   }
 
   const totalSeconds = Math.ceil(ms / 1000);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -41,7 +41,12 @@ export type {
 } from './model-params';
 
 // Cooldown time formatting utilities
-export { formatMinutesToMinSec, formatMsToMinSec } from './format-time';
+export {
+  formatMinutesToMinSec,
+  formatMsToMinSec,
+  INDEFINITE_COOLDOWN_MS,
+  INDEFINITE_COOLDOWN_THRESHOLD_MS,
+} from './format-time';
 
 // Quota ranking (most-constrained selection) shared by backend and frontend
 export { constrainedRatio, mostConstrained, sortMostConstrainedFirst } from './quota-ranking';

--- a/packages/shared/test/format-time.test.ts
+++ b/packages/shared/test/format-time.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  formatMinutesToMinSec,
+  formatMsToMinSec,
+  INDEFINITE_COOLDOWN_MS,
+  INDEFINITE_COOLDOWN_THRESHOLD_MS,
+} from '../src/format-time';
+
+describe('formatMinutesToMinSec', () => {
+  it('formats whole minutes', () => {
+    expect(formatMinutesToMinSec(2)).toBe('2m');
+  });
+
+  it('formats fractional minutes to seconds', () => {
+    expect(formatMinutesToMinSec(0.5)).toBe('30s');
+    expect(formatMinutesToMinSec(1.5)).toBe('1m 30s');
+  });
+
+  it('handles zero or negative inputs', () => {
+    expect(formatMinutesToMinSec(0)).toBe('0s');
+    expect(formatMinutesToMinSec(-1)).toBe('0s');
+  });
+});
+
+describe('formatMsToMinSec', () => {
+  it('formats standard millisecond durations', () => {
+    expect(formatMsToMinSec(120000)).toBe('2m');
+    expect(formatMsToMinSec(30000)).toBe('30s');
+    expect(formatMsToMinSec(90000)).toBe('1m 30s');
+  });
+
+  it('formats indefinite cooldowns for balance errors', () => {
+    expect(formatMsToMinSec(INDEFINITE_COOLDOWN_MS, 'quota exhausted - Account balance')).toBe(
+      'until positive balance'
+    );
+    expect(formatMsToMinSec(INDEFINITE_COOLDOWN_MS, 'Low credit balance')).toBe(
+      'until positive balance'
+    );
+  });
+
+  it('formats indefinite cooldowns for non-balance errors', () => {
+    expect(formatMsToMinSec(INDEFINITE_COOLDOWN_MS, 'Quota limit reached')).toBe('until reset');
+    expect(formatMsToMinSec(INDEFINITE_COOLDOWN_THRESHOLD_MS)).toBe('until reset');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes an issue where exhausted provider quota meters without a reset timestamp (such as Kilo credit balance or OpenRouter credits) were assigned a short interval-based cooldown (e.g. 4 minutes) and automatically exited cooldown while the balance remained negative.

## Why / Context
When a balance meter is exhausted (negative or zero balance), there is no scheduled upstream reset date. Setting a short 4-minute cooldown timer caused the provider to automatically exit cooldown and resume receiving traffic while still having a negative balance. A negative balance requires explicit replenishment/recovery, so the provider must remain on cooldown indefinitely until a subsequent check detects a positive balance or an administrator manually clears the cooldown.

## Changes
- **Quota Scheduler (`quota-scheduler.ts`)**: Updated `applyCooldownsFromResult` to inject an indefinite cooldown (`INDEFINITE_COOLDOWN_MS`, 100 years) when a meter is exhausted and lacks a future `resetsAt` timestamp.
- **Shared Utilities (`format-time.ts`, `index.ts`)**:
  - Exported `INDEFINITE_COOLDOWN_MS` and `INDEFINITE_COOLDOWN_THRESHOLD_MS`.
  - Updated `formatMsToMinSec` to format indefinite cooldowns (`>= 30 days`) as `"until positive balance"` (for balance/credit/payment errors) or `"until reset"`.
- **Frontend Dashboard & Models UI**:
  - Updated `LiveTab`, `ServiceAlertsCard`, `AliasTableRow`, and `AliasMobileCard` to pass error messages to `formatMsToMinSec` and display `"Until positive balance"` or `"Until reset"` in alerts and popover details instead of countdown timers or dates.
- **Testing**: Added unit tests in `quota-scheduler.test.ts` and `packages/shared/test/format-time.test.ts` to cover indefinite cooldown duration, formatting, and recovery upon positive balance checks.

## Testing
- Ran unit tests (`bun run test` / `bun test` in shared).
- Ran type checks (`bun run typecheck`).
- Ran format checks (`bun run format:check`).
