### PR TITLE
feat: alias-as-fallback-target

### DIFF
--- a/packages/backend/drizzle/migrations/0061_add_alias_as_fallback_target.sql
+++ b/packages/backend/drizzle/migrations/0061_add_alias_as_fallback_target.sql
@@ -1,0 +1,18 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_model_alias_targets` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`alias_id` integer NOT NULL,
+	`provider_slug` text,
+	`model_name` text,
+	`target_alias_slug` text,
+	`enabled` integer DEFAULT 1 NOT NULL,
+	`group_name` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`alias_id`) REFERENCES `model_aliases`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_model_alias_targets`("id", "alias_id", "provider_slug", "model_name", "target_alias_slug", "enabled", "group_name", "sort_order") SELECT "id", "alias_id", "provider_slug", "model_name", NULL, "enabled", "group_name", "sort_order" FROM `model_alias_targets`;--> statement-breakpoint
+DROP TABLE `model_alias_targets`;--> statement-breakpoint
+ALTER TABLE `__new_model_alias_targets` RENAME TO `model_alias_targets`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_alias_targets` ON `model_alias_targets` (`alias_id`,`provider_slug`,`model_name`);

--- a/packages/backend/drizzle/migrations/meta/0061_snapshot.json
+++ b/packages/backend/drizzle/migrations/meta/0061_snapshot.json
@@ -1,0 +1,3890 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4ff89035-9c72-4fb8-af6f-c928b0c720f5",
+  "prevId": "ed384ef9-c266-472b-af2f-0216fdd21032",
+  "tables": {
+    "alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "columns": [
+            "alias_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_names": {
+          "name": "quota_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allow_raw_passthrough": {
+          "name": "allow_raw_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "allowed_ips": {
+          "name": "allowed_ips",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "beta": {
+          "name": "beta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "columns": [
+            "secret"
+          ],
+          "isUnique": true
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "columns": [
+            "secret_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "debug_logs": {
+      "name": "debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inference_errors": {
+      "name": "inference_errors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_keys": {
+      "name": "mcp_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "cooldown_until": {
+          "name": "cooldown_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_keys_mcp_server_id_mcp_servers_id_fk": {
+          "name": "mcp_keys_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_keys",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_oauth_authorization_codes": {
+      "name": "mcp_oauth_authorization_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_secret_hash": {
+          "name": "api_key_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_oauth_authorization_codes_code_hash_unique": {
+          "name": "mcp_oauth_authorization_codes_code_hash_unique",
+          "columns": [
+            "code_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_oauth_authorization_codes_client_id": {
+          "name": "idx_mcp_oauth_authorization_codes_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_oauth_authorization_codes_expires_at": {
+          "name": "idx_mcp_oauth_authorization_codes_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_oauth_clients_client_id_unique": {
+          "name": "mcp_oauth_clients_client_id_unique",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_secret_hash": {
+          "name": "api_key_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_oauth_tokens_access_token_hash_unique": {
+          "name": "mcp_oauth_tokens_access_token_hash_unique",
+          "columns": [
+            "access_token_hash"
+          ],
+          "isUnique": true
+        },
+        "mcp_oauth_tokens_refresh_token_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_token_hash_unique",
+          "columns": [
+            "refresh_token_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_oauth_tokens_client_id": {
+          "name": "idx_mcp_oauth_tokens_client_id",
+          "columns": [
+            "client_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_oauth_tokens_key_name": {
+          "name": "idx_mcp_oauth_tokens_key_name",
+          "columns": [
+            "key_name"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_oauth_tokens_access_token_expires_at": {
+          "name": "idx_mcp_oauth_tokens_access_token_expires_at",
+          "columns": [
+            "access_token_expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            "server_name"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'remote_http'"
+        },
+        "launcher": {
+          "name": "launcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startup_timeout_ms": {
+          "name": "startup_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_cooldown_ms": {
+          "name": "rate_limit_cooldown_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60000
+        },
+        "quota_cooldown_ms": {
+          "name": "quota_cooldown_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 86400000
+        },
+        "auth_scheme": {
+          "name": "auth_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meter_snapshots": {
+      "name": "meter_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_type": {
+          "name": "checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_state": {
+          "name": "utilization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_value": {
+          "name": "period_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "period_unit": {
+          "name": "period_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "period_cycle": {
+          "name": "period_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_meter_checker_meter_checked": {
+          "name": "idx_meter_checker_meter_checked",
+          "columns": [
+            "checker_id",
+            "meter_key",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_meter_provider_checked": {
+          "name": "idx_meter_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_meter_checked_at": {
+          "name": "idx_meter_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_alias_targets": {
+      "name": "model_alias_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_alias_slug": {
+          "name": "target_alias_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_aliases": {
+      "name": "model_aliases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_architecture": {
+          "name": "model_architecture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enforce_limits": {
+          "name": "enforce_limits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sticky_session": {
+          "name": "sticky_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "preferred_api": {
+          "name": "preferred_api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pi_model": {
+          "name": "pi_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_groups": {
+          "name": "target_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction": {
+          "name": "compaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_credentials": {
+      "name": "oauth_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pi_ai_custom_models": {
+      "name": "pi_ai_custom_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pi_ai_custom_models_name_unique": {
+          "name": "pi_ai_custom_models_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pi_ai_custom_providers": {
+      "name": "pi_ai_custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pi_ai_custom_providers_name_unique": {
+          "name": "pi_ai_custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            "expiry"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "columns": [
+            "provider",
+            "model"
+          ],
+          "name": "provider_cooldowns_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_models": {
+      "name": "provider_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_compat": {
+          "name": "auto_compat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pi_ai_model_id": {
+          "name": "pi_ai_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "columns": [
+            "provider_id",
+            "model_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_performance": {
+      "name": "provider_performance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "e2e_tokens_per_sec": {
+          "name": "e2e_tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            "provider",
+            "model",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stall_cooldown": {
+          "name": "stall_cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "gemini_thinking_enabled": {
+          "name": "gemini_thinking_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction": {
+          "name": "compaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_autosync_enabled": {
+          "name": "model_autosync_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_autosync_interval": {
+          "name": "model_autosync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "gpu_profile": {
+          "name": "gpu_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_ram_gb": {
+          "name": "gpu_ram_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_bandwidth_tb_s": {
+          "name": "gpu_bandwidth_tb_s",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_flops_tflop": {
+          "name": "gpu_flops_tflop",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gpu_power_draw_watts": {
+          "name": "gpu_power_draw_watts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_compat": {
+          "name": "auto_compat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_ttfb_ms": {
+          "name": "stall_ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_ttfb_bytes": {
+          "name": "stall_ttfb_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_min_bps": {
+          "name": "stall_min_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_window_ms": {
+          "name": "stall_window_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stall_grace_period_ms": {
+          "name": "stall_grace_period_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pi_ai_provider": {
+          "name": "pi_ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_passthrough": {
+          "name": "raw_passthrough",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_snapshots": {
+      "name": "quota_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            "provider",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            "checker_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            "group_id",
+            "window_type",
+            "checked_at"
+          ],
+          "isUnique": false
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            "checked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quota_state": {
+      "name": "quota_state",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "quota_state_key_name_quota_name_pk": {
+          "columns": [
+            "key_name",
+            "quota_name"
+          ],
+          "name": "quota_state_key_name_quota_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "request_usage": {
+      "name": "request_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_raw": {
+          "name": "is_raw",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "request_method": {
+          "name": "request_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": true
+        },
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            "request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_client_request_id": {
+          "name": "idx_request_usage_client_request_id",
+          "columns": [
+            "client_request_id"
+          ],
+          "isUnique": false
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            "api_key",
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "response_items": {
+      "name": "response_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            "response_id",
+            "item_index"
+          ],
+          "isUnique": false
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "responses": {
+      "name": "responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            "previous_response_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_settings": {
+      "name": "system_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shared": {
+          "name": "shared",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "warn_at": {
+          "name": "warn_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/backend/drizzle/migrations/meta/_journal.json
+++ b/packages/backend/drizzle/migrations/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1785963110749,
       "tag": "0060_add_mcp_oauth_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "6",
+      "when": 1786930336000,
+      "tag": "0061_add_alias_as_fallback_target",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/migrations_pg/0077_add_alias_as_fallback_target.sql
+++ b/packages/backend/drizzle/migrations_pg/0077_add_alias_as_fallback_target.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "model_alias_targets" ALTER COLUMN "provider_slug" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "model_alias_targets" ALTER COLUMN "model_name" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "model_alias_targets" ADD COLUMN "target_alias_slug" text;

--- a/packages/backend/drizzle/migrations_pg/meta/0077_snapshot.json
+++ b/packages/backend/drizzle/migrations_pg/meta/0077_snapshot.json
@@ -1,0 +1,4023 @@
+{
+  "id": "ca08fe63-b7af-4f5f-ab52-4658449c93cf",
+  "prevId": "95f3766f-60aa-48bf-a880-0532c236b3d5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alias_metadata_overrides": {
+      "name": "alias_metadata_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_length": {
+          "name": "context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_prompt": {
+          "name": "pricing_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_completion": {
+          "name": "pricing_completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_read": {
+          "name": "pricing_input_cache_read",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_input_cache_write": {
+          "name": "pricing_input_cache_write",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_input_modalities": {
+          "name": "architecture_input_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_output_modalities": {
+          "name": "architecture_output_modalities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "architecture_tokenizer": {
+          "name": "architecture_tokenizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_parameters": {
+          "name": "supported_parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_context_length": {
+          "name": "top_provider_context_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_provider_max_completion_tokens": {
+          "name": "top_provider_max_completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alias_metadata_overrides_alias_id_model_aliases_id_fk": {
+          "name": "alias_metadata_overrides_alias_id_model_aliases_id_fk",
+          "tableFrom": "alias_metadata_overrides",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_metadata_overrides": {
+          "name": "uq_alias_metadata_overrides",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_names": {
+          "name": "quota_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_raw_passthrough": {
+          "name": "allow_raw_passthrough",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowed_ips": {
+          "name": "allowed_ips",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beta": {
+          "name": "beta",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_name_unique": {
+          "name": "api_keys_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "api_keys_secret_unique": {
+          "name": "api_keys_secret_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret"
+          ]
+        },
+        "api_keys_secret_hash_unique": {
+          "name": "api_keys_secret_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_request": {
+          "name": "transformed_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response": {
+          "name": "transformed_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_snapshot": {
+          "name": "raw_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_response_snapshot": {
+          "name": "transformed_response_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_debug_logs_request_id": {
+          "name": "idx_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_created_at": {
+          "name": "idx_debug_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_debug_logs_api_key": {
+          "name": "idx_debug_logs_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items": {
+          "name": "items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_account_id": {
+          "name": "plexus_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_updated": {
+          "name": "idx_conversations_updated",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inference_errors": {
+      "name": "inference_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_errors_request_id": {
+          "name": "idx_errors_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_date": {
+          "name": "idx_errors_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inference_errors_api_key": {
+          "name": "idx_inference_errors_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_debug_logs": {
+      "name": "mcp_debug_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request_headers": {
+          "name": "raw_request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_request_body": {
+          "name": "raw_request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_headers": {
+          "name": "raw_response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response_body": {
+          "name": "raw_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_debug_logs_request_id": {
+          "name": "idx_mcp_debug_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_debug_logs_request_id_unique": {
+          "name": "mcp_debug_logs_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_keys": {
+      "name": "mcp_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cooldown_until": {
+          "name": "cooldown_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_keys_mcp_server_id_mcp_servers_id_fk": {
+          "name": "mcp_keys_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_keys",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_authorization_codes": {
+      "name": "mcp_oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_secret_hash": {
+          "name": "api_key_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_authorization_codes_client_id": {
+          "name": "idx_mcp_oauth_authorization_codes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_oauth_authorization_codes_expires_at": {
+          "name": "idx_mcp_oauth_authorization_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_authorization_codes_code_hash_unique": {
+          "name": "mcp_oauth_authorization_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_clients_client_id_unique": {
+          "name": "mcp_oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_tokens": {
+      "name": "mcp_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_secret_hash": {
+          "name": "api_key_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_tokens_client_id": {
+          "name": "idx_mcp_oauth_tokens_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_oauth_tokens_key_name": {
+          "name": "idx_mcp_oauth_tokens_key_name",
+          "columns": [
+            {
+              "expression": "key_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_oauth_tokens_access_token_expires_at": {
+          "name": "idx_mcp_oauth_tokens_access_token_expires_at",
+          "columns": [
+            {
+              "expression": "access_token_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_tokens_access_token_hash_unique": {
+          "name": "mcp_oauth_tokens_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "mcp_oauth_tokens_refresh_token_hash_unique": {
+          "name": "mcp_oauth_tokens_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_request_usage": {
+      "name": "mcp_request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jsonrpc_method": {
+          "name": "jsonrpc_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_debug": {
+          "name": "has_debug",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_request_usage_server_name": {
+          "name": "idx_mcp_request_usage_server_name",
+          "columns": [
+            {
+              "expression": "server_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_request_usage_created_at": {
+          "name": "idx_mcp_request_usage_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_request_usage_request_id_unique": {
+          "name": "mcp_request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upstream_url": {
+          "name": "upstream_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'remote_http'"
+        },
+        "launcher": {
+          "name": "launcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_timeout_ms": {
+          "name": "startup_timeout_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_cooldown_ms": {
+          "name": "rate_limit_cooldown_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60000
+        },
+        "quota_cooldown_ms": {
+          "name": "quota_cooldown_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 86400000
+        },
+        "auth_scheme": {
+          "name": "auth_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meter_snapshots": {
+      "name": "meter_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_type": {
+          "name": "checker_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meter_key": {
+          "name": "meter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_state": {
+          "name": "utilization_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_value": {
+          "name": "period_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_unit": {
+          "name": "period_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_cycle": {
+          "name": "period_cycle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_meter_checker_meter_checked": {
+          "name": "idx_meter_checker_meter_checked",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "meter_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meter_provider_checked": {
+          "name": "idx_meter_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_meter_checked_at": {
+          "name": "idx_meter_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_alias_targets": {
+      "name": "model_alias_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_slug": {
+          "name": "provider_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_alias_slug": {
+          "name": "target_alias_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "model_alias_targets_alias_id_model_aliases_id_fk": {
+          "name": "model_alias_targets_alias_id_model_aliases_id_fk",
+          "tableFrom": "model_alias_targets",
+          "tableTo": "model_aliases",
+          "columnsFrom": [
+            "alias_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_alias_targets": {
+          "name": "uq_alias_targets",
+          "nullsNotDistinct": false,
+          "columns": [
+            "alias_id",
+            "provider_slug",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_aliases": {
+      "name": "model_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "selector_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "alias_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selector'"
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_aliases": {
+          "name": "additional_aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advanced": {
+          "name": "advanced",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "metadata_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source_path": {
+          "name": "metadata_source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_image_fallthrough": {
+          "name": "use_image_fallthrough",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_architecture": {
+          "name": "model_architecture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_limits": {
+          "name": "enforce_limits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sticky_session": {
+          "name": "sticky_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferred_api": {
+          "name": "preferred_api",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pi_model": {
+          "name": "pi_model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_groups": {
+          "name": "target_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction": {
+          "name": "compaction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_aliases_slug_unique": {
+          "name": "model_aliases_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_credentials": {
+      "name": "oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_oauth_credentials": {
+          "name": "uq_oauth_credentials",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oauth_provider_type",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pi_ai_custom_models": {
+      "name": "pi_ai_custom_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pi_ai_custom_models_name_unique": {
+          "name": "pi_ai_custom_models_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pi_ai_custom_providers": {
+      "name": "pi_ai_custom_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pi_ai_custom_providers_name_unique": {
+          "name": "pi_ai_custom_providers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_cooldowns": {
+      "name": "provider_cooldowns",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cooldowns_expiry": {
+          "name": "idx_cooldowns_expiry",
+          "columns": [
+            {
+              "expression": "expiry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "provider_cooldowns_provider_model_pk": {
+          "name": "provider_cooldowns_provider_model_pk",
+          "columns": [
+            "provider",
+            "model"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_models": {
+      "name": "provider_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_config": {
+          "name": "pricing_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "model_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_via": {
+          "name": "access_via",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_compat": {
+          "name": "auto_compat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pi_ai_model_id": {
+          "name": "pi_ai_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_models_provider_id_providers_id_fk": {
+          "name": "provider_models_provider_id_providers_id_fk",
+          "tableFrom": "provider_models",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_provider_models": {
+          "name": "uq_provider_models",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id",
+            "model_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_performance": {
+      "name": "provider_performance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_to_first_token_ms": {
+          "name": "time_to_first_token_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "e2e_tokens_per_sec": {
+          "name": "e2e_tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_provider_performance_lookup": {
+          "name": "idx_provider_performance_lookup",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_base_url": {
+          "name": "api_base_url",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider_type": {
+          "name": "oauth_provider_type",
+          "type": "oauth_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_credential_id": {
+          "name": "oauth_credential_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "disable_cooldown": {
+          "name": "disable_cooldown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stall_cooldown": {
+          "name": "stall_cooldown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_tokens": {
+          "name": "estimate_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_claude_masking": {
+          "name": "use_claude_masking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gemini_thinking_enabled": {
+          "name": "gemini_thinking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra_body": {
+          "name": "extra_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compaction": {
+          "name": "compaction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_type": {
+          "name": "quota_checker_type",
+          "type": "quota_checker_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_id": {
+          "name": "quota_checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_checker_enabled": {
+          "name": "quota_checker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "quota_checker_interval": {
+          "name": "quota_checker_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "quota_checker_options": {
+          "name": "quota_checker_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_autosync_enabled": {
+          "name": "model_autosync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_autosync_interval": {
+          "name": "model_autosync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "gpu_profile": {
+          "name": "gpu_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_ram_gb": {
+          "name": "gpu_ram_gb",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_bandwidth_tb_s": {
+          "name": "gpu_bandwidth_tb_s",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_flops_tflop": {
+          "name": "gpu_flops_tflop",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gpu_power_draw_watts": {
+          "name": "gpu_power_draw_watts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_compat": {
+          "name": "auto_compat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_ttfb_ms": {
+          "name": "stall_ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_ttfb_bytes": {
+          "name": "stall_ttfb_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_min_bps": {
+          "name": "stall_min_bps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_window_ms": {
+          "name": "stall_window_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stall_grace_period_ms": {
+          "name": "stall_grace_period_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pi_ai_provider": {
+          "name": "pi_ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_passthrough": {
+          "name": "raw_passthrough",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_providers_slug": {
+          "name": "idx_providers_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_oauth_credential_id_oauth_credentials_id_fk": {
+          "name": "providers_oauth_credential_id_oauth_credentials_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "oauth_credentials",
+          "columnsFrom": [
+            "oauth_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "providers_slug_unique": {
+          "name": "providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_snapshots": {
+      "name": "quota_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checker_id": {
+          "name": "checker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_type": {
+          "name": "window_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utilization_percent": {
+          "name": "utilization_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resets_at": {
+          "name": "resets_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_quota_provider_checked": {
+          "name": "idx_quota_provider_checked",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checker_window": {
+          "name": "idx_quota_checker_window",
+          "columns": [
+            {
+              "expression": "checker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_group_window": {
+          "name": "idx_quota_group_window",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quota_checked_at": {
+          "name": "idx_quota_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quota_state": {
+      "name": "quota_state",
+      "schema": "",
+      "columns": {
+        "key_name": {
+          "name": "key_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota_name": {
+          "name": "quota_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_usage": {
+          "name": "current_usage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "quota_state_key_name_quota_name_pk": {
+          "name": "quota_state_key_name_quota_name_pk",
+          "columns": [
+            "key_name",
+            "quota_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_usage": {
+      "name": "request_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_request_id": {
+          "name": "client_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_api_type": {
+          "name": "incoming_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "retry_history": {
+          "name": "retry_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incoming_model_alias": {
+          "name": "incoming_model_alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_model_name": {
+          "name": "canonical_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model_name": {
+          "name": "selected_model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_provider": {
+          "name": "final_attempt_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_attempt_model": {
+          "name": "final_attempt_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_attempted_providers": {
+          "name": "all_attempted_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outgoing_api_type": {
+          "name": "outgoing_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cache_write": {
+          "name": "tokens_cache_write",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_input": {
+          "name": "cost_input",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_output": {
+          "name": "cost_output",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cached": {
+          "name": "cost_cached",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_cache_write": {
+          "name": "cost_cache_write",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_total": {
+          "name": "cost_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_metadata": {
+          "name": "cost_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttft_ms": {
+          "name": "ttft_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_per_sec": {
+          "name": "tokens_per_sec",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_streamed": {
+          "name": "is_streamed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_passthrough": {
+          "name": "is_passthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_raw": {
+          "name": "is_raw",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_method": {
+          "name": "request_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_estimated": {
+          "name": "tokens_estimated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tools_defined": {
+          "name": "tools_defined",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls_enabled": {
+          "name": "parallel_tool_calls_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls_count": {
+          "name": "tool_calls_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_vision_fallthrough": {
+          "name": "is_vision_fallthrough",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_descriptor_request": {
+          "name": "is_descriptor_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vision_fallthrough_model": {
+          "name": "vision_fallthrough_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kwh_used": {
+          "name": "kwh_used",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reported_cost": {
+          "name": "provider_reported_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_request_usage_date": {
+          "name": "idx_request_usage_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_provider": {
+          "name": "idx_request_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_request_id": {
+          "name": "idx_request_usage_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_client_request_id": {
+          "name": "idx_request_usage_client_request_id",
+          "columns": [
+            {
+              "expression": "client_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_usage_api_key": {
+          "name": "idx_request_usage_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "request_usage_request_id_unique": {
+          "name": "request_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "request_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_items": {
+      "name": "response_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_index": {
+          "name": "item_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_data": {
+          "name": "item_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_response_items_response": {
+          "name": "idx_response_items_response",
+          "columns": [
+            {
+              "expression": "response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_response_items_type": {
+          "name": "idx_response_items_type",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.responses": {
+      "name": "responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object": {
+          "name": "object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_items": {
+          "name": "output_items",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_logprobs": {
+          "name": "top_logprobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parallel_tool_calls": {
+          "name": "parallel_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_choice": {
+          "name": "tool_choice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text_config": {
+          "name": "text_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_config": {
+          "name": "reasoning_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_input_tokens": {
+          "name": "usage_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_output_tokens": {
+          "name": "usage_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_reasoning_tokens": {
+          "name": "usage_reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_cached_tokens": {
+          "name": "usage_cached_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_total_tokens": {
+          "name": "usage_total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_response_id": {
+          "name": "previous_response_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store": {
+          "name": "store",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "background": {
+          "name": "background",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "truncation": {
+          "name": "truncation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incomplete_details": {
+          "name": "incomplete_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_identifier": {
+          "name": "safety_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_key": {
+          "name": "prompt_cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_cache_retention": {
+          "name": "prompt_cache_retention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_provider": {
+          "name": "plexus_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_target_model": {
+          "name": "plexus_target_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_api_type": {
+          "name": "plexus_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plexus_canonical_model": {
+          "name": "plexus_canonical_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_responses_conversation": {
+          "name": "idx_responses_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_created_at": {
+          "name": "idx_responses_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_status": {
+          "name": "idx_responses_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_responses_previous": {
+          "name": "idx_responses_previous",
+          "columns": [
+            {
+              "expression": "previous_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_quota_definitions": {
+      "name": "user_quota_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "quota_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_type": {
+          "name": "limit_type",
+          "type": "limit_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_providers": {
+          "name": "allowed_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_models": {
+          "name": "excluded_models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_providers": {
+          "name": "excluded_providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared": {
+          "name": "shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "warn_at": {
+          "name": "warn_at",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_quota_definitions_name_unique": {
+          "name": "user_quota_definitions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.oauth_provider_type": {
+      "name": "oauth_provider_type",
+      "schema": "public",
+      "values": [
+        "anthropic",
+        "openai-codex",
+        "github-copilot",
+        "google-gemini-cli",
+        "google-antigravity"
+      ]
+    },
+    "public.quota_checker_type": {
+      "name": "quota_checker_type",
+      "schema": "public",
+      "values": [
+        "naga",
+        "synthetic",
+        "nanogpt",
+        "zai",
+        "moonshot",
+        "minimax",
+        "minimax-coding",
+        "openrouter",
+        "kilo",
+        "openai-codex",
+        "claude-code",
+        "kimi-code",
+        "copilot",
+        "wisdomgate",
+        "apertis",
+        "apertis-coding-plan",
+        "poe",
+        "routing-run",
+        "gemini-cli",
+        "antigravity",
+        "novita",
+        "ollama",
+        "neuralwatt",
+        "zenmux",
+        "devpass",
+        "wafer",
+        "opencode-go",
+        "crof",
+        "exedev",
+        "hyper",
+        "sakana",
+        "cline"
+      ]
+    },
+    "public.alias_priority": {
+      "name": "alias_priority",
+      "schema": "public",
+      "values": [
+        "selector",
+        "api_match"
+      ]
+    },
+    "public.limit_type": {
+      "name": "limit_type",
+      "schema": "public",
+      "values": [
+        "requests",
+        "tokens",
+        "cost"
+      ]
+    },
+    "public.metadata_source": {
+      "name": "metadata_source",
+      "schema": "public",
+      "values": [
+        "openrouter",
+        "models.dev",
+        "catwalk",
+        "custom"
+      ]
+    },
+    "public.model_type": {
+      "name": "model_type",
+      "schema": "public",
+      "values": [
+        "chat",
+        "embeddings",
+        "transcriptions",
+        "speech",
+        "image",
+        "responses"
+      ]
+    },
+    "public.quota_type": {
+      "name": "quota_type",
+      "schema": "public",
+      "values": [
+        "rolling",
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.selector_strategy": {
+      "name": "selector_strategy",
+      "schema": "public",
+      "values": [
+        "random",
+        "in_order",
+        "cost",
+        "latency",
+        "usage",
+        "performance"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/migrations_pg/meta/_journal.json
+++ b/packages/backend/drizzle/migrations_pg/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1785963111200,
       "tag": "0076_add_mcp_oauth_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1786930336329,
+      "tag": "0077_add_alias_as_fallback_target",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/drizzle/schema/postgres/model-alias-targets.ts
+++ b/packages/backend/drizzle/schema/postgres/model-alias-targets.ts
@@ -8,8 +8,9 @@ export const modelAliasTargets = pgTable(
     aliasId: integer('alias_id')
       .notNull()
       .references(() => modelAliases.id, { onDelete: 'cascade' }),
-    providerSlug: text('provider_slug').notNull(),
-    modelName: text('model_name').notNull(),
+    providerSlug: text('provider_slug'),
+    modelName: text('model_name'),
+    targetAliasSlug: text('target_alias_slug'),
     enabled: boolean('enabled').notNull().default(true),
     groupName: text('group_name'), // target group label
     sortOrder: integer('sort_order').notNull().default(0),

--- a/packages/backend/drizzle/schema/sqlite/model-alias-targets.ts
+++ b/packages/backend/drizzle/schema/sqlite/model-alias-targets.ts
@@ -8,8 +8,9 @@ export const modelAliasTargets = sqliteTable(
     aliasId: integer('alias_id')
       .notNull()
       .references(() => modelAliases.id, { onDelete: 'cascade' }),
-    providerSlug: text('provider_slug').notNull(),
-    modelName: text('model_name').notNull(),
+    providerSlug: text('provider_slug'),
+    modelName: text('model_name'),
+    targetAliasSlug: text('target_alias_slug'),
     enabled: integer('enabled').notNull().default(1),
     groupName: text('group_name'), // target group label
     sortOrder: integer('sort_order').notNull().default(0),

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -713,11 +713,19 @@ export const ProviderConfigSchema = z
     message: 'raw_passthrough currently supports static API-key providers only',
   });
 
-const ModelTargetSchema = z.object({
-  provider: z.string(),
-  model: z.string(),
-  enabled: z.boolean().default(true).optional(),
-});
+const ModelTargetSchema = z
+  .object({
+    provider: z.string().optional(),
+    model: z.string().optional(),
+    alias: z.string().min(1).optional(),
+    enabled: z.boolean().default(true).optional(),
+  })
+  .refine(
+    (data) => (data.alias ? !data.provider && !data.model : !!data.provider && !!data.model),
+    {
+      message: "A target must specify either 'alias' or both 'provider' and 'model', but not both",
+    }
+  );
 
 const SelectorTypeSchema = z.enum([
   'random',
@@ -736,20 +744,80 @@ const ModelTargetGroupSchema = z.object({
 });
 
 export function findDuplicateAliasTargets(
-  targetGroups: Array<{ targets: Array<{ provider: string; model: string }> }> | undefined
-): Array<{ provider: string; model: string }> {
+  targetGroups:
+    | Array<{ targets: Array<{ provider?: string; model?: string; alias?: string }> }>
+    | undefined
+): Array<{ provider?: string; model?: string; alias?: string }> {
   const seen = new Set<string>();
-  const duplicates = new Map<string, { provider: string; model: string }>();
+  const duplicates = new Map<string, { provider?: string; model?: string; alias?: string }>();
 
   for (const group of targetGroups ?? []) {
     for (const target of group.targets) {
-      const key = JSON.stringify([target.provider, target.model]);
+      const key = target.alias
+        ? JSON.stringify(['alias', target.alias])
+        : JSON.stringify([target.provider, target.model]);
       if (seen.has(key)) duplicates.set(key, target);
       else seen.add(key);
     }
   }
 
   return Array.from(duplicates.values());
+}
+
+/**
+ * Walks the alias-ref graph (target.alias references) starting from every
+ * alias and throws if a cycle is found. Called at config-load time as a hard
+ * validation error — route-time expansion also guards with a visited-set as
+ * a safety net, but cycles should never reach the router.
+ */
+export function assertNoAliasRefCycles(models: Record<string, ModelConfig> | undefined): void {
+  if (!models) return;
+
+  // target.alias may reference either a canonical model key or one of its
+  // additional_aliases (nicknames) — resolve nicknames to their canonical
+  // key so cycles routed through a nickname are still detected, matching
+  // how the router resolves alias refs at request time (see findAlias).
+  const canonicalBySlug = new Map<string, string>();
+  for (const key of Object.keys(models)) {
+    canonicalBySlug.set(key, key);
+    for (const nickname of models[key]?.additional_aliases ?? []) {
+      if (!canonicalBySlug.has(nickname)) canonicalBySlug.set(nickname, key);
+    }
+  }
+
+  const referencedAliases = (slug: string): string[] => {
+    const model = models[slug];
+    if (!model?.target_groups) return [];
+    const refs: string[] = [];
+    for (const group of model.target_groups) {
+      for (const target of group.targets) {
+        if (target.alias) refs.push(canonicalBySlug.get(target.alias) ?? target.alias);
+      }
+    }
+    return refs;
+  };
+
+  for (const startSlug of Object.keys(models)) {
+    const path: string[] = [];
+    const visiting = new Set<string>();
+
+    const walk = (slug: string) => {
+      if (visiting.has(slug)) {
+        const cycleStart = path.indexOf(slug);
+        const cycle = [...path.slice(cycleStart), slug].join(' -> ');
+        throw new Error(`Alias reference cycle detected: ${cycle}`);
+      }
+      visiting.add(slug);
+      path.push(slug);
+      for (const ref of referencedAliases(slug)) {
+        walk(ref);
+      }
+      path.pop();
+      visiting.delete(slug);
+    };
+
+    walk(startSlug);
+  }
 }
 
 export function findDuplicateAdditionalAliases(additionalAliases: string[] | undefined): string[] {
@@ -971,7 +1039,9 @@ export const ModelConfigSchema = z
       context.addIssue({
         code: 'custom',
         path: ['target_groups'],
-        message: `Duplicate target '${target.provider}/${target.model}' is not allowed`,
+        message: target.alias
+          ? `Duplicate target 'alias:${target.alias}' is not allowed`
+          : `Duplicate target '${target.provider}/${target.model}' is not allowed`,
       });
     }
 
@@ -1252,6 +1322,8 @@ export function validateConfig(configJson: string): PlexusConfig {
 }
 
 function hydrateConfig(config: z.infer<typeof RawPlexusConfigSchema>): PlexusConfig {
+  assertNoAliasRefCycles(config.models);
+
   // Resolve GPU profiles for providers loaded from config.
   // If a provider has gpu_profile set but the numeric fields aren't populated,
   // resolve them now so the backend never needs to resolve at request time.

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -791,7 +791,9 @@ export function assertNoAliasRefCycles(models: Record<string, ModelConfig> | und
     const refs: string[] = [];
     for (const group of model.target_groups) {
       for (const target of group.targets) {
-        if (target.alias) refs.push(canonicalBySlug.get(target.alias) ?? target.alias);
+        if (target.enabled !== false && target.alias) {
+          refs.push(canonicalBySlug.get(target.alias) ?? target.alias);
+        }
       }
     }
     return refs;

--- a/packages/backend/src/db/__tests__/alias-as-fallback-target-migration.test.ts
+++ b/packages/backend/src/db/__tests__/alias-as-fallback-target-migration.test.ts
@@ -1,0 +1,388 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { Database } from 'bun:sqlite';
+import { closeDatabase, initializeDatabase, getDatabase, getSchema } from '../client';
+import { ConfigRepository } from '../config-repository';
+import { toDbBoolean } from '../../utils/normalize';
+
+/**
+ * Regression suite for the `model_alias_targets` table-recreation migration
+ * (alias-as-fallback-target, SQLite migration 0061).
+ *
+ * Background: drizzle-kit generated `INSERT INTO __new_model_alias_targets (...)
+ * SELECT ..., "target_alias_slug", ... FROM model_alias_targets` where
+ * `target_alias_slug` did not exist on the source table. Under SQLite's
+ * double-quoted-string misfeature that dangling identifier silently became the
+ * string literal 'target_alias_slug' in EVERY row, which then made
+ * `rowToModelConfig` treat every concrete target as an alias-reference —
+ * breaking all model configurations. We reproduced it on a realistic 13-alias /
+ * 23-target DB and confirmed the fix (generation now emits NULL for
+ * source-absent columns).
+ *
+ * This suite builds the real pre-feature schema + data, applies the actual 0061
+ * migration SQL, and asserts no corruption — the regression that guards against
+ * re-introducing the bug.
+ */
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../../drizzle/migrations');
+
+interface Journal {
+  entries: Array<{ tag: string }>;
+}
+
+function splitStatements(sql: string): string[] {
+  return sql
+    .split('--> statement-breakpoint')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Rows represent the realistic pre-feature dataset: 13 aliases, 23 concrete targets. */
+const ALIASES: Array<{
+  slug: string;
+  selector: string;
+  targets: Array<{ provider: string; model: string }>;
+}> = [
+  {
+    slug: 'claude-sonnet',
+    selector: 'random',
+    targets: [
+      { provider: 'anthropic', model: 'claude-sonnet-4-5' },
+      { provider: 'openrouter', model: 'anthropic/claude-sonnet-4-5' },
+    ],
+  },
+  {
+    slug: 'claude-opus',
+    selector: 'in_order',
+    targets: [
+      { provider: 'anthropic', model: 'claude-opus-4-1' },
+      { provider: 'openrouter', model: 'anthropic/claude-opus-4-1' },
+    ],
+  },
+  {
+    slug: 'gpt-4o',
+    selector: 'random',
+    targets: [
+      { provider: 'openai', model: 'gpt-4o' },
+      { provider: 'openrouter', model: 'openai/gpt-4o' },
+    ],
+  },
+  {
+    slug: 'gpt-4o-mini',
+    selector: 'random',
+    targets: [{ provider: 'openai', model: 'gpt-4o-mini' }],
+  },
+  {
+    slug: 'gemini-pro',
+    selector: 'in_order',
+    targets: [{ provider: 'google', model: 'gemini-2.5-pro' }],
+  },
+  {
+    slug: 'gemini-flash',
+    selector: 'random',
+    targets: [{ provider: 'google', model: 'gemini-2.5-flash' }],
+  },
+  {
+    slug: 'deepseek-r1',
+    selector: 'random',
+    targets: [
+      { provider: 'deepseek', model: 'deepseek-r1' },
+      { provider: 'openrouter', model: 'deepseek/deepseek-r1' },
+    ],
+  },
+  {
+    slug: 'llama-3-70b',
+    selector: 'in_order',
+    targets: [{ provider: 'meta', model: 'llama-3-70b' }],
+  },
+  { slug: 'qwen-max', selector: 'random', targets: [{ provider: 'alibaba', model: 'qwen-max' }] },
+  {
+    slug: 'mistral-large',
+    selector: 'random',
+    targets: [
+      { provider: 'mistral', model: 'mistral-large-latest' },
+      { provider: 'openrouter', model: 'mistralai/mistral-large' },
+    ],
+  },
+  {
+    slug: 'command-r-plus',
+    selector: 'in_order',
+    targets: [{ provider: 'cohere', model: 'command-r-plus' }],
+  },
+  { slug: 'grok-beta', selector: 'random', targets: [{ provider: 'xai', model: 'grok-beta' }] },
+  {
+    slug: 'o1-preview',
+    selector: 'in_order',
+    targets: [
+      { provider: 'openai', model: 'o1-preview' },
+      { provider: 'openrouter', model: 'openai/o1-preview' },
+    ],
+  },
+];
+const TOTAL_TARGETS = ALIASES.reduce((sum, a) => sum + a.targets.length, 0); // 23
+
+let dbPath: string;
+
+beforeEach(async () => {
+  await closeDatabase();
+  dbPath = path.join(
+    os.tmpdir(),
+    `plexus-alias-migration-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`
+  );
+  buildPreFeatureDb(dbPath);
+});
+
+afterEach(async () => {
+  await closeDatabase();
+  if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+});
+
+/** Build the pre-feature (0060) schema by applying prior migrations, then seed data. */
+function buildPreFeatureDb(path_: string): void {
+  const sqlite = new Database(path_);
+  const journal = JSON.parse(
+    fs.readFileSync(path.join(MIGRATIONS_DIR, 'meta', '_journal.json'), 'utf8')
+  ) as Journal;
+  const preFeature = journal.entries.filter((e) => !e.tag.startsWith('0061'));
+
+  for (const entry of preFeature) {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, `${entry.tag}.sql`), 'utf8');
+    for (const stmt of splitStatements(sql)) sqlite.run(stmt);
+  }
+
+  // Seed 13 aliases + 23 concrete targets (legacy: provider_slug/model_name NOT NULL).
+  const now = Math.floor(Date.now() / 1000);
+  for (const alias of ALIASES) {
+    const ins = sqlite
+      .prepare(
+        'INSERT INTO model_aliases (slug, selector, priority, model_type, target_groups, use_image_fallthrough, enforce_limits, sticky_session, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+      )
+      .run(
+        alias.slug,
+        alias.selector,
+        'selector',
+        'text',
+        JSON.stringify([{ name: 'default', selector: alias.selector }]),
+        0,
+        0,
+        0,
+        now,
+        now
+      );
+    const aliasId = Number(ins.lastInsertRowid);
+    for (const t of alias.targets) {
+      sqlite
+        .prepare(
+          'INSERT INTO model_alias_targets (alias_id, provider_slug, model_name, enabled, group_name, sort_order) VALUES (?, ?, ?, ?, ?, ?)'
+        )
+        .run(aliasId, t.provider, t.model, 1, 'default', 0);
+    }
+  }
+  sqlite.close();
+}
+
+/** Apply a migration SQL file to the DB (process one statement at a time). */
+function applyMigrationFile(path_: string, tag: string): void {
+  const sqlite = new Database(path_);
+  const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, `${tag}.sql`), 'utf8');
+  for (const stmt of splitStatements(sql)) sqlite.run(stmt);
+  sqlite.close();
+}
+
+/** Read raw target rows back from the DB. */
+function readTargets(path_: string): Array<{
+  providerSlug: string | null;
+  modelName: string | null;
+  targetAliasSlug: string | null;
+  groupName: string | null;
+}> {
+  const sqlite = new Database(path_, { readonly: true });
+  const rows = sqlite
+    .query(
+      'SELECT provider_slug AS providerSlug, model_name AS modelName, target_alias_slug AS targetAliasSlug, group_name AS groupName FROM model_alias_targets ORDER BY id'
+    )
+    .all() as Array<{
+    providerSlug: string | null;
+    modelName: string | null;
+    targetAliasSlug: string | null;
+    groupName: string | null;
+  }>;
+  sqlite.close();
+  return rows;
+}
+
+describe('alias-as-fallback-target migration (0061) data integrity', () => {
+  it('preserves all 23 targets with provider/model intact and target_alias_slug NULL', () => {
+    applyMigrationFile(dbPath, '0061_add_alias_as_fallback_target');
+    const targets = readTargets(dbPath);
+
+    expect(targets).toHaveLength(TOTAL_TARGETS); // no rows lost
+    for (const t of targets) {
+      // Concrete targets must keep their provider and model verbatim.
+      expect(t.providerSlug).toBeTruthy();
+      expect(t.modelName).toBeTruthy();
+      // The migration must NOT have injected the literal column-name string.
+      expect(t.targetAliasSlug).toBeNull();
+    }
+  });
+
+  it('target_groups JSON and group_name survive (grouping intact)', () => {
+    applyMigrationFile(dbPath, '0061_add_alias_as_fallback_target');
+    const sqlite = new Database(dbPath, { readonly: true });
+    const groups = sqlite
+      .query("SELECT COUNT(*) AS c FROM model_alias_targets WHERE group_name = 'default'")
+      .get() as { c: number };
+    const aliasGroups = sqlite
+      .query('SELECT COUNT(*) AS c FROM model_aliases WHERE target_groups IS NOT NULL')
+      .get() as { c: number };
+    sqlite.close();
+    expect(groups.c).toBe(TOTAL_TARGETS);
+    expect(aliasGroups.c).toBe(ALIASES.length);
+  });
+});
+
+describe('repository round-trip after migration', () => {
+  it('loads every alias with concrete {provider, model} targets (not alias references)', async () => {
+    applyMigrationFile(dbPath, '0061_add_alias_as_fallback_target');
+    initializeDatabase(`sqlite://${dbPath}`);
+    const repo = new ConfigRepository();
+    const models = await repo.getAllAliases();
+
+    expect(Object.keys(models)).toHaveLength(ALIASES.length);
+    for (const alias of ALIASES) {
+      const cfg = models[alias.slug];
+      expect(cfg, `alias ${alias.slug} should load`).toBeDefined();
+      const groups = cfg!.target_groups ?? [];
+      expect(groups).toHaveLength(1);
+      const targets = groups[0]!.targets ?? [];
+      expect(targets).toHaveLength(alias.targets.length);
+
+      for (let i = 0; i < alias.targets.length; i++) {
+        const loaded = targets[i]!;
+        expect(loaded).not.toHaveProperty('alias');
+        expect(loaded.provider).toBe(alias.targets[i]!.provider);
+        expect(loaded.model).toBe(alias.targets[i]!.model);
+      }
+    }
+  });
+});
+
+describe('repair of already-corrupted databases', () => {
+  it('nulls the literal corrupt slug only on concrete targets, and is idempotent', async () => {
+    // Simulate the production corruption: every target got target_alias_slug = 'target_alias_slug'.
+    applyMigrationFile(dbPath, '0061_add_alias_as_fallback_target');
+    const sqlite = new Database(dbPath);
+    sqlite.prepare("UPDATE model_alias_targets SET target_alias_slug = 'target_alias_slug'").run();
+    sqlite.close();
+
+    initializeDatabase(`sqlite://${dbPath}`);
+    const repo = new ConfigRepository();
+
+    const first = await repo.repairCorruptedAliasFallbackSlugs();
+    expect(first).toBe(TOTAL_TARGETS);
+
+    // After repair, concrete targets are restored.
+    const models = await repo.getAllAliases();
+    for (const alias of ALIASES) {
+      const targets = models[alias.slug]!.target_groups![0]!.targets!;
+      for (const loaded of targets) {
+        expect(loaded).not.toHaveProperty('alias');
+        expect(loaded.provider).toBeTruthy();
+      }
+    }
+
+    // Second run repairs nothing.
+    const second = await repo.repairCorruptedAliasFallbackSlugs();
+    expect(second).toBe(0);
+  });
+
+  it('does not touch a legitimate fallback-alias reference', async () => {
+    // A genuine alias target (no provider/model) must never be nulled.
+    applyMigrationFile(dbPath, '0061_add_alias_as_fallback_target');
+    const sqlite = new Database(dbPath);
+    const aliasId = (sqlite.query('SELECT id FROM model_aliases LIMIT 1').get() as { id: number })
+      .id;
+    // Add a real fallback target that references another alias slug.
+    sqlite
+      .prepare(
+        "INSERT INTO model_alias_targets (alias_id, provider_slug, model_name, target_alias_slug, enabled, group_name, sort_order) VALUES (?, NULL, NULL, 'gpt-4o', 1, 'default', 99)"
+      )
+      .run(aliasId);
+    // Also plant the corrupt literal on a concrete row.
+    sqlite
+      .prepare(
+        "UPDATE model_alias_targets SET target_alias_slug = 'target_alias_slug' WHERE provider_slug IS NOT NULL LIMIT 1"
+      )
+      .run();
+    sqlite.close();
+
+    initializeDatabase(`sqlite://${dbPath}`);
+    const repo = new ConfigRepository();
+    await repo.repairCorruptedAliasFallbackSlugs();
+
+    const sqlite2 = new Database(dbPath, { readonly: true });
+    const fallback = sqlite2
+      .query("SELECT target_alias_slug FROM model_alias_targets WHERE target_alias_slug = 'gpt-4o'")
+      .all() as Array<{ target_alias_slug: string }>;
+    sqlite2.close();
+    expect(fallback).toHaveLength(1); // the real alias reference survived
+  });
+});
+
+describe('mixed concrete + alias targets round-trip (saveAlias -> getAlias)', () => {
+  it('persists and reloads a mix of concrete and fallback-alias targets', async () => {
+    applyMigrationFile(dbPath, '0061_add_alias_as_fallback_target');
+    initializeDatabase(`sqlite://${dbPath}`);
+    const repo = new ConfigRepository();
+
+    await repo.saveAlias('mixed', {
+      target_groups: [
+        {
+          name: 'primary',
+          selector: 'random',
+          targets: [{ provider: 'anthropic', model: 'claude-sonnet-4-5' }, { alias: 'gpt-4o' }],
+        },
+      ],
+    } as any);
+
+    const cfg = await repo.getAlias('mixed');
+    const targets = cfg!.target_groups![0]!.targets!;
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      enabled: true,
+    });
+    expect(targets[1]).toEqual({ alias: 'gpt-4o', enabled: true });
+
+    // And the raw rows encode it correctly — scoped to the 'mixed' alias only,
+    // since the seeded aliases contribute their own targets.
+    const sqlite = new Database(dbPath, { readonly: true });
+    const mixedId = (
+      sqlite.query("SELECT id FROM model_aliases WHERE slug = 'mixed'").get() as { id: number }
+    ).id;
+    const rows = sqlite
+      .query(
+        'SELECT provider_slug, model_name, target_alias_slug FROM model_alias_targets WHERE alias_id = ? ORDER BY sort_order'
+      )
+      .all(mixedId) as Array<{
+      provider_slug: string | null;
+      model_name: string | null;
+      target_alias_slug: string | null;
+    }>;
+    sqlite.close();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      provider_slug: 'anthropic',
+      model_name: 'claude-sonnet-4-5',
+      target_alias_slug: null,
+    });
+    expect(rows[1]).toMatchObject({
+      provider_slug: null,
+      model_name: null,
+      target_alias_slug: 'gpt-4o',
+    });
+  });
+});

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -848,6 +848,76 @@ export class ConfigRepository {
     return Number(affected);
   }
 
+  /**
+   * One-time startup repair for databases corrupted by the buggy
+   * `model_alias_targets` table-recreation migration (alias-as-fallback-target).
+   *
+   * Background: the generated SQLite migration added the `target_alias_slug`
+   * column in the same table-recreation step that dropped NOT NULL on
+   * `provider_slug`/`model_name`. drizzle-kit's `INSERT ... SELECT` referenced
+   * the new column name on the source table, where it did not exist. Under
+   * SQLite's double-quoted-string misfeature that identifier was silently
+   * treated as a **string literal**, so every pre-existing concrete target row
+   * ended up with `target_alias_slug = 'target_alias_slug'` instead of NULL.
+   * On load, `rowToModelConfig` then mistook each concrete target for an
+   * alias-reference, discarding its provider/model — breaking every alias.
+   *
+   * This nulls the corrupt literal value, but ONLY for rows that still carry a
+   * concrete provider+model (the signature of a corrupted concrete target, not
+   * a legitimate fallback-alias reference). It is idempotent: a second run finds
+   * nothing to fix.
+   *
+   * Returns the number of rows repaired.
+   */
+  async repairCorruptedAliasFallbackSlugs(): Promise<number> {
+    const schema = this.schema();
+    // Guard: only run when the column exists (it always does post-migration,
+    // but this keeps the repair a no-op on schemas that pre-date the feature).
+    const hasColumn = await this.hasColumn('model_alias_targets', 'target_alias_slug');
+    if (!hasColumn) return 0;
+
+    const result = await this.db()
+      .update(schema.modelAliasTargets)
+      .set({ targetAliasSlug: null })
+      .where(
+        sql`${schema.modelAliasTargets.targetAliasSlug} = 'target_alias_slug'
+          AND ${schema.modelAliasTargets.providerSlug} IS NOT NULL
+          AND ${schema.modelAliasTargets.modelName} IS NOT NULL`
+      );
+    const affected =
+      (result as any)?.rowsAffected ?? (result as any)?.changes ?? (result as any)?.rowCount ?? 0;
+    return Number(affected);
+  }
+
+  /**
+   * Best-effort check for whether a column exists on a table. Returns true if
+   * the column is present (or introspection is unavailable), so callers can
+   * degrade safely to "column exists" rather than failing startup.
+   */
+  private async hasColumn(table: string, column: string): Promise<boolean> {
+    const dialect = getCurrentDialect();
+    try {
+      if (dialect === 'sqlite') {
+        const rows = (await this.db().all(sql`PRAGMA table_info(${sql.raw(table)})`)) as Array<{
+          name?: string;
+        }>;
+        return rows.some((r) => r.name === column);
+      }
+      // Postgres was never affected (its migration used ALTER COLUMN), but keep
+      // the guard symmetric.
+      const rows = (await this.db().all(sql`
+        SELECT column_name AS name
+        FROM information_schema.columns
+        WHERE table_name = ${table} AND column_name = ${column}
+      `)) as Array<{ name?: string }>;
+      return rows.length > 0;
+    } catch {
+      // If introspection fails, assume the column exists so we don't block
+      // startup; the UPDATE simply matches nothing on affected rows.
+      return true;
+    }
+  }
+
   async saveAlias(slug: string, config: ModelConfig): Promise<void> {
     const schema = this.schema();
     const timestamp = now();

--- a/packages/backend/src/db/config-repository.ts
+++ b/packages/backend/src/db/config-repository.ts
@@ -917,8 +917,9 @@ export class ConfigRepository {
           for (const t of group.targets) {
             targetRows.push({
               aliasId,
-              providerSlug: t.provider,
-              modelName: t.model,
+              providerSlug: t.alias ? null : t.provider,
+              modelName: t.alias ? null : t.model,
+              targetAliasSlug: t.alias ?? null,
               enabled: fromBool(t.enabled !== false),
               groupName: group.name,
               sortOrder: sortIdx++,
@@ -988,11 +989,11 @@ export class ConfigRepository {
         const groupTargets = targetRows
           .filter((t: any) => t.groupName === def.name)
           .sort((a: any, b: any) => a.sortOrder - b.sortOrder)
-          .map((t: any) => ({
-            provider: t.providerSlug,
-            model: t.modelName,
-            enabled: toBool(t.enabled),
-          }));
+          .map((t: any) =>
+            t.targetAliasSlug
+              ? { alias: t.targetAliasSlug, enabled: toBool(t.enabled) }
+              : { provider: t.providerSlug, model: t.modelName, enabled: toBool(t.enabled) }
+          );
         targetGroups.push({
           name: def.name,
           selector: def.selector as import('../config').SelectorType,

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -206,6 +206,12 @@ try {
   // One-time migration: rewrite legacy model_type 'chat'/'responses' → 'text'.
   await configService.migrateModelTypes();
 
+  // One-time repair: null out model_alias_targets.target_alias_slug rows
+  // corrupted by the alias-as-fallback-target table-recreation migration
+  // (the literal column-name string was written under SQLite DQS). Idempotent;
+  // no-op on clean/corrected databases.
+  await configService.repairCorruptedAliasFallbackSlugs();
+
   // One-time cleanup: drop any persisted Gemini CLI / Antigravity OAuth
   // providers + credentials (those providers were removed).
   await configService.dropRetiredOAuthProviders();

--- a/packages/backend/src/routes/management/config.ts
+++ b/packages/backend/src/routes/management/config.ts
@@ -7,6 +7,7 @@ import {
   McpServerConfigSchema,
   CompactionConfigSchema,
   normalizeKeyConfig,
+  assertNoAliasRefCycles,
 } from '../../config';
 import { validateRawProviderSlug } from '../../services/dispatch/raw-passthrough';
 import { ConfigService } from '../../services/configuration/config-service';
@@ -294,6 +295,9 @@ export async function registerConfigRoutes(
       return reply.code(400).send({ error: 'Validation failed', details: result.error.issues });
     }
     try {
+      const currentModels = await configService.getRepository().getAllAliases();
+      assertNoAliasRefCycles({ ...currentModels, [slug]: result.data });
+
       await configService.saveAlias(slug, result.data);
 
       await recalculateEnergyIfChanged(
@@ -329,6 +333,9 @@ export async function registerConfigRoutes(
       if (!result.success) {
         return reply.code(400).send({ error: 'Validation failed', details: result.error.issues });
       }
+      const currentModels = await configService.getRepository().getAllAliases();
+      assertNoAliasRefCycles({ ...currentModels, [slug]: result.data });
+
       await configService.saveAlias(slug, result.data);
 
       await recalculateEnergyIfChanged(

--- a/packages/backend/src/services/__tests__/alias-as-fallback.test.ts
+++ b/packages/backend/src/services/__tests__/alias-as-fallback.test.ts
@@ -190,6 +190,89 @@ describe('Alias-as-fallback-target', () => {
     expect(result[0]?.model).toBe('model-2');
   });
 
+  test('alias-ref expansions are appended after selector-ordered concrete targets', async () => {
+    setConfigForTesting(
+      makeConfig({
+        A: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ alias: 'B' }, { provider: 'p2', model: 'model-2' }],
+            },
+          ],
+        },
+        B: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-1' }],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await Router.resolveCandidates('A');
+    expect(result).toHaveLength(2);
+    expect(result[0]?.provider).toBe('p2');
+    expect(result[1]?.provider).toBe('p1');
+  });
+
+  test('alias-ref declared after a concrete target stays as fallback', async () => {
+    setConfigForTesting(
+      makeConfig({
+        A: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p2', model: 'model-2' }, { alias: 'B' }],
+            },
+          ],
+        },
+        B: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-1' }],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await Router.resolveCandidates('A');
+    expect(result).toHaveLength(2);
+    expect(result[0]?.provider).toBe('p2');
+    expect(result[1]?.provider).toBe('p1');
+  });
+
+  test('direct/<alias>/<group> resolves a group containing only an alias-ref', async () => {
+    setConfigForTesting(
+      makeConfig({
+        A: {
+          target_groups: [{ name: 'primary', selector: 'in_order', targets: [{ alias: 'B' }] }],
+        },
+        B: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-1' }],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await Router.resolve('direct/A/primary');
+    expect(result.provider).toBe('p1');
+    expect(result.model).toBe('model-1');
+  });
+
   test('assertNoAliasRefCycles throws on A -> B -> A', () => {
     const models = {
       A: {

--- a/packages/backend/src/services/__tests__/alias-as-fallback.test.ts
+++ b/packages/backend/src/services/__tests__/alias-as-fallback.test.ts
@@ -289,4 +289,25 @@ describe('Alias-as-fallback-target', () => {
 
     expect(() => assertNoAliasRefCycles(models)).toThrow(/Alias reference cycle detected/);
   });
+
+  test('ignores disabled alias-ref edges when detecting cycles', () => {
+    const models = {
+      A: {
+        target_groups: [
+          {
+            name: 'primary',
+            selector: 'in_order' as const,
+            targets: [{ alias: 'B', enabled: false }],
+          },
+        ],
+      },
+      B: {
+        target_groups: [
+          { name: 'primary', selector: 'in_order' as const, targets: [{ alias: 'A' }] },
+        ],
+      },
+    } as any;
+
+    expect(() => assertNoAliasRefCycles(models)).not.toThrow();
+  });
 });

--- a/packages/backend/src/services/__tests__/alias-as-fallback.test.ts
+++ b/packages/backend/src/services/__tests__/alias-as-fallback.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { Router } from '../routing/router';
+import { CooldownManager } from '../runtime/cooldown-manager';
+import { setConfigForTesting, assertNoAliasRefCycles } from '../../config';
+
+const cooldownManager = CooldownManager.getInstance();
+
+function makeConfig(models: Record<string, any>) {
+  return {
+    providers: {
+      p1: {
+        type: 'openai',
+        api_base_url: 'https://p1.example.com/v1',
+        models: { 'model-1': {} },
+      },
+      p2: {
+        type: 'openai',
+        api_base_url: 'https://p2.example.com/v1',
+        models: { 'model-2': {} },
+      },
+      p3: {
+        type: 'openai',
+        api_base_url: 'https://p3.example.com/v1',
+        models: { 'model-3': {} },
+      },
+    },
+    models,
+    keys: {},
+  } as any;
+}
+
+describe('Alias-as-fallback-target', () => {
+  beforeEach(async () => {
+    await cooldownManager.clearCooldown();
+  });
+
+  afterEach(async () => {
+    await cooldownManager.clearCooldown();
+  });
+
+  test('alias-ref expands to referenced alias target', async () => {
+    setConfigForTesting(
+      makeConfig({
+        A: {
+          target_groups: [{ name: 'primary', selector: 'in_order', targets: [{ alias: 'B' }] }],
+        },
+        B: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-1' }],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await Router.resolveCandidates('A');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.provider).toBe('p1');
+    expect(result[0]?.model).toBe('model-1');
+  });
+
+  test('nested alias-refs (2+ levels) expand to the deepest concrete targets', async () => {
+    setConfigForTesting(
+      makeConfig({
+        A: {
+          target_groups: [{ name: 'primary', selector: 'in_order', targets: [{ alias: 'B' }] }],
+        },
+        B: {
+          target_groups: [{ name: 'primary', selector: 'in_order', targets: [{ alias: 'C' }] }],
+        },
+        C: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p3', model: 'model-3' }],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await Router.resolveCandidates('A');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.provider).toBe('p3');
+    expect(result[0]?.model).toBe('model-3');
+  });
+
+  test('referenced alias keeps its own target_groups/selectors when expanded', async () => {
+    setConfigForTesting(
+      makeConfig({
+        A: {
+          target_groups: [{ name: 'primary', selector: 'in_order', targets: [{ alias: 'B' }] }],
+        },
+        B: {
+          target_groups: [
+            {
+              name: 'b-primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-1' }],
+            },
+            {
+              name: 'b-fallback',
+              selector: 'in_order',
+              targets: [{ provider: 'p2', model: 'model-2' }],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await Router.resolveCandidates('A');
+    expect(result).toHaveLength(2);
+    expect(result[0]?.provider).toBe('p1');
+    expect(result[1]?.provider).toBe('p2');
+  });
+
+  test('two alias-refs resolving to the same (provider, model) dedupe to one candidate', async () => {
+    setConfigForTesting(
+      makeConfig({
+        A: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ alias: 'B' }, { alias: 'C' }],
+            },
+          ],
+        },
+        B: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-1' }],
+            },
+          ],
+        },
+        C: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-1' }],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await Router.resolveCandidates('A');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.provider).toBe('p1');
+    expect(result[0]?.model).toBe('model-1');
+  });
+
+  test('enabled:false on an alias-ref target skips it', async () => {
+    setConfigForTesting(
+      makeConfig({
+        A: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [
+                { alias: 'B', enabled: false },
+                { provider: 'p2', model: 'model-2' },
+              ],
+            },
+          ],
+        },
+        B: {
+          target_groups: [
+            {
+              name: 'primary',
+              selector: 'in_order',
+              targets: [{ provider: 'p1', model: 'model-1' }],
+            },
+          ],
+        },
+      })
+    );
+
+    const result = await Router.resolveCandidates('A');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.provider).toBe('p2');
+    expect(result[0]?.model).toBe('model-2');
+  });
+
+  test('assertNoAliasRefCycles throws on A -> B -> A', () => {
+    const models = {
+      A: {
+        target_groups: [
+          { name: 'primary', selector: 'in_order' as const, targets: [{ alias: 'B' }] },
+        ],
+      },
+      B: {
+        target_groups: [
+          { name: 'primary', selector: 'in_order' as const, targets: [{ alias: 'A' }] },
+        ],
+      },
+    } as any;
+
+    expect(() => assertNoAliasRefCycles(models)).toThrow(/Alias reference cycle detected/);
+  });
+});

--- a/packages/backend/src/services/configuration/config-service.ts
+++ b/packages/backend/src/services/configuration/config-service.ts
@@ -123,6 +123,28 @@ export class ConfigService {
   }
 
   /**
+   * One-time startup repair for databases corrupted by the buggy
+   * `model_alias_targets` table-recreation migration (alias-as-fallback-target).
+   *
+   * See `ConfigRepository.repairCorruptedAliasFallbackSlugs()` for the full
+   * background. Idempotent: a second run repairs nothing. On any repair the
+   * in-memory config cache is rebuilt so the running process stops serving the
+   * corrupted alias-target mappings immediately.
+   */
+  async repairCorruptedAliasFallbackSlugs(): Promise<number> {
+    const repaired = await this.repo.repairCorruptedAliasFallbackSlugs();
+    if (repaired > 0) {
+      logger.warn(
+        `Repaired ${repaired} model_alias_targets row(s) corrupted by the ` +
+          'alias-as-fallback-target migration (target_alias_slug was set to the ' +
+          'literal column name); provider/model targets restored.'
+      );
+      await this.executeRebuild();
+    }
+    return repaired;
+  }
+
+  /**
    * One-time startup cleanup: Gemini CLI / Antigravity OAuth were removed.
    * Any persisted provider that still references them is
    * dead, unroutable config. Drop those provider records (cascade) and delete

--- a/packages/backend/src/services/configuration/config-service.ts
+++ b/packages/backend/src/services/configuration/config-service.ts
@@ -1,5 +1,6 @@
 import { ConfigRepository, OAuthCredentialsData } from '../../db/config-repository';
 import { logger } from '../../utils/logger';
+import { assertNoAliasRefCycles } from '../../config';
 import type {
   PlexusConfig,
   ProviderConfig,
@@ -468,6 +469,7 @@ export class ConfigService {
   private async doRebuild(): Promise<void> {
     const providers = await this.repo.getAllProviders();
     const models = await this.repo.getAllAliases();
+    assertNoAliasRefCycles(models);
     const keys = await this.repo.getAllKeys();
     const userQuotas = await this.repo.getAllUserQuotas();
     const mcpServers = await this.repo.getAllMcpServers();

--- a/packages/backend/src/services/models/model-metadata-manager.ts
+++ b/packages/backend/src/services/models/model-metadata-manager.ts
@@ -1003,12 +1003,13 @@ export function resolveAutomaticModelIdentity(
 
   const targets = (modelConfig.target_groups ?? [])
     .flatMap((group) => group.targets)
-    .filter((target) => target.enabled !== false);
+    .filter((target) => target.enabled !== false && !target.alias);
   const identities = targets.map((target) => {
-    const provider = providers[target.provider];
-    const providerModel = getProviderModelConfig(provider, target.model);
-    const model = providerModel?.pi_ai_model_id ?? target.model;
-    const providerId = provider?.pi_ai_provider ?? inferProviderFromModel(model) ?? target.provider;
+    const provider = providers[target.provider!];
+    const providerModel = getProviderModelConfig(provider, target.model!);
+    const model = providerModel?.pi_ai_model_id ?? target.model!;
+    const providerId =
+      provider?.pi_ai_provider ?? inferProviderFromModel(model) ?? target.provider!;
     return { provider: normalizeCatalogProvider(providerId, model), model };
   });
 

--- a/packages/backend/src/services/routing/background-explorer.ts
+++ b/packages/backend/src/services/routing/background-explorer.ts
@@ -76,6 +76,7 @@ export class BackgroundExplorer {
 
     for (const target of group.targets) {
       if (target.enabled === false) continue;
+      if (target.alias || !target.provider || !target.model) continue;
       const providerCfg = providers[target.provider];
       if (!providerCfg || providerCfg.enabled === false) continue;
 
@@ -101,7 +102,7 @@ export class BackgroundExplorer {
           // Re-check staleness in case another trigger raced us.
           if (Date.now() - captured.lastProbedAt < thresholdMs) return;
 
-          this.queue.push({ provider: target.provider, model: target.model });
+          this.queue.push({ provider: target.provider!, model: target.model! });
           this.pumpWorkers();
         })
         .catch((err) => {

--- a/packages/backend/src/services/routing/router.ts
+++ b/packages/backend/src/services/routing/router.ts
@@ -372,26 +372,39 @@ async function buildGroupCandidates(
   // Concrete targets keep the selector-decided order (`results`, which may
   // be a strict subset of `concreteTargets` after health/concurrency/API
   // filtering — the selector never reorders across a filtered-out target,
-  // so positional remapping into group.targets is unsafe). Alias-ref
-  // expansions are appended afterward, in their declared relative order,
-  // as additional fallback candidates.
-  const merged: RouteResult[] = [...results];
+  // so positional remapping into group.targets is unsafe). Build a lookup
+  // of the ordered concrete results, then walk group.targets in their
+  // declared order so alias-ref expansions land in their author-declared
+  // position relative to concrete targets, instead of always trailing.
+  const resultsByKey = new Map<string, RouteResult>();
+  for (const result of results) {
+    resultsByKey.set(`${result.provider}\u0000${result.model}`, result);
+  }
+
+  const merged: RouteResult[] = [];
   for (const target of group.targets) {
-    if (!target.alias) continue;
-    if (target.enabled === false) continue;
-    if (visited.has(target.alias)) {
-      logger.warn(
-        `Router: alias-ref cycle detected while expanding '${target.alias}'; skipping to avoid infinite recursion.`
+    if (target.alias) {
+      if (target.enabled === false) continue;
+      if (visited.has(target.alias)) {
+        logger.warn(
+          `Router: alias-ref cycle detected while expanding '${target.alias}'; skipping to avoid infinite recursion.`
+        );
+        continue;
+      }
+      const nested = await Router.resolveCandidates(
+        target.alias,
+        incomingApiType,
+        sessionKey,
+        visited
       );
+      merged.push(...nested);
       continue;
     }
-    const nested = await Router.resolveCandidates(
-      target.alias,
-      incomingApiType,
-      sessionKey,
-      visited
-    );
-    merged.push(...nested);
+
+    const result = resultsByKey.get(`${target.provider}\u0000${target.model}`);
+    if (result) {
+      merged.push(result);
+    }
   }
 
   BackgroundExplorer.getInstance()?.maybeTrigger(group);
@@ -513,53 +526,30 @@ export class Router {
         if (alias?.target_groups) {
           const group = alias.target_groups.find((g) => g.name === groupName);
           if (group) {
-            const enriched = await filterGroupTargets(
-              group.targets.filter((t) => !t.alias),
+            const candidates = await buildGroupCandidates(
+              group,
               config,
               alias,
               incomingApiType,
-              modelName
+              modelName,
+              canonicalModel,
+              null,
+              withVisited(new Set(), canonicalModel)
             );
 
-            if (enriched.length === 0) {
-              throw new Error(
-                `No healthy targets in group '${groupName}' for alias '${aliasName}'`
-              );
-            }
-
-            const selector = SelectorFactory.getSelector(group.selector);
-            const target = await selector.select(enriched);
+            const [target] = dedupeCandidates(candidates);
 
             if (!target) {
               throw new Error(
-                `No target selected in group '${groupName}' for alias '${aliasName}'`
+                `No healthy targets in group '${groupName}' for alias '${aliasName}'`
               );
-            }
-
-            BackgroundExplorer.getInstance()?.maybeTrigger(group);
-
-            const providerConfig = config.providers[target.provider!];
-            if (!providerConfig) {
-              throw new Error(`Provider '${target.provider}' not found`);
-            }
-
-            let modelConfig = undefined;
-            if (!Array.isArray(providerConfig.models) && providerConfig.models) {
-              modelConfig = providerConfig.models[target.model!];
             }
 
             logger.info(
               `Router: Direct group routing to '${target.provider}/${target.model}' from group '${groupName}' of alias '${aliasName}'`
             );
 
-            return {
-              provider: target.provider!,
-              model: target.model!,
-              config: providerConfig,
-              modelConfig,
-              incomingModelAlias: modelName,
-              canonicalModel,
-            };
+            return target;
           }
 
           const error = new Error(
@@ -579,29 +569,25 @@ export class Router {
     const { alias, canonicalModel } = findAlias(config, modelName);
 
     if (alias && alias.target_groups && alias.target_groups.length > 0) {
+      const visited = withVisited(new Set(), canonicalModel);
       for (const group of alias.target_groups) {
-        const enriched = await filterGroupTargets(
-          group.targets.filter((t) => !t.alias),
+        const candidates = await buildGroupCandidates(
+          group,
           config,
           alias,
-          incomingApiType
+          incomingApiType,
+          modelName,
+          canonicalModel,
+          null,
+          visited
         );
 
-        if (enriched.length === 0) continue;
-
-        const selector = SelectorFactory.getSelector(group.selector);
-        const target = await selector.select(enriched);
-
-        if (!target) continue;
+        if (candidates.length === 0) continue;
 
         BackgroundExplorer.getInstance()?.maybeTrigger(group);
 
-        const providerConfig = config.providers[target.provider!];
-        if (!providerConfig) {
-          throw new Error(
-            `Provider '${target.provider}' configured for alias '${modelName}' not found`
-          );
-        }
+        const deduped = dedupeCandidates(candidates);
+        const target = deduped[0]!;
 
         logger.info(
           `Router: Selected '${target.provider}/${target.model}' using strategy '${group.selector}'.`
@@ -610,19 +596,7 @@ export class Router {
           `Router resolving ${modelName} (canonical: ${canonicalModel}). Target provider: ${target.provider}, Target model: ${target.model}`
         );
 
-        let modelConfig = undefined;
-        if (!Array.isArray(providerConfig.models) && providerConfig.models) {
-          modelConfig = providerConfig.models[target.model!];
-        }
-
-        return {
-          provider: target.provider!,
-          model: target.model!,
-          config: providerConfig,
-          modelConfig,
-          incomingModelAlias: modelName,
-          canonicalModel,
-        };
+        return target;
       }
 
       throw new Error(`No healthy target selected for alias '${modelName}'`);

--- a/packages/backend/src/services/routing/router.ts
+++ b/packages/backend/src/services/routing/router.ts
@@ -64,11 +64,14 @@ async function filterGroupTargets(
   if (groupTargets.length === 0) return [];
 
   // 1. Filter out disabled targets and disabled providers
-  const enabledTargets = groupTargets.filter((target) => {
-    if (target.enabled === false) return false;
-    const providerConfig = config.providers[target.provider];
-    return providerConfig && providerConfig.enabled !== false;
-  });
+  const enabledTargets = groupTargets.filter(
+    (target): target is ModelTarget & { provider: string; model: string } => {
+      if (target.enabled === false) return false;
+      if (!target.provider || !target.model) return false;
+      const providerConfig = config.providers[target.provider];
+      return !!providerConfig && providerConfig.enabled !== false;
+    }
+  );
 
   if (enabledTargets.length === 0) return [];
 
@@ -195,9 +198,9 @@ async function filterGroupTargets(
   }
 
   const findApiCompatibleTargets = (
-    targets: ModelTarget[],
+    targets: (ModelTarget & { provider: string; model: string })[],
     requestedApiType: string
-  ): ModelTarget[] => {
+  ): (ModelTarget & { provider: string; model: string })[] => {
     const normalizedIncoming = requestedApiType.toLowerCase();
     return targets.filter((target) => {
       const providerConfig = config.providers[target.provider];
@@ -310,11 +313,98 @@ async function selectOrderedTargets(
   return ordered;
 }
 
+function withVisited(visited: Set<string>, slug: string): Set<string> {
+  const next = new Set(visited);
+  next.add(slug);
+  return next;
+}
+
+function dedupeCandidates(candidates: RouteResult[]): RouteResult[] {
+  const seen = new Set<string>();
+  const result: RouteResult[] = [];
+  for (const candidate of candidates) {
+    const key = `${candidate.provider}\u0000${candidate.model}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(candidate);
+  }
+  return result;
+}
+
+async function buildGroupCandidates(
+  group: ModelTargetGroup,
+  config: ReturnType<typeof getConfig>,
+  alias: ModelConfig,
+  incomingApiType: string | undefined,
+  logModelName: string | undefined,
+  canonicalModel: string,
+  sessionKey: string | null | undefined,
+  visited: Set<string>
+): Promise<RouteResult[]> {
+  const concreteTargets = group.targets.filter((t) => !t.alias);
+
+  const enriched = await filterGroupTargets(
+    concreteTargets,
+    config,
+    alias,
+    incomingApiType,
+    logModelName
+  );
+  const ordered = await selectOrderedTargets(group.selector, enriched);
+
+  const results: RouteResult[] = ordered.map((target) => {
+    const providerConfig = config.providers[target.provider!];
+    let modelConfig = undefined;
+    if (providerConfig && !Array.isArray(providerConfig.models) && providerConfig.models) {
+      modelConfig = providerConfig.models[target.model!];
+    }
+    return {
+      provider: target.provider!,
+      model: target.model!,
+      config: providerConfig!,
+      modelConfig,
+      modelArchitecture: config.models?.[canonicalModel]?.model_architecture,
+      incomingModelAlias: logModelName,
+      canonicalModel,
+    };
+  });
+
+  // Concrete targets keep the selector-decided order (`results`, which may
+  // be a strict subset of `concreteTargets` after health/concurrency/API
+  // filtering — the selector never reorders across a filtered-out target,
+  // so positional remapping into group.targets is unsafe). Alias-ref
+  // expansions are appended afterward, in their declared relative order,
+  // as additional fallback candidates.
+  const merged: RouteResult[] = [...results];
+  for (const target of group.targets) {
+    if (!target.alias) continue;
+    if (target.enabled === false) continue;
+    if (visited.has(target.alias)) {
+      logger.warn(
+        `Router: alias-ref cycle detected while expanding '${target.alias}'; skipping to avoid infinite recursion.`
+      );
+      continue;
+    }
+    const nested = await Router.resolveCandidates(
+      target.alias,
+      incomingApiType,
+      sessionKey,
+      visited
+    );
+    merged.push(...nested);
+  }
+
+  BackgroundExplorer.getInstance()?.maybeTrigger(group);
+
+  return merged;
+}
+
 export class Router {
   static async resolveCandidates(
     modelName: string,
     incomingApiType?: string,
-    sessionKey?: string | null
+    sessionKey?: string | null,
+    visited: Set<string> = new Set()
   ): Promise<RouteResult[]> {
     const config = getConfig();
 
@@ -327,41 +417,17 @@ export class Router {
       if (alias?.target_groups) {
         const group = alias.target_groups.find((g) => g.name === groupName);
         if (group) {
-          const enriched = await filterGroupTargets(
-            group.targets,
+          const results = await buildGroupCandidates(
+            group,
             config,
             alias,
             incomingApiType,
-            modelName
+            modelName,
+            canonicalModel,
+            sessionKey,
+            withVisited(visited, canonicalModel)
           );
-
-          if (enriched.length === 0) return [];
-
-          const ordered = await selectOrderedTargets(group.selector, enriched);
-
-          BackgroundExplorer.getInstance()?.maybeTrigger(group);
-
-          const results: RouteResult[] = [];
-          for (const target of ordered) {
-            const providerConfig = config.providers[target.provider];
-            if (!providerConfig) continue;
-
-            let modelConfig = undefined;
-            if (!Array.isArray(providerConfig.models) && providerConfig.models) {
-              modelConfig = providerConfig.models[target.model];
-            }
-
-            results.push({
-              provider: target.provider,
-              model: target.model,
-              config: providerConfig,
-              modelConfig,
-              modelArchitecture: config.models?.[canonicalModel]?.model_architecture,
-              incomingModelAlias: modelName,
-              canonicalModel,
-            });
-          }
-          return results;
+          return dedupeCandidates(results);
         }
         // Alias exists but group doesn't → fall through to resolve() which throws 404
         return [];
@@ -375,7 +441,15 @@ export class Router {
       return [];
     }
 
-    const orderedCandidates: RouteResult[] = [];
+    if (visited.has(canonicalModel)) {
+      logger.warn(
+        `Router: alias-ref cycle detected while expanding '${canonicalModel}'; skipping to avoid infinite recursion.`
+      );
+      return [];
+    }
+    const nextVisited = withVisited(visited, canonicalModel);
+
+    let orderedCandidates: RouteResult[] = [];
 
     // Sticky session: if enabled and we have a session key, look up the
     // provider:model used last turn. We don't return early — we still build
@@ -391,40 +465,20 @@ export class Router {
     }
 
     for (const group of alias.target_groups) {
-      const enriched = await filterGroupTargets(
-        group.targets,
+      const results = await buildGroupCandidates(
+        group,
         config,
         alias,
         incomingApiType,
-        modelName
+        modelName,
+        canonicalModel,
+        sessionKey,
+        nextVisited
       );
-
-      if (enriched.length === 0) continue;
-
-      const ordered = await selectOrderedTargets(group.selector, enriched);
-
-      BackgroundExplorer.getInstance()?.maybeTrigger(group);
-
-      for (const target of ordered) {
-        const providerConfig = config.providers[target.provider];
-        if (!providerConfig) continue;
-
-        let modelConfig = undefined;
-        if (!Array.isArray(providerConfig.models) && providerConfig.models) {
-          modelConfig = providerConfig.models[target.model];
-        }
-
-        orderedCandidates.push({
-          provider: target.provider,
-          model: target.model,
-          config: providerConfig,
-          modelConfig,
-          modelArchitecture: config.models?.[modelName]?.model_architecture,
-          incomingModelAlias: modelName,
-          canonicalModel,
-        });
-      }
+      orderedCandidates.push(...results);
     }
+
+    orderedCandidates = dedupeCandidates(orderedCandidates);
 
     if (stickyPick) {
       const idx = orderedCandidates.findIndex(
@@ -460,7 +514,7 @@ export class Router {
           const group = alias.target_groups.find((g) => g.name === groupName);
           if (group) {
             const enriched = await filterGroupTargets(
-              group.targets,
+              group.targets.filter((t) => !t.alias),
               config,
               alias,
               incomingApiType,
@@ -484,14 +538,14 @@ export class Router {
 
             BackgroundExplorer.getInstance()?.maybeTrigger(group);
 
-            const providerConfig = config.providers[target.provider];
+            const providerConfig = config.providers[target.provider!];
             if (!providerConfig) {
               throw new Error(`Provider '${target.provider}' not found`);
             }
 
             let modelConfig = undefined;
             if (!Array.isArray(providerConfig.models) && providerConfig.models) {
-              modelConfig = providerConfig.models[target.model];
+              modelConfig = providerConfig.models[target.model!];
             }
 
             logger.info(
@@ -499,8 +553,8 @@ export class Router {
             );
 
             return {
-              provider: target.provider,
-              model: target.model,
+              provider: target.provider!,
+              model: target.model!,
               config: providerConfig,
               modelConfig,
               incomingModelAlias: modelName,
@@ -526,7 +580,12 @@ export class Router {
 
     if (alias && alias.target_groups && alias.target_groups.length > 0) {
       for (const group of alias.target_groups) {
-        const enriched = await filterGroupTargets(group.targets, config, alias, incomingApiType);
+        const enriched = await filterGroupTargets(
+          group.targets.filter((t) => !t.alias),
+          config,
+          alias,
+          incomingApiType
+        );
 
         if (enriched.length === 0) continue;
 
@@ -537,7 +596,7 @@ export class Router {
 
         BackgroundExplorer.getInstance()?.maybeTrigger(group);
 
-        const providerConfig = config.providers[target.provider];
+        const providerConfig = config.providers[target.provider!];
         if (!providerConfig) {
           throw new Error(
             `Provider '${target.provider}' configured for alias '${modelName}' not found`
@@ -553,12 +612,12 @@ export class Router {
 
         let modelConfig = undefined;
         if (!Array.isArray(providerConfig.models) && providerConfig.models) {
-          modelConfig = providerConfig.models[target.model];
+          modelConfig = providerConfig.models[target.model!];
         }
 
         return {
-          provider: target.provider,
-          model: target.model,
+          provider: target.provider!,
+          model: target.model!,
           config: providerConfig,
           modelConfig,
           incomingModelAlias: modelName,

--- a/packages/backend/src/services/routing/router.ts
+++ b/packages/backend/src/services/routing/router.ts
@@ -398,7 +398,8 @@ async function buildGroupCandidates(
     for (const candidate of nested) {
       merged.push({
         ...candidate,
-        modelArchitecture: config.models?.[canonicalModel]?.model_architecture,
+        modelArchitecture:
+          config.models?.[canonicalModel]?.model_architecture ?? candidate.modelArchitecture,
         canonicalModel,
         incomingModelAlias: logModelName,
       });

--- a/packages/backend/src/services/routing/router.ts
+++ b/packages/backend/src/services/routing/router.ts
@@ -369,41 +369,38 @@ async function buildGroupCandidates(
     };
   });
 
-  // Concrete targets keep the selector-decided order (`results`, which may
-  // be a strict subset of `concreteTargets` after health/concurrency/API
-  // filtering — the selector never reorders across a filtered-out target,
-  // so positional remapping into group.targets is unsafe). Build a lookup
-  // of the ordered concrete results, then walk group.targets in their
-  // declared order so alias-ref expansions land in their author-declared
-  // position relative to concrete targets, instead of always trailing.
-  const resultsByKey = new Map<string, RouteResult>();
-  for (const result of results) {
-    resultsByKey.set(`${result.provider}\u0000${result.model}`, result);
-  }
+  // Selector order is authoritative for concrete targets. Alias-ref
+  // expansions are appended after the selector-ordered concrete candidates,
+  // in their declared relative order. This preserves selector behaviour
+  // (cost/random/latency/performance/usage) while making alias-refs act
+  // as fallback chains.
+  const merged: RouteResult[] = [...results];
 
-  const merged: RouteResult[] = [];
   for (const target of group.targets) {
-    if (target.alias) {
-      if (target.enabled === false) continue;
-      if (visited.has(target.alias)) {
-        logger.warn(
-          `Router: alias-ref cycle detected while expanding '${target.alias}'; skipping to avoid infinite recursion.`
-        );
-        continue;
-      }
-      const nested = await Router.resolveCandidates(
-        target.alias,
-        incomingApiType,
-        sessionKey,
-        visited
+    if (!target.alias) continue;
+    if (target.enabled === false) continue;
+    if (visited.has(target.alias)) {
+      logger.warn(
+        `Router: alias-ref cycle detected while expanding '${target.alias}'; skipping to avoid infinite recursion.`
       );
-      merged.push(...nested);
       continue;
     }
-
-    const result = resultsByKey.get(`${target.provider}\u0000${target.model}`);
-    if (result) {
-      merged.push(result);
+    const nested = await Router.resolveCandidates(
+      target.alias,
+      incomingApiType,
+      sessionKey,
+      visited
+    );
+    // Rewrite metadata to the outer alias so downstream logic (extraBody,
+    // advanced behaviors, context limits, vision fallthrough, compaction,
+    // sticky sessions) treats the request as the outer alias, not the
+    // referenced one.
+    for (const candidate of nested) {
+      merged.push({
+        ...candidate,
+        canonicalModel,
+        incomingModelAlias: logModelName,
+      });
     }
   }
 

--- a/packages/backend/src/services/routing/router.ts
+++ b/packages/backend/src/services/routing/router.ts
@@ -398,6 +398,7 @@ async function buildGroupCandidates(
     for (const candidate of nested) {
       merged.push({
         ...candidate,
+        modelArchitecture: config.models?.[canonicalModel]?.model_architecture,
         canonicalModel,
         incomingModelAlias: logModelName,
       });

--- a/packages/backend/src/services/routing/selectors/__tests__/e2e-performance.test.ts
+++ b/packages/backend/src/services/routing/selectors/__tests__/e2e-performance.test.ts
@@ -145,7 +145,7 @@ describe('E2EPerformanceSelector', () => {
       const seen = new Set<string>();
       for (let i = 0; i < 30; i++) {
         const selected = await selector.select(targets);
-        seen.add(selected!.provider);
+        seen.add(selected!.provider!);
       }
       // All three providers should appear in the exploration pool
       expect(seen.has('p1')).toBe(true);

--- a/packages/frontend/src/components/models/AliasMobileCard.tsx
+++ b/packages/frontend/src/components/models/AliasMobileCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Trash2, Loader2, CheckCircle, AlertTriangle, Play } from 'lucide-react';
+import { Trash2, Loader2, CheckCircle, AlertTriangle, Play, Link2 } from 'lucide-react';
 import { CopyButton } from '../ui/CopyButton';
 import { Badge } from '../ui/Badge';
 import { Button } from '../ui/Button';
@@ -146,6 +146,36 @@ export const AliasMobileCard: React.FC<Props> = ({
           ) : (
             <div className="space-y-2">
               {firstTargetGroup.targets.map((t, i) => {
+                if (t.alias) {
+                  const isTargetDisabled = t.enabled === false;
+                  return (
+                    <div
+                      key={`alias-${t.alias}-${i}`}
+                      className={`rounded border border-border-glass bg-bg-glass px-2 py-2 ${
+                        isTargetDisabled ? 'opacity-70' : ''
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 flex-1">
+                          <div
+                            className={`flex items-center gap-1 truncate text-xs font-medium ${
+                              isTargetDisabled ? 'text-danger line-through' : 'text-text-secondary'
+                            }`}
+                          >
+                            <Link2 size={12} className="text-primary opacity-70" />
+                            alias: {t.alias}
+                          </div>
+                        </div>
+                        <Switch
+                          checked={t.enabled !== false}
+                          onChange={(val) => onToggleTarget(alias, 0, i, val)}
+                          size="sm"
+                        />
+                      </div>
+                    </div>
+                  );
+                }
+
                 const provider = providers.find((p) => p.id === t.provider);
                 const isProviderDisabled = provider?.enabled === false;
                 const isTargetDisabled = t.enabled === false;
@@ -198,7 +228,7 @@ export const AliasMobileCard: React.FC<Props> = ({
                         <button
                           type="button"
                           onClick={() => {
-                            if (isDisabled) return;
+                            if (isDisabled || !t.provider || !t.model) return;
                             let testApiTypes: string[] = ['chat'];
                             if (alias.type === 'embeddings') testApiTypes = ['embeddings'];
                             else if (alias.type === 'image') testApiTypes = ['images'];

--- a/packages/frontend/src/components/models/AliasTableRow.tsx
+++ b/packages/frontend/src/components/models/AliasTableRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Edit2, Trash2, Clock, Play, Loader2, CheckCircle, XCircle } from 'lucide-react';
+import { Edit2, Trash2, Clock, Play, Loader2, CheckCircle, XCircle, Link2 } from 'lucide-react';
 import { CopyButton } from '../ui/CopyButton';
 import { Badge } from '../ui/Badge';
 import { Switch } from '../ui/Switch';
@@ -149,6 +149,30 @@ export const AliasTableRow: React.FC<AliasTableRowProps> = ({
               </div>
               <div className="flex flex-col gap-0.5">
                 {group.targets.map((t, targetIdx) => {
+                  if (t.alias) {
+                    const isTargetDisabled = t.enabled === false;
+                    return (
+                      <div
+                        key={`alias-${t.alias}-${targetIdx}`}
+                        className={`flex items-center gap-1.5 text-[11px] transition-opacity ${
+                          isTargetDisabled
+                            ? 'opacity-70 line-through text-danger'
+                            : 'text-text-secondary'
+                        }`}
+                      >
+                        <Link2 size={12} className="text-primary opacity-70" />
+                        <Switch
+                          checked={t.enabled !== false}
+                          onChange={(val) => onToggleTarget(alias, groupIdx, targetIdx, val)}
+                          size="sm"
+                        />
+                        <div className="flex-1 truncate" title={`alias: ${t.alias}`}>
+                          alias: {t.alias}
+                        </div>
+                      </div>
+                    );
+                  }
+
                   const provider = providers.find((p) => p.id === t.provider);
                   const isProviderDisabled = provider?.enabled === false;
                   const isTargetDisabled = t.enabled === false;
@@ -186,7 +210,7 @@ export const AliasTableRow: React.FC<AliasTableRowProps> = ({
                         <div
                           onClick={(e) => {
                             e.stopPropagation();
-                            if (!isDisabled) {
+                            if (!isDisabled && t.provider && t.model) {
                               let testApiTypes: string[] = ['chat'];
                               if (alias.type === 'embeddings') testApiTypes = ['embeddings'];
                               else if (alias.type === 'image') testApiTypes = ['images'];
@@ -219,7 +243,7 @@ export const AliasTableRow: React.FC<AliasTableRowProps> = ({
                         />
                         <div className="flex-1 truncate" title={`${t.provider} → ${t.model}`}>
                           {t.provider} →{' '}
-                          {t.model.includes('/')
+                          {t.model?.includes('/')
                             ? `…/${t.model.split('/').slice(1).join('/')}`
                             : t.model}
                         </div>

--- a/packages/frontend/src/components/models/ModelMetadataEditor.tsx
+++ b/packages/frontend/src/components/models/ModelMetadataEditor.tsx
@@ -145,7 +145,7 @@ export function ModelMetadataEditor({ editingAlias, setEditingAlias, isModalOpen
       editingAlias.id.trim().length > 0 ||
       !!editingAlias.pi_model?.model_id ||
       editingAlias.target_groups.some((group) =>
-        group.targets.some((target) => target.enabled !== false && target.model.trim().length > 0)
+        group.targets.some((target) => target.enabled !== false && !!target.model?.trim().length)
       );
     if (!isOpen || metadataSource !== 'auto' || !hasInput) {
       setAutomaticResolution(null);

--- a/packages/frontend/src/components/models/TargetGroupEditor.tsx
+++ b/packages/frontend/src/components/models/TargetGroupEditor.tsx
@@ -9,6 +9,7 @@ interface TargetGroupEditorProps {
   groups: AliasTargetGroup[];
   providers: Array<{ id: string; name: string }>;
   availableModels: Array<{ id: string; providerId: string; name: string }>;
+  availableAliases: string[];
   onChange: (groups: AliasTargetGroup[]) => void;
 }
 
@@ -18,6 +19,7 @@ export const TargetGroupEditor: React.FC<TargetGroupEditorProps> = ({
   groups,
   providers,
   availableModels,
+  availableAliases,
   onChange,
 }) => {
   const [dragState, setDragState] = useState<{
@@ -96,6 +98,29 @@ export const TargetGroupEditor: React.FC<TargetGroupEditorProps> = ({
       } else {
         targets[targetIdx] = { ...targets[targetIdx], enabled: value as boolean };
       }
+      next[groupIdx] = { ...next[groupIdx], targets };
+      return next;
+    });
+  };
+
+  const setTargetAlias = (groupIdx: number, targetIdx: number, alias: string) => {
+    setGroups((prev) => {
+      const next = [...prev];
+      const targets = [...next[groupIdx].targets];
+      targets[targetIdx] = { alias, enabled: true };
+      next[groupIdx] = { ...next[groupIdx], targets };
+      return next;
+    });
+  };
+
+  const setTargetType = (groupIdx: number, targetIdx: number, type: 'model' | 'alias') => {
+    setGroups((prev) => {
+      const next = [...prev];
+      const targets = [...next[groupIdx].targets];
+      targets[targetIdx] =
+        type === 'alias'
+          ? { alias: availableAliases[0] ?? '', enabled: true }
+          : { provider: '', model: '', enabled: true };
       next[groupIdx] = { ...next[groupIdx], targets };
       return next;
     });
@@ -290,20 +315,25 @@ export const TargetGroupEditor: React.FC<TargetGroupEditorProps> = ({
                   dragOver?.mode === 'target' &&
                   dragOver.groupIdx === groupIdx &&
                   dragOver.targetIdx === targetIdx;
-                const modelOptions = dedupeModels(
-                  availableModels.filter((model) => model.providerId === target.provider)
-                ).filter(
-                  (model) =>
-                    model.id === target.model ||
-                    !groups.some((candidateGroup, candidateGroupIdx) =>
-                      candidateGroup.targets.some(
-                        (candidateTarget, candidateTargetIdx) =>
-                          (candidateGroupIdx !== groupIdx || candidateTargetIdx !== targetIdx) &&
-                          getModelOptionKey(candidateTarget.provider, candidateTarget.model) ===
-                            getModelOptionKey(model.providerId, model.id)
-                      )
-                    )
-                );
+                const isAliasTarget = !!target.alias;
+                const modelOptions = isAliasTarget
+                  ? []
+                  : dedupeModels(
+                      availableModels.filter((model) => model.providerId === target.provider)
+                    ).filter(
+                      (model) =>
+                        model.id === target.model ||
+                        !groups.some((candidateGroup, candidateGroupIdx) =>
+                          candidateGroup.targets.some(
+                            (candidateTarget, candidateTargetIdx) =>
+                              (candidateGroupIdx !== groupIdx ||
+                                candidateTargetIdx !== targetIdx) &&
+                              !candidateTarget.alias &&
+                              getModelOptionKey(candidateTarget.provider, candidateTarget.model) ===
+                                getModelOptionKey(model.providerId, model.id)
+                          )
+                        )
+                    );
 
                 return (
                   <div
@@ -360,37 +390,68 @@ export const TargetGroupEditor: React.FC<TargetGroupEditorProps> = ({
                       </button>
                     </div>
                     <select
-                      className="flex-1 min-w-0 font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                      className="font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
                       style={{ padding: '3px 6px', height: '26px' }}
-                      value={target.provider}
+                      value={isAliasTarget ? 'alias' : 'model'}
                       onChange={(e) =>
-                        updateTarget(groupIdx, targetIdx, 'provider', e.target.value)
+                        setTargetType(groupIdx, targetIdx, e.target.value as 'model' | 'alias')
                       }
                     >
-                      <option value="">Provider...</option>
-                      {providers.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
+                      <option value="model">Model</option>
+                      <option value="alias">Alias</option>
                     </select>
-                    <select
-                      className="flex-[2] min-w-0 font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
-                      style={{ padding: '3px 6px', height: '26px' }}
-                      value={target.model}
-                      onChange={(e) => updateTarget(groupIdx, targetIdx, 'model', e.target.value)}
-                      disabled={!target.provider}
-                    >
-                      <option value="">Model...</option>
-                      {modelOptions.map((model) => (
-                        <option
-                          key={getModelOptionKey(model.providerId, model.id)}
-                          value={model.id}
+                    {isAliasTarget ? (
+                      <select
+                        className="flex-1 min-w-0 font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                        style={{ padding: '3px 6px', height: '26px' }}
+                        value={target.alias ?? ''}
+                        onChange={(e) => setTargetAlias(groupIdx, targetIdx, e.target.value)}
+                      >
+                        <option value="">Alias...</option>
+                        {availableAliases.map((aliasSlug) => (
+                          <option key={aliasSlug} value={aliasSlug}>
+                            {aliasSlug}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <>
+                        <select
+                          className="flex-1 min-w-0 font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                          style={{ padding: '3px 6px', height: '26px' }}
+                          value={target.provider ?? ''}
+                          onChange={(e) =>
+                            updateTarget(groupIdx, targetIdx, 'provider', e.target.value)
+                          }
                         >
-                          {model.name}
-                        </option>
-                      ))}
-                    </select>
+                          <option value="">Provider...</option>
+                          {providers.map((p) => (
+                            <option key={p.id} value={p.id}>
+                              {p.name}
+                            </option>
+                          ))}
+                        </select>
+                        <select
+                          className="flex-[2] min-w-0 font-body text-xs text-text bg-bg-glass border border-border-glass rounded-sm outline-none focus:border-primary"
+                          style={{ padding: '3px 6px', height: '26px' }}
+                          value={target.model ?? ''}
+                          onChange={(e) =>
+                            updateTarget(groupIdx, targetIdx, 'model', e.target.value)
+                          }
+                          disabled={!target.provider}
+                        >
+                          <option value="">Model...</option>
+                          {modelOptions.map((model) => (
+                            <option
+                              key={getModelOptionKey(model.providerId, model.id)}
+                              value={model.id}
+                            >
+                              {model.name}
+                            </option>
+                          ))}
+                        </select>
+                      </>
+                    )}
                     <Switch
                       checked={target.enabled !== false}
                       onChange={(val) => updateTarget(groupIdx, targetIdx, 'enabled', val)}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -491,7 +491,13 @@ export type AliasMetadata =
 export interface AliasTargetGroup {
   name: string;
   selector: string;
-  targets: Array<{ provider: string; model: string; apiType?: string[]; enabled?: boolean }>;
+  targets: Array<{
+    provider?: string;
+    model?: string;
+    alias?: string;
+    apiType?: string[];
+    enabled?: boolean;
+  }>;
 }
 
 export type PreferredApiValue = 'chat_completions' | 'messages' | 'gemini' | 'responses';
@@ -1205,11 +1211,18 @@ function aliasToConfigPayload(alias: Alias): Record<string, unknown> {
     target_groups: targetGroups.map((group) => ({
       name: group.name,
       selector: group.selector,
-      targets: group.targets.map((target) => ({
-        provider: target.provider,
-        model: target.model,
-        ...(target.enabled === false && { enabled: false }),
-      })),
+      targets: group.targets.map((target) =>
+        target.alias
+          ? {
+              alias: target.alias,
+              ...(target.enabled === false && { enabled: false }),
+            }
+          : {
+              provider: target.provider,
+              model: target.model,
+              ...(target.enabled === false && { enabled: false }),
+            }
+      ),
     })),
   };
 }
@@ -2217,6 +2230,13 @@ export const api = {
 
       Object.entries(aliasMap).forEach(([key, val]) => {
         const readTarget = (t: any) => {
+          if (t.alias) {
+            return {
+              alias: t.alias as string,
+              enabled: t.enabled !== false,
+            };
+          }
+
           const providerConfig = providers[t.provider];
           const inferredTypes =
             providerConfig?.type || inferProviderTypes(providerConfig?.api_base_url);

--- a/packages/frontend/src/lib/modelList.test.ts
+++ b/packages/frontend/src/lib/modelList.test.ts
@@ -57,6 +57,28 @@ const aliases: Alias[] = [
 ];
 
 describe('model list helpers', () => {
+  test('ignores alias-ref targets when deriving provider labels and options', () => {
+    const aliasWithFallback: Alias = {
+      id: 'delta',
+      target_groups: [
+        {
+          name: 'default',
+          selector: 'in_order',
+          targets: [
+            { provider: 'openai', model: 'gpt-4o-mini' },
+            { alias: 'gamma', enabled: true },
+          ],
+        },
+      ],
+    };
+
+    expect(getAliasProviderLabels(aliasWithFallback, providers)).toEqual(['OpenAI (openai)']);
+    expect(getAliasTargetCount(aliasWithFallback)).toBe(2);
+    expect(getModelListProviderOptions([aliasWithFallback], providers)).toEqual([
+      'OpenAI (openai)',
+    ]);
+  });
+
   test('derives provider labels and target counts from aliases', () => {
     expect(getAliasProviderLabels(aliases[0], providers)).toEqual([
       'Anthropic (anthropic)',

--- a/packages/frontend/src/lib/modelList.ts
+++ b/packages/frontend/src/lib/modelList.ts
@@ -23,6 +23,7 @@ export const getAliasProviderLabels = (alias: Alias, providers: Provider[]) => {
 
   for (const group of alias.target_groups) {
     for (const target of group.targets) {
+      if (!target.provider) continue;
       labels.add(getProviderDisplayLabel(providerById.get(target.provider), target.provider));
     }
   }
@@ -35,7 +36,7 @@ export const getModelListProviderOptions = (aliases: Alias[], providers: Provide
   for (const alias of aliases) {
     for (const group of alias.target_groups) {
       for (const target of group.targets) {
-        providerIds.add(target.provider);
+        if (target.provider) providerIds.add(target.provider);
       }
     }
   }

--- a/packages/frontend/src/lib/modelOptions.test.ts
+++ b/packages/frontend/src/lib/modelOptions.test.ts
@@ -55,4 +55,28 @@ describe('model option helpers', () => {
       },
     ]);
   });
+
+  test('keeps distinct alias-ref targets without colliding on missing provider/model', () => {
+    const groups: AliasTargetGroup[] = [
+      {
+        name: 'primary',
+        selector: 'in_order',
+        targets: [
+          { alias: 'fallback-a', enabled: true },
+          { alias: 'fallback-b', enabled: true },
+          { alias: 'fallback-a', enabled: true },
+        ],
+      },
+    ];
+
+    expect(dedupeAliasTargets(groups)).toEqual([
+      {
+        ...groups[0],
+        targets: [
+          { alias: 'fallback-a', enabled: true },
+          { alias: 'fallback-b', enabled: true },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/frontend/src/lib/modelOptions.ts
+++ b/packages/frontend/src/lib/modelOptions.ts
@@ -1,7 +1,7 @@
 import type { AliasTargetGroup, Model } from './api';
 
-export const getModelOptionKey = (providerId: string, modelId: string) =>
-  `${providerId}\u0000${modelId}`;
+export const getModelOptionKey = (providerId: string | undefined, modelId: string | undefined) =>
+  `${providerId ?? ''}\u0000${modelId ?? ''}`;
 
 export const dedupeModels = <T extends Pick<Model, 'id' | 'providerId'>>(models: T[]): T[] => {
   const seen = new Set<string>();
@@ -40,7 +40,9 @@ export const dedupeAliasTargets = (groups: AliasTargetGroup[]): AliasTargetGroup
   return groups.map((group) => ({
     ...group,
     targets: group.targets.filter((target) => {
-      const key = getModelOptionKey(target.provider, target.model);
+      const key = target.alias
+        ? `alias\u0000${target.alias}`
+        : getModelOptionKey(target.provider, target.model);
       if (seen.has(key)) return false;
       seen.add(key);
       return true;

--- a/packages/frontend/src/pages/Models.tsx
+++ b/packages/frontend/src/pages/Models.tsx
@@ -116,6 +116,13 @@ export const Models = () => {
     [allAliases, providers]
   );
 
+  // Aliases eligible as fallback targets: exclude the alias currently being
+  // edited to avoid an obvious self-reference.
+  const availableAliasSlugs = useMemo(
+    () => allAliases.map((a) => a.id).filter((id) => id !== originalId && id !== editingAlias.id),
+    [allAliases, originalId, editingAlias.id]
+  );
+
   const visibleAliases = useMemo(
     () =>
       filterAndSortAliasesForModelsPage(
@@ -608,6 +615,7 @@ export const Models = () => {
                 groups={editingAlias.target_groups}
                 providers={providers}
                 availableModels={availableModels}
+                availableAliases={availableAliasSlugs}
                 onChange={(groups) => setEditingAlias({ ...editingAlias, target_groups: groups })}
               />
             </div>

--- a/scripts/__tests__/sqlite-migration-rewrite.test.ts
+++ b/scripts/__tests__/sqlite-migration-rewrite.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractRecreationInserts,
+  rewriteTableRecreationInserts,
+  validateTableRecreationInserts,
+  snapshotTableColumns,
+  type Snapshot,
+} from '../lib/sqlite-migration-rewrite';
+
+/**
+ * Builds a minimal snapshot where only one table's column set matters for tests.
+ */
+function snapshot(table: string, columns: string[]): Snapshot {
+  const cols: Record<string, unknown> = {};
+  for (const c of columns) cols[c] = {};
+  return { tables: { [table]: { columns: cols } } };
+}
+
+// The canonical offending statement (identical in shape to the generated
+// alias-as-fallback-target migration that corrupted production data):
+// `target_alias_slug` is new to the source table, so the bare double-quoted
+// reference is a dangling identifier that SQLite DQS silently treats as a
+// string literal.
+const OFFENDING_SQL =
+  'INSERT INTO `__new_model_alias_targets`("id", "alias_id", "provider_slug", "model_name", "target_alias_slug", "enabled", "group_name", "sort_order") ' +
+  'SELECT "id", "alias_id", "provider_slug", "model_name", "target_alias_slug", "enabled", "group_name", "sort_order" FROM `model_alias_targets`;';
+
+const LEGACY_COLS = [
+  'id',
+  'alias_id',
+  'provider_slug',
+  'model_name',
+  'enabled',
+  'group_name',
+  'sort_order',
+];
+
+describe('extractRecreationInserts', () => {
+  it('extracts a table-recreation INSERT with its column lists', () => {
+    const inserts = extractRecreationInserts(OFFENDING_SQL);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]!.sourceTable).toBe('model_alias_targets');
+    expect(inserts[0]!.insertColumns).toContain('target_alias_slug');
+    expect(inserts[0]!.selectTerms.map((t) => t.identifier)).toContain('target_alias_slug');
+  });
+
+  it('returns nothing for a plain CREATE TABLE with no recreation', () => {
+    const sql = 'CREATE TABLE `foo`("a", "b"); INSERT INTO `foo`("a","b") VALUES (1,2);';
+    expect(extractRecreationInserts(sql)).toHaveLength(0);
+  });
+
+  it('returns nothing when dest and source table names disagree', () => {
+    // A shape we don't model; must skip rather than mis-rewrite.
+    const sql = 'INSERT INTO `__new_bar`("a") SELECT "a" FROM `baz`;';
+    expect(extractRecreationInserts(sql)).toHaveLength(0);
+  });
+});
+
+describe('snapshotTableColumns', () => {
+  it('reads column names from a snapshot table', () => {
+    const cols = snapshotTableColumns(snapshot('t', ['a', 'b']), 't');
+    expect(cols).toEqual(new Set(['a', 'b']));
+  });
+
+  it('returns empty set for a missing snapshot or table', () => {
+    expect(snapshotTableColumns(null, 't').size).toBe(0);
+    expect(snapshotTableColumns(snapshot('t', ['a']), 'other').size).toBe(0);
+  });
+});
+
+describe('rewriteTableRecreationInserts', () => {
+  it('replaces source-absent columns with NULL (the production fix)', () => {
+    const prev = snapshot('model_alias_targets', LEGACY_COLS);
+    const out = rewriteTableRecreationInserts(OFFENDING_SQL, prev);
+    expect(out).toContain(
+      'SELECT "id", "alias_id", "provider_slug", "model_name", NULL, "enabled", "group_name", "sort_order" FROM `model_alias_targets`'
+    );
+    // The INSERT column list is preserved verbatim.
+    expect(out).toContain(
+      '`__new_model_alias_targets`("id", "alias_id", "provider_slug", "model_name", "target_alias_slug", "enabled", "group_name", "sort_order")'
+    );
+  });
+
+  it('does not touch columns that exist in the source', () => {
+    const prev = snapshot('model_alias_targets', LEGACY_COLS);
+    const out = rewriteTableRecreationInserts(OFFENDING_SQL, prev);
+    // All legacy columns keep their double-quoted form.
+    for (const c of LEGACY_COLS) {
+      expect(out).toContain(`"${c}"`);
+    }
+  });
+
+  it('is a no-op when there is nothing to rewrite (pure constraint change)', () => {
+    // A recreation that only changes a PK: every SELECT column exists.
+    const safeSql =
+      'INSERT INTO `__new_quota_state`("key_name", "quota_name") SELECT "key_name", "quota_name" FROM `quota_state`;';
+    const prev = snapshot('quota_state', ['key_name', 'quota_name']);
+    expect(rewriteTableRecreationInserts(safeSql, prev)).toBe(safeSql);
+  });
+
+  it('preserves multiple table recreations and rewrites only the offending one', () => {
+    const prev = {
+      tables: {
+        quota_state: { columns: { key_name: {}, quota_name: {}, window_start: {} } },
+        model_alias_targets: {
+          columns: Object.fromEntries(LEGACY_COLS.map((c) => [c, {}])),
+        },
+      },
+    };
+    const sql =
+      'INSERT INTO `__new_quota_state`("key_name", "quota_name", "window_start") SELECT "key_name", "quota_name", "window_start" FROM `quota_state`;\n' +
+      OFFENDING_SQL;
+    const out = rewriteTableRecreationInserts(sql, prev as Snapshot);
+    // First statement untouched.
+    expect(out).toContain('SELECT "key_name", "quota_name", "window_start" FROM `quota_state`');
+    // Second statement rewritten.
+    expect(out).toContain(
+      'SELECT "id", "alias_id", "provider_slug", "model_name", NULL, "enabled", "group_name", "sort_order" FROM `model_alias_targets`'
+    );
+  });
+
+  it('treats a NULL/e expression SELECT term as already-safe (no rewrite)', () => {
+    const prev = snapshot('t', ['a']);
+    const sql = 'INSERT INTO `__new_t`("a", "b") SELECT "a", NULL FROM `t`;';
+    const out = rewriteTableRecreationInserts(sql, prev);
+    expect(out).toBe(sql);
+  });
+
+  it('is a no-op when no previous snapshot is available', () => {
+    expect(rewriteTableRecreationInserts(OFFENDING_SQL, null)).toBe(OFFENDING_SQL);
+  });
+
+  it('throws on INSERT/SELECT arity mismatch', () => {
+    const prev = snapshot('t', ['a', 'b']);
+    const sql = 'INSERT INTO `__new_t`("a", "b", "c") SELECT "a", "b" FROM `t`;';
+    expect(() => rewriteTableRecreationInserts(sql, prev)).toThrow(/columns but SELECT has/);
+  });
+});
+
+describe('validateTableRecreationInserts', () => {
+  it('flags an offending statement before rewrite', () => {
+    const prev = snapshot('model_alias_targets', LEGACY_COLS);
+    const offenses = validateTableRecreationInserts(OFFENDING_SQL, '0061_x.sql', prev);
+    expect(offenses).toHaveLength(1);
+    expect(offenses[0]!.sourceTable).toBe('model_alias_targets');
+    expect(offenses[0]!.absentColumns).toEqual(['target_alias_slug']);
+  });
+
+  it('passes a correctly-rewritten statement', () => {
+    const prev = snapshot('model_alias_targets', LEGACY_COLS);
+    const rewritten = rewriteTableRecreationInserts(OFFENDING_SQL, prev);
+    expect(validateTableRecreationInserts(rewritten, '0061_x.sql', prev)).toEqual([]);
+  });
+
+  it('skips validation when the source snapshot is unavailable', () => {
+    // No snapshot -> can't know -> don't fail (first migration case).
+    expect(validateTableRecreationInserts(OFFENDING_SQL, 'x.sql', null)).toEqual([]);
+  });
+});

--- a/scripts/generate-migrations.ts
+++ b/scripts/generate-migrations.ts
@@ -2,6 +2,14 @@
 import { $ } from 'bun';
 import { parseArgs } from 'util';
 import { execSync } from 'node:child_process';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  loadJournal,
+  loadPreviousSnapshot,
+  rewriteTableRecreationInserts,
+  validateTableRecreationInserts,
+} from './lib/sqlite-migration-rewrite';
 
 const VALID_NAME_REGEX = /^[a-z][a-z0-9_]*$/;
 
@@ -63,13 +71,85 @@ if (!VALID_NAME_REGEX.test(name)) {
   process.exit(1);
 }
 
+// Capture the set of SQLite migration files *before* generation so we can
+// post-process only the freshly generated one(s).
+const SQLITE_MIGRATIONS_DIR = join('packages', 'backend', 'drizzle', 'migrations');
+const beforeSqlite = new Set(listSqlFiles(SQLITE_MIGRATIONS_DIR));
+
 console.log(`Generating SQLite migrations with name: ${name}`);
 await $`cd packages/backend && node node_modules/drizzle-kit/bin.cjs generate --name ${name} --config drizzle.config.sqlite.ts`;
+
+// drizzle-kit's SQLite table-recreation codegen references new columns in the
+// `INSERT ... SELECT` that don't exist on the source table. Under SQLite's
+// double-quoted-string misfeature this silently writes the literal column
+// name into every row. Rewrite those SELECT terms to NULL and validate.
+postProcessSqliteMigrations(SQLITE_MIGRATIONS_DIR, beforeSqlite);
 
 console.log(`Generating Postgres migrations with name: ${name}`);
 await $`cd packages/backend && node node_modules/drizzle-kit/bin.cjs generate --name ${name} --config drizzle.config.postgres.ts`;
 
 console.log('Done!');
+
+/** List `*.sql` filenames in a migrations directory (names only). */
+function listSqlFiles(dir: string): string[] {
+  try {
+    return readdirSync(dir).filter((f) => f.endsWith('.sql'));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Rewrite + validate freshly generated SQLite migration files so table
+ * recreations never SELECT a column absent from the source snapshot.
+ *
+ * This guards against the SQLite double-quoted-string data-corruption bug
+ * where `INSERT INTO __new_t (..., "newcol", ...) SELECT ..., "newcol", ... FROM t`
+ * silently fills `newcol` with the literal string 'newcol'.
+ */
+function postProcessSqliteMigrations(dir: string, before: Set<string>): void {
+  const after = listSqlFiles(dir);
+  const newFiles = after.filter((f) => !before.has(f));
+  if (newFiles.length === 0) return;
+
+  const journal = loadJournal(dir);
+
+  for (const file of newFiles) {
+    const filePath = join(dir, file);
+    const original = readFileSync(filePath, 'utf8');
+    // The migration tag is the filename without `.sql`.
+    const tag = file.replace(/\.sql$/, '');
+    const prevSnapshot = loadPreviousSnapshot(dir, journal, tag);
+
+    const rewritten = rewriteTableRecreationInserts(original, prevSnapshot);
+    if (rewritten !== original) {
+      writeFileSync(filePath, rewritten);
+      console.log(
+        `Rewrote table-recreation INSERT...SELECT in ${file} (NULL for source-absent columns)`
+      );
+    }
+
+    // Fail generation if anything dangerous survives the rewrite.
+    const offenses = validateTableRecreationInserts(
+      readFileSync(filePath, 'utf8'),
+      file,
+      prevSnapshot
+    );
+    if (offenses.length > 0) {
+      console.error(
+        `Error: SQLite table-recreation migration ${file} still references ` +
+          'columns absent from the source snapshot (would silently corrupt data under SQLite DQS):'
+      );
+      for (const o of offenses) {
+        console.error(`  table ${o.sourceTable}: ${o.absentColumns.join(', ')}`);
+      }
+      console.error(
+        'Fix the migration so the INSERT...SELECT uses NULL for any column new to the source table.'
+      );
+      process.exit(1);
+    }
+  }
+}
 
 /**
  * Derive a descriptive migration name from a git branch name.

--- a/scripts/lib/sqlite-migration-rewrite.ts
+++ b/scripts/lib/sqlite-migration-rewrite.ts
@@ -1,0 +1,277 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * SQLite table-recreation migration rewrite + validation.
+ *
+ * Background
+ * ----------
+ * drizzle-kit generates SQLite schema changes that can't be expressed as a
+ * single `ALTER TABLE` (e.g. dropping NOT NULL, changing a PK) as a full
+ * table recreation:
+ *
+ *   CREATE TABLE `__new_<t>` (...);
+ *   INSERT INTO `__new_<t>`("c1", "c2", ..., "cN")
+ *     SELECT "c1", "c2", ..., "cN" FROM `<t>`;
+ *   DROP TABLE `<t>`;
+ *   ALTER TABLE `__new_<t>` RENAME TO `<t>`;
+ *
+ * When such a recreation *also* adds a brand-new column in the same step,
+ * drizzle-kit lists the new column in BOTH the INSERT column list AND the
+ * SELECT column list. But the new column does not exist in the source table,
+ * so `SELECT "<newcol>" FROM <t>` references a column that isn't there.
+ *
+ * Under SQLite's double-quoted-string (DQS) misfeature — which is active in
+ * `bun:sqlite` regardless of `PRAGMA dqs` — a double-quoted unknown identifier
+ * is silently treated as a **string literal** rather than raising an error.
+ * The result is catastrophic, silent data corruption: every row's new column
+ * is filled with the literal column-name string (e.g. `'target_alias_slug'`)
+ * instead of NULL.
+ *
+ * This module fixes the generation pipeline so the `INSERT ... SELECT` emits
+ * `NULL` for any destination column that is absent from the source
+ * table (per the previous migration snapshot), and validates that no
+ * source-absent column reference survives.
+ *
+ * It is generic: it inspects every `INSERT INTO \`__new_<t>\` ... SELECT ...
+ * FROM \`<t>\`` in a migration, not any one hardcoded column.
+ */
+
+/** Column list shape we need from a drizzle snapshot. */
+export interface SnapshotTable {
+  columns: Record<string, unknown>;
+}
+export interface Snapshot {
+  tables: Record<string, SnapshotTable>;
+}
+
+/**
+ * Parse a drizzle column list like `"a", "b", "c"` into bare names.
+ * Handles double-quoted identifiers and trims whitespace.
+ */
+function parseColumnList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+    .map((p) => p.replace(/^"(.*)"$/, '$1'));
+}
+
+/**
+ * Parse a SELECT projection list like `"a", "b", NULL, "c"` into terms.
+ * Each term retains its original textual form so it can be re-emitted verbatim
+ * when kept; `isQuotedIdentifier` / `identifier` describe what it references.
+ */
+interface SelectTerm {
+  /** Original text, trimmed (e.g. `"target_alias_slug"` or `NULL`). */
+  raw: string;
+  isQuotedIdentifier: boolean;
+  identifier: string | null;
+}
+
+function parseSelectList(raw: string): SelectTerm[] {
+  return raw
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+    .map((p) => {
+      const m = p.match(/^"([^"]+)"$/);
+      if (m) return { raw: p, isQuotedIdentifier: true, identifier: m[1]! };
+      return { raw: p, isQuotedIdentifier: false, identifier: null };
+    });
+}
+
+/** Matches `INSERT INTO \`__new_<table>\`(...) SELECT ... FROM \`<table>\``. */
+const TABLE_RECREATION_INSERT =
+  /INSERT INTO `__new_(\w+)`\s*\(([^)]*)\)\s*SELECT\s+([\s\S]*?)\s+FROM\s+`(\w+)`/g;
+
+export interface RecreationInsert {
+  /** Full matched statement text (the regex match[0]). */
+  fullMatch: string;
+  sourceTable: string;
+  insertColumns: string[];
+  selectTerms: SelectTerm[];
+}
+
+/** Extract every table-recreation INSERT statement from a migration body. */
+export function extractRecreationInserts(sql: string): RecreationInsert[] {
+  const results: RecreationInsert[] = [];
+  // Reset state in case the regex literal was used before (it's a /g regex).
+  TABLE_RECREATION_INSERT.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TABLE_RECREATION_INSERT.exec(sql)) !== null) {
+    const sourceTable = m[4]!;
+    const destTable = m[1]!;
+    // The `__new_<dest>` and `FROM <source>` table names should agree. If they
+    // ever disagree the migration is doing something we don't model; skip it
+    // rather than guessing (validation will then flag it if it matters).
+    if (destTable !== sourceTable) continue;
+    results.push({
+      fullMatch: m[0],
+      sourceTable,
+      insertColumns: parseColumnList(m[2]!),
+      selectTerms: parseSelectList(m[3]!),
+    });
+  }
+  return results;
+}
+
+/** Columns present on a table in a snapshot (empty if table/snapshot absent). */
+export function snapshotTableColumns(
+  snapshot: Snapshot | null | undefined,
+  table: string
+): Set<string> {
+  if (!snapshot) return new Set();
+  const t = snapshot.tables?.[table];
+  if (!t || !t.columns) return new Set();
+  return new Set(Object.keys(t.columns));
+}
+
+/**
+ * Rewrite all table-recreation INSERT statements so destination columns absent
+ * from the source snapshot are populated with NULL instead of a dangling
+ * double-quoted identifier. Returns the rewritten SQL (unchanged if no
+ * recreation inserts reference absent columns).
+ *
+ * Throws if an INSERT column list and SELECT projection have mismatched arity
+ * (drizzle always emits them 1:1; a mismatch means unexpected SQL shape).
+ */
+export function rewriteTableRecreationInserts(
+  sql: string,
+  prevSnapshot: Snapshot | null | undefined
+): string {
+  const inserts = extractRecreationInserts(sql);
+  if (inserts.length === 0) return sql;
+
+  let out = sql;
+  for (const ins of inserts) {
+    if (ins.insertColumns.length !== ins.selectTerms.length) {
+      throw new Error(
+        `Cannot rewrite table recreation for "${ins.sourceTable}": INSERT has ` +
+          `${ins.insertColumns.length} columns but SELECT has ${ins.selectTerms.length} terms`
+      );
+    }
+    const sourceCols = snapshotTableColumns(prevSnapshot, ins.sourceTable);
+    if (sourceCols.size === 0) {
+      // No source schema to diff against (missing snapshot, or the table is
+      // absent from it): we can't tell which columns are new, so leave the
+      // statement untouched rather than risk an incorrect rewrite.
+      continue;
+    }
+
+    let changed = false;
+    const newTerms = ins.selectTerms.map((term) => {
+      if (term.isQuotedIdentifier && term.identifier !== null && !sourceCols.has(term.identifier)) {
+        changed = true;
+        return 'NULL';
+      }
+      return term.raw;
+    });
+
+    if (!changed) continue;
+
+    const newSelectList = newTerms.join(', ');
+    const replacement =
+      `INSERT INTO \`__new_${ins.sourceTable}\`` +
+      `(${ins.insertColumns.map((c) => `"${c}"`).join(', ')}) ` +
+      `SELECT ${newSelectList} FROM \`${ins.sourceTable}\``;
+    // Replace only the first occurrence of this exact match (matches are unique
+    // enough by their column list).
+    out = out.replace(ins.fullMatch, replacement);
+  }
+  return out;
+}
+
+// ─── Journal / snapshot loading helpers (fs-backed) ────────────────────────
+
+export interface JournalEntry {
+  tag: string;
+  when: number;
+  breakpoints: boolean;
+}
+export interface Journal {
+  entries: JournalEntry[];
+}
+
+/** Numeric 4-digit prefix of a migration tag (e.g. "0061_add_..." -> "0061"). */
+export function migrationPrefix(tag: string): string {
+  return tag.split('_')[0]!;
+}
+
+/** Load and parse a migration journal (`meta/_journal.json`). */
+export function loadJournal(migrationsDir: string): Journal {
+  const journalPath = join(migrationsDir, 'meta', '_journal.json');
+  let raw: string;
+  try {
+    raw = readFileSync(journalPath, 'utf8');
+  } catch (e) {
+    throw new Error(`Could not read migration journal at ${journalPath}: ${String(e)}`);
+  }
+  try {
+    return JSON.parse(raw) as Journal;
+  } catch (e) {
+    throw new Error(`Corrupt migration journal at ${journalPath}: ${String(e)}`);
+  }
+}
+
+/**
+ * Load the snapshot describing schema state BEFORE a given migration applies.
+ * For migration at journal index `i`, that is the snapshot produced by entry
+ * `i-1`. Returns null for the first migration (empty DB) or if the file is
+ * missing.
+ */
+export function loadPreviousSnapshot(
+  migrationsDir: string,
+  journal: Journal,
+  migrationTag: string
+): Snapshot | null {
+  const idx = journal.entries.findIndex((e) => e.tag === migrationTag);
+  if (idx <= 0) return null; // first migration, or unknown tag
+  const prevTag = journal.entries[idx - 1]!.tag;
+  const snapshotPath = join(migrationsDir, 'meta', `${migrationPrefix(prevTag)}_snapshot.json`);
+  if (!existsSync(snapshotPath)) return null;
+  let raw: string;
+  try {
+    raw = readFileSync(snapshotPath, 'utf8');
+  } catch (e) {
+    throw new Error(`Could not read snapshot at ${snapshotPath}: ${String(e)}`);
+  }
+  try {
+    return JSON.parse(raw) as Snapshot;
+  } catch (e) {
+    throw new Error(`Corrupt migration snapshot at ${snapshotPath}: ${String(e)}`);
+  }
+}
+
+export interface ValidationOffense {
+  migrationFile: string;
+  sourceTable: string;
+  absentColumns: string[];
+}
+
+/**
+ * Validate that no table-recreation INSERT references a column absent from the
+ * source snapshot. Returns the list of offenses (empty = clean).
+ */
+export function validateTableRecreationInserts(
+  sql: string,
+  migrationFile: string,
+  prevSnapshot: Snapshot | null | undefined
+): ValidationOffense[] {
+  const offenses: ValidationOffense[] = [];
+  for (const ins of extractRecreationInserts(sql)) {
+    const sourceCols = snapshotTableColumns(prevSnapshot, ins.sourceTable);
+    if (sourceCols.size === 0) continue; // unknown source state; skip
+    const absent = ins.selectTerms
+      .filter((t) => t.isQuotedIdentifier && t.identifier !== null && !sourceCols.has(t.identifier))
+      .map((t) => t.identifier!);
+    if (absent.length > 0) {
+      offenses.push({
+        migrationFile,
+        sourceTable: ins.sourceTable,
+        absentColumns: absent,
+      });
+    }
+  }
+  return offenses;
+}

--- a/scripts/lint-migrations.ts
+++ b/scripts/lint-migrations.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env bun
-import { readdirSync } from 'fs';
+import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
+import {
+  loadJournal,
+  loadPreviousSnapshot,
+  validateTableRecreationInserts,
+} from './lib/sqlite-migration-rewrite';
 
 const MIGRATION_DIRS = [
   'packages/backend/drizzle/migrations',
@@ -241,3 +246,67 @@ if (hasError) {
 }
 
 console.log('Migration naming looks good.');
+
+// Second pass: validate SQLite table-recreation migrations don't reference
+// columns absent from the source snapshot. Under SQLite's double-quoted-string
+// (DQS) misfeature such a reference silently writes the literal column name
+// into every row (data corruption). `bun run generate-migrations` rewrites
+// these to NULL automatically; this lint is the CI safety net that catches
+// any migration that slips through (e.g. hand-authored or stale).
+validateRecreationInserts();
+
+function validateRecreationInserts(): void {
+  for (const dir of MIGRATION_DIRS) {
+    const fullDir = join(process.cwd(), dir);
+    let sqlFiles: string[];
+    try {
+      sqlFiles = readdirSync(fullDir)
+        .filter((f) => f.endsWith('.sql'))
+        .sort();
+    } catch {
+      continue;
+    }
+    if (sqlFiles.length === 0) continue;
+
+    let journal;
+    try {
+      journal = loadJournal(fullDir);
+    } catch (e) {
+      console.error(`Error loading migration journal in ${dir}: ${String(e)}`);
+      hasError = true;
+      continue;
+    }
+
+    for (const file of sqlFiles) {
+      const tag = file.replace(/\.sql$/, '');
+      let prevSnapshot;
+      try {
+        prevSnapshot = loadPreviousSnapshot(fullDir, journal, tag);
+      } catch (e) {
+        console.error(`Error loading previous snapshot for ${file}: ${String(e)}`);
+        hasError = true;
+        continue;
+      }
+      const sql = readFileSync(join(fullDir, file), 'utf8');
+      const offenses = validateTableRecreationInserts(sql, file, prevSnapshot);
+      for (const o of offenses) {
+        console.error(
+          `Error: SQLite table-recreation migration ${file} references columns ` +
+            `absent from its source table ${o.sourceTable}: ${o.absentColumns.join(', ')}.\n` +
+            '  Under SQLite DQS this silently writes the literal column name into every row. ' +
+            'Use NULL for any column new to the source table.'
+        );
+        hasError = true;
+      }
+    }
+  }
+
+  if (hasError) {
+    console.error(
+      '\nRe-run `bun run generate-migrations` to auto-rewrite table-recreation INSERT...SELECT statements.'
+    );
+    process.exit(1);
+  }
+
+  console.log('SQLite table-recreation INSERT...SELECT migrations look safe.');
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Adds support for using one model alias as a fallback target for another alias.

### Backend

- Extends alias targets to support either:
  - A concrete `{ provider, model }` target, or
  - An `{ alias }` reference, but not both.
- Persists alias references in `model_alias_targets.target_alias_slug`, while allowing `provider_slug` and `model_name` to be nullable.
- Expands nested alias references during routing and preserves the referenced alias’s target groups and selectors.
- Treats alias references as fallback candidates after selector-ordered concrete targets.
- Skips disabled alias references and deduplicates candidates resolving to the same provider/model.
- Adds cycle detection during configuration loading, alias updates, and configuration rebuilds, with nickname-aware resolution.
- Excludes alias references from provider/model metadata discovery and background exploration.
- Adds startup repair for SQLite databases affected by the original table-recreation migration, restoring corrupted concrete targets without modifying legitimate alias references.

### Frontend

- Adds an Alias/Model target selector to the target group editor.
- Allows selecting another alias as a fallback target while excluding the alias currently being edited.
- Displays alias targets with a link indicator and independent enable/disable controls in desktop and mobile alias views.
- Updates API types, serialization, model lists, deduplication, and metadata handling for targets without provider/model fields.

### Migrations and tooling

- Adds SQLite and PostgreSQL migrations for the new `target_alias_slug` column and nullable concrete-target fields.
- Corrects the SQLite migration to populate the new column with `NULL` for existing concrete targets.
- Updates migration generation and linting to detect unsafe SQLite table-recreation `INSERT ... SELECT` statements that reference columns absent from the source table, rewriting them to `NULL` and failing validation if unsafe references remain.

### Tests

- Adds routing coverage for direct, nested, disabled, ordered, deduplicated, and cyclic alias references.
- Adds migration integrity and corruption-repair regression tests.
- Adds frontend tests for alias-target deduplication and provider/model list handling.
<!-- kody-pr-summary:end -->