### PR TITLE
fix(dispatch): strip account-bound advisor result on cross-account 400 (auto-compat)

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -17,6 +17,12 @@ import {
   refundThinkingSignatureStrip,
   stripThinkingSignatureBlocks,
   MAX_THINKING_SIGNATURE_STRIP_RETRIES,
+  createAdvisorResultStripState,
+  matchAdvisorResultError,
+  planAdvisorResultStrip,
+  refundAdvisorResultStrip,
+  stripAdvisorResultBlocks,
+  MAX_ADVISOR_RESULT_STRIP_RETRIES,
   createLiteToolStripState,
   matchLiteUnsupportedToolsError,
   planLiteToolStrip,
@@ -1270,6 +1276,236 @@ describe('planThinkingSignatureStrip', () => {
   test('refundThinkingSignatureStrip never drives attempts below zero', () => {
     const state = createThinkingSignatureStripState();
     refundThinkingSignatureStrip(state);
+    expect(state.attempts).toBe(0);
+  });
+});
+
+describe('matchAdvisorResultError', () => {
+  test('matches the exact production error body', () => {
+    const body = JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'Advisor tool result content could not be processed.',
+      },
+      request_id: 'req_test123',
+    });
+    expect(matchAdvisorResultError(body)).toBe(true);
+  });
+
+  test('matches regardless of case', () => {
+    expect(matchAdvisorResultError('ADVISOR TOOL RESULT CONTENT COULD NOT BE PROCESSED')).toBe(
+      true
+    );
+  });
+
+  test('returns false for an unrelated 400 body', () => {
+    expect(matchAdvisorResultError('{"error":{"message":"Invalid request: missing model"}}')).toBe(
+      false
+    );
+  });
+
+  test('returns false for an advisor-adjacent but unrelated error', () => {
+    expect(matchAdvisorResultError('{"error":{"message":"advisor tool is not enabled"}}')).toBe(
+      false
+    );
+  });
+
+  test('returns false for an empty body', () => {
+    expect(matchAdvisorResultError('')).toBe(false);
+  });
+});
+
+describe('stripAdvisorResultBlocks', () => {
+  // Mirrors the echoed on-wire shape: an assistant `server_tool_use` advisor
+  // invocation followed by its account-bound (encrypted) `advisor_tool_result`.
+  const advisorInvocation = {
+    type: 'server_tool_use',
+    id: 'srvtoolu_abc',
+    name: 'advisor',
+    input: {},
+  };
+  const advisorResult = {
+    type: 'advisor_tool_result',
+    tool_use_id: 'srvtoolu_abc',
+    content: { type: 'advisor_redacted_result', encrypted_content: 'EqQhCio-sealed-by-account-a' },
+  };
+
+  test('strips the advisor result and its paired invocation, preserving sibling text', () => {
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'let me consult' }, advisorInvocation, advisorResult],
+        },
+      ],
+    };
+    const snapshot = structuredClone(payload);
+
+    const result = stripAdvisorResultBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    expect(result.payload.messages).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'let me consult' }] },
+    ]);
+    // Copy-on-write: the ORIGINAL payload argument is never mutated.
+    expect(payload).toEqual(snapshot);
+  });
+
+  test('pairs invocation and result by id even when they sit in separate messages', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'assistant', content: [{ type: 'text', text: 'thinking' }, advisorInvocation] },
+        { role: 'assistant', content: [advisorResult, { type: 'text', text: 'the answer' }] },
+      ],
+    };
+
+    const result = stripAdvisorResultBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    // Invocation removed from message 0 (paired by id), leaving its text.
+    expect(result.payload.messages[0].content).toEqual([{ type: 'text', text: 'thinking' }]);
+    // Result removed from message 1, leaving its text.
+    expect(result.payload.messages[1].content).toEqual([{ type: 'text', text: 'the answer' }]);
+  });
+
+  test('leaves an unrelated server_tool_use (no matching advisor result) untouched', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'server_tool_use', id: 'srvtoolu_web', name: 'web_search', input: {} },
+            advisorInvocation,
+            advisorResult,
+          ],
+        },
+      ],
+    };
+
+    const result = stripAdvisorResultBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    // Only the advisor pair is gone; the web_search server tool use remains.
+    expect(result.payload.messages[0].content).toEqual([
+      { type: 'server_tool_use', id: 'srvtoolu_web', name: 'web_search', input: {} },
+    ]);
+  });
+
+  test('drops a message emptied by the strip when doing so keeps alternation valid', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+        { role: 'assistant', content: [advisorInvocation, advisorResult] },
+        { role: 'user', content: [{ type: 'text', text: 'q2' }] },
+      ],
+    };
+
+    const result = stripAdvisorResultBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    // The emptied assistant message is dropped; but that would leave two
+    // consecutive user messages, so a placeholder is substituted instead.
+    expect(result.payload.messages).toHaveLength(3);
+    expect(result.payload.messages[1]).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: '[advisor result elided]' }],
+    });
+  });
+
+  test('drops an emptied message entirely when alternation stays valid without it', () => {
+    const payload: Record<string, any> = {
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+        { role: 'assistant', content: [advisorInvocation, advisorResult] },
+      ],
+    };
+
+    const result = stripAdvisorResultBlocks(payload);
+
+    expect(result.strippedCount).toBe(1);
+    // Nothing follows the emptied assistant message, so it is dropped outright.
+    expect(result.payload.messages).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+    ]);
+  });
+
+  test('returns the payload unchanged (0 strips) when there is no advisor result', () => {
+    const payload: Record<string, any> = {
+      model: 'claude-x',
+      messages: [{ role: 'assistant', content: [{ type: 'text', text: 'hi' }] }],
+    };
+
+    const result = stripAdvisorResultBlocks(payload);
+
+    expect(result.strippedCount).toBe(0);
+    // Same reference back — nothing to rebuild.
+    expect(result.payload).toBe(payload);
+  });
+
+  test('returns 0 strips for a non-Anthropic (Responses API) payload', () => {
+    const payload: Record<string, any> = { model: 'gpt-5.5', input: 'hi' };
+    const result = stripAdvisorResultBlocks(payload);
+    expect(result.strippedCount).toBe(0);
+    expect(result.payload).toBe(payload);
+  });
+});
+
+describe('planAdvisorResultStrip', () => {
+  const advisorBody = JSON.stringify({
+    error: { message: 'Advisor tool result content could not be processed.' },
+  });
+  const anthropicPayload = { model: 'claude-x', messages: [] };
+
+  test('MAX_ADVISOR_RESULT_STRIP_RETRIES is exactly 1 (one strip-retry per target)', () => {
+    expect(MAX_ADVISOR_RESULT_STRIP_RETRIES).toBe(1);
+  });
+
+  test('plans a strip-retry on the first matching 400 for an Anthropic messages payload', () => {
+    const state = createAdvisorResultStripState();
+    expect(planAdvisorResultStrip(advisorBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('does not plan a retry when the body does not name an advisor-result error', () => {
+    const state = createAdvisorResultStripState();
+    expect(
+      planAdvisorResultStrip('{"error":{"message":"Invalid request"}}', anthropicPayload, state)
+    ).toBe(false);
+    expect(state.attempts).toBe(0);
+  });
+
+  test('does not plan a retry when the outbound payload is not Anthropic-messages-shaped', () => {
+    const state = createAdvisorResultStripState();
+    const responsesPayload = { model: 'gpt-5.5', input: 'hi' };
+    expect(planAdvisorResultStrip(advisorBody, responsesPayload, state)).toBe(false);
+    expect(state.attempts).toBe(0);
+  });
+
+  test('retry bound: a second advisor 400 on the same target does not plan a second strip-retry', () => {
+    const state = createAdvisorResultStripState();
+    expect(planAdvisorResultStrip(advisorBody, anthropicPayload, state)).toBe(true);
+    expect(planAdvisorResultStrip(advisorBody, anthropicPayload, state)).toBe(false);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('refundAdvisorResultStrip returns the budget after a 0-strip plan, so a later genuine advisor 400 can still strip-retry', () => {
+    const state = createAdvisorResultStripState();
+
+    expect(planAdvisorResultStrip(advisorBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+
+    refundAdvisorResultStrip(state);
+    expect(state.attempts).toBe(0);
+
+    expect(planAdvisorResultStrip(advisorBody, anthropicPayload, state)).toBe(true);
+    expect(state.attempts).toBe(1);
+  });
+
+  test('refundAdvisorResultStrip never drives attempts below zero', () => {
+    const state = createAdvisorResultStripState();
+    refundAdvisorResultStrip(state);
     expect(state.attempts).toBe(0);
   });
 });

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -934,6 +934,226 @@ export function refundThinkingSignatureStrip(state: ThinkingSignatureStripState)
 }
 
 // ---------------------------------------------------------------------------
+// Reactive auto-compat: strip-and-retry on account-bound Anthropic advisor
+// server-tool result content
+// ---------------------------------------------------------------------------
+//
+// The `advisor` server-side tool (beta `advisor-tool-2026-03-01`) returns its
+// result as an account/session-bound ENCRYPTED blob echoed back on every later
+// turn, paired with the assistant's `server_tool_use` invocation:
+//   { "type": "server_tool_use", "id": "srvtoolu_…", "name": "advisor", … }
+//   { "type": "advisor_tool_result", "tool_use_id": "srvtoolu_…",
+//     "content": { "type": "advisor_redacted_result", "encrypted_content": "…" } }
+// This is the same signed-blob mechanism as `redacted_thinking`: sealed under
+// the specific Claude account that produced it. When alias-level failover
+// replays that conversation against a DIFFERENT account (e.g. the sticky
+// account 529s and dispatch falls over to a sibling in the same pool),
+// Anthropic can't decrypt a blob sealed by another account and 400s:
+//   {"type":"error","error":{"type":"invalid_request_error",
+//    "message":"Advisor tool result content could not be processed."}}
+// Every remaining account in the pool rejects it the same way, so failing over
+// doesn't help. Strip the advisor exchange (the sealed result plus its paired
+// `server_tool_use` invocation, so the invocation isn't left unresolved) and
+// retry the SAME target once.
+
+/**
+ * Matches Anthropic's advisor sealed-result-rejection 400, e.g.
+ * `Advisor tool result content could not be processed.`. The wording names
+ * the advisor result generically (not a specific message index), so a plain
+ * substring/case-insensitive match is sufficient and won't misfire on
+ * unrelated 400s.
+ */
+const ADVISOR_RESULT_ERROR_PATTERN = /advisor tool result content could not be processed/i;
+
+/**
+ * True when an upstream error response body names an advisor result that
+ * could not be processed (an account-bound blob replayed against the wrong
+ * account).
+ */
+export function matchAdvisorResultError(responseBody: string): boolean {
+  if (!responseBody) return false;
+  return ADVISOR_RESULT_ERROR_PATTERN.test(responseBody);
+}
+
+function isAdvisorResultBlock(block: any): boolean {
+  return !!block && typeof block === 'object' && block.type === 'advisor_tool_result';
+}
+
+function isAdvisorInvocationBlock(block: any, sealedIds: Set<string>): boolean {
+  return (
+    !!block &&
+    typeof block === 'object' &&
+    (block.type === 'server_tool_use' || block.type === 'advisor_tool_use') &&
+    typeof block.id === 'string' &&
+    sealedIds.has(block.id)
+  );
+}
+
+// A fresh array/object per call (see reasoningElidedPlaceholder) so multiple
+// emptied advisor messages in one payload never alias the same mutable array.
+function advisorElidedPlaceholder(): Array<{ type: 'text'; text: string }> {
+  return [{ type: 'text', text: '[advisor result elided]' }];
+}
+
+export interface AdvisorResultStripResult {
+  /**
+   * The payload with every `advisor_tool_result` block — and the paired
+   * `server_tool_use`/`advisor_tool_use` invocation that produced it, matched
+   * by `tool_use_id` → `id` — removed. Copy-on-write when `strippedCount` > 0
+   * (identical semantics to `ThinkingSignatureStripResult`): the root and its
+   * `messages` array are shallow-cloned, each changed message is shallow-cloned,
+   * and untouched messages are shared by reference; the input payload is never
+   * mutated. Identical to the input `payload` reference when `strippedCount`
+   * is 0.
+   */
+  payload: Record<string, any>;
+  /**
+   * Number of `advisor_tool_result` blocks actually removed (0 when the
+   * payload isn't Anthropic-messages-shaped or carried no advisor result).
+   * Callers MUST treat 0 as "nothing changed" and skip the retry — the
+   * structural `isAnthropicMessagesPayload` gate also matches OpenAI
+   * chat-completions payloads, which never carry advisor blocks, so a 0-strip
+   * retry would resend a byte-identical request.
+   */
+  strippedCount: number;
+}
+
+/**
+ * Removes every `advisor_tool_result` block, plus its paired
+ * `server_tool_use`/`advisor_tool_use` invocation (matched by
+ * `tool_use_id` → `id`, across all messages so placement in the same or a
+ * separate message both work), copy-on-write. Emptied-content handling mirrors
+ * `stripThinkingSignatureBlocks`: when a message's `content` becomes empty the
+ * message is dropped UNLESS doing so would break user/assistant alternation or
+ * orphan a following `tool_result`, in which case an `[advisor result elided]`
+ * text placeholder is substituted so the conversation shape stays valid.
+ */
+export function stripAdvisorResultBlocks(payload: Record<string, any>): AdvisorResultStripResult {
+  if (!isAnthropicMessagesPayload(payload)) return { payload, strippedCount: 0 };
+
+  // Pass 1: collect the ids of every sealed advisor result so we can also
+  // drop the paired invocation and never leave a `server_tool_use` unresolved.
+  const sealedIds = new Set<string>();
+  for (const message of payload.messages) {
+    if (!message || !Array.isArray(message.content)) continue;
+    for (const block of message.content) {
+      if (isAdvisorResultBlock(block) && typeof block.tool_use_id === 'string') {
+        sealedIds.add(block.tool_use_id);
+      }
+    }
+  }
+
+  let strippedCount = 0;
+  const perMessage: Array<{
+    message: any;
+    content: any;
+    isArrayContent: boolean;
+    changed: boolean;
+  }> = payload.messages.map((message: any) => {
+    if (!message || !Array.isArray(message.content)) {
+      return { message, content: message?.content, isArrayContent: false, changed: false };
+    }
+    const kept = message.content.filter((block: any) => {
+      if (isAdvisorResultBlock(block)) {
+        strippedCount++;
+        return false;
+      }
+      if (isAdvisorInvocationBlock(block, sealedIds)) {
+        return false;
+      }
+      return true;
+    });
+    return {
+      message,
+      content: kept,
+      isArrayContent: true,
+      changed: kept.length !== message.content.length,
+    };
+  });
+
+  if (strippedCount === 0) return { payload, strippedCount: 0 };
+
+  const result: any[] = [];
+  for (let i = 0; i < perMessage.length; i++) {
+    const { message, content, isArrayContent, changed } = perMessage[i]!;
+
+    if (!isArrayContent || content.length > 0) {
+      result.push(changed ? { ...message, content } : message);
+      continue;
+    }
+
+    // Content became empty after stripping — decide drop vs. placeholder,
+    // identically to stripThinkingSignatureBlocks.
+    const prevMessage = result[result.length - 1];
+    const nextMessage = perMessage[i + 1]?.message;
+
+    const wouldBreakAlternation =
+      !!prevMessage && !!nextMessage && prevMessage.role === nextMessage.role;
+    const nextHasToolResult = contentHasBlockType(nextMessage?.content, 'tool_result');
+    const prevHasToolUse = contentHasBlockType(prevMessage?.content, 'tool_use');
+    const wouldOrphanToolResult = nextHasToolResult && !prevHasToolUse;
+
+    if (wouldBreakAlternation || wouldOrphanToolResult) {
+      result.push({ ...message, content: advisorElidedPlaceholder() });
+    }
+    // else: drop — push nothing for this message.
+  }
+
+  return { payload: { ...payload, messages: result }, strippedCount };
+}
+
+/** Per-target, per-request bound: at most one advisor-result-strip-and-retry cycle. */
+export const MAX_ADVISOR_RESULT_STRIP_RETRIES = 1;
+
+/** Tracks advisor-result-strip-and-retry progress for a single target within one request. */
+export interface AdvisorResultStripState {
+  attempts: number;
+}
+
+export function createAdvisorResultStripState(): AdvisorResultStripState {
+  return { attempts: 0 };
+}
+
+/**
+ * Decides whether an upstream 400 naming an unprocessable advisor result
+ * should trigger a strip-and-retry cycle against the same target, recording
+ * the attempt in `state` when it does. Returns `false` when the retry should
+ * NOT happen because:
+ *   - the body doesn't name the advisor-result error, OR
+ *   - the outbound payload isn't Anthropic-messages-shaped, OR
+ *   - MAX_ADVISOR_RESULT_STRIP_RETRIES has already been used for this target
+ *     (bounded to exactly one retry — once the advisor exchange is gone, a
+ *     repeat 400 means stripping it didn't fix it, so normal failover should
+ *     proceed rather than retrying again).
+ */
+export function planAdvisorResultStrip(
+  responseBody: string,
+  payload: any,
+  state: AdvisorResultStripState
+): boolean {
+  if (state.attempts >= MAX_ADVISOR_RESULT_STRIP_RETRIES) return false;
+  if (!matchAdvisorResultError(responseBody)) return false;
+  if (!isAnthropicMessagesPayload(payload)) return false;
+
+  state.attempts++;
+  return true;
+}
+
+/**
+ * Refunds the attempt recorded by the most recent `planAdvisorResultStrip`
+ * when the paired `stripAdvisorResultBlocks` turned out to be a no-op
+ * (`strippedCount` 0 — the structural `messages`-array check matched a payload
+ * that carries no advisor result). No retry happened, so the budget must not
+ * be consumed: a LATER genuine advisor-result 400 on the same target must
+ * still get its one strip-and-retry. Loop safety matches
+ * `refundThinkingSignatureStrip` — the refund is issued only on the advisor
+ * branch's no-strip path, which never `continue`s.
+ */
+export function refundAdvisorResultStrip(state: AdvisorResultStripState): void {
+  if (state.attempts > 0) state.attempts--;
+}
+
+// ---------------------------------------------------------------------------
 // Unsupported responses:lite tools: proactive strip + reactive strip-and-retry
 // ---------------------------------------------------------------------------
 //

--- a/packages/backend/src/services/dispatch/standard-attempt-request.ts
+++ b/packages/backend/src/services/dispatch/standard-attempt-request.ts
@@ -7,16 +7,21 @@ import type { StallConfig } from '../inspectors/stall-inspector';
 import { CooldownManager } from '../runtime/cooldown-manager';
 import type { RequestManagerHost } from './request-manager';
 import {
+  createAdvisorResultStripState,
   createLiteToolStripState,
   createThinkingSignatureStripState,
   createUnsupportedParamStripState,
   deleteDottedPath,
+  planAdvisorResultStrip,
   planLiteToolStrip,
   planThinkingSignatureStrip,
   planUnsupportedParamStrip,
+  refundAdvisorResultStrip,
   refundThinkingSignatureStrip,
+  stripAdvisorResultBlocks,
   stripLiteUnsupportedTools,
   stripThinkingSignatureBlocks,
+  MAX_ADVISOR_RESULT_STRIP_RETRIES,
   MAX_LITE_TOOL_STRIP_RETRIES,
   MAX_THINKING_SIGNATURE_STRIP_RETRIES,
   MAX_UNSUPPORTED_PARAM_STRIP_RETRIES,
@@ -125,15 +130,16 @@ export async function executeStandardAttempt(
 
   // Reactive auto-compat: bounded per-target state so a strip-and-retry
   // cycle (see the 400 handling below) can't loop forever (see
-  // dispatcher-auto-compat.ts for the matching/bound logic). Three
-  // independent mechanisms, three independent budgets — none resets another's
+  // dispatcher-auto-compat.ts for the matching/bound logic). Four
+  // independent mechanisms, four independent budgets — none resets another's
   // counter, so the combined worst case for this target is bounded at
   // exactly 1 (initial attempt) + MAX_THINKING_SIGNATURE_STRIP_RETRIES +
-  // MAX_UNSUPPORTED_PARAM_STRIP_RETRIES + MAX_LITE_TOOL_STRIP_RETRIES fetches,
-  // however the mechanisms interleave — they can't ping-pong into an
-  // unbounded loop.
+  // MAX_ADVISOR_RESULT_STRIP_RETRIES + MAX_UNSUPPORTED_PARAM_STRIP_RETRIES +
+  // MAX_LITE_TOOL_STRIP_RETRIES fetches, however the mechanisms interleave —
+  // they can't ping-pong into an unbounded loop.
   const paramStripState = createUnsupportedParamStripState();
   const thinkingStripState = createThinkingSignatureStripState();
+  const advisorStripState = createAdvisorResultStripState();
   const liteToolStripState = createLiteToolStripState();
 
   // Looped so a strip-and-retry can redo the fetch against the SAME target
@@ -266,10 +272,15 @@ export async function executeStandardAttempt(
       //      blocks were signed by a DIFFERENT Claude model/session than
       //      the one we're now targeting, and Anthropic 400s naming the
       //      stale signature specifically.
-      //   2. Unsupported/unknown parameters: some upstreams 400 naming one specific
+      //   2. Account-bound advisor results: failover can replay a
+      //      conversation whose `advisor_tool_result` was sealed (encrypted)
+      //      by a DIFFERENT Claude account than the one we're now targeting,
+      //      and Anthropic 400s "Advisor tool result content could not be
+      //      processed." — same failure class as (1).
+      //   3. Unsupported/unknown parameters: some upstreams 400 naming one specific
       //      client-sent field (e.g. LobeHub's gpt-5.5 traffic sending
       //      safety_identifier / prompt_cache_key that a provider rejects).
-      //   3. Unsupported responses:lite tools: real Codex CLI traffic
+      //   4. Unsupported responses:lite tools: real Codex CLI traffic
       //      declares a `web_search` tool by default, but the
       //      responses:lite wire contract only allows function/custom/
       //      tool_search tools — the 400 names the restriction generically,
@@ -301,6 +312,32 @@ export async function executeStandardAttempt(
           // the one-per-target budget stays available for a later genuine
           // signature 400. Loop-safe because this branch never `continue`s.
           refundThinkingSignatureStrip(thinkingStripState);
+        }
+
+        if (planAdvisorResultStrip(errorText, providerPayload, advisorStripState)) {
+          const stripResult = stripAdvisorResultBlocks(providerPayload);
+          if (stripResult.strippedCount > 0) {
+            // Copy-on-write, like the thinking-signature strip above: a NEW
+            // payload is returned and the original (whose `messages` can be
+            // shared by reference with the long-lived request) is never
+            // mutated, so a successful strip reassigns the binding.
+            providerPayload = stripResult.payload;
+            logger.warn(
+              `Auto-compat: ${route.provider}/${route.model} rejected an account-bound advisor ` +
+                `result — stripped ${stripResult.strippedCount} advisor exchange(s) and retrying the ` +
+                `same target (attempt ${advisorStripState.attempts}/${MAX_ADVISOR_RESULT_STRIP_RETRIES})`
+            );
+            continue;
+          }
+          // Zero blocks stripped — planAdvisorResultStrip's structural
+          // `messages`-array check also matches OpenAI-format payloads, which
+          // never carry advisor blocks. Retrying would resend a byte-identical
+          // request, so fall through to the unsupported-param check / normal
+          // failover handling below instead of retrying this target — and
+          // refund the planned attempt so a later genuine advisor 400 still
+          // gets its one strip-and-retry. Loop-safe: this branch never
+          // `continue`s.
+          refundAdvisorResultStrip(advisorStripState);
         }
 
         const paramToStrip = planUnsupportedParamStrip(errorText, paramStripState);


### PR DESCRIPTION
## Why this is needed

We run `claude-opus-4-8` as a pool across 4 separate Claude OAuth accounts (`selector: random`, `sticky_session: true`). Pooling several Max subscriptions behind one endpoint is why we use the gateway at all.

The Anthropic `advisor` server tool (beta `advisor-tool-2026-03-01`) doesn't survive that setup. When the model calls `advisor`, Anthropic returns the result as an encrypted blob bound to the account that produced it, then echoes it back on later turns:

```json
{ "type": "advisor_tool_result",
  "content": { "type": "advisor_redacted_result", "encrypted_content": "EqQh…" } }
```

Only the origin account can decrypt it. It's the same class of sealed content as `redacted_thinking`.

### How it breaks

1. Sticky session pins the conversation to the account that sealed the blob. Fine while that account is up.
2. That account returns a transient 529.
3. Failover replays the same conversation on a different account.
4. The new account can't decrypt the blob, so Anthropic returns 400 `Advisor tool result content could not be processed.`
5. Every other account rejects it the same way. `All targets failed`, and the turn dies with no recovery.

Failover is normally the safety net. Here it's the thing that kills the request. A payload carrying account-bound content is only valid on its origin account, so trying siblings always fails.

### Impact we measured

Before this change, one day of normal use (Aug 14) produced 21 terminal `All targets failed` advisor errors, one for every time a sticky account blipped mid-conversation.

After deploying it, the reactive strip healed roughly 130 advisor 400s in a single evening with zero terminal failures. The instance has run about 30 hours since with no advisor errors at all under continuous traffic.

### Known limitation

The strip is reactive, so it fires after the 400. If the origin account is overloaded at the same moment and the per-target retry budget runs out before it recovers, a request can still fail. We saw 3 such cases in the first few minutes after deploy during a traffic burst. A proactive version would keep failover on the origin account's `oauth_account` whenever the payload carries sealed content, avoiding the wasted round-trips. This PR stays reactive to match the existing thinking-signature recovery and keep the change small.

---

<!-- kody-pr-summary:start -->
## Summary

Implemented reactive auto-compatibility for account-bound Anthropic advisor results during dispatch.

### Changes

- Detects Anthropic 400 responses indicating an unprocessable `advisor_tool_result`.
- Removes the rejected advisor result and its paired tool invocation by ID.
- Preserves message structure, alternation, and unrelated content when stripping blocks.
- Retries the same target once after a successful strip.
- Avoids retrying when no advisor blocks are present and refunds the retry budget.
- Integrates advisor-result handling with existing dispatch auto-compatibility mechanisms.
- Adds comprehensive tests covering error matching, payload stripping, message handling, retry limits, and budget refunds.
<!-- kody-pr-summary:end -->