### PR TITLE
fix(dispatcher): skip cooldown on deadline expired provider errors

### DIFF
--- a/packages/backend/src/services/__tests__/cooldown-manager.test.ts
+++ b/packages/backend/src/services/__tests__/cooldown-manager.test.ts
@@ -226,6 +226,19 @@ describe('CooldownManager', () => {
       expect(cooldowns.some((c) => c.provider === 'synthetic_new')).toBe(false);
     });
 
+    test('does not create cooldown when lastError indicates deadline expired', async () => {
+      const cm = CooldownManager.getInstance();
+      await cm.markProviderFailure(
+        'google-s',
+        'gemini-3.6-flash',
+        undefined,
+        '503 Deadline expired before operation could complete.'
+      );
+
+      const cooldowns = cm.getCooldowns();
+      expect(cooldowns.some((c) => c.provider === 'google-s')).toBe(false);
+    });
+
     test('filters existing cooldowns when provider switches to disable_cooldown=true', async () => {
       const cm = CooldownManager.getInstance();
 

--- a/packages/backend/src/services/__tests__/dispatcher-quota-errors.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-quota-errors.test.ts
@@ -3,7 +3,7 @@ import { Dispatcher } from '../dispatch/dispatcher';
 import { setConfigForTesting } from '../../config';
 import type { UnifiedChatRequest } from '../../types/unified';
 import { CooldownManager } from '../runtime/cooldown-manager';
-import { QUOTA_ERROR_PATTERNS } from '../../utils/constants';
+import { QUOTA_ERROR_PATTERNS, DEADLINE_EXPIRED_PATTERNS } from '../../utils/constants';
 
 // @earendil-works/pi-ai is mocked globally in vitest.setup.ts — do not add a
 // per-file vi.mock() call here.  With isolate: false all files share one
@@ -292,5 +292,52 @@ describe('Dispatcher Quota Error Detection', () => {
     expect(QUOTA_ERROR_PATTERNS).toContain('quota exceeded');
     expect(QUOTA_ERROR_PATTERNS).toContain('out of credits');
     expect(QUOTA_ERROR_PATTERNS).toContain('insufficient balance');
+  });
+
+  test('503 error with "Deadline expired before operation could complete." does NOT trigger cooldown', async () => {
+    fetchMock.mockImplementation(async () =>
+      errorResponse(503, 'Deadline expired before operation could complete.')
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+      expect(error.routingContext?.attemptCount).toBe(2);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    }
+
+    // Verify NO cooldown was set for either provider (deadline expired is a transient request error, not provider health issue)
+    const isP1Healthy = await CooldownManager.getInstance().isProviderHealthy('p1', 'model-1');
+    const isP2Healthy = await CooldownManager.getInstance().isProviderHealthy('p2', 'model-2');
+    expect(isP1Healthy).toBe(true);
+    expect(isP2Healthy).toBe(true);
+  });
+
+  test('500 error with "deadline_exceeded" pattern does NOT trigger cooldown', async () => {
+    fetchMock.mockImplementation(async () =>
+      errorResponse(500, 'DEADLINE_EXCEEDED: upstream request deadline expired')
+    );
+
+    const dispatcher = new Dispatcher();
+
+    try {
+      await dispatcher.dispatch(makeChatRequest());
+      throw new Error('expected dispatch to fail');
+    } catch (error: any) {
+      expect(error.message).toContain('All targets failed');
+    }
+
+    const isP1Healthy = await CooldownManager.getInstance().isProviderHealthy('p1', 'model-1');
+    expect(isP1Healthy).toBe(true);
+  });
+
+  test('all deadline expired error patterns are defined', () => {
+    expect(DEADLINE_EXPIRED_PATTERNS).toContain('deadline expired');
+    expect(DEADLINE_EXPIRED_PATTERNS).toContain('deadline_exceeded');
+    expect(DEADLINE_EXPIRED_PATTERNS).toContain('deadline exceeded');
   });
 });

--- a/packages/backend/src/services/dispatch/dispatcher.ts
+++ b/packages/backend/src/services/dispatch/dispatcher.ts
@@ -14,7 +14,7 @@ import {
 import { QuotaEnforcer } from '../quota/quota-enforcer';
 import { buildQuotaExceededError } from '../quota/quota-middleware';
 import { logger } from '../../utils/logger';
-import { QUOTA_ERROR_PATTERNS } from '../../utils/constants';
+import { QUOTA_ERROR_PATTERNS, DEADLINE_EXPIRED_PATTERNS } from '../../utils/constants';
 import { CooldownManager } from '../runtime/cooldown-manager';
 import { StickySessionManager } from '../routing/sticky-session-manager';
 import { RouteResult } from '../routing/router';
@@ -717,13 +717,25 @@ export class Dispatcher {
       );
     }
 
+    const isDeadlineExpired = DEADLINE_EXPIRED_PATTERNS.some((p) =>
+      errorText.toLowerCase().includes(p.toLowerCase())
+    );
+
+    if (isDeadlineExpired) {
+      logger.warn(
+        `Detected deadline expired error in response from ${route.provider}/${route.model} — skipping cooldown`
+      );
+    }
+
     // Trigger cooldown for all provider errors except:
     // - 413 (payload too large) and 422 (unprocessable entity): caller errors, not provider failures
     // - 400 without a quota pattern: likely a request validation error, not a provider failure
+    // - Deadline expired errors: transient request deadline expiration, not a provider failure
     const isCallerError =
       response.status === 413 ||
       response.status === 422 ||
-      (response.status === 400 && !isQuota400);
+      (response.status === 400 && !isQuota400) ||
+      isDeadlineExpired;
 
     if (!isCallerError) {
       let cooldownDuration: number | undefined;

--- a/packages/backend/src/services/runtime/cooldown-manager.ts
+++ b/packages/backend/src/services/runtime/cooldown-manager.ts
@@ -4,6 +4,7 @@ import { lt, eq, sql, and, desc } from 'drizzle-orm';
 import { getConfig } from '../../config';
 import { DebugManager } from '../observability/debug-manager';
 import { getCurrentRequestId } from '../observability/request-context';
+import { DEADLINE_EXPIRED_PATTERNS } from '../../utils/constants';
 
 export interface Target {
   provider: string;
@@ -188,6 +189,16 @@ export class CooldownManager {
     if (this.isCooldownDisabledForProvider(provider)) {
       logger.debug(
         `Skipping cooldown for provider '${provider}' model '${model}' (disable_cooldown=true)`
+      );
+      return;
+    }
+
+    if (
+      lastError &&
+      DEADLINE_EXPIRED_PATTERNS.some((p) => lastError.toLowerCase().includes(p.toLowerCase()))
+    ) {
+      logger.debug(
+        `Skipping cooldown for provider '${provider}' model '${model}' (deadline expired error)`
       );
       return;
     }

--- a/packages/backend/src/utils/constants.ts
+++ b/packages/backend/src/utils/constants.ts
@@ -17,6 +17,16 @@ export const QUOTA_ERROR_PATTERNS = [
 ];
 
 /**
+ * Patterns to detect deadline expired / transient timeout errors from providers (e.g. Google).
+ * These are transient request execution timeouts and should not trigger provider cooldowns.
+ */
+export const DEADLINE_EXPIRED_PATTERNS = [
+  'deadline expired',
+  'deadline_exceeded',
+  'deadline exceeded',
+];
+
+/**
  * Default prompt for vision-to-text conversion.
  */
 export const DEFAULT_VISION_DESCRIPTION_PROMPT = `Please provide a comprehensive and detailed description of this image for a highly intelligent text-only language model.


### PR DESCRIPTION
## Summary
Prevents transient request execution timeouts (such as Google's `503 Deadline expired before operation could complete.` or `DEADLINE_EXCEEDED`) from putting upstream LLM providers/models on exponential backoff cooldowns.

## Why / Context
When upstream providers (e.g. Google Gemini via AI Studio or Vertex) time out on a complex or long generation request, they return errors containing deadline expired patterns. Previously, HTTP 503 errors triggered provider/model cooldowns, rendering the target unavailable for subsequent requests across all users. Since a deadline expiration is a single-request execution timeout rather than a persistent service outage or quota exhaustion, it should not trigger exponential backoff.

## Changes
- **Constants**: Defined `DEADLINE_EXPIRED_PATTERNS` (`'deadline expired'`, `'deadline_exceeded'`, `'deadline exceeded'`) in `packages/backend/src/utils/constants.ts`.
- **Dispatcher**: Updated `handleProviderError` in `dispatcher.ts` to detect deadline expired error patterns and treat them as non-cooldown errors (`cooldownTriggered: false`), allowing failover/retries to proceed without setting target cooldowns.
- **Cooldown Manager**: Added a guard in `markProviderFailure` in `cooldown-manager.ts` to skip cooldown creation if the error message contains a deadline expired pattern.
- **Tests**: Added unit tests in `dispatcher-quota-errors.test.ts` and `cooldown-manager.test.ts` verifying 503/500 deadline expired errors skip cooldown.

## Testing
- Ran backend test suite (`bun run test`) with new test cases covering 503 and 500 status deadline expired error responses.
- Verified TypeScript compilation (`bun run typecheck`) and formatting (`bun run format:check`).
