### PR TITLE
fix(release): use claude-code-base-action for release notes (fixes push event failure)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,9 +257,13 @@ jobs:
 
       - name: Run release notes agent
         id: release_notes_agent
-        uses: anthropics/claude-code-action@v1
+        # claude-code-action detects GitHub event type (PR/issue/comment) and
+        # rejects unsupported ones, including `push` — which is how this
+        # workflow is triggered. claude-code-base-action is the same Claude
+        # Code executor without the GitHub event/webhook layer, so it runs
+        # the agentic prompt (full Read/Write tool use) regardless of event.
+        uses: anthropics/claude-code-base-action@v0.0.63
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ env.LLM_API_KEY }}
           claude_args: |
             --model ${{ vars.LLM_MODEL_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,10 +265,9 @@ jobs:
         uses: anthropics/claude-code-base-action@v0.0.63
         with:
           anthropic_api_key: ${{ env.LLM_API_KEY }}
-          claude_args: |
-            --model ${{ vars.LLM_MODEL_ID }}
-            --max-turns 10
-            --allowedTools "Read,Write"
+          model: ${{ vars.LLM_MODEL_ID }}
+          max_turns: '10'
+          allowed_tools: 'Read,Write'
           prompt: |
             Read `.github/prompts/release-notes.md` and follow its instructions exactly.
             The release tag is `${{ needs.setup.outputs.tag }}`. Do not perform any other work.


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Updated the release notes workflow to use `anthropics/claude-code-base-action@v0.0.63` instead of `anthropics/claude-code-action@v1`.

This prevents release-note generation from failing when the workflow is triggered by a `push` event, which the standard Claude Code action does not support. The workflow now:

- Passes the model, turn limit, and allowed tools through the base action’s dedicated inputs.
- Continues to use the configured Anthropic API key.
- Preserves the existing release-notes prompt and read/write tool access.
- Removes the unnecessary GitHub token and `claude_args` configuration.
<!-- kody-pr-summary:end -->