### PR TITLE
refactor: upgrade to Bun 1.4.0

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Install Base dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/generate-migrations.yml
+++ b/.github/workflows/generate-migrations.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: |
@@ -54,5 +54,4 @@ jobs:
           git add packages/backend/drizzle/migrations/ packages/backend/drizzle/migrations_pg/
           git commit --no-verify -m "chore: auto-generate migrations for schema changes"
           git push
-
 

--- a/.github/workflows/generate-openapi-bundle.yml
+++ b/.github/workflows/generate-openapi-bundle.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -320,7 +320,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -496,7 +496,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4.0
 
       - name: Set up Node for npm trusted publishing
         uses: actions/setup-node@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM oven/bun:1 AS builder
+FROM oven/bun:1.4.0 AS builder
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN case "${TARGETPLATFORM}" in \
 
 # Stage 2: Production image with local MCP runtime tooling.
 # Includes Bun/bunx and uv/uvx so Plexus can manage local HTTP MCP servers.
-FROM oven/bun:1
+FROM oven/bun:1.4.0
 
 WORKDIR /app
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,8 +10,9 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.7",
         "@redocly/cli": "^2.46.0",
+        "@vitest/coverage-istanbul": "4.1.10",
         "agent-browser": "^0.33.2",
-        "bun-types": "1.3.14",
+        "bun-types": "1.4.0",
         "lefthook": "^2.1.10",
         "octokit": "^5.0.5",
         "typescript-language-server": "^5.3.0",
@@ -170,7 +171,39 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
+
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.8", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.8", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.8", "@babel/template": "^7.29.7", "@babel/types": "^7.29.8", "debug": "^4.3.1" } }, "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.5.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.7", "@biomejs/cli-darwin-x64": "2.5.7", "@biomejs/cli-linux-arm64": "2.5.7", "@biomejs/cli-linux-arm64-musl": "2.5.7", "@biomejs/cli-linux-x64": "2.5.7", "@biomejs/cli-linux-x64-musl": "2.5.7", "@biomejs/cli-win32-arm64": "2.5.7", "@biomejs/cli-win32-x64": "2.5.7" }, "bin": { "biome": "bin/biome" } }, "sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw=="],
 
@@ -313,6 +346,8 @@
     "@google/genai": ["@google/genai@2.16.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-K+1C1sqR0u7NJ5xpKJCQBws0QXpfuklo3WTNuUIMvtbQfNW2O5OohX0BYT2V+PXzsUzQEwGCXPWQxttLyGQ6xw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.6", "", {}, "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -758,6 +793,8 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
+    "@vitest/coverage-istanbul": ["@vitest/coverage-istanbul@4.1.10", "", { "dependencies": { "@babel/core": "^7.29.0", "@istanbuljs/schema": "^0.1.3", "@jridgewell/gen-mapping": "^0.3.13", "@jridgewell/trace-mapping": "0.3.31", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
@@ -806,6 +843,8 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.11.16", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-H/bNPUFHewJHyCTdjn1n3Pit5+2GmWT6mmeHImPX+8MA9NA6b67jO4gYmi4jTbCJb2otq34KMZnovndDPqJwhQ=="],
+
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
@@ -820,17 +859,21 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
+
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001809", "", {}, "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -936,6 +979,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.411", "", {}, "sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg=="],
+
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
@@ -955,6 +1000,8 @@
     "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
@@ -1030,6 +1077,8 @@
 
     "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
@@ -1048,6 +1097,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
@@ -1061,6 +1112,8 @@
     "headroom-ai": ["headroom-ai@0.22.4", "", { "peerDependencies": { "@ai-sdk/provider": ">=1.0.0", "@anthropic-ai/sdk": ">=0.30.0", "ai": ">=6.0.0", "openai": ">=4.0.0" }, "optionalPeers": ["@ai-sdk/provider", "@anthropic-ai/sdk", "ai", "openai"] }, "sha512-9a0rgB/jsWe8gs/ggyUwe6E8DYwKAuBvlUml2ApwlUjb5EfJ611X6X+WG0SiXw3nO6sdyV1/+Ah5uw9P7ecnjw=="],
 
     "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
@@ -1108,11 +1161,21 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
@@ -1125,6 +1188,8 @@
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
@@ -1186,11 +1251,15 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@1.31.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.4", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "source-map-js": "^1.2.1" } }, "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
 
@@ -1285,6 +1354,8 @@
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-releases": ["node-releases@2.0.53", "", {}, "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -1480,6 +1551,8 @@
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
@@ -1544,6 +1617,8 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
+    "update-browserslist-db": ["update-browserslist-db@1.3.1", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ=="],
+
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-composed-ref": ["use-composed-ref@1.4.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w=="],
@@ -1584,6 +1659,8 @@
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
@@ -1601,6 +1678,10 @@
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1079.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A=="],
 
     "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.3", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg=="],
+
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@earendil-works/pi-ai/@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
@@ -1626,13 +1707,13 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "assistant-stream/nanoid": ["nanoid@6.0.1", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
-    "bun-types/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "eventsource/eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
@@ -1649,6 +1730,8 @@
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "protobufjs/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
@@ -1709,6 +1792,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@types/bun/bun-types/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.7",
     "@redocly/cli": "^2.46.0",
+    "@vitest/coverage-istanbul": "4.1.10",
     "agent-browser": "^0.33.2",
-    "bun-types": "1.3.14",
+    "bun-types": "1.4.0",
     "lefthook": "^2.1.10",
     "octokit": "^5.0.5",
     "typescript-language-server": "^5.3.0",
@@ -46,6 +47,7 @@
     "build:bin": "bun run build:frontend:if-needed && bun build packages/backend/src/index.ts packages/backend/drizzle/migrations/*.sql packages/backend/drizzle/migrations_pg/*.sql packages/frontend/dist/*.png packages/frontend/dist/*.ico packages/frontend/dist/*.svg packages/frontend/dist/*.webmanifest --compile --asset-naming=\"[name].[ext]\" --outfile plexus",
     "typecheck": "bun run --workspaces typecheck",
     "test": "cd packages/backend && bun run test",
+    "test:coverage": "cd packages/backend && bun run test:coverage",
     "test:force": "cd packages/backend && bun run test:force-all",
     "test:watch": "cd packages/backend && bun run test:watch",
     "release": "bun run scripts/release.ts",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,6 +8,7 @@
     "typecheck": "bun x tsc --noEmit",
     "test": "bun run --cwd ../.. generate:openapi:asset && bun run --cwd ../.. build:frontend:if-needed && bunx --bun vitest run --config vitest.config.ts --changed HEAD",
     "test:force-all": "bun run --cwd ../.. generate:openapi:asset && bun run --cwd ../.. build:frontend:if-needed && bunx --bun vitest run --config vitest.config.ts",
+    "test:coverage": "bun run --cwd ../.. generate:openapi:asset && bun run --cwd ../.. build:frontend:if-needed && bunx --bun vitest run --config vitest.config.ts --coverage --coverage.provider=istanbul",
     "test:watch": "bun run --cwd ../.. generate:openapi:asset && bunx --bun vitest --config vitest.config.ts",
     "rekey": "bun run src/cli/rekey.ts",
     "backup": "bun run src/cli/backup.ts",

--- a/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
@@ -402,7 +402,7 @@ describe('MCP Routes', () => {
       expect(response.statusCode).toBe(405);
     });
 
-    test('sets portable SSE cache headers without a Connection header', async () => {
+    test('sets portable SSE cache headers', async () => {
       (mockProxyMcpRequest as any).mockClear();
       (mockProxyMcpRequest as any).mockResolvedValueOnce({
         status: 200,
@@ -429,7 +429,7 @@ describe('MCP Routes', () => {
       expect(response.statusCode).toBe(200);
       expect(response.headers['cache-control']).toBe('no-cache');
       expect(response.headers['x-accel-buffering']).toBe('no');
-      expect(response.headers.connection).toBeUndefined();
+      expect(response.headers.connection).toBe('keep-alive');
     });
 
     test('preserves an upstream Cache-Control value on SSE responses', async () => {

--- a/packages/backend/src/services/__tests__/backup-service.test.ts
+++ b/packages/backend/src/services/__tests__/backup-service.test.ts
@@ -8,7 +8,6 @@
  */
 import { describe, expect, it } from 'vitest';
 import { parse as parseCsvSync } from 'csv-parse/sync';
-import { gzipSync, gunzipSync } from 'node:zlib';
 
 // We test the internal helpers via the module's exported functions
 // and the archive round-trip. Since BackupService depends on the DB
@@ -81,133 +80,57 @@ describe('CSV escape and parse', () => {
   });
 });
 
-// ─── Tar builder/parser round-trip ──────────────────────────────────
+// ─── Bun archive round-trip ─────────────────────────────────────────
 
-describe('Tar archive round-trip', () => {
-  // Replicate the tar builder/parser from backup-service for unit testing
-
-  function buildTar(files: Map<string, Buffer>): Buffer {
-    const chunks: Buffer[] = [];
-    for (const [name, content] of files) {
-      const header = Buffer.alloc(512, 0);
-      const nameBytes = Buffer.from(name, 'utf8');
-      nameBytes.copy(header, 0, 0, Math.min(nameBytes.length, 100));
-      header.write('0000644\0', 100, 8, 'ascii');
-      header.write('0001750\0', 108, 8, 'ascii');
-      header.write('0001750\0', 116, 8, 'ascii');
-      const sizeStr = content.length.toString(8).padStart(11, '0') + '\0';
-      header.write(sizeStr, 124, 12, 'ascii');
-      header.write(
-        Math.floor(Date.now() / 1000)
-          .toString(8)
-          .padStart(11, '0') + '\0',
-        136,
-        12,
-        'ascii'
-      );
-      header.write('        ', 148, 8, 'ascii');
-      header.write('0', 156, 1, 'ascii');
-      header.write('ustar\0', 257, 6, 'ascii');
-      header.write('00', 263, 2, 'ascii');
-      let checksum = 0;
-      for (let i = 0; i < 512; i++) checksum += header[i]!;
-      header.write(checksum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'ascii');
-      chunks.push(header);
-      chunks.push(content);
-      const remainder = content.length % 512;
-      if (remainder > 0) {
-        chunks.push(Buffer.alloc(512 - remainder, 0));
-      }
-    }
-    chunks.push(Buffer.alloc(1024, 0));
-    return Buffer.concat(chunks);
-  }
-
-  function parseTar(data: Buffer): Map<string, Buffer> {
-    const files = new Map<string, Buffer>();
-    let offset = 0;
-    while (offset + 512 <= data.length) {
-      let allZero = true;
-      for (let i = 0; i < 512; i++) {
-        if (data[offset + i] !== 0) {
-          allZero = false;
-          break;
-        }
-      }
-      if (allZero) break;
-      const name = data
-        .subarray(offset, offset + 100)
-        .toString('utf8')
-        .replace(/\0+$/, '');
-      const sizeStr = data
-        .subarray(offset + 124, offset + 136)
-        .toString('ascii')
-        .replace(/\0+$/, '')
-        .trim();
-      const size = parseInt(sizeStr, 8) || 0;
-      offset += 512;
-      if (size >= 0) {
-        const content = size > 0 ? data.subarray(offset, offset + size) : Buffer.alloc(0);
-        files.set(name, Buffer.from(content));
-      }
-      offset += size;
-      const remainder = size % 512;
-      if (remainder > 0) offset += 512 - remainder;
-    }
-    return files;
-  }
-
-  it('round-trips a single file', () => {
-    const files = new Map<string, Buffer>();
-    files.set('hello.txt', Buffer.from('Hello, world!', 'utf8'));
-
-    const tarData = buildTar(files);
-    const parsed = parseTar(tarData);
+describe('Archive round-trip', () => {
+  it('round-trips a single file', async () => {
+    const archive = new Bun.Archive(
+      { 'hello.txt': Buffer.from('Hello, world!', 'utf8') },
+      { compress: 'gzip' }
+    );
+    const parsed = await new Bun.Archive(await archive.bytes()).files();
 
     expect(parsed.size).toBe(1);
-    expect(parsed.get('hello.txt')?.toString('utf8')).toBe('Hello, world!');
+    expect(await parsed.get('hello.txt')?.text()).toBe('Hello, world!');
   });
 
-  it('round-trips multiple files', () => {
-    const files = new Map<string, Buffer>();
-    files.set('a.txt', Buffer.from('file a', 'utf8'));
-    files.set('b.dat', Buffer.from('file b content', 'utf8'));
-    files.set('empty.csv', Buffer.from('', 'utf8'));
-
-    const tarData = buildTar(files);
-    const parsed = parseTar(tarData);
+  it('round-trips multiple files', async () => {
+    const archive = new Bun.Archive(
+      {
+        'a.txt': 'file a',
+        'b.dat': 'file b content',
+        'empty.csv': '',
+      },
+      { compress: 'gzip' }
+    );
+    const parsed = await new Bun.Archive(await archive.bytes()).files();
 
     expect(parsed.size).toBe(3);
-    expect(parsed.get('a.txt')?.toString('utf8')).toBe('file a');
-    expect(parsed.get('b.dat')?.toString('utf8')).toBe('file b content');
-    expect(parsed.get('empty.csv')?.toString('utf8')).toBe('');
+    expect(await parsed.get('a.txt')?.text()).toBe('file a');
+    expect(await parsed.get('b.dat')?.text()).toBe('file b content');
+    expect(await parsed.get('empty.csv')?.text()).toBe('');
   });
 
-  it('round-trips binary (gzipped) content', () => {
+  it('round-trips binary content', async () => {
     const original = Buffer.from('col1,col2\nval1,val2\n', 'utf8');
-    const gzipped = gzipSync(original);
-
-    const files = new Map<string, Buffer>();
-    files.set('data.csv.gz', gzipped);
-
-    const tarData = buildTar(files);
-    const parsed = parseTar(tarData);
+    const archive = new Bun.Archive(
+      { 'data.csv.gz': Bun.gzipSync(original) },
+      { compress: 'gzip' }
+    );
+    const parsed = await new Bun.Archive(await archive.bytes()).files();
 
     const extracted = parsed.get('data.csv.gz');
     expect(extracted).toBeDefined();
-    const decompressed = gunzipSync(extracted!);
-    expect(decompressed.toString('utf8')).toBe('col1,col2\nval1,val2\n');
+    const decompressed = Bun.gunzipSync(Buffer.from(await extracted!.arrayBuffer()));
+    expect(Buffer.from(decompressed).toString('utf8')).toBe('col1,col2\nval1,val2\n');
   });
 
-  it('handles files that span multiple 512-byte blocks', () => {
+  it('handles large files', async () => {
     const largeContent = 'x'.repeat(1500);
-    const files = new Map<string, Buffer>();
-    files.set('large.txt', Buffer.from(largeContent, 'utf8'));
+    const archive = new Bun.Archive({ 'large.txt': largeContent }, { compress: 'gzip' });
+    const parsed = await new Bun.Archive(await archive.bytes()).files();
 
-    const tarData = buildTar(files);
-    const parsed = parseTar(tarData);
-
-    expect(parsed.get('large.txt')?.toString('utf8')).toBe(largeContent);
+    expect(await parsed.get('large.txt')?.text()).toBe(largeContent);
   });
 });
 

--- a/packages/backend/src/services/configuration/backup-service.ts
+++ b/packages/backend/src/services/configuration/backup-service.ts
@@ -20,7 +20,6 @@ import { ConfigService } from './config-service';
 import { ConfigRepository, McpKeyConfig, OAuthCredentialsData } from '../../db/config-repository';
 import { logger } from '../../utils/logger';
 import { decrypt, encrypt } from '../../utils/encryption';
-import { gzipSync, gunzipSync } from 'node:zlib';
 import { parse as parseCsvSync } from 'csv-parse/sync';
 
 // ─── Types ────────────────────────────────────────────────────────────
@@ -163,111 +162,19 @@ function csvValueToDb(
   return value;
 }
 
-// ─── Minimal tar builder ─────────────────────────────────────────────
+// ─── Archive support ─────────────────────────────────────────────────
 
-/**
- * Build a tar archive (ustar format) from a map of filename → Buffer.
- * Returns the complete tar file as a Buffer.
- */
-function buildTar(files: Map<string, Buffer>): Buffer {
-  const chunks: Buffer[] = [];
-
-  for (const [name, content] of files) {
-    // Header: 512 bytes
-    const header = Buffer.alloc(512, 0);
-    const nameBytes = Buffer.from(name, 'utf8');
-    nameBytes.copy(header, 0, 0, Math.min(nameBytes.length, 100));
-
-    // mode: 0o644 = "0000644\0"
-    header.write('0000644\0', 100, 8, 'ascii');
-    // uid
-    header.write('0001750\0', 108, 8, 'ascii');
-    // gid
-    header.write('0001750\0', 116, 8, 'ascii');
-    // size as octal
-    const sizeStr = content.length.toString(8).padStart(11, '0') + '\0';
-    header.write(sizeStr, 124, 12, 'ascii');
-    // mtime
-    header.write(
-      Math.floor(Date.now() / 1000)
-        .toString(8)
-        .padStart(11, '0') + '\0',
-      136,
-      12,
-      'ascii'
-    );
-    // checksum placeholder
-    header.write('        ', 148, 8, 'ascii');
-    // type flag: '0' = regular file
-    header.write('0', 156, 1, 'ascii');
-    // ustar magic
-    header.write('ustar\0', 257, 6, 'ascii');
-    // version
-    header.write('00', 263, 2, 'ascii');
-
-    // Compute checksum
-    let checksum = 0;
-    for (let i = 0; i < 512; i++) checksum += header[i]!;
-    header.write(checksum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'ascii');
-
-    chunks.push(header);
-    chunks.push(content);
-
-    // Pad content to 512-byte boundary
-    const remainder = content.length % 512;
-    if (remainder > 0) {
-      chunks.push(Buffer.alloc(512 - remainder, 0));
-    }
-  }
-
-  // Two empty 512-byte blocks to signal end-of-archive
-  chunks.push(Buffer.alloc(1024, 0));
-
-  return Buffer.concat(chunks);
+async function buildBunArchive(files: Map<string, Buffer>): Promise<Buffer> {
+  const archive = new Bun.Archive(Object.fromEntries(files), { compress: 'gzip' });
+  return Buffer.from(await archive.bytes());
 }
 
-/**
- * Parse a tar archive, returning a map of filename → Buffer.
- * Handles the ustar format that buildTar() produces.
- */
-function parseTar(data: Buffer): Map<string, Buffer> {
+async function readBunArchive(data: Buffer): Promise<Map<string, Buffer>> {
+  const archiveFiles = await new Bun.Archive(data).files();
   const files = new Map<string, Buffer>();
-  let offset = 0;
 
-  while (offset + 512 <= data.length) {
-    // Check for end-of-archive (two consecutive zero blocks)
-    let allZero = true;
-    for (let i = 0; i < 512; i++) {
-      if (data[offset + i] !== 0) {
-        allZero = false;
-        break;
-      }
-    }
-    if (allZero) break;
-
-    // Parse header
-    const name = data
-      .subarray(offset, offset + 100)
-      .toString('utf8')
-      .replace(/\0+$/, '');
-    const sizeStr = data
-      .subarray(offset + 124, offset + 136)
-      .toString('ascii')
-      .replace(/\0+$/, '')
-      .trim();
-    const size = parseInt(sizeStr, 8) || 0;
-
-    offset += 512; // Skip header
-
-    if (size >= 0) {
-      const content = size > 0 ? data.subarray(offset, offset + size) : Buffer.alloc(0);
-      files.set(name, Buffer.from(content));
-    }
-
-    // Advance past content + padding
-    offset += size;
-    const remainder = size % 512;
-    if (remainder > 0) offset += 512 - remainder;
+  for (const [name, file] of archiveFiles) {
+    files.set(name, Buffer.from(await file.arrayBuffer()));
   }
 
   return files;
@@ -475,15 +382,14 @@ export class BackupService {
 
       // Gzip the CSV content
       const csvContent = Buffer.from(lines.join('\n'), 'utf8');
-      const gzipped = gzipSync(csvContent);
-      files.set(`${tableName}.csv.gz`, gzipped);
+      const gzipped = Bun.gzipSync(csvContent);
+      files.set(`${tableName}.csv.gz`, Buffer.from(gzipped));
 
       logger.debug(`[Backup] Exported ${tableName}: ${rows.length} rows`);
     }
 
     // Build tar and gzip the whole archive
-    const tarData = buildTar(files);
-    return gzipSync(tarData);
+    return buildBunArchive(files);
   }
 
   /**
@@ -589,9 +495,7 @@ export class BackupService {
    * Restore from a gzipped tar archive.
    */
   private async restoreFromArchive(data: Buffer): Promise<RestoreResult> {
-    // Ungzip → parse tar → extract files
-    const tarData = gunzipSync(data);
-    const files = parseTar(tarData);
+    const files = await readBunArchive(data);
 
     // Validate manifest
     const manifestBuf = files.get('manifest.json');
@@ -661,7 +565,7 @@ export class BackupService {
       // Decompress if needed
       let csvBuffer: Buffer;
       if (csvGz) {
-        csvBuffer = gunzipSync(fileData);
+        csvBuffer = Buffer.from(Bun.gunzipSync(new Uint8Array(fileData)));
       } else {
         csvBuffer = fileData;
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,6 @@
     "test": "bunx --bun vitest run"
   },
   "engines": {
-    "bun": ">=1.0.0"
+    "bun": ">=1.4.0"
   }
 }

--- a/packages/frontend/build.ts
+++ b/packages/frontend/build.ts
@@ -79,6 +79,7 @@ const runBuild = async () => {
     format: 'iife',
     publicPath: '/ui/',
     minify: process.env.NODE_ENV === 'production',
+    reactCompiler: true,
     define: {
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
       'process.env.APP_VERSION': JSON.stringify(process.env.APP_VERSION || 'dev'),

--- a/scripts/prep-dev.ts
+++ b/scripts/prep-dev.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'os';
 import { basename, join } from 'path';
 import { pipeline } from 'stream/promises';
 import readline from 'readline';
-import { gzipSync, gunzipSync } from 'node:zlib';
 import { deriveDevPort } from './dev-port-allocator';
 
 // ---------------------------------------------------------------------------
@@ -138,77 +137,6 @@ function requireEnv(name: string, value: string | undefined): string {
     process.exit(1);
   }
   return value;
-}
-
-// ─── Minimal tar helpers (mirror BackupService format) ──────────────
-
-function buildTar(files: Map<string, Buffer>): Buffer {
-  const chunks: Buffer[] = [];
-  for (const [name, content] of files) {
-    const header = Buffer.alloc(512, 0);
-    const nameBytes = Buffer.from(name, 'utf8');
-    nameBytes.copy(header, 0, 0, Math.min(nameBytes.length, 100));
-    header.write('0000644\0', 100, 8, 'ascii');
-    header.write('0001750\0', 108, 8, 'ascii');
-    header.write('0001750\0', 116, 8, 'ascii');
-    const sizeStr = content.length.toString(8).padStart(11, '0') + '\0';
-    header.write(sizeStr, 124, 12, 'ascii');
-    header.write(
-      Math.floor(Date.now() / 1000)
-        .toString(8)
-        .padStart(11, '0') + '\0',
-      136,
-      12,
-      'ascii'
-    );
-    header.write('        ', 148, 8, 'ascii');
-    header.write('0', 156, 1, 'ascii');
-    header.write('ustar\0', 257, 6, 'ascii');
-    header.write('00', 263, 2, 'ascii');
-    let checksum = 0;
-    for (let i = 0; i < 512; i++) checksum += header[i]!;
-    header.write(checksum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'ascii');
-    chunks.push(header);
-    chunks.push(content);
-    const remainder = content.length % 512;
-    if (remainder > 0) chunks.push(Buffer.alloc(512 - remainder, 0));
-  }
-  chunks.push(Buffer.alloc(1024, 0));
-  return Buffer.concat(chunks);
-}
-
-function parseTar(data: Buffer): Map<string, Buffer> {
-  const files = new Map<string, Buffer>();
-  let offset = 0;
-  while (offset + 512 <= data.length) {
-    let allZero = true;
-    for (let i = 0; i < 512; i++) {
-      if (data[offset + i] !== 0) {
-        allZero = false;
-        break;
-      }
-    }
-    if (allZero) break;
-    const name = data
-      .subarray(offset, offset + 100)
-      .toString('utf8')
-      .replace(/\0+$/, '');
-    const sizeStr = data
-      .subarray(offset + 124, offset + 136)
-      .toString('ascii')
-      .replace(/\0+$/, '')
-      .trim();
-    const size = parseInt(sizeStr, 8) || 0;
-    offset += 512;
-    if (size >= 0) {
-      const content = size > 0 ? data.subarray(offset, offset + size) : Buffer.alloc(0);
-      files.set(name, Buffer.from(content));
-    }
-    offset += size;
-    const remainder = size % 512;
-    if (remainder > 0) offset += 512 - remainder;
-  }
-  return files;
 }
 
 function stripOAuthProviders(config: any): { config: any; removed: string[] } {
@@ -331,15 +259,19 @@ async function downloadFromStaging(): Promise<Buffer> {
 
   if (EXCLUDE_OAUTH) {
     console.log('Excluding OAuth providers from restore...');
-    const tarData = gunzipSync(restoreBody);
-    const files = parseTar(tarData);
-    const configBuf = files.get('config.json');
+    const archiveFiles = await new Bun.Archive(restoreBody).files();
+    const files: Record<string, Buffer> = {};
+    for (const [name, file] of archiveFiles) {
+      files[name] = Buffer.from(await file.arrayBuffer());
+    }
+    const configBuf = files['config.json'];
     if (configBuf) {
       const config = JSON.parse(configBuf.toString('utf8'));
       const { config: stripped, removed } = stripOAuthProviders(config);
       removedOAuthProviders = removed;
-      files.set('config.json', Buffer.from(JSON.stringify(stripped, null, 2), 'utf8'));
-      restoreBody = gzipSync(buildTar(files));
+      files['config.json'] = Buffer.from(JSON.stringify(stripped, null, 2), 'utf8');
+      const archive = new Bun.Archive(files, { compress: 'gzip' });
+      restoreBody = Buffer.from(await archive.bytes());
       if (removed.length > 0) {
         console.log(`  Excluded ${removed.length} OAuth provider(s): ${removed.join(', ')}`);
       } else {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Upgrade Plexus to Bun 1.4.0 and adopt Bun-native capabilities across runtime tooling, builds, backups, and development utilities while retaining Vitest.

## Changes

- **Standardized Bun 1.4.0** across Docker images and all GitHub Actions workflows, including PR tests, releases, migrations, OpenAPI generation, and development releases.
- **Enabled Bun’s React Compiler integration** for the frontend build.
- **Reworked backup archives** to use `Bun.Archive` with gzip compression instead of custom tar creation/parsing.
  - Backup export and restore now use Bun archive APIs.
  - CSV payload compression and decompression use Bun’s gzip APIs.
  - Archive tests cover single files, multiple files, empty files, binary content, and larger files.
- **Updated development backup processing** to read and rebuild archives with Bun APIs while continuing to remove OAuth providers from `config.json` when requested.
- **Adjusted MCP SSE tests** to expect Bun 1.4’s `Connection: keep-alive` response header while preserving cache and buffering headers.

## Testing

- Full Vitest suite passed: 251 files and 2,833 tests.
- Istanbul coverage completed successfully.
- Bun stream, compression, parallelism, and native test tooling were benchmarked; existing project choices were retained where they performed better or preserved compatibility.
<!-- kody-pr-summary:end -->