### PR TITLE
fix(release): pin release-notes agent to a current Claude Code version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,15 +259,20 @@ jobs:
         id: release_notes_agent
         # claude-code-action detects GitHub event type (PR/issue/comment) and
         # rejects unsupported ones, including `push` — which is how this
-        # workflow is triggered. claude-code-base-action is the same Claude
-        # Code executor without the GitHub event/webhook layer, so it runs
-        # the agentic prompt (full Read/Write tool use) regardless of event.
-        uses: anthropics/claude-code-base-action@v0.0.63
+        # workflow is triggered. The base-action/ subdirectory of the same
+        # repo is the underlying Claude Code executor without the GitHub
+        # event/webhook layer, so it runs regardless of event. Referencing
+        # it here (rather than the separately-tagged anthropics/claude-code-
+        # base-action mirror, whose tags lag far behind and pin an ancient
+        # Claude Code CLI version) keeps it on the same current v1 release
+        # line as claude-code-action.
+        uses: anthropics/claude-code-action/base-action@v1.0.193
         with:
           anthropic_api_key: ${{ env.LLM_API_KEY }}
-          model: ${{ vars.LLM_MODEL_ID }}
-          max_turns: '10'
-          allowed_tools: 'Read,Write'
+          claude_args: |
+            --model ${{ vars.LLM_MODEL_ID }}
+            --max-turns 10
+            --allowedTools "Read,Write"
           prompt: |
             Read `.github/prompts/release-notes.md` and follow its instructions exactly.
             The release tag is `${{ needs.setup.outputs.tag }}`. Do not perform any other work.

--- a/packages/backend/src/services/quota/__tests__/quota-enforcer.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-enforcer.test.ts
@@ -466,6 +466,14 @@ describe('QuotaEnforcer', () => {
     });
 
     test('limitType change resets the bucket instead of leaking stale usage', async () => {
+      // Pin the clock: the leaky bucket decays usage by elapsed real time
+      // (see computeSnapshot's `elapsedMs * leakRate`), so without a fixed
+      // clock this test is flaky — any wall-clock jitter between the write
+      // and the read below shaves fractions of a token off currentUsage,
+      // which can round down to 4999 under CI load.
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date('2026-03-15T12:00:00.000Z'));
+
       setConfigForTesting(
         createTestConfig(
           { q: { type: 'rolling', limitType: 'tokens', limit: 10000, duration: '1h' } },


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

- Updated the release-notes workflow to use `anthropics/claude-code-action/base-action@v1.0.193`, keeping the executor on the current Claude Code v1 release line instead of the separately tagged, outdated base-action mirror.
- Migrated Claude configuration to the action’s `claude_args` format while preserving the configured model, 10-turn limit, and `Read`/`Write` tool access.
- Stabilized the quota enforcer test for `limitType` changes by using a fixed fake system clock, preventing elapsed-time bucket decay from causing flaky assertions under CI load.
<!-- kody-pr-summary:end -->