### PR TITLE
fix(ci): limit repomap tool installation

### DIFF
--- a/.github/workflows/generate-repomap.yml
+++ b/.github/workflows/generate-repomap.yml
@@ -30,6 +30,7 @@ jobs:
         uses: jdx/mise-action@v3
         with:
           cache: true
+          install_args: bun github:universal-ctags/ctags-nightly-build
 
       - name: Generate and push repomap
         shell: bash


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary
Restricts the repomap workflow’s mise setup to installing only the tools required for repomap generation: Bun and universal-ctags.

## Impact
Prevents unrelated tools declared in `mise.toml`, including `@kodus/cli@latest`, from blocking the workflow before the repomap generation step runs. Workflow caching remains enabled.
<!-- kody-pr-summary:end -->