### PR TITLE
fix(dispatcher): trigger cooldown and failover on early stream errors and OpenRouter 429s

### DIFF
--- a/packages/backend/src/services/__tests__/cooldown-parsers.test.ts
+++ b/packages/backend/src/services/__tests__/cooldown-parsers.test.ts
@@ -1,9 +1,109 @@
 import { describe, expect, test } from 'vitest';
 import { CooldownParserRegistry } from '../runtime/cooldown-parsers';
+import {
+  resolveCooldownProviderType,
+  parseCooldownDurationForProvider,
+} from '../providers/provider-cooldown';
 
 describe('CooldownParserRegistry', () => {
   test('Returns null for unregistered provider type', () => {
     const result = CooldownParserRegistry.parseCooldown('unknown-provider', 'reset after 20s');
     expect(result).toBe(null);
+  });
+
+  describe('openai-codex parser', () => {
+    test('parses minute duration correctly', () => {
+      const errorText = 'Usage limit reached. Try again in ~45 min.';
+      const result = CooldownParserRegistry.parseCooldown('openai-codex', errorText);
+      expect(result).toBe(45 * 60 * 1000);
+    });
+  });
+
+  describe('openrouter parser', () => {
+    test('parses metadata.retry_after_seconds', () => {
+      const payload = JSON.stringify({
+        message: 'Provider returned error',
+        code: 429,
+        metadata: {
+          raw: 'openai/gpt-5.6-luna is temporarily rate-limited upstream. Please retry shortly, or add your own key to accumulate your rate limits: https://openrouter.ai/settings/integrations',
+          provider_name: 'OpenInference',
+          is_byok: false,
+          retry_after_seconds: 29,
+        },
+      });
+      const result = CooldownParserRegistry.parseCooldown('openrouter', payload);
+      expect(result).toBe(29 * 1000);
+    });
+
+    test('parses error.metadata.retry_after_seconds_raw', () => {
+      const payload = JSON.stringify({
+        error: {
+          message: 'Provider returned error',
+          code: 429,
+          metadata: {
+            raw: 'google/gemma-4-26b-a4b-it:free is temporarily rate-limited upstream.',
+            retry_after_seconds_raw: 28.5,
+          },
+        },
+      });
+      const result = CooldownParserRegistry.parseCooldown('openrouter', payload);
+      expect(result).toBe(28500);
+    });
+
+    test('parses Retry-After header inside metadata', () => {
+      const payload = JSON.stringify({
+        error: {
+          code: 429,
+          metadata: {
+            headers: {
+              'Retry-After': '15',
+            },
+          },
+        },
+      });
+      const result = CooldownParserRegistry.parseCooldown('openrouter', payload);
+      expect(result).toBe(15 * 1000);
+    });
+
+    test('parses regex fallback for text format', () => {
+      const errorText = 'Rate limited. Retry after 30s';
+      const result = CooldownParserRegistry.parseCooldown('openrouter', errorText);
+      expect(result).toBe(30 * 1000);
+    });
+  });
+});
+
+describe('provider-cooldown resolution', () => {
+  test('resolves openrouter type when provider name contains openrouter', () => {
+    const route: any = {
+      provider: 'openrouter-s',
+      model: 'openai/gpt-5.6-luna',
+      config: { api_base_url: 'https://openrouter.ai/api/v1' },
+    };
+    expect(resolveCooldownProviderType(route)).toBe('openrouter');
+  });
+
+  test('resolves openrouter type when api_base_url is openrouter.ai', () => {
+    const route: any = {
+      provider: 'custom-proxy',
+      model: 'openai/gpt-5.6-luna',
+      config: { api_base_url: 'https://openrouter.ai/api/v1' },
+    };
+    expect(resolveCooldownProviderType(route)).toBe('openrouter');
+  });
+
+  test('parseCooldownDurationForProvider parses OpenRouter error payload fallback', () => {
+    const payload = JSON.stringify({
+      error: {
+        message: 'Provider returned error',
+        code: 429,
+        metadata: {
+          raw: 'openai/gpt-5.6-luna is temporarily rate-limited upstream. https://openrouter.ai/settings/integrations',
+          retry_after_seconds: 20,
+        },
+      },
+    });
+    const result = parseCooldownDurationForProvider('chat', payload, 'HTTP');
+    expect(result).toBe(20 * 1000);
   });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-stream-probe.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-stream-probe.test.ts
@@ -121,4 +121,104 @@ describe('probeStreamingStart', () => {
       expect(error.message).toBe('connection reset');
     }
   });
+
+  test('detects OpenRouter upstream rate limit SSE error and returns ok: false with parsed cooldown', async () => {
+    const encoder = new TextEncoder();
+    const errorPayload = {
+      message: 'Provider returned error',
+      code: 429,
+      metadata: {
+        raw: 'openai/gpt-5.6-luna is temporarily rate-limited upstream. Please retry shortly, or add your own key to accumulate your rate limits: https://openrouter.ai/settings/integrations',
+        provider_name: 'OpenInference',
+        is_byok: false,
+        retry_after_seconds: 29,
+      },
+    };
+    const chunk = encoder.encode(`data: ${JSON.stringify(errorPayload)}\n\n`);
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+
+    const response = new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+
+    const dispatcher = new Dispatcher();
+    const result = await (dispatcher as any).probeStreamingStart(response);
+
+    expect(result.ok).toBe(false);
+    expect(result.error.message).toContain(
+      'openai/gpt-5.6-luna is temporarily rate-limited upstream'
+    );
+    expect(result.error.statusCode).toBe(429);
+    expect(result.error.cooldownDuration).toBe(29000);
+    expect(result.error.isStreamError).toBe(true);
+  });
+
+  test('detects Anthropic SSE error event and returns ok: false', async () => {
+    const encoder = new TextEncoder();
+    const errorEvent =
+      'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Anthropic rate limit hit"}}\n\n';
+    const chunk = encoder.encode(errorEvent);
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+
+    const response = new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+
+    const dispatcher = new Dispatcher();
+    const result = await (dispatcher as any).probeStreamingStart(response);
+
+    expect(result.ok).toBe(false);
+    expect(result.error.message).toBe('Anthropic rate limit hit');
+    expect(result.error.statusCode).toBe(429);
+    expect(result.error.isStreamError).toBe(true);
+  });
+
+  test('does not falsely flag normal delta content mentioning the word error', async () => {
+    const encoder = new TextEncoder();
+    const normalPayload = {
+      id: 'chatcmpl-123',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'gpt-5.6-luna',
+      choices: [
+        {
+          index: 0,
+          delta: { content: 'Here is the error log you requested.' },
+          finish_reason: null,
+        },
+      ],
+    };
+    const chunk = encoder.encode(`data: ${JSON.stringify(normalPayload)}\n\n`);
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+
+    const response = new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+
+    const dispatcher = new Dispatcher();
+    const result = await (dispatcher as any).probeStreamingStart(response);
+
+    expect(result.ok).toBe(true);
+  });
 });

--- a/packages/backend/src/services/__tests__/dispatcher-stream-probe.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-stream-probe.test.ts
@@ -187,6 +187,48 @@ describe('probeStreamingStart', () => {
     expect(result.error.isStreamError).toBe(true);
   });
 
+  test('detects SSE error split across multiple chunks in stall-aware probe', async () => {
+    const encoder = new TextEncoder();
+    const errorPayload = {
+      message: 'Provider returned error',
+      code: 429,
+      metadata: {
+        raw: 'openai/gpt-5.6-luna is temporarily rate-limited upstream.',
+        retry_after_seconds: 15,
+      },
+    };
+    const jsonStr = `data: ${JSON.stringify(errorPayload)}\n\n`;
+    const half = Math.floor(jsonStr.length / 2);
+    const chunk1 = encoder.encode(jsonStr.slice(0, half));
+    const chunk2 = encoder.encode(jsonStr.slice(half));
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk1);
+        controller.enqueue(chunk2);
+        controller.close();
+      },
+    });
+
+    const response = new Response(stream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+
+    const dispatcher = new Dispatcher();
+    const result = await (dispatcher as any).probeStreamingStart(response, {
+      ttfbMs: 1000,
+      ttfbBytes: 500,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error.message).toContain(
+      'openai/gpt-5.6-luna is temporarily rate-limited upstream'
+    );
+    expect(result.error.statusCode).toBe(429);
+    expect(result.error.cooldownDuration).toBe(15000);
+  });
+
   test('does not falsely flag normal delta content mentioning the word error', async () => {
     const encoder = new TextEncoder();
     const normalPayload = {

--- a/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
+++ b/packages/backend/src/services/dispatch/__tests__/standard-attempt-request.test.ts
@@ -319,6 +319,37 @@ describe('executeStandardAttempt — thinking-signature strip-and-retry', () => 
     // long-lived request) was never mutated in place.
     expect(providerPayload).toEqual(snapshot);
   });
+
+  it('retries on early stream error from probeStreamingStart', async () => {
+    const executeProviderRequest = vi.fn(
+      async () =>
+        new Response('data: {"error":{"code":429,"message":"Rate limit"}}\n\n', { status: 200 })
+    );
+    const streamError = new Error('openai/gpt-5.6-luna is temporarily rate-limited upstream');
+    (streamError as any).isStreamError = true;
+    (streamError as any).statusCode = 429;
+    (streamError as any).cooldownDuration = 30000;
+
+    const probeStreamingStart = vi.fn().mockResolvedValue({
+      ok: false,
+      error: streamError,
+      streamStarted: false,
+    });
+    const host = makeHost({ executeProviderRequest, probeStreamingStart });
+
+    const request = makeStreamingRequest();
+    const result = await executeStandardAttempt(
+      makeContext(host, {}, { request, requestWithTargetModel: request, targetApiType: 'chat' })
+    );
+    expect(result.outcome).toBe('retry');
+    expect(host.appendFailureAttempt).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      streamError,
+      'chat',
+      true
+    );
+  });
 });
 
 describe('failover-policy 402 status code handling', () => {

--- a/packages/backend/src/services/dispatch/dispatcher.ts
+++ b/packages/backend/src/services/dispatch/dispatcher.ts
@@ -740,14 +740,29 @@ export class Dispatcher {
     if (!isCallerError) {
       let cooldownDuration: number | undefined;
 
-      // For 429 errors, try to parse provider-specific cooldown duration
-      if (response.status === 429) {
-        // Get provider type for parser lookup
-        cooldownDuration = parseCooldownDurationForProvider(
-          resolveCooldownProviderType(route),
-          errorText,
-          'HTTP'
-        );
+      // For 429/503 errors, check Retry-After header first, then try to parse provider-specific cooldown duration
+      if (response.status === 429 || response.status === 503) {
+        const retryAfterHeader = response.headers.get('retry-after');
+        if (retryAfterHeader) {
+          const seconds = parseFloat(retryAfterHeader);
+          if (Number.isFinite(seconds) && seconds > 0) {
+            cooldownDuration = Math.ceil(seconds * 1000);
+          } else {
+            const dateParsed = Date.parse(retryAfterHeader);
+            if (Number.isFinite(dateParsed) && dateParsed > Date.now()) {
+              cooldownDuration = dateParsed - Date.now();
+            }
+          }
+        }
+
+        if (!cooldownDuration) {
+          // Get provider type for parser lookup
+          cooldownDuration = parseCooldownDurationForProvider(
+            resolveCooldownProviderType(route),
+            errorText,
+            'HTTP'
+          );
+        }
       }
 
       // Mark provider+model as failed with optional duration

--- a/packages/backend/src/services/dispatch/media-dispatcher.ts
+++ b/packages/backend/src/services/dispatch/media-dispatcher.ts
@@ -751,7 +751,8 @@ export class MediaDispatcher {
               failoverEnabled &&
               i < targets.length - 1 &&
               !streamProbe.streamStarted &&
-              host.isRetryableNetworkError(error, failover?.retryableErrors || []);
+              (host.isRetryableNetworkError(error, failover?.retryableErrors || []) ||
+                (error as any).isStreamError === true);
 
             if (canRetry) {
               await host.recordAttemptMetric(route, request.requestId, false);
@@ -760,7 +761,7 @@ export class MediaDispatcher {
               CooldownManager.getInstance().markProviderFailure(
                 route.provider,
                 route.model,
-                undefined,
+                (error as any).cooldownDuration,
                 error.message
               );
               host.saveIntermediateError(request.requestId, 'speech', error);
@@ -768,6 +769,15 @@ export class MediaDispatcher {
                 `Failover: retrying speech stream before first byte after ${route.provider}/${route.model} failure: ${error.message}`
               );
               continue;
+            }
+
+            if ((error as any).isStreamError) {
+              CooldownManager.getInstance().markProviderFailure(
+                route.provider,
+                route.model,
+                (error as any).cooldownDuration,
+                error.message
+              );
             }
 
             throw error;

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -414,7 +414,9 @@ export async function executeStandardAttempt(
         hasNextTarget &&
         !streamProbe.streamStarted &&
         (host.isRetryableNetworkError(error, retryableErrors) ||
-          error.message?.includes('stalled'));
+          error.message?.includes('stalled') ||
+          (error as any).isStreamError === true ||
+          (error as any).routingContext?.statusCode !== undefined);
 
       if (canRetry) {
         attemptTimeout.cleanup();
@@ -434,7 +436,7 @@ export async function executeStandardAttempt(
           CooldownManager.getInstance().markProviderFailure(
             route.provider,
             route.model,
-            undefined,
+            (error as any).cooldownDuration,
             host.formatFailureReason(error)
           );
         }
@@ -444,6 +446,15 @@ export async function executeStandardAttempt(
         );
         doRelease();
         return { outcome: 'retry', error };
+      }
+
+      if ((error as any).isStreamError || (error as any).routingContext?.cooldownTriggered) {
+        CooldownManager.getInstance().markProviderFailure(
+          route.provider,
+          route.model,
+          (error as any).cooldownDuration,
+          host.formatFailureReason(error)
+        );
       }
 
       doRelease();

--- a/packages/backend/src/services/probes/stream-probe.ts
+++ b/packages/backend/src/services/probes/stream-probe.ts
@@ -1,6 +1,137 @@
 import { logger } from '../../utils/logger';
 import type { StallConfig } from '../inspectors/stall-inspector';
 
+/**
+ * Inspects the initial raw stream bytes for early SSE/JSON error events
+ * (such as OpenRouter/OpenAI 429 rate limit or server errors sent with HTTP 200).
+ */
+export function parseInitialStreamError(chunk: Uint8Array): Error | null {
+  if (!chunk || chunk.length === 0) return null;
+  const text = new TextDecoder().decode(chunk).trim();
+  if (!text) return null;
+
+  // 1. Try parsing SSE lines or raw JSON
+  const lines = text.split('\n');
+  let eventType = '';
+  let dataStr = '';
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line.startsWith('event:')) {
+      eventType = line.slice(6).trim();
+    } else if (line.startsWith('data:')) {
+      dataStr = line.slice(5).trim();
+    }
+  }
+
+  let candidateJson = dataStr;
+  if (!candidateJson && (text.startsWith('{') || text.startsWith('['))) {
+    candidateJson = text;
+  }
+
+  if (!candidateJson || candidateJson === '[DONE]') {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(candidateJson);
+    if (!parsed || typeof parsed !== 'object') return null;
+
+    // Normal completion chunks with choices or content blocks are not error payloads
+    const isNormalChoiceChunk =
+      Array.isArray(parsed.choices) &&
+      parsed.choices.length > 0 &&
+      parsed.choices[0]?.delta !== undefined;
+    const isNormalAnthropicChunk =
+      parsed.type === 'message_start' ||
+      parsed.type === 'content_block_start' ||
+      parsed.type === 'content_block_delta' ||
+      parsed.type === 'message_delta' ||
+      parsed.type === 'message_stop';
+    if (isNormalChoiceChunk || isNormalAnthropicChunk) {
+      return null;
+    }
+
+    const hasErrorProp = parsed.error !== undefined && parsed.error !== null;
+    const isErrorEvent =
+      eventType === 'error' ||
+      parsed.type === 'error' ||
+      parsed.event === 'error' ||
+      parsed.type === 'response.failed';
+    const isErrorStatus =
+      (typeof parsed.code === 'number' && parsed.code >= 400) ||
+      (typeof parsed.status === 'number' && parsed.status >= 400);
+    const isProviderReturnedError =
+      parsed.message === 'Provider returned error' ||
+      parsed.error?.message === 'Provider returned error';
+
+    if (!hasErrorProp && !isErrorEvent && !isErrorStatus && !isProviderReturnedError) {
+      return null;
+    }
+
+    const errorObj =
+      typeof parsed.error === 'object' && parsed.error !== null ? parsed.error : parsed;
+    const meta = errorObj.metadata || parsed.metadata;
+    const rawMsg = meta?.raw;
+    const message =
+      (typeof rawMsg === 'string' && rawMsg.trim()) ||
+      errorObj.message ||
+      parsed.message ||
+      (typeof parsed.error === 'string' ? parsed.error : 'Stream error from upstream provider');
+
+    let statusCode = 502;
+    if (typeof errorObj.code === 'number') {
+      statusCode = errorObj.code;
+    } else if (typeof parsed.code === 'number') {
+      statusCode = parsed.code;
+    } else if (typeof errorObj.status === 'number') {
+      statusCode = errorObj.status;
+    } else if (typeof errorObj.code === 'string' && !isNaN(Number(errorObj.code))) {
+      statusCode = Number(errorObj.code);
+    } else if (
+      String(message).toLowerCase().includes('rate-limited') ||
+      String(message).toLowerCase().includes('rate limit') ||
+      errorObj.type === 'rate_limit_error'
+    ) {
+      statusCode = 429;
+    }
+
+    let cooldownDuration: number | undefined;
+    const retrySec = meta?.retry_after_seconds ?? meta?.retry_after_seconds_raw;
+    if (retrySec !== undefined && retrySec !== null) {
+      const sec = typeof retrySec === 'number' ? retrySec : parseFloat(String(retrySec));
+      if (Number.isFinite(sec) && sec > 0) {
+        cooldownDuration = Math.ceil(sec * 1000);
+      }
+    }
+    if (!cooldownDuration) {
+      const headerRetry = meta?.headers?.['Retry-After'] || meta?.headers?.['retry-after'];
+      if (headerRetry) {
+        const sec = parseFloat(headerRetry);
+        if (Number.isFinite(sec) && sec > 0) {
+          cooldownDuration = Math.ceil(sec * 1000);
+        }
+      }
+    }
+
+    const err = new Error(String(message));
+    (err as any).isStreamError = true;
+    (err as any).statusCode = statusCode;
+    (err as any).routingContext = {
+      statusCode,
+      providerResponse: text,
+      cooldownTriggered: true,
+    };
+    if (cooldownDuration) {
+      (err as any).cooldownDuration = cooldownDuration;
+    }
+
+    return err;
+  } catch {
+    return null;
+  }
+}
+
 export async function probeStreamingStart(
   response: Response,
   stallConfig?: StallConfig | null
@@ -75,6 +206,19 @@ export async function probeStreamingStart(
     }
 
     const first = readResult as ReadableStreamReadResult<Uint8Array>;
+    if (!first.done && first.value) {
+      const initialError = parseInitialStreamError(first.value);
+      if (initialError) {
+        reader.cancel().catch(() => {});
+        logger.warn(`probeStreamingStart: detected early stream error: ${initialError.message}`);
+        return {
+          ok: false,
+          error: initialError,
+          streamStarted: false,
+        };
+      }
+    }
+
     const replay = new ReadableStream<Uint8Array>({
       start(controller) {
         if (!first.done && first.value) {
@@ -178,6 +322,19 @@ async function probeStreamingStartWithStallCheck(
       chunks.push(value);
       totalBytes += value.length;
       streamStarted = true;
+    }
+
+    if (chunks.length > 0) {
+      const initialError = parseInitialStreamError(chunks[0]!);
+      if (initialError) {
+        reader.cancel().catch(() => {});
+        logger.warn(`probeStreamingStart: detected early stream error: ${initialError.message}`);
+        return {
+          ok: false,
+          error: initialError,
+          streamStarted: false,
+        };
+      }
     }
 
     // TTFB threshold met (or stream ended naturally) — build replay stream

--- a/packages/backend/src/services/probes/stream-probe.ts
+++ b/packages/backend/src/services/probes/stream-probe.ts
@@ -1,135 +1,158 @@
 import { logger } from '../../utils/logger';
 import type { StallConfig } from '../inspectors/stall-inspector';
 
+function concatChunks(chunks: Uint8Array[]): Uint8Array {
+  if (chunks.length === 1) return chunks[0]!;
+  let totalLength = 0;
+  for (const c of chunks) totalLength += c.length;
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const c of chunks) {
+    result.set(c, offset);
+    offset += c.length;
+  }
+  return result;
+}
+
 /**
  * Inspects the initial raw stream bytes for early SSE/JSON error events
  * (such as OpenRouter/OpenAI 429 rate limit or server errors sent with HTTP 200).
+ * Supports single chunks or arrays of chunks that may contain multi-read SSE frames.
  */
-export function parseInitialStreamError(chunk: Uint8Array): Error | null {
-  if (!chunk || chunk.length === 0) return null;
-  const text = new TextDecoder().decode(chunk).trim();
+export function parseInitialStreamError(input: Uint8Array | Uint8Array[]): Error | null {
+  const bytes = Array.isArray(input) ? concatChunks(input) : input;
+  if (!bytes || bytes.length === 0) return null;
+  const text = new TextDecoder().decode(bytes).trim();
   if (!text) return null;
 
   // 1. Try parsing SSE lines or raw JSON
   const lines = text.split('\n');
   let eventType = '';
-  let dataStr = '';
+  const dataLines: string[] = [];
 
   for (const rawLine of lines) {
     const line = rawLine.trim();
     if (line.startsWith('event:')) {
       eventType = line.slice(6).trim();
     } else if (line.startsWith('data:')) {
-      dataStr = line.slice(5).trim();
+      dataLines.push(line.slice(5).trim());
     }
   }
 
-  let candidateJson = dataStr;
-  if (!candidateJson && (text.startsWith('{') || text.startsWith('['))) {
-    candidateJson = text;
+  const candidateJsonStrings: string[] = [];
+  if (dataLines.length > 0) {
+    candidateJsonStrings.push(...dataLines);
+    if (dataLines.length > 1) {
+      candidateJsonStrings.push(dataLines.join('\n'));
+    }
+  }
+  if (text.startsWith('{') || text.startsWith('[')) {
+    candidateJsonStrings.push(text);
   }
 
-  if (!candidateJson || candidateJson === '[DONE]') {
-    return null;
-  }
+  for (const candidateJson of candidateJsonStrings) {
+    if (!candidateJson || candidateJson === '[DONE]') continue;
 
-  try {
-    const parsed = JSON.parse(candidateJson);
-    if (!parsed || typeof parsed !== 'object') return null;
+    try {
+      const parsed = JSON.parse(candidateJson);
+      if (!parsed || typeof parsed !== 'object') continue;
 
-    // Normal completion chunks with choices or content blocks are not error payloads
-    const isNormalChoiceChunk =
-      Array.isArray(parsed.choices) &&
-      parsed.choices.length > 0 &&
-      parsed.choices[0]?.delta !== undefined;
-    const isNormalAnthropicChunk =
-      parsed.type === 'message_start' ||
-      parsed.type === 'content_block_start' ||
-      parsed.type === 'content_block_delta' ||
-      parsed.type === 'message_delta' ||
-      parsed.type === 'message_stop';
-    if (isNormalChoiceChunk || isNormalAnthropicChunk) {
-      return null;
-    }
-
-    const hasErrorProp = parsed.error !== undefined && parsed.error !== null;
-    const isErrorEvent =
-      eventType === 'error' ||
-      parsed.type === 'error' ||
-      parsed.event === 'error' ||
-      parsed.type === 'response.failed';
-    const isErrorStatus =
-      (typeof parsed.code === 'number' && parsed.code >= 400) ||
-      (typeof parsed.status === 'number' && parsed.status >= 400);
-    const isProviderReturnedError =
-      parsed.message === 'Provider returned error' ||
-      parsed.error?.message === 'Provider returned error';
-
-    if (!hasErrorProp && !isErrorEvent && !isErrorStatus && !isProviderReturnedError) {
-      return null;
-    }
-
-    const errorObj =
-      typeof parsed.error === 'object' && parsed.error !== null ? parsed.error : parsed;
-    const meta = errorObj.metadata || parsed.metadata;
-    const rawMsg = meta?.raw;
-    const message =
-      (typeof rawMsg === 'string' && rawMsg.trim()) ||
-      errorObj.message ||
-      parsed.message ||
-      (typeof parsed.error === 'string' ? parsed.error : 'Stream error from upstream provider');
-
-    let statusCode = 502;
-    if (typeof errorObj.code === 'number') {
-      statusCode = errorObj.code;
-    } else if (typeof parsed.code === 'number') {
-      statusCode = parsed.code;
-    } else if (typeof errorObj.status === 'number') {
-      statusCode = errorObj.status;
-    } else if (typeof errorObj.code === 'string' && !isNaN(Number(errorObj.code))) {
-      statusCode = Number(errorObj.code);
-    } else if (
-      String(message).toLowerCase().includes('rate-limited') ||
-      String(message).toLowerCase().includes('rate limit') ||
-      errorObj.type === 'rate_limit_error'
-    ) {
-      statusCode = 429;
-    }
-
-    let cooldownDuration: number | undefined;
-    const retrySec = meta?.retry_after_seconds ?? meta?.retry_after_seconds_raw;
-    if (retrySec !== undefined && retrySec !== null) {
-      const sec = typeof retrySec === 'number' ? retrySec : parseFloat(String(retrySec));
-      if (Number.isFinite(sec) && sec > 0) {
-        cooldownDuration = Math.ceil(sec * 1000);
+      // Normal completion chunks with choices or content blocks are not error payloads
+      const isNormalChoiceChunk =
+        Array.isArray(parsed.choices) &&
+        parsed.choices.length > 0 &&
+        parsed.choices[0]?.delta !== undefined;
+      const isNormalAnthropicChunk =
+        parsed.type === 'message_start' ||
+        parsed.type === 'content_block_start' ||
+        parsed.type === 'content_block_delta' ||
+        parsed.type === 'message_delta' ||
+        parsed.type === 'message_stop';
+      if (isNormalChoiceChunk || isNormalAnthropicChunk) {
+        continue;
       }
-    }
-    if (!cooldownDuration) {
-      const headerRetry = meta?.headers?.['Retry-After'] || meta?.headers?.['retry-after'];
-      if (headerRetry) {
-        const sec = parseFloat(headerRetry);
+
+      const hasErrorProp = parsed.error !== undefined && parsed.error !== null;
+      const isErrorEvent =
+        eventType === 'error' ||
+        parsed.type === 'error' ||
+        parsed.event === 'error' ||
+        parsed.type === 'response.failed';
+      const isErrorStatus =
+        (typeof parsed.code === 'number' && parsed.code >= 400) ||
+        (typeof parsed.status === 'number' && parsed.status >= 400);
+      const isProviderReturnedError =
+        parsed.message === 'Provider returned error' ||
+        parsed.error?.message === 'Provider returned error';
+
+      if (!hasErrorProp && !isErrorEvent && !isErrorStatus && !isProviderReturnedError) {
+        continue;
+      }
+
+      const errorObj =
+        typeof parsed.error === 'object' && parsed.error !== null ? parsed.error : parsed;
+      const meta = errorObj.metadata || parsed.metadata;
+      const rawMsg = meta?.raw;
+      const message =
+        (typeof rawMsg === 'string' && rawMsg.trim()) ||
+        errorObj.message ||
+        parsed.message ||
+        (typeof parsed.error === 'string' ? parsed.error : 'Stream error from upstream provider');
+
+      let statusCode = 502;
+      if (typeof errorObj.code === 'number') {
+        statusCode = errorObj.code;
+      } else if (typeof parsed.code === 'number') {
+        statusCode = parsed.code;
+      } else if (typeof errorObj.status === 'number') {
+        statusCode = errorObj.status;
+      } else if (typeof errorObj.code === 'string' && !isNaN(Number(errorObj.code))) {
+        statusCode = Number(errorObj.code);
+      } else if (
+        String(message).toLowerCase().includes('rate-limited') ||
+        String(message).toLowerCase().includes('rate limit') ||
+        errorObj.type === 'rate_limit_error'
+      ) {
+        statusCode = 429;
+      }
+
+      let cooldownDuration: number | undefined;
+      const retrySec = meta?.retry_after_seconds ?? meta?.retry_after_seconds_raw;
+      if (retrySec !== undefined && retrySec !== null) {
+        const sec = typeof retrySec === 'number' ? retrySec : parseFloat(String(retrySec));
         if (Number.isFinite(sec) && sec > 0) {
           cooldownDuration = Math.ceil(sec * 1000);
         }
       }
-    }
+      if (!cooldownDuration) {
+        const headerRetry = meta?.headers?.['Retry-After'] || meta?.headers?.['retry-after'];
+        if (headerRetry) {
+          const sec = parseFloat(headerRetry);
+          if (Number.isFinite(sec) && sec > 0) {
+            cooldownDuration = Math.ceil(sec * 1000);
+          }
+        }
+      }
 
-    const err = new Error(String(message));
-    (err as any).isStreamError = true;
-    (err as any).statusCode = statusCode;
-    (err as any).routingContext = {
-      statusCode,
-      providerResponse: text,
-      cooldownTriggered: true,
-    };
-    if (cooldownDuration) {
-      (err as any).cooldownDuration = cooldownDuration;
-    }
+      const err = new Error(String(message));
+      (err as any).isStreamError = true;
+      (err as any).statusCode = statusCode;
+      (err as any).routingContext = {
+        statusCode,
+        providerResponse: text,
+        cooldownTriggered: true,
+      };
+      if (cooldownDuration) {
+        (err as any).cooldownDuration = cooldownDuration;
+      }
 
-    return err;
-  } catch {
-    return null;
+      return err;
+    } catch {
+      // incomplete or invalid JSON chunk, continue checking
+    }
   }
+
+  return null;
 }
 
 export async function probeStreamingStart(
@@ -325,7 +348,7 @@ async function probeStreamingStartWithStallCheck(
     }
 
     if (chunks.length > 0) {
-      const initialError = parseInitialStreamError(chunks[0]!);
+      const initialError = parseInitialStreamError(chunks);
       if (initialError) {
         reader.cancel().catch(() => {});
         logger.warn(`probeStreamingStart: detected early stream error: ${initialError.message}`);

--- a/packages/backend/src/services/providers/provider-cooldown.ts
+++ b/packages/backend/src/services/providers/provider-cooldown.ts
@@ -8,6 +8,22 @@ export function resolveCooldownProviderType(route: RouteResult): string | undefi
     return route.config.oauth_provider.trim();
   }
 
+  if (typeof route.config.pi_ai_provider === 'string' && route.config.pi_ai_provider.trim()) {
+    return route.config.pi_ai_provider.trim();
+  }
+
+  const providerName = route.provider.toLowerCase();
+  if (providerName.includes('openrouter')) {
+    return 'openrouter';
+  }
+
+  if (typeof route.config.api_base_url === 'string') {
+    const url = route.config.api_base_url.toLowerCase();
+    if (url.includes('openrouter.ai')) {
+      return 'openrouter';
+    }
+  }
+
   return getProviderTypes(route.config)[0];
 }
 
@@ -16,19 +32,34 @@ export function parseCooldownDurationForProvider(
   errorText: string,
   source: 'HTTP' | 'OAuth'
 ): number | undefined {
-  if (!providerType) {
-    return undefined;
+  if (providerType) {
+    const parsedDuration = CooldownParserRegistry.parseCooldown(providerType, errorText);
+
+    if (parsedDuration !== null) {
+      logger.info(
+        `${source}: Parsed cooldown duration for ${providerType}: ${parsedDuration}ms (${parsedDuration / 1000}s)`
+      );
+      return parsedDuration;
+    }
   }
 
-  const parsedDuration = CooldownParserRegistry.parseCooldown(providerType, errorText);
-
-  if (parsedDuration !== null) {
-    logger.info(
-      `${source}: Parsed cooldown duration for ${providerType}: ${parsedDuration}ms (${parsedDuration / 1000}s)`
-    );
-    return parsedDuration;
+  // Fallback: check if error text contains OpenRouter-specific markers
+  if (
+    errorText.includes('openrouter.ai') ||
+    errorText.includes('retry_after_seconds') ||
+    errorText.includes('is_byok')
+  ) {
+    const openrouterDuration = CooldownParserRegistry.parseCooldown('openrouter', errorText);
+    if (openrouterDuration !== null) {
+      logger.info(
+        `${source}: Parsed OpenRouter cooldown duration from error body: ${openrouterDuration}ms (${openrouterDuration / 1000}s)`
+      );
+      return openrouterDuration;
+    }
   }
 
-  logger.debug(`${source}: No cooldown duration parsed for ${providerType}, using default`);
+  logger.debug(
+    `${source}: No cooldown duration parsed for ${providerType || 'unknown'}, using default`
+  );
   return undefined;
 }

--- a/packages/backend/src/services/runtime/cooldown-parsers.ts
+++ b/packages/backend/src/services/runtime/cooldown-parsers.ts
@@ -31,6 +31,51 @@ export class CooldownParserRegistry {
         return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 * 1000 : null;
       },
     });
+
+    // Built-in parser for OpenRouter rate limit and upstream provider error messages.
+    // Extracts retry_after_seconds from metadata or Retry-After header fields.
+    CooldownParserRegistry.register('openrouter', {
+      parseCooldownDuration(errorText: string): number | null {
+        try {
+          const data = JSON.parse(errorText);
+          const meta = data.error?.metadata || data.metadata;
+          const retrySec = meta?.retry_after_seconds ?? meta?.retry_after_seconds_raw;
+          if (retrySec !== undefined && retrySec !== null) {
+            const sec = typeof retrySec === 'number' ? retrySec : parseFloat(String(retrySec));
+            if (Number.isFinite(sec) && sec > 0) {
+              return Math.ceil(sec * 1000);
+            }
+          }
+          const headerRetry = meta?.headers?.['Retry-After'] || meta?.headers?.['retry-after'];
+          if (headerRetry) {
+            const sec = parseFloat(headerRetry);
+            if (Number.isFinite(sec) && sec > 0) {
+              return Math.ceil(sec * 1000);
+            }
+          }
+        } catch {
+          // not JSON, fall through to regex parsing
+        }
+
+        const secMatch = /retry(?:-|\s+)after[:\s]+(\d+(?:\.\d+)?)\s*s(?:ec(?:onds?)?)?/i.exec(
+          errorText
+        );
+        if (secMatch && secMatch[1]) {
+          const sec = parseFloat(secMatch[1]);
+          if (Number.isFinite(sec) && sec > 0) return Math.ceil(sec * 1000);
+        }
+
+        const minMatch = /retry(?:-|\s+)after[:\s]+(\d+(?:\.\d+)?)\s*m(?:in(?:utes?)?)?/i.exec(
+          errorText
+        );
+        if (minMatch && minMatch[1]) {
+          const min = parseFloat(minMatch[1]);
+          if (Number.isFinite(min) && min > 0) return Math.ceil(min * 60 * 1000);
+        }
+
+        return null;
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Enhances dispatcher cooldown and failover handling for early streaming failures, including OpenRouter rate-limit responses delivered through HTTP 200 SSE streams.

## Changes

- Detects structured errors in the initial streaming response, including:
  - OpenRouter/OpenAI-style `429` provider errors
  - Anthropic SSE `error` events
  - Error frames split across multiple stream chunks
- Preserves normal streaming content, including messages that merely contain the word “error.”
- Extracts stream error metadata such as:
  - HTTP/status codes
  - Provider error messages
  - `retry_after_seconds`
  - `retry_after_seconds_raw`
  - Embedded `Retry-After` headers
- Marks detected stream failures with cooldown and routing metadata so they can participate in retry and failover decisions.
- Enables standard and media dispatchers to retry early stream errors on alternate targets when failover is available.
- Records provider failures with the parsed cooldown duration, including when the stream error is not retried.
- Adds OpenRouter provider detection based on provider name or `api_base_url`, including fallback detection from OpenRouter-specific error payloads.
- Adds provider cooldown parsing for OpenRouter JSON and text-formatted retry durations.
- Uses the HTTP `Retry-After` response header for `429` and `503` responses before applying provider-specific parsing.

## Tests

Adds coverage for:

- OpenRouter cooldown metadata and header parsing
- OpenRouter provider resolution
- Early OpenRouter and Anthropic SSE errors
- Errors spanning multiple stream chunks
- Retry behavior for early stream errors
- Cooldown recording during standard and media failover
- Avoiding false positives for normal content containing “error”
<!-- kody-pr-summary:end -->