### PR TITLE
fix: improve usage analytics and backup restores

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,247 @@
+# Usage Analytics Range Correctness and Performance Plan
+
+## Objective
+
+Correct Issue #823 across Dashboard Usage Analytics and Detailed Usage without making the default dashboard slower or returning unbounded analytics payloads.
+
+Success means:
+
+- Hour, Day, Week, Month, and Custom use the complete requested time window.
+- Custom dates are editable and are sent unchanged to the backend.
+- KPI cards, time series, and categorical breakdowns no longer depend on 100- or 5,000-row client samples.
+- Default dashboard requests do not compute grouped analytics unless the active view needs them.
+- Initial loads show skeletons; later refreshes retain existing data with an accessible loading indicator.
+- Series, grouped dimensions, custom ranges, cache entries, and serialized responses have explicit bounds.
+
+## Confirmed Problems
+
+1. `packages/frontend/src/components/dashboard/tabs/UsageTab.tsx` receives the Custom range callback but does not pass it to `TimeRangeSelector`. Selecting Custom can therefore issue a zero-duration request.
+2. Dashboard model/provider/API-key charts aggregate only the newest 5,000 raw records in `packages/frontend/src/lib/api.ts`.
+3. `packages/frontend/src/pages/DetailedUsage.tsx` derives KPI cards from at most 5,000 rows and categorical views from at most 100 rows.
+4. Backend `summary.stats` intersects the requested range with a fixed seven-day window, making Week and Month statistics identical on staging.
+5. Detailed Usage time-series metrics are incomplete: cost can be undercounted, while errors, duration, TTFT, and TPS are zero in the server-summary path.
+6. Usage Analytics has no content loading state and can show empty charts while requests are still pending.
+7. Global summary queries filter `request_usage.start_time`, but no standalone `start_time` index exists.
+
+## Staging Baseline
+
+Read-only `plexuscli` measurements showed:
+
+- Preset summaries: approximately 0.94–1.03 seconds and 2–8 KiB.
+- A 5,000-row projected breakdown response: approximately 1.35 MiB.
+- A 100-row full usage response: approximately 188 KiB.
+- Actual matching rows were approximately 2,800 for Day, 17,700 for Week, and 75,500 for Month.
+
+These measurements establish that server-side aggregation should reduce transfer volume substantially, while query latency must be measured before adding indexes.
+
+After implementation, a 20-request direct HTTP run against the dev proxy measured:
+
+- Basic Day summary: 5,102 bytes, p95 6 ms.
+- Basic Month summary: 10,588 bytes, p95 2 ms.
+- Month summary with provider/model/API-key breakdowns: 21,712 bytes, p95 2 ms.
+- Responses included both `MISS` and `HIT` cache headers; the larger maximum times
+  were isolated cold/proxy requests, while repeated cached requests were 1–3 ms.
+
+These measurements are endpoint-level results and are not substitutes for a
+database benchmark on 100k- or 1m-row synthetic datasets.
+
+The production-path checks now also enforce the 16 KiB basic-response and 128 KiB
+grouped-response limits before a result enters the cache. Summary telemetry records
+range, dialect, query duration, result cardinality, response bytes, and cache state.
+Detailed Usage List mode requests only the displayed fields for its 100-row preview.
+
+## Target API Contract
+
+Extend `GET /v0/management/usage/summary` rather than adding another endpoint.
+
+The default response remains `series`, `stats`, and `today`. Optional grouped dimensions are requested explicitly:
+
+```text
+?range=month&breakdowns=provider,modelAlias,apiKey&breakdownLimit=10
+```
+
+### Range semantics
+
+- `hour`: rolling 1 hour.
+- `day`: rolling 24 hours.
+- `week`: rolling 7 days.
+- `month`: rolling 30 days.
+- `custom`: inclusive supplied boundaries, with a maximum duration of 12 months.
+- `stats` and `series` use the same `[rangeStart, rangeEnd]` boundaries.
+- Custom series retains adaptive resolution and never exceeds 100 buckets.
+
+### Metrics
+
+Return the following in `stats`, each series bucket, and each grouped entry where meaningful:
+
+- Requests and errors.
+- Input, output, reasoning, cached, and cache-write tokens.
+- Total tokens using the quota formula: input + output + reasoning + cached + cache-write.
+- Total cost.
+- Average duration, TTFT, and tokens per second.
+- Success rate.
+
+### Group bounds
+
+- Grouping is opt-in and absent from ordinary summary responses.
+- Permit at most three dimensions per request.
+- Default to the top 10 groups; clamp the requested limit to 50.
+- Sort deterministically by request count, then name.
+- Return an exact `Other` rollup plus `totalDimensions` and `truncated` metadata.
+- Reject unsupported dimensions or excessive limits before executing queries.
+- Keep basic responses under 16 KiB and grouped responses under approximately 128 KiB.
+
+## Workstreams and Dependencies
+
+### Workstream A: Backend aggregate contract
+
+**Starts first and blocks frontend data integration.** Documentation and loading-state work can proceed independently.
+
+1. Keep range parsing and bucket resolution centralized in `packages/backend/src/routes/management/usage.ts`.
+2. Remove `statsStart`; make stats use the selected range exactly.
+3. Add rich aggregates to the existing series and stats queries so the added fields do not require additional scans.
+4. Parse and validate canonicalized `breakdowns` and `breakdownLimit` parameters.
+5. Execute only requested grouped queries and apply `scopedKeyName(request)` to every aggregate.
+6. Preserve page semantics for model aliases, direct traffic, probe traffic, statuses, and API-key display without exposing secrets.
+7. Return top groups, exact `Other` values, and truncation metadata.
+8. Keep SQLite queries sequential. Consider bounded Postgres concurrency only after measurement.
+
+### Workstream B: Backend cache and performance instrumentation
+
+**Can proceed in parallel with Workstream A after the final query parameters are named.** It blocks final performance acceptance, not frontend compilation.
+
+1. Add a principal-scoped in-memory cache around completed summary responses.
+2. Cache preset requests for 10 seconds and historical Custom requests for approximately 60 seconds.
+3. Include role/key scope, range, dates, normalized dimensions, and limits in the cache key.
+4. Coalesce simultaneous identical requests and never cache failures.
+5. Record route duration, logical query duration, result cardinality, response bytes, cache hit/miss, dialect, and selected range.
+6. Ensure the cache cannot share admin results with limited principals.
+
+### Workstream C: API documentation and generated types
+
+**Can proceed in parallel with backend implementation once the response shape is agreed.** Regeneration waits for source YAML completion.
+
+1. Update `docs/openapi/paths/v0_management_usage_summary.yaml` with real preset durations, Custom limits, optional grouping, and validation responses.
+2. Update `docs/openapi/components/schemas/UsageSummary.yaml` with range-scoped stats, rich metrics, grouped response types, and the quota token formula.
+3. Update stale frontend comments describing stats as fixed seven-day data.
+4. Regenerate `packages/backend/src/assets/openapi.json` and `scripts/openapi-types.ts`; do not edit generated artifacts manually.
+
+### Workstream D: Dashboard Usage Analytics
+
+**Custom wiring and loading UI can proceed independently. Aggregate integration depends on Workstream A.**
+
+1. Pass `customDateRange` and `onCustomDateRangeChange` from `UsageTab` to `TimeRangeSelector`.
+2. Replace three 5,000-row breakdown requests with one summary request containing model/provider/API-key breakdowns.
+3. Keep provider/model concurrency on its existing endpoint.
+4. Add request-generation or cancellation guards so older ranges cannot overwrite current state.
+5. Show card-shaped skeletons on initial load.
+6. During range refresh, retain existing charts and show an accessible loading status until replacements arrive.
+7. Do not show an empty state until its request has settled successfully.
+
+### Workstream E: Detailed Usage
+
+**Loading UI can proceed independently. Aggregate integration depends on Workstream A.**
+
+1. Populate KPI cards from `summary.stats`, not raw records.
+2. Populate all time-chart metrics from rich `summary.series`.
+3. Request only the active provider/model/API-key/status breakdown for categorical views.
+4. Remove analytical reductions over the limited `records` array.
+5. Fetch 100 raw rows only when List mode needs them; complete request browsing remains on Logs.
+6. Retain the existing Refresh button spinner and add skeleton KPIs/chart content for initial load.
+7. Preserve existing content with a small loading indicator on range/group refresh.
+8. Guard polling and manual refreshes against stale responses.
+
+### Workstream F: Limited-user Overall Dashboard
+
+**Depends on Workstream A and can run in parallel with Workstreams D and E.**
+
+1. Replace the two 5,000-row provider/model requests with optional summary breakdowns.
+2. Keep identity and quota calls independent so slow analytics do not block primary account data.
+3. Consume range-scoped stats directly instead of reconstructing totals from series.
+4. Preserve existing progressive card rendering and cancellation behavior.
+
+### Workstream G: Regression tests
+
+**Backend fixtures can be prepared in parallel; assertions depend on Workstream A.** Load the `vitest` skill before editing tests.
+
+Extend `packages/backend/src/routes/management/__tests__/usage-summary.test.ts` to cover:
+
+- Every preset and valid Custom ranges.
+- Missing, invalid, reversed, and over-12-month Custom ranges.
+- Inclusive range boundaries and out-of-range exclusion.
+- Range-scoped stats and all rich metric calculations.
+- Quota-formula token totals.
+- Each grouping dimension, top-N behavior, `Other`, and deterministic ordering.
+- Admin versus limited-principal scoping.
+- Cache-key separation and in-flight request coalescing.
+- High-cardinality fixtures proving bucket/group/response bounds.
+
+## Performance Gate and Optional Index
+
+Benchmark SQLite and Postgres with representative 100k- and 1m-row datasets before changing schema.
+
+Initial budgets:
+
+- Basic cached summary p95 under 100 ms.
+- Basic cold summary p95 under 750 ms.
+- Bounded grouped summary p95 under 1 second.
+- No measurable regression to request writes during dashboard polling.
+
+If cold global summaries miss the budget, add `request_usage(start_time)` to both dialect schemas through the `db-schema-migrations` workflow. Edit only Drizzle schema files; never manually create migration files. Pre-aggregated tables, materialized views, and covering indexes are follow-up options, not part of this implementation.
+
+## Integration Order
+
+1. Finalize the response/query contract.
+2. Implement Workstreams A, B, and C in parallel where dependencies permit.
+3. Implement frontend loading-state portions of D and E independently.
+4. After A stabilizes, integrate D, E, and F in parallel.
+5. Complete G against the integrated contract.
+6. Run the performance gate and add the optional index only if required.
+7. Regenerate OpenAPI artifacts, run all checks, and perform browser verification.
+8. After deployment, repeat read-only staging CLI latency, payload, and full-range total comparisons.
+
+## Verification
+
+Run:
+
+```bash
+bun run test
+bun run typecheck
+bun run lint:openapi
+bun run format:check
+bun run generate:openapi:asset
+bun run sync:openapi:types
+```
+
+Load the `frontend-testing` skill, start `bun run dev:agent --detach`, and verify with a real browser:
+
+- Initial skeletons and refresh indicators.
+- Distinct Day, Week, and Month totals and breakdowns.
+- Custom initialization, editing, validation, and exact request dates.
+- Accurate Detailed Usage KPIs and every grouping mode.
+- No stale data after rapid range/group changes.
+- List mode remains a 100-row preview.
+- Default Live Metrics dashboard never requests grouped analytics; Usage Analytics
+  requests them because its active view needs the breakdown cards.
+- Limited Overall Dashboard no longer transfers large raw breakdown datasets.
+
+The dev-proxy verification passed these UI checks after the database was populated:
+the Day summary showed 3,160 requests, Week 18,089, and Month 75,980; the Day
+provider/model concurrency endpoints returned 81/94 points; and Custom loaded and
+displayed editable dates with HTTP 200 summary/concurrency requests.
+
+## Scope Boundaries
+
+- No Detailed Usage list pagination or analytics export.
+- No concurrency redesign.
+- No schema change unless benchmarks fail.
+- No blocking full-page spinner during ordinary refreshes.
+- No pre-aggregated tables or materialized views in the initial solution.
+
+## Critical Files
+
+- `packages/backend/src/routes/management/usage.ts`
+- `packages/backend/src/routes/management/__tests__/usage-summary.test.ts`
+- `packages/frontend/src/lib/api.ts`
+- `packages/frontend/src/components/dashboard/tabs/UsageTab.tsx`
+- `packages/frontend/src/pages/DetailedUsage.tsx`

--- a/docs/openapi/components/schemas/UsageSummary.yaml
+++ b/docs/openapi/components/schemas/UsageSummary.yaml
@@ -5,8 +5,7 @@ properties:
   range:
     type: string
     description: >
-      Time range for series data. Format depends on query param (e.g. "24h",
-      "7d", custom start/end). Affects only the series field.
+      Requested time range. Both series and stats use this range.
   series:
     type: array
     items:
@@ -19,12 +18,18 @@ properties:
         requests:
           type: integer
           description: Number of requests in this bucket.
+        errors:
+          type: integer
+          description: Number of non-success requests in this bucket.
         inputTokens:
           type: integer
           description: Sum of input tokens across all requests.
         outputTokens:
           type: integer
           description: Sum of output tokens across all requests.
+        reasoningTokens:
+          type: integer
+          description: Sum of reasoning tokens across all requests.
         cachedTokens:
           type: integer
           description: Sum of cached tokens across all requests.
@@ -34,23 +39,80 @@ properties:
         tokens:
           type: integer
           description: >
-            Total token count = inputTokens + outputTokens + cachedTokens + cacheWriteTokens.
+            Total token count = inputTokens + outputTokens + reasoningTokens +
+            cachedTokens + cacheWriteTokens.
+        totalCost:
+          type: number
+          description: Sum of request costs in the bucket.
+        avgDurationMs:
+          type: number
+          description: Average request duration in milliseconds.
+        avgTtftMs:
+          type: number
+          description: Average time to first token in milliseconds.
+        avgTokensPerSec:
+          type: number
+          description: Average reported tokens per second.
   stats:
     type: object
-    description: Rolling 7-day aggregation window.
+    description: Aggregation over the requested range.
     properties:
       totalRequests:
         type: integer
-        description: Total requests in the 7-day window.
+        description: Total requests in the requested range.
+      totalErrors:
+        type: integer
+        description: Total non-success requests in the requested range.
       totalTokens:
         type: integer
-        description: Total tokens (input + output + cached + cacheWrite) in the window.
+        description: >
+          Total tokens (input + output + reasoning + cached + cacheWrite) in
+          the requested range.
+      inputTokens:
+        type: integer
+        description: Total uncached input tokens.
+      outputTokens:
+        type: integer
+        description: Total output tokens.
+      reasoningTokens:
+        type: integer
+        description: Total reasoning tokens.
+      cachedTokens:
+        type: integer
+        description: Total cached input tokens.
+      cacheWriteTokens:
+        type: integer
+        description: Total cache-write tokens.
+      totalCost:
+        type: number
+        description: Total request cost in the requested range.
       avgDurationMs:
         type: number
         description: Average request duration in milliseconds.
       totalDurationMs:
         type: integer
         description: Sum of all request durations in milliseconds.
+      avgTtftMs:
+        type: number
+        description: Average time to first token in milliseconds.
+      avgTokensPerSec:
+        type: number
+        description: Average reported tokens per second.
+      successRate:
+        type: number
+        description: Percentage of requests whose status is success.
+  grouped:
+    type: object
+    description: Optional top-N aggregates for requested dimensions.
+    properties:
+      provider:
+        $ref: ./UsageSummaryBreakdown.yaml
+      modelAlias:
+        $ref: ./UsageSummaryBreakdown.yaml
+      apiKey:
+        $ref: ./UsageSummaryBreakdown.yaml
+      status:
+        $ref: ./UsageSummaryBreakdown.yaml
   today:
     type: object
     description: Aggregation since local midnight (time-of-day based, not UTC).

--- a/docs/openapi/components/schemas/UsageSummaryBreakdown.yaml
+++ b/docs/openapi/components/schemas/UsageSummaryBreakdown.yaml
@@ -1,0 +1,13 @@
+type: object
+description: Optional top-N aggregates for one requested dimension.
+properties:
+  items:
+    type: array
+    items:
+      $ref: ./UsageSummaryGroup.yaml
+  totalDimensions:
+    type: integer
+    description: Total distinct groups in the requested range.
+  truncated:
+    type: boolean
+    description: Whether groups were omitted from the named items.

--- a/docs/openapi/components/schemas/UsageSummaryGroup.yaml
+++ b/docs/openapi/components/schemas/UsageSummaryGroup.yaml
@@ -1,0 +1,34 @@
+type: object
+description: Aggregate metrics for one usage dimension value.
+properties:
+  name:
+    type: string
+    description: Group label; API-key labels are display-safe prefixes.
+  requests:
+    type: integer
+  errors:
+    type: integer
+  inputTokens:
+    type: integer
+  outputTokens:
+    type: integer
+  reasoningTokens:
+    type: integer
+  cachedTokens:
+    type: integer
+  cacheWriteTokens:
+    type: integer
+  totalTokens:
+    type: integer
+  totalCost:
+    type: number
+  avgDurationMs:
+    type: number
+  totalDurationMs:
+    type: number
+  avgTtftMs:
+    type: number
+  avgTokensPerSec:
+    type: number
+  successRate:
+    type: number

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -601,6 +601,12 @@ components:
   schemas:
     WebSearchCoercionAdapterOptions:
       $ref: ./components/schemas/WebSearchCoercionAdapterOptions.yaml
+    UsageSummary:
+      $ref: ./components/schemas/UsageSummary.yaml
+    UsageSummaryBreakdown:
+      $ref: ./components/schemas/UsageSummaryBreakdown.yaml
+    UsageSummaryGroup:
+      $ref: ./components/schemas/UsageSummaryGroup.yaml
   securitySchemes:
     PlexusApiKey:
       type: http

--- a/docs/openapi/paths/v0_management_usage_summary.yaml
+++ b/docs/openapi/paths/v0_management_usage_summary.yaml
@@ -3,30 +3,35 @@ get:
     - Management — Usage
   summary: Aggregated usage time-series and totals
   description: |
-    Returns bucketed series plus 7-day and since-midnight rollups.
+    Returns range-scoped bucketed series and totals plus a since-midnight
+    rollup. Optional grouped breakdowns are computed server-side over the
+    complete requested range.
 
     ## Scoping
 
     Limited principals see only their own key's data; admins see global data.
 
-    ## Bucket algorithm
+    ## Range and bucket algorithm
 
     The endpoint uses adaptive bucketing to ensure meaningful visualizations:
-    - `hour` — returns hourly buckets for the last 24 hours
-    - `day` — returns daily buckets for the last 30 days
-    - `week` — returns weekly buckets for the last 12 weeks
-    - `month` — returns monthly buckets for the last 12 months
+    - `hour` — the last hour, in one-minute buckets
+    - `day` — the last 24 hours, in one-hour buckets
+    - `week` — the last 7 days, in one-day buckets
+    - `month` — the last 30 days, in one-day buckets
     - `custom` — requires `startDate` and `endDate`; buckets are auto-sized
-      based on the range duration
+      based on the range duration and the range may not exceed 12 months.
 
     ## Response structure
 
     - **series** — Time-bucketed data, where each bucket contains aggregated
       counts and token sums
-    - **stats** — Fixed 7-day rolling window (always the last 7 days, regardless
-      of `range`)
+    - **stats** — Aggregation over the requested range, including rich usage
+      and performance metrics
     - **today** — Aggregation since local midnight (not UTC), giving a
       "day-so-far" view
+    - **grouped** — Optional top-N grouped aggregates. Request dimensions with
+      the comma-separated `breakdowns` parameter. At most three dimensions are
+      allowed, and omitted groups are represented by an `Other` item.
   security:
     - AdminKey: []
   parameters:
@@ -53,13 +58,46 @@ get:
         type: string
         format: date-time
       description: Required with `range=custom`.
+    - in: query
+      name: breakdowns
+      schema:
+        type: string
+        example: provider,modelAlias
+      description: >
+        Optional comma-separated dimensions: provider, modelAlias, apiKey,
+        or status. At most three dimensions are allowed.
+    - in: query
+      name: breakdownLimit
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 50
+        default: 10
+      description: Maximum number of named groups returned per dimension.
+    - in: query
+      name: exclude
+      schema:
+        type: string
+        example: directModels,probe
+      description: >
+        Optional comma-separated dimension-specific exclusions. `directModels`
+        excludes model aliases beginning with `direct/`; `probe` excludes the
+        internal probe API key from API-key breakdowns.
   responses:
     '200':
       description: Aggregates.
+      headers:
+        X-Usage-Summary-Cache:
+          description: Whether the response was served from the in-memory summary cache.
+          schema:
+            type: string
+            enum: [HIT, MISS]
       content:
         application/json:
           schema:
             $ref: ../components/schemas/UsageSummary.yaml
     '400':
       description: Invalid `range` or custom-range parameters.
+    '413':
+      description: Requested aggregate response exceeds the response-size limit.
   operationId: getV0ManagementUsageSummary

--- a/packages/backend/src/assets/openapi.json
+++ b/packages/backend/src/assets/openapi.json
@@ -6392,7 +6392,7 @@
           "Management — Usage"
         ],
         "summary": "Aggregated usage time-series and totals",
-        "description": "Returns bucketed series plus 7-day and since-midnight rollups.\n\n## Scoping\n\nLimited principals see only their own key's data; admins see global data.\n\n## Bucket algorithm\n\nThe endpoint uses adaptive bucketing to ensure meaningful visualizations:\n- `hour` — returns hourly buckets for the last 24 hours\n- `day` — returns daily buckets for the last 30 days\n- `week` — returns weekly buckets for the last 12 weeks\n- `month` — returns monthly buckets for the last 12 months\n- `custom` — requires `startDate` and `endDate`; buckets are auto-sized\n  based on the range duration\n\n## Response structure\n\n- **series** — Time-bucketed data, where each bucket contains aggregated\n  counts and token sums\n- **stats** — Fixed 7-day rolling window (always the last 7 days, regardless\n  of `range`)\n- **today** — Aggregation since local midnight (not UTC), giving a\n  \"day-so-far\" view\n",
+        "description": "Returns range-scoped bucketed series and totals plus a since-midnight\nrollup. Optional grouped breakdowns are computed server-side over the\ncomplete requested range.\n\n## Scoping\n\nLimited principals see only their own key's data; admins see global data.\n\n## Range and bucket algorithm\n\nThe endpoint uses adaptive bucketing to ensure meaningful visualizations:\n- `hour` — the last hour, in one-minute buckets\n- `day` — the last 24 hours, in one-hour buckets\n- `week` — the last 7 days, in one-day buckets\n- `month` — the last 30 days, in one-day buckets\n- `custom` — requires `startDate` and `endDate`; buckets are auto-sized\n  based on the range duration and the range may not exceed 12 months.\n\n## Response structure\n\n- **series** — Time-bucketed data, where each bucket contains aggregated\n  counts and token sums\n- **stats** — Aggregation over the requested range, including rich usage\n  and performance metrics\n- **today** — Aggregation since local midnight (not UTC), giving a\n  \"day-so-far\" view\n- **grouped** — Optional top-N grouped aggregates. Request dimensions with\n  the comma-separated `breakdowns` parameter. At most three dimensions are\n  allowed, and omitted groups are represented by an `Other` item.\n",
         "security": [
           {
             "AdminKey": []
@@ -6431,11 +6431,52 @@
               "format": "date-time"
             },
             "description": "Required with `range=custom`."
+          },
+          {
+            "in": "query",
+            "name": "breakdowns",
+            "schema": {
+              "type": "string",
+              "example": "provider,modelAlias"
+            },
+            "description": "Optional comma-separated dimensions: provider, modelAlias, apiKey, or status. At most three dimensions are allowed.\n"
+          },
+          {
+            "in": "query",
+            "name": "breakdownLimit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            },
+            "description": "Maximum number of named groups returned per dimension."
+          },
+          {
+            "in": "query",
+            "name": "exclude",
+            "schema": {
+              "type": "string",
+              "example": "directModels,probe"
+            },
+            "description": "Optional comma-separated dimension-specific exclusions. `directModels` excludes model aliases beginning with `direct/`; `probe` excludes the internal probe API key from API-key breakdowns.\n"
           }
         ],
         "responses": {
           "200": {
             "description": "Aggregates.",
+            "headers": {
+              "X-Usage-Summary-Cache": {
+                "description": "Whether the response was served from the in-memory summary cache.",
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "HIT",
+                    "MISS"
+                  ]
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -6446,6 +6487,9 @@
           },
           "400": {
             "description": "Invalid `range` or custom-range parameters."
+          },
+          "413": {
+            "description": "Requested aggregate response exceeds the response-size limit."
           }
         },
         "operationId": "getV0ManagementUsageSummary"
@@ -10385,6 +10429,263 @@
           "target": "openrouter"
         }
       },
+      "UsageSummary": {
+        "type": "object",
+        "description": "Aggregated usage statistics over time windows.\n",
+        "properties": {
+          "range": {
+            "type": "string",
+            "description": "Requested time range. Both series and stats use this range.\n"
+          },
+          "series": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Time-bucketed aggregation.",
+              "properties": {
+                "bucketStartMs": {
+                  "type": "integer",
+                  "description": "Start of the time bucket (epoch ms)."
+                },
+                "requests": {
+                  "type": "integer",
+                  "description": "Number of requests in this bucket."
+                },
+                "errors": {
+                  "type": "integer",
+                  "description": "Number of non-success requests in this bucket."
+                },
+                "inputTokens": {
+                  "type": "integer",
+                  "description": "Sum of input tokens across all requests."
+                },
+                "outputTokens": {
+                  "type": "integer",
+                  "description": "Sum of output tokens across all requests."
+                },
+                "reasoningTokens": {
+                  "type": "integer",
+                  "description": "Sum of reasoning tokens across all requests."
+                },
+                "cachedTokens": {
+                  "type": "integer",
+                  "description": "Sum of cached tokens across all requests."
+                },
+                "cacheWriteTokens": {
+                  "type": "integer",
+                  "description": "Sum of cache-write tokens across all requests."
+                },
+                "tokens": {
+                  "type": "integer",
+                  "description": "Total token count = inputTokens + outputTokens + reasoningTokens + cachedTokens + cacheWriteTokens.\n"
+                },
+                "totalCost": {
+                  "type": "number",
+                  "description": "Sum of request costs in the bucket."
+                },
+                "avgDurationMs": {
+                  "type": "number",
+                  "description": "Average request duration in milliseconds."
+                },
+                "avgTtftMs": {
+                  "type": "number",
+                  "description": "Average time to first token in milliseconds."
+                },
+                "avgTokensPerSec": {
+                  "type": "number",
+                  "description": "Average reported tokens per second."
+                }
+              }
+            }
+          },
+          "stats": {
+            "type": "object",
+            "description": "Aggregation over the requested range.",
+            "properties": {
+              "totalRequests": {
+                "type": "integer",
+                "description": "Total requests in the requested range."
+              },
+              "totalErrors": {
+                "type": "integer",
+                "description": "Total non-success requests in the requested range."
+              },
+              "totalTokens": {
+                "type": "integer",
+                "description": "Total tokens (input + output + reasoning + cached + cacheWrite) in the requested range.\n"
+              },
+              "inputTokens": {
+                "type": "integer",
+                "description": "Total uncached input tokens."
+              },
+              "outputTokens": {
+                "type": "integer",
+                "description": "Total output tokens."
+              },
+              "reasoningTokens": {
+                "type": "integer",
+                "description": "Total reasoning tokens."
+              },
+              "cachedTokens": {
+                "type": "integer",
+                "description": "Total cached input tokens."
+              },
+              "cacheWriteTokens": {
+                "type": "integer",
+                "description": "Total cache-write tokens."
+              },
+              "totalCost": {
+                "type": "number",
+                "description": "Total request cost in the requested range."
+              },
+              "avgDurationMs": {
+                "type": "number",
+                "description": "Average request duration in milliseconds."
+              },
+              "totalDurationMs": {
+                "type": "integer",
+                "description": "Sum of all request durations in milliseconds."
+              },
+              "avgTtftMs": {
+                "type": "number",
+                "description": "Average time to first token in milliseconds."
+              },
+              "avgTokensPerSec": {
+                "type": "number",
+                "description": "Average reported tokens per second."
+              },
+              "successRate": {
+                "type": "number",
+                "description": "Percentage of requests whose status is success."
+              }
+            }
+          },
+          "grouped": {
+            "type": "object",
+            "description": "Optional top-N aggregates for requested dimensions.",
+            "properties": {
+              "provider": {
+                "$ref": "#/components/schemas/UsageSummaryBreakdown"
+              },
+              "modelAlias": {
+                "$ref": "#/components/schemas/UsageSummaryBreakdown"
+              },
+              "apiKey": {
+                "$ref": "#/components/schemas/UsageSummaryBreakdown"
+              },
+              "status": {
+                "$ref": "#/components/schemas/UsageSummaryBreakdown"
+              }
+            }
+          },
+          "today": {
+            "type": "object",
+            "description": "Aggregation since local midnight (time-of-day based, not UTC).",
+            "properties": {
+              "requests": {
+                "type": "integer",
+                "description": "Number of requests since midnight."
+              },
+              "inputTokens": {
+                "type": "integer",
+                "description": "Input tokens since midnight."
+              },
+              "outputTokens": {
+                "type": "integer",
+                "description": "Output tokens since midnight."
+              },
+              "reasoningTokens": {
+                "type": "integer",
+                "description": "Reasoning tokens since midnight."
+              },
+              "cachedTokens": {
+                "type": "integer",
+                "description": "Cached tokens since midnight."
+              },
+              "cacheWriteTokens": {
+                "type": "integer",
+                "description": "Cache-write tokens since midnight."
+              },
+              "totalCost": {
+                "type": "number",
+                "description": "Total cost in dollars since midnight."
+              }
+            }
+          }
+        }
+      },
+      "UsageSummaryBreakdown": {
+        "type": "object",
+        "description": "Optional top-N aggregates for one requested dimension.",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UsageSummaryGroup"
+            }
+          },
+          "totalDimensions": {
+            "type": "integer",
+            "description": "Total distinct groups in the requested range."
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "Whether groups were omitted from the named items."
+          }
+        }
+      },
+      "UsageSummaryGroup": {
+        "type": "object",
+        "description": "Aggregate metrics for one usage dimension value.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Group label; API-key labels are display-safe prefixes."
+          },
+          "requests": {
+            "type": "integer"
+          },
+          "errors": {
+            "type": "integer"
+          },
+          "inputTokens": {
+            "type": "integer"
+          },
+          "outputTokens": {
+            "type": "integer"
+          },
+          "reasoningTokens": {
+            "type": "integer"
+          },
+          "cachedTokens": {
+            "type": "integer"
+          },
+          "cacheWriteTokens": {
+            "type": "integer"
+          },
+          "totalTokens": {
+            "type": "integer"
+          },
+          "totalCost": {
+            "type": "number"
+          },
+          "avgDurationMs": {
+            "type": "number"
+          },
+          "totalDurationMs": {
+            "type": "number"
+          },
+          "avgTtftMs": {
+            "type": "number"
+          },
+          "avgTokensPerSec": {
+            "type": "number"
+          },
+          "successRate": {
+            "type": "number"
+          }
+        }
+      },
       "ChatCompletionRequest": {
         "description": "OpenAI Chat Completions request (pass-through; full OpenAI schema accepted).",
         "type": "object",
@@ -13202,109 +13503,6 @@
           "hasError": {
             "type": "boolean",
             "description": "Whether error records exist for this request (mirrors presence in `inference_errors` table).\n"
-          }
-        }
-      },
-      "UsageSummary": {
-        "type": "object",
-        "description": "Aggregated usage statistics over time windows.\n",
-        "properties": {
-          "range": {
-            "type": "string",
-            "description": "Time range for series data. Format depends on query param (e.g. \"24h\", \"7d\", custom start/end). Affects only the series field.\n"
-          },
-          "series": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "Time-bucketed aggregation.",
-              "properties": {
-                "bucketStartMs": {
-                  "type": "integer",
-                  "description": "Start of the time bucket (epoch ms)."
-                },
-                "requests": {
-                  "type": "integer",
-                  "description": "Number of requests in this bucket."
-                },
-                "inputTokens": {
-                  "type": "integer",
-                  "description": "Sum of input tokens across all requests."
-                },
-                "outputTokens": {
-                  "type": "integer",
-                  "description": "Sum of output tokens across all requests."
-                },
-                "cachedTokens": {
-                  "type": "integer",
-                  "description": "Sum of cached tokens across all requests."
-                },
-                "cacheWriteTokens": {
-                  "type": "integer",
-                  "description": "Sum of cache-write tokens across all requests."
-                },
-                "tokens": {
-                  "type": "integer",
-                  "description": "Total token count = inputTokens + outputTokens + cachedTokens + cacheWriteTokens.\n"
-                }
-              }
-            }
-          },
-          "stats": {
-            "type": "object",
-            "description": "Rolling 7-day aggregation window.",
-            "properties": {
-              "totalRequests": {
-                "type": "integer",
-                "description": "Total requests in the 7-day window."
-              },
-              "totalTokens": {
-                "type": "integer",
-                "description": "Total tokens (input + output + cached + cacheWrite) in the window."
-              },
-              "avgDurationMs": {
-                "type": "number",
-                "description": "Average request duration in milliseconds."
-              },
-              "totalDurationMs": {
-                "type": "integer",
-                "description": "Sum of all request durations in milliseconds."
-              }
-            }
-          },
-          "today": {
-            "type": "object",
-            "description": "Aggregation since local midnight (time-of-day based, not UTC).",
-            "properties": {
-              "requests": {
-                "type": "integer",
-                "description": "Number of requests since midnight."
-              },
-              "inputTokens": {
-                "type": "integer",
-                "description": "Input tokens since midnight."
-              },
-              "outputTokens": {
-                "type": "integer",
-                "description": "Output tokens since midnight."
-              },
-              "reasoningTokens": {
-                "type": "integer",
-                "description": "Reasoning tokens since midnight."
-              },
-              "cachedTokens": {
-                "type": "integer",
-                "description": "Cached tokens since midnight."
-              },
-              "cacheWriteTokens": {
-                "type": "integer",
-                "description": "Cache-write tokens since midnight."
-              },
-              "totalCost": {
-                "type": "number",
-                "description": "Total cost in dollars since midnight."
-              }
-            }
           }
         }
       },

--- a/packages/backend/src/routes/management/__tests__/backup.test.ts
+++ b/packages/backend/src/routes/management/__tests__/backup.test.ts
@@ -50,7 +50,7 @@ describe('Backup management routes', () => {
   let mockMcpUsageStorage: any;
 
   beforeEach(async () => {
-    fastify = Fastify();
+    fastify = Fastify({ bodyLimit: 30 * 1024 * 1024 });
     mockUsageStorage = {
       deleteAllUsageLogs: vi.fn(async () => true),
       deleteAllErrors: vi.fn(async () => true),
@@ -116,6 +116,18 @@ describe('Backup management routes', () => {
       });
 
       expect(res.statusCode).toBe(400);
+    });
+
+    it('accepts full restore archives larger than the global body limit', async () => {
+      const res = await fastify.inject({
+        method: 'POST',
+        url: '/v0/management/restore',
+        payload: Buffer.alloc(31 * 1024 * 1024),
+        headers: { 'content-type': 'application/gzip' },
+      });
+
+      expect(res.statusCode).toBe(500);
+      expect(res.statusCode).not.toBe(413);
     });
   });
 

--- a/packages/backend/src/routes/management/__tests__/usage-summary.test.ts
+++ b/packages/backend/src/routes/management/__tests__/usage-summary.test.ts
@@ -87,6 +87,7 @@ describe('Usage summary route', () => {
     });
 
     expect(response.statusCode).toBe(200);
+    expect(response.payload.length).toBeLessThan(16 * 1024);
 
     const body = response.json() as {
       series: Array<{
@@ -120,5 +121,251 @@ describe('Usage summary route', () => {
     expect(body.today.requests).toBe(3);
     expect(body.today.inputTokens).toBe(60);
     expect(body.today.outputTokens).toBe(30);
+  });
+
+  it('scopes stats to the requested range and returns bounded breakdowns', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00.000Z'));
+
+    const now = new Date().getTime();
+    const rows = [
+      {
+        requestId: 'usage-summary-old',
+        startTime: now - 20 * 24 * 60 * 60 * 1000,
+        provider: 'old-provider',
+        incomingModelAlias: 'old-model',
+        apiKey: 'old-key',
+        responseStatus: 'error',
+        tokensInput: 1,
+        tokensOutput: 2,
+        tokensReasoning: 3,
+        tokensCached: 4,
+        tokensCacheWrite: 5,
+        costTotal: 0.5,
+        durationMs: 100,
+        ttftMs: 20,
+        tokensPerSec: 2,
+      },
+      {
+        requestId: 'usage-summary-recent-1',
+        startTime: now - 2 * 24 * 60 * 60 * 1000,
+        provider: 'recent-provider',
+        incomingModelAlias: 'recent-model',
+        apiKey: 'recent-key',
+        responseStatus: 'success',
+        tokensInput: 10,
+        tokensOutput: 20,
+        tokensReasoning: 30,
+        tokensCached: 40,
+        tokensCacheWrite: 50,
+        costTotal: 1,
+        durationMs: 200,
+        ttftMs: 40,
+        tokensPerSec: 4,
+      },
+      {
+        requestId: 'usage-summary-recent-2',
+        startTime: now - 60 * 60 * 1000,
+        provider: 'recent-provider',
+        incomingModelAlias: 'recent-model',
+        apiKey: 'recent-key',
+        responseStatus: 'success',
+        tokensInput: 11,
+        tokensOutput: 21,
+        tokensReasoning: 31,
+        tokensCached: 41,
+        tokensCacheWrite: 51,
+        costTotal: 2,
+        durationMs: 300,
+        ttftMs: 60,
+        tokensPerSec: 6,
+      },
+      {
+        requestId: 'usage-summary-outside',
+        startTime: now - 40 * 24 * 60 * 60 * 1000,
+        provider: 'outside-provider',
+        incomingModelAlias: 'outside-model',
+        apiKey: 'outside-key',
+        responseStatus: 'success',
+        tokensInput: 100,
+        tokensOutput: 100,
+        tokensReasoning: 100,
+        tokensCached: 100,
+        tokensCacheWrite: 100,
+        costTotal: 100,
+        durationMs: 100,
+        ttftMs: 10,
+        tokensPerSec: 1,
+      },
+    ].map((row) => ({
+      ...row,
+      date: new Date(row.startTime).toISOString(),
+      isStreamed: 0,
+      isPassthrough: 0,
+      tokensEstimated: 0,
+      createdAt: row.startTime,
+    }));
+
+    await db.insert(schema.requestUsage).values(rows);
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/usage/summary?range=month&breakdowns=provider&breakdownLimit=1',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['x-usage-summary-cache']).toBe('MISS');
+    expect(response.payload.length).toBeLessThan(128 * 1024);
+    const body = response.json();
+    expect(body.stats.totalRequests).toBe(3);
+    expect(body.stats.totalErrors).toBe(1);
+    expect(body.stats.totalTokens).toBe(320);
+    expect(body.stats.totalCost).toBe(3.5);
+    expect(body.stats.avgDurationMs).toBe(200);
+    expect(body.grouped.provider.totalDimensions).toBe(2);
+    expect(body.grouped.provider.truncated).toBe(true);
+    expect(body.grouped.provider.items).toHaveLength(2);
+    expect(body.grouped.provider.items[0].name).toBe('recent-provider');
+    expect(body.grouped.provider.items[0].requests).toBe(2);
+    expect(body.grouped.provider.items[1].name).toBe('Other');
+    expect(body.grouped.provider.items[1].requests).toBe(1);
+    expect(body.grouped.provider.items[1].totalTokens).toBe(15);
+    expect(body.grouped.provider.items[1].totalCost).toBe(0.5);
+    expect(body.grouped.provider.items[1].avgDurationMs).toBe(100);
+    expect(body.grouped.provider.items[1].avgTtftMs).toBe(20);
+    expect(body.grouped.provider.items[1].avgTokensPerSec).toBe(2);
+
+    const otherDimensions = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/usage/summary?range=month&breakdowns=modelAlias,apiKey,status&breakdownLimit=3',
+    });
+    expect(otherDimensions.statusCode).toBe(200);
+    const otherBody = otherDimensions.json();
+    expect(otherBody.grouped.modelAlias.items[0].name).toBe('recent-model');
+    expect(otherBody.grouped.apiKey.items[0].name).toBe('recent-k...');
+    expect(otherBody.grouped.status.items.map((item: { name: string }) => item.name)).toEqual([
+      'success',
+      'error',
+    ]);
+
+    const cachedResponse = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/usage/summary?range=month&breakdowns=provider&breakdownLimit=1',
+    });
+    expect(cachedResponse.headers['x-usage-summary-cache']).toBe('HIT');
+    expect(cachedResponse.payload.length).toBeLessThan(128 * 1024);
+
+    const customStart = new Date(now - 20 * 24 * 60 * 60 * 1000 - 60_000).toISOString();
+    const customEnd = new Date(now - 20 * 24 * 60 * 60 * 1000 + 60_000).toISOString();
+    const customResponse = await fastify.inject({
+      method: 'GET',
+      url: `/v0/management/usage/summary?range=custom&startDate=${customStart}&endDate=${customEnd}`,
+    });
+
+    expect(customResponse.statusCode).toBe(200);
+    expect(customResponse.headers['x-usage-summary-cache']).toBe('MISS');
+    expect(customResponse.json().stats.totalRequests).toBe(1);
+    expect(customResponse.json().stats.totalTokens).toBe(15);
+  });
+
+  it('rejects custom ranges longer than twelve months', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00.000Z'));
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/usage/summary?range=custom&startDate=2024-01-01T00:00:00.000Z&endDate=2026-07-01T00:00:00.000Z',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toContain('12 months');
+  });
+
+  it('applies each preset window independently', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00.000Z'));
+
+    const now = new Date().getTime();
+    const offsets = [
+      30 * 60 * 1000,
+      20 * 60 * 60 * 1000,
+      3 * 24 * 60 * 60 * 1000,
+      10 * 24 * 60 * 60 * 1000,
+      40 * 24 * 60 * 60 * 1000,
+    ];
+    await db.insert(schema.requestUsage).values(
+      offsets.map((offset, index) => {
+        const startTime = now - offset;
+        return {
+          requestId: `usage-summary-preset-${index}`,
+          date: new Date(startTime).toISOString(),
+          startTime,
+          durationMs: 100,
+          isStreamed: 0,
+          isPassthrough: 0,
+          tokensEstimated: 0,
+          tokensInput: 1,
+          tokensOutput: 1,
+          createdAt: startTime,
+        };
+      })
+    );
+
+    for (const [range, expected] of [
+      ['hour', 1],
+      ['day', 2],
+      ['week', 3],
+      ['month', 4],
+    ] as const) {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: `/v0/management/usage/summary?range=${range}`,
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().stats.totalRequests).toBe(expected);
+    }
+  });
+
+  it('rejects malformed, reversed, and future custom ranges', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-07T12:00:00.000Z'));
+
+    const cases = [
+      'range=custom',
+      'range=custom&startDate=not-a-date&endDate=2026-07-07T00:00:00.000Z',
+      'range=custom&startDate=2026-07-07T01:00:00.000Z&endDate=2026-07-07T00:00:00.000Z',
+      'range=custom&startDate=2026-07-07T00:00:00.000Z&endDate=2026-07-07T13:00:00.000Z',
+    ];
+
+    for (const query of cases) {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: `/v0/management/usage/summary?${query}`,
+      });
+      expect(response.statusCode).toBe(400);
+    }
+  });
+
+  it('validates breakdown limits and dimensions before querying', async () => {
+    const tooManyBreakdowns = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/usage/summary?breakdowns=provider,modelAlias,apiKey,status',
+    });
+    expect(tooManyBreakdowns.statusCode).toBe(400);
+    expect(tooManyBreakdowns.json().error).toContain('At most 3');
+
+    const invalidBreakdown = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/usage/summary?breakdowns=sourceIp',
+    });
+    expect(invalidBreakdown.statusCode).toBe(400);
+    expect(invalidBreakdown.json().error).toContain('Unsupported breakdown');
+
+    const invalidLimit = await fastify.inject({
+      method: 'GET',
+      url: '/v0/management/usage/summary?breakdowns=provider&breakdownLimit=51',
+    });
+    expect(invalidLimit.statusCode).toBe(400);
+    expect(invalidLimit.json().error).toContain('between 1 and 50');
   });
 });

--- a/packages/backend/src/routes/management/backup.ts
+++ b/packages/backend/src/routes/management/backup.ts
@@ -4,6 +4,8 @@ import { BackupService } from '../../services/configuration/backup-service';
 import type { UsageStorageService } from '../../services/observability/usage-storage';
 import type { McpUsageStorageService } from '../../services/mcp-proxy/mcp-usage-storage';
 
+const RESTORE_BODY_LIMIT = 100 * 1024 * 1024;
+
 export async function registerBackupRoutes(
   fastify: FastifyInstance,
   usageStorage?: UsageStorageService,
@@ -55,41 +57,45 @@ export async function registerBackupRoutes(
    *
    * This is a destructive operation — all existing data is replaced.
    */
-  fastify.post('/v0/management/restore', async (request, reply) => {
-    try {
-      const contentType = request.headers['content-type'] || '';
-      let result;
+  fastify.post(
+    '/v0/management/restore',
+    { bodyLimit: RESTORE_BODY_LIMIT },
+    async (request, reply) => {
+      try {
+        const contentType = request.headers['content-type'] || '';
+        let result;
 
-      if (
-        contentType.includes('application/gzip') ||
-        contentType.includes('application/octet-stream') ||
-        contentType.includes('application/x-gzip')
-      ) {
-        // Binary archive
-        if (!Buffer.isBuffer(request.body)) {
-          return reply.code(400).send({ error: 'Expected binary body for archive restore' });
+        if (
+          contentType.includes('application/gzip') ||
+          contentType.includes('application/octet-stream') ||
+          contentType.includes('application/x-gzip')
+        ) {
+          // Binary archive
+          if (!Buffer.isBuffer(request.body)) {
+            return reply.code(400).send({ error: 'Expected binary body for archive restore' });
+          }
+          logger.info('[Backup] Starting full archive restore');
+          result = await backupService.restoreFullBackup(request.body);
+        } else {
+          // JSON config-only envelope
+          const body = request.body as Record<string, unknown>;
+          if (!body || !body.plexus_backup) {
+            return reply.code(400).send({ error: 'Invalid backup: missing plexus_backup field' });
+          }
+          logger.info('[Backup] Starting config-only restore');
+          result = await backupService.restoreFullBackup(body);
         }
-        logger.info('[Backup] Starting full archive restore');
-        result = await backupService.restoreFullBackup(request.body);
-      } else {
-        // JSON config-only envelope
-        const body = request.body as Record<string, unknown>;
-        if (!body || !body.plexus_backup) {
-          return reply.code(400).send({ error: 'Invalid backup: missing plexus_backup field' });
-        }
-        logger.info('[Backup] Starting config-only restore');
-        result = await backupService.restoreFullBackup(body);
+
+        // After restore, restart the server so all services pick up the new data.
+        // We send the response first, then close/exit after a short delay —
+        // the process manager (bun --watch, Docker, systemd) will respawn us.
+        return reply.send(result);
+      } catch (e: any) {
+        logger.error('[Backup] Restore failed:', e);
+        return reply.code(500).send({ error: e.message || 'Backup restore failed' });
       }
-
-      // After restore, restart the server so all services pick up the new data.
-      // We send the response first, then close/exit after a short delay —
-      // the process manager (bun --watch, Docker, systemd) will respawn us.
-      return reply.send(result);
-    } catch (e: any) {
-      logger.error('[Backup] Restore failed:', e);
-      return reply.code(500).send({ error: e.message || 'Backup restore failed' });
     }
-  });
+  );
 
   // Allow binary body parsing for .tar.gz uploads
   fastify.addContentTypeParser(

--- a/packages/backend/src/routes/management/usage.ts
+++ b/packages/backend/src/routes/management/usage.ts
@@ -8,6 +8,7 @@ import {
   type UsageSortField,
 } from '../../services/observability/usage-storage';
 import { isLimited, scopedKeyName } from './_principal';
+import { logger } from '../../utils/logger';
 
 const USAGE_FIELDS = new Set([
   'requestId',
@@ -60,6 +61,195 @@ type UsageStreamClient = {
   scopeKey: string | null;
   send: (eventType: UsageStreamEventName, record: any) => void;
 };
+
+const SUMMARY_CACHE_TTL_MS = 10_000;
+const HISTORICAL_SUMMARY_CACHE_TTL_MS = 60_000;
+const MAX_CUSTOM_RANGE_MS = 366 * 24 * 60 * 60 * 1000;
+const MAX_BREAKDOWN_DIMENSIONS = 3;
+const DEFAULT_BREAKDOWN_LIMIT = 10;
+const MAX_BREAKDOWN_LIMIT = 50;
+const MAX_SUMMARY_RESPONSE_BYTES = 128 * 1024;
+const MAX_BASIC_SUMMARY_RESPONSE_BYTES = 16 * 1024;
+const MAX_SUMMARY_CACHE_ENTRIES = 100;
+
+const BREAKDOWN_DIMENSIONS = ['provider', 'modelAlias', 'apiKey', 'status'] as const;
+type BreakdownDimension = (typeof BREAKDOWN_DIMENSIONS)[number];
+const SUMMARY_EXCLUSIONS = ['directModels', 'probe'] as const;
+type SummaryExclusion = (typeof SUMMARY_EXCLUSIONS)[number];
+
+type SummaryAggregate = {
+  requests: number;
+  errors: number;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  cachedTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  totalCost: number;
+  avgDurationMs: number;
+  totalDurationMs: number;
+  totalTtftMs: number;
+  totalTokensPerSec: number;
+  avgTtftMs: number;
+  avgTokensPerSec: number;
+};
+
+type SummaryGroup = {
+  name: string;
+  requests: number;
+  errors: number;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  cachedTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  totalCost: number;
+  avgDurationMs: number;
+  totalDurationMs: number;
+  avgTtftMs: number;
+  avgTokensPerSec: number;
+  successRate: number;
+};
+
+type SummaryResponse = {
+  range: string;
+  series: Array<{
+    bucketStartMs: number;
+    requests: number;
+    errors: number;
+    inputTokens: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    cachedTokens: number;
+    cacheWriteTokens: number;
+    tokens: number;
+    totalCost: number;
+    avgDurationMs: number;
+    avgTtftMs: number;
+    avgTokensPerSec: number;
+  }>;
+  stats: {
+    totalRequests: number;
+    totalErrors: number;
+    totalTokens: number;
+    inputTokens: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    cachedTokens: number;
+    cacheWriteTokens: number;
+    totalCost: number;
+    avgDurationMs: number;
+    totalDurationMs: number;
+    avgTtftMs: number;
+    avgTokensPerSec: number;
+    successRate: number;
+  };
+  today: Record<string, number>;
+  grouped?: Partial<
+    Record<
+      BreakdownDimension,
+      {
+        items: SummaryGroup[];
+        totalDimensions: number;
+        truncated: boolean;
+      }
+    >
+  >;
+};
+
+class SummaryResponseTooLargeError extends Error {}
+
+const toNumber = (value: unknown): number =>
+  value === null || value === undefined ? 0 : Number(value);
+
+const toSummaryAggregate = (row: any): SummaryAggregate => {
+  const inputTokens = toNumber(row.inputTokens);
+  const outputTokens = toNumber(row.outputTokens);
+  const reasoningTokens = toNumber(row.reasoningTokens);
+  const cachedTokens = toNumber(row.cachedTokens);
+  const cacheWriteTokens = toNumber(row.cacheWriteTokens);
+
+  return {
+    requests: toNumber(row.requests),
+    errors: toNumber(row.errors),
+    inputTokens,
+    outputTokens,
+    reasoningTokens,
+    cachedTokens,
+    cacheWriteTokens,
+    totalTokens: inputTokens + outputTokens + reasoningTokens + cachedTokens + cacheWriteTokens,
+    totalCost: toNumber(row.totalCost),
+    avgDurationMs: toNumber(row.avgDurationMs),
+    totalDurationMs: toNumber(row.totalDurationMs),
+    totalTtftMs: toNumber(row.totalTtftMs),
+    totalTokensPerSec: toNumber(row.totalTokensPerSec),
+    avgTtftMs: toNumber(row.avgTtftMs),
+    avgTokensPerSec: toNumber(row.avgTokensPerSec),
+  };
+};
+
+const withSuccessRate = <T extends SummaryAggregate>(aggregate: T) => ({
+  ...aggregate,
+  successRate:
+    aggregate.requests > 0
+      ? ((aggregate.requests - aggregate.errors) / aggregate.requests) * 100
+      : 0,
+});
+
+const toSummaryGroup = (name: string, aggregate: SummaryAggregate): SummaryGroup => ({
+  name,
+  requests: aggregate.requests,
+  errors: aggregate.errors,
+  inputTokens: aggregate.inputTokens,
+  outputTokens: aggregate.outputTokens,
+  reasoningTokens: aggregate.reasoningTokens,
+  cachedTokens: aggregate.cachedTokens,
+  cacheWriteTokens: aggregate.cacheWriteTokens,
+  totalTokens: aggregate.totalTokens,
+  totalCost: aggregate.totalCost,
+  avgDurationMs: aggregate.avgDurationMs,
+  totalDurationMs: aggregate.totalDurationMs,
+  avgTtftMs: aggregate.avgTtftMs,
+  avgTokensPerSec: aggregate.avgTokensPerSec,
+  successRate:
+    aggregate.requests > 0
+      ? ((aggregate.requests - aggregate.errors) / aggregate.requests) * 100
+      : 0,
+});
+
+const subtractAggregates = (
+  total: SummaryAggregate,
+  included: SummaryAggregate
+): SummaryAggregate => ({
+  requests: Math.max(0, total.requests - included.requests),
+  errors: Math.max(0, total.errors - included.errors),
+  inputTokens: Math.max(0, total.inputTokens - included.inputTokens),
+  outputTokens: Math.max(0, total.outputTokens - included.outputTokens),
+  reasoningTokens: Math.max(0, total.reasoningTokens - included.reasoningTokens),
+  cachedTokens: Math.max(0, total.cachedTokens - included.cachedTokens),
+  cacheWriteTokens: Math.max(0, total.cacheWriteTokens - included.cacheWriteTokens),
+  totalTokens: Math.max(0, total.totalTokens - included.totalTokens),
+  totalCost: Math.max(0, total.totalCost - included.totalCost),
+  avgDurationMs:
+    total.requests > included.requests
+      ? Math.max(0, total.totalDurationMs - included.totalDurationMs) /
+        (total.requests - included.requests)
+      : 0,
+  totalDurationMs: Math.max(0, total.totalDurationMs - included.totalDurationMs),
+  totalTtftMs: Math.max(0, total.totalTtftMs - included.totalTtftMs),
+  totalTokensPerSec: Math.max(0, total.totalTokensPerSec - included.totalTokensPerSec),
+  avgTtftMs:
+    total.requests > included.requests
+      ? Math.max(0, total.totalTtftMs - included.totalTtftMs) / (total.requests - included.requests)
+      : 0,
+  avgTokensPerSec:
+    total.requests > included.requests
+      ? Math.max(0, total.totalTokensPerSec - included.totalTokensPerSec) /
+        (total.requests - included.requests)
+      : 0,
+});
 
 export class UsageEventsBroadcaster {
   private readonly clients = new Set<UsageStreamClient>();
@@ -192,13 +382,15 @@ export async function registerUsageRoutes(
     }
   });
 
+  const summaryCache = new Map<string, { expiresAt: number; promise: Promise<SummaryResponse> }>();
+
   fastify.get('/v0/management/usage/summary', async (request, reply) => {
+    const requestStartedAt = performance.now();
     const query = request.query as any;
     const range = query.range || 'day';
     const startDateStr = query.startDate;
     const endDateStr = query.endDate;
 
-    // Validate custom date range if provided
     if (range === 'custom') {
       if (!startDateStr || !endDateStr) {
         return reply
@@ -207,7 +399,7 @@ export async function registerUsageRoutes(
       }
       const startDate = new Date(startDateStr);
       const endDate = new Date(endDateStr);
-      if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+      if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
         return reply.code(400).send({ error: 'Invalid date format' });
       }
       if (endDate < startDate) {
@@ -217,14 +409,54 @@ export async function registerUsageRoutes(
       return reply.code(400).send({ error: 'Invalid range' });
     }
 
-    const now = new Date();
+    const requestedBreakdowns = String(query.breakdowns || '')
+      .split(',')
+      .map((value: string) => value.trim())
+      .filter(Boolean);
+    const breakdowns = Array.from(new Set(requestedBreakdowns)) as BreakdownDimension[];
+    const invalidBreakdown = breakdowns.find((value) => !BREAKDOWN_DIMENSIONS.includes(value));
+    if (invalidBreakdown) {
+      return reply.code(400).send({ error: `Unsupported breakdown: ${invalidBreakdown}` });
+    }
+    if (breakdowns.length > MAX_BREAKDOWN_DIMENSIONS) {
+      return reply
+        .code(400)
+        .send({ error: `At most ${MAX_BREAKDOWN_DIMENSIONS} breakdowns are supported` });
+    }
+
+    const requestedExclusions = String(query.exclude || '')
+      .split(',')
+      .map((value: string) => value.trim())
+      .filter(Boolean);
+    const exclusions = Array.from(new Set(requestedExclusions)) as SummaryExclusion[];
+    const invalidExclusion = exclusions.find((value) => !SUMMARY_EXCLUSIONS.includes(value));
+    if (invalidExclusion) {
+      return reply.code(400).send({ error: `Unsupported exclusion: ${invalidExclusion}` });
+    }
+
+    const parsedLimit =
+      query.breakdownLimit === undefined ? DEFAULT_BREAKDOWN_LIMIT : Number(query.breakdownLimit);
+    if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > MAX_BREAKDOWN_LIMIT) {
+      return reply.code(400).send({
+        error: `breakdownLimit must be an integer between 1 and ${MAX_BREAKDOWN_LIMIT}`,
+      });
+    }
+
+    const currentTime = new Date();
+    const now = new Date(currentTime);
     now.setSeconds(0, 0);
     let rangeStart = new Date(now);
     let rangeEnd = new Date(now);
 
-    if (range === 'custom' && startDateStr && endDateStr) {
+    if (range === 'custom') {
       rangeStart = new Date(startDateStr);
       rangeEnd = new Date(endDateStr);
+      if (rangeEnd > currentTime) {
+        return reply.code(400).send({ error: 'endDate cannot be in the future' });
+      }
+      if (rangeEnd.getTime() - rangeStart.getTime() > MAX_CUSTOM_RANGE_MS) {
+        return reply.code(400).send({ error: 'custom range cannot exceed 12 months' });
+      }
     } else {
       switch (range as 'hour' | 'day' | 'week' | 'month') {
         case 'hour':
@@ -242,119 +474,127 @@ export async function registerUsageRoutes(
       }
     }
 
-    const todayStart = new Date(now);
-    todayStart.setHours(0, 0, 0, 0);
-    const statsStart = new Date(now);
-    statsStart.setDate(statsStart.getDate() - 7);
-
-    let stepSeconds = 60;
-    if (range === 'custom') {
-      // Calculate appropriate step based on range duration (adaptive bucketing)
-      const durationMs = rangeEnd.getTime() - rangeStart.getTime();
-      const durationMinutes = durationMs / (1000 * 60);
-      const durationSeconds = durationMs / 1000;
-
-      // Adaptive bucketing thresholds (matching frontend LiveTab)
-      const useMinuteBuckets = durationMinutes <= 30;
-      const use5MinuteBuckets = durationMinutes <= 24 * 60;
-      const useHourlyBuckets = durationMinutes <= 7 * 24 * 60;
-
-      if (useMinuteBuckets) {
-        stepSeconds = 60; // 1-minute buckets
-      } else if (use5MinuteBuckets) {
-        stepSeconds = 300; // 5-minute buckets
-      } else if (useHourlyBuckets) {
-        stepSeconds = 3600; // 1-hour buckets
-      } else {
-        stepSeconds = 21600; // 6-hour buckets for very long ranges
-      }
-
-      // Ensure maximum 100 buckets to prevent performance issues
-      const maxBuckets = 100;
-      const calculatedBuckets = Math.ceil(durationSeconds / stepSeconds);
-      if (calculatedBuckets > maxBuckets) {
-        stepSeconds = Math.ceil(durationSeconds / maxBuckets);
-      }
-    } else {
-      switch (range) {
-        case 'hour':
-          stepSeconds = 60;
-          break;
-        case 'day':
-          stepSeconds = 60 * 60;
-          break;
-        case 'week':
-        case 'month':
-          stepSeconds = 60 * 60 * 24;
-          break;
+    const normalizedBreakdowns = BREAKDOWN_DIMENSIONS.filter((value) => breakdowns.includes(value));
+    const principalKey = scopedKeyName(request);
+    const scopeKey = principalKey ? `limited:${principalKey}` : 'admin';
+    const cacheKey = JSON.stringify({
+      scopeKey,
+      range,
+      startDate: rangeStart.toISOString(),
+      endDate: rangeEnd.toISOString(),
+      breakdowns: normalizedBreakdowns,
+      exclusions: SUMMARY_EXCLUSIONS.filter((value) => exclusions.includes(value)),
+      breakdownLimit: parsedLimit,
+    });
+    const cached = summaryCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      reply.header('X-Usage-Summary-Cache', 'HIT');
+      logger.debug('Usage summary cache hit', {
+        range,
+        breakdownCount: normalizedBreakdowns.length,
+        durationMs: Math.round(performance.now() - requestStartedAt),
+      });
+      try {
+        return reply.send(await cached.promise);
+      } catch (e: any) {
+        if (e instanceof SummaryResponseTooLargeError) {
+          return reply.code(413).send({ error: e.message });
+        }
+        return reply.code(500).send({ error: e.message });
       }
     }
 
-    const db = usageStorage.getDb();
-    const schema = getSchema();
-    const dialect = getCurrentDialect();
-    const stepMs = stepSeconds * 1000;
-    const nowMs = now.getTime();
-    const rangeStartMs = rangeStart.getTime();
-    const rangeEndMs = rangeEnd.getTime();
-    const statsStartMs = statsStart.getTime();
-    const todayStartMs = todayStart.getTime();
+    const summaryPromise = (async (): Promise<SummaryResponse> => {
+      const todayStart = new Date(now);
+      todayStart.setHours(0, 0, 0, 0);
+      let stepSeconds = 60;
+      if (range === 'custom') {
+        const durationMs = rangeEnd.getTime() - rangeStart.getTime();
+        const durationMinutes = durationMs / (1000 * 60);
+        const durationSeconds = durationMs / 1000;
+        if (durationMinutes <= 30) stepSeconds = 60;
+        else if (durationMinutes <= 24 * 60) stepSeconds = 300;
+        else if (durationMinutes <= 7 * 24 * 60) stepSeconds = 3600;
+        else stepSeconds = 21600;
+        if (Math.ceil(durationSeconds / stepSeconds) > 100) {
+          stepSeconds = Math.ceil(durationSeconds / 100);
+        }
+      } else {
+        switch (range) {
+          case 'hour':
+            stepSeconds = 60;
+            break;
+          case 'day':
+            stepSeconds = 60 * 60;
+            break;
+          case 'week':
+          case 'month':
+            stepSeconds = 60 * 60 * 24;
+            break;
+        }
+      }
 
-    const stepMsLiteral = sql.raw(String(stepMs));
-    const bucketStartMs =
-      dialect === 'sqlite'
-        ? sql<number>`CAST((CAST(${schema.requestUsage.startTime} AS INTEGER) / ${stepMsLiteral}) * ${stepMsLiteral} AS INTEGER)`
-        : sql<number>`FLOOR(${schema.requestUsage.startTime}::double precision / ${stepMsLiteral}) * ${stepMsLiteral}`;
+      const db = usageStorage.getDb();
+      const schema = getSchema();
+      const dialect = getCurrentDialect();
+      const stepMs = stepSeconds * 1000;
+      const nowMs = now.getTime();
+      const rangeStartMs = rangeStart.getTime();
+      const rangeEndMs = rangeEnd.getTime();
+      const todayStartMs = todayStart.getTime();
+      const stepMsLiteral = sql.raw(String(stepMs));
+      const bucketStartMs =
+        dialect === 'sqlite'
+          ? sql<number>`CAST((CAST(${schema.requestUsage.startTime} AS INTEGER) / ${stepMsLiteral}) * ${stepMsLiteral} AS INTEGER)`
+          : sql<number>`FLOOR(${schema.requestUsage.startTime}::double precision / ${stepMsLiteral}) * ${stepMsLiteral}`;
+      const keyFilter = principalKey ? eq(schema.requestUsage.apiKey, principalKey) : undefined;
+      const rangeFilter = [
+        gte(schema.requestUsage.startTime, rangeStartMs),
+        lte(schema.requestUsage.startTime, rangeEndMs),
+        ...(keyFilter ? [keyFilter] : []),
+      ];
+      const aggregateSelection = {
+        requests: sql<number>`COUNT(*)`,
+        errors: sql<number>`COALESCE(SUM(CASE WHEN ${schema.requestUsage.responseStatus} IS NULL OR ${schema.requestUsage.responseStatus} != 'success' THEN 1 ELSE 0 END), 0)`,
+        inputTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensInput}), 0)`,
+        outputTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensOutput}), 0)`,
+        reasoningTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensReasoning}), 0)`,
+        cachedTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensCached}), 0)`,
+        cacheWriteTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensCacheWrite}), 0)`,
+        totalCost: sql<number>`COALESCE(SUM(${schema.requestUsage.costTotal}), 0)`,
+        avgDurationMs: sql<number>`COALESCE(SUM(COALESCE(${schema.requestUsage.durationMs}, 0)) * 1.0 / NULLIF(COUNT(*), 0), 0)`,
+        totalDurationMs: sql<number>`COALESCE(SUM(${schema.requestUsage.durationMs}), 0)`,
+        totalTtftMs: sql<number>`COALESCE(SUM(COALESCE(${schema.requestUsage.ttftMs}, 0)), 0)`,
+        totalTokensPerSec: sql<number>`COALESCE(SUM(COALESCE(${schema.requestUsage.tokensPerSec}, 0)), 0)`,
+        avgTtftMs: sql<number>`COALESCE(SUM(COALESCE(${schema.requestUsage.ttftMs}, 0)) * 1.0 / NULLIF(COUNT(*), 0), 0)`,
+        avgTokensPerSec: sql<number>`COALESCE(SUM(COALESCE(${schema.requestUsage.tokensPerSec}, 0)) * 1.0 / NULLIF(COUNT(*), 0), 0)`,
+      };
+      const getBreakdownFilter = (dimension: BreakdownDimension) => {
+        const conditions = [...rangeFilter];
+        if (dimension === 'modelAlias' && exclusions.includes('directModels')) {
+          conditions.push(
+            sql`(${schema.requestUsage.incomingModelAlias} IS NULL OR ${schema.requestUsage.incomingModelAlias} NOT LIKE 'direct/%')`
+          );
+        }
+        if (dimension === 'apiKey' && exclusions.includes('probe')) {
+          conditions.push(
+            sql`(${schema.requestUsage.apiKey} IS NULL OR ${schema.requestUsage.apiKey} != 'probe')`
+          );
+        }
+        return conditions;
+      };
 
-    const toNumber = (value: unknown) =>
-      value === null || value === undefined ? 0 : Number(value);
-
-    // Scope by the limited user's key if applicable.
-    const summaryScopeKey = scopedKeyName(request);
-    const keyFilter = summaryScopeKey ? eq(schema.requestUsage.apiKey, summaryScopeKey) : undefined;
-
-    try {
+      const queryStartedAt = performance.now();
       const seriesRows = await db
-        .select({
-          bucketStartMs,
-          requests: sql<number>`COUNT(*)`,
-          inputTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensInput}), 0)`,
-          outputTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensOutput}), 0)`,
-          cachedTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensCached}), 0)`,
-          cacheWriteTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensCacheWrite}), 0)`,
-        })
+        .select({ bucketStartMs, ...aggregateSelection })
         .from(schema.requestUsage)
-        .where(
-          and(
-            gte(schema.requestUsage.startTime, rangeStartMs),
-            lte(schema.requestUsage.startTime, rangeEndMs),
-            ...(keyFilter ? [keyFilter] : [])
-          )
-        )
+        .where(and(...rangeFilter))
         .groupBy(bucketStartMs)
         .orderBy(bucketStartMs);
-
       const statsRows = await db
-        .select({
-          requests: sql<number>`COUNT(*)`,
-          inputTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensInput}), 0)`,
-          outputTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensOutput}), 0)`,
-          cachedTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensCached}), 0)`,
-          cacheWriteTokens: sql<number>`COALESCE(SUM(${schema.requestUsage.tokensCacheWrite}), 0)`,
-          avgDurationMs: sql<number>`COALESCE(AVG(${schema.requestUsage.durationMs}), 0)`,
-          totalDurationMs: sql<number>`COALESCE(SUM(${schema.requestUsage.durationMs}), 0)`,
-        })
+        .select(aggregateSelection)
         .from(schema.requestUsage)
-        .where(
-          and(
-            gte(schema.requestUsage.startTime, statsStartMs),
-            lte(schema.requestUsage.startTime, nowMs),
-            ...(keyFilter ? [keyFilter] : []),
-            gte(schema.requestUsage.startTime, rangeStartMs),
-            lte(schema.requestUsage.startTime, rangeEndMs)
-          )
-        );
-
+        .where(and(...rangeFilter));
       const todayRows = await db
         .select({
           requests: sql<number>`COUNT(*)`,
@@ -374,62 +614,178 @@ export async function registerUsageRoutes(
           )
         );
 
-      const statsRow = statsRows[0] || {
-        requests: 0,
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedTokens: 0,
-        cacheWriteTokens: 0,
-        avgDurationMs: 0,
-        totalDurationMs: 0,
-      };
+      const stats = withSuccessRate(toSummaryAggregate(statsRows[0] || {}));
+      const grouped: SummaryResponse['grouped'] = {};
+      for (const dimension of normalizedBreakdowns) {
+        const groupField =
+          dimension === 'provider'
+            ? sql`COALESCE(${schema.requestUsage.provider}, 'unknown')`
+            : dimension === 'modelAlias'
+              ? sql`COALESCE(${schema.requestUsage.incomingModelAlias}, ${schema.requestUsage.selectedModelName}, 'unknown')`
+              : dimension === 'status'
+                ? sql`COALESCE(${schema.requestUsage.responseStatus}, 'unknown')`
+                : schema.requestUsage.apiKey;
+        const groupRows = await db
+          .select({
+            key: groupField,
+            totalDimensions: sql<number>`COUNT(*) OVER ()`,
+            ...aggregateSelection,
+          })
+          .from(schema.requestUsage)
+          .where(and(...getBreakdownFilter(dimension)))
+          .groupBy(groupField)
+          .orderBy(sql`COUNT(*) DESC`, groupField)
+          .limit(parsedLimit);
+        const topItems = groupRows.map((row: any) => {
+          const name =
+            dimension === 'apiKey'
+              ? row.key === 'probe'
+                ? 'probe'
+                : row.key
+                  ? String(row.key).length > 8
+                    ? `${String(row.key).slice(0, 8)}...`
+                    : String(row.key)
+                  : 'unknown'
+              : String(row.key ?? 'unknown');
+          return toSummaryGroup(name, toSummaryAggregate(row));
+        });
+        const included = groupRows.reduce((aggregate: SummaryAggregate, row: any) => {
+          const current = toSummaryAggregate(row);
+          return {
+            ...aggregate,
+            requests: aggregate.requests + current.requests,
+            errors: aggregate.errors + current.errors,
+            inputTokens: aggregate.inputTokens + current.inputTokens,
+            outputTokens: aggregate.outputTokens + current.outputTokens,
+            reasoningTokens: aggregate.reasoningTokens + current.reasoningTokens,
+            cachedTokens: aggregate.cachedTokens + current.cachedTokens,
+            cacheWriteTokens: aggregate.cacheWriteTokens + current.cacheWriteTokens,
+            totalTokens: aggregate.totalTokens + current.totalTokens,
+            totalCost: aggregate.totalCost + current.totalCost,
+            totalDurationMs: aggregate.totalDurationMs + current.totalDurationMs,
+            totalTtftMs: aggregate.totalTtftMs + current.totalTtftMs,
+            totalTokensPerSec: aggregate.totalTokensPerSec + current.totalTokensPerSec,
+            avgDurationMs: 0,
+            avgTtftMs: 0,
+            avgTokensPerSec: 0,
+          };
+        }, toSummaryAggregate({}));
+        const groupedTotalRows = await db
+          .select(aggregateSelection)
+          .from(schema.requestUsage)
+          .where(and(...getBreakdownFilter(dimension)));
+        const groupedTotal = toSummaryAggregate(groupedTotalRows[0] || {});
+        const totalDimensions = toNumber(groupRows[0]?.totalDimensions);
+        if (totalDimensions > topItems.length) {
+          topItems.push(toSummaryGroup('Other', subtractAggregates(groupedTotal, included)));
+        }
+        grouped[dimension] = {
+          items: topItems,
+          totalDimensions,
+          truncated: totalDimensions > parsedLimit,
+        };
+      }
 
-      const todayRow = todayRows[0] || {
-        requests: 0,
-        inputTokens: 0,
-        outputTokens: 0,
-        reasoningTokens: 0,
-        cachedTokens: 0,
-        cacheWriteTokens: 0,
-        totalCost: 0,
-      };
-
-      return reply.send({
+      const response: SummaryResponse = {
         range,
-        series: seriesRows.map((row: any) => ({
-          bucketStartMs: toNumber(row.bucketStartMs),
-          requests: toNumber(row.requests),
-          inputTokens: toNumber(row.inputTokens),
-          outputTokens: toNumber(row.outputTokens),
-          cachedTokens: toNumber(row.cachedTokens),
-          cacheWriteTokens: toNumber(row.cacheWriteTokens),
-          tokens:
-            toNumber(row.inputTokens) +
-            toNumber(row.outputTokens) +
-            toNumber(row.cachedTokens) +
-            toNumber(row.cacheWriteTokens),
-        })),
+        series: seriesRows.map((row: any) => {
+          const aggregate = toSummaryAggregate(row);
+          return {
+            bucketStartMs: toNumber(row.bucketStartMs),
+            requests: aggregate.requests,
+            errors: aggregate.errors,
+            inputTokens: aggregate.inputTokens,
+            outputTokens: aggregate.outputTokens,
+            reasoningTokens: aggregate.reasoningTokens,
+            cachedTokens: aggregate.cachedTokens,
+            cacheWriteTokens: aggregate.cacheWriteTokens,
+            tokens: aggregate.totalTokens,
+            totalCost: aggregate.totalCost,
+            avgDurationMs: aggregate.avgDurationMs,
+            avgTtftMs: aggregate.avgTtftMs,
+            avgTokensPerSec: aggregate.avgTokensPerSec,
+          };
+        }),
         stats: {
-          totalRequests: toNumber(statsRow.requests),
-          totalTokens:
-            toNumber(statsRow.inputTokens) +
-            toNumber(statsRow.outputTokens) +
-            toNumber(statsRow.cachedTokens) +
-            toNumber(statsRow.cacheWriteTokens),
-          avgDurationMs: toNumber(statsRow.avgDurationMs),
-          totalDurationMs: toNumber(statsRow.totalDurationMs),
+          totalRequests: stats.requests,
+          totalErrors: stats.errors,
+          totalTokens: stats.totalTokens,
+          inputTokens: stats.inputTokens,
+          outputTokens: stats.outputTokens,
+          reasoningTokens: stats.reasoningTokens,
+          cachedTokens: stats.cachedTokens,
+          cacheWriteTokens: stats.cacheWriteTokens,
+          totalCost: stats.totalCost,
+          avgDurationMs: stats.avgDurationMs,
+          totalDurationMs: stats.totalDurationMs,
+          avgTtftMs: stats.avgTtftMs,
+          avgTokensPerSec: stats.avgTokensPerSec,
+          successRate: stats.successRate,
         },
         today: {
-          requests: toNumber(todayRow.requests),
-          inputTokens: toNumber(todayRow.inputTokens),
-          outputTokens: toNumber(todayRow.outputTokens),
-          reasoningTokens: toNumber(todayRow.reasoningTokens),
-          cachedTokens: toNumber(todayRow.cachedTokens),
-          cacheWriteTokens: toNumber(todayRow.cacheWriteTokens),
-          totalCost: toNumber(todayRow.totalCost),
+          requests: toNumber(todayRows[0]?.requests),
+          inputTokens: toNumber(todayRows[0]?.inputTokens),
+          outputTokens: toNumber(todayRows[0]?.outputTokens),
+          reasoningTokens: toNumber(todayRows[0]?.reasoningTokens),
+          cachedTokens: toNumber(todayRows[0]?.cachedTokens),
+          cacheWriteTokens: toNumber(todayRows[0]?.cacheWriteTokens),
+          totalCost: toNumber(todayRows[0]?.totalCost),
         },
+      };
+      if (normalizedBreakdowns.length > 0) response.grouped = grouped;
+      const responseBytes = Buffer.byteLength(JSON.stringify(response), 'utf8');
+      const responseLimit =
+        normalizedBreakdowns.length > 0
+          ? MAX_SUMMARY_RESPONSE_BYTES
+          : MAX_BASIC_SUMMARY_RESPONSE_BYTES;
+      if (responseBytes > responseLimit) {
+        throw new SummaryResponseTooLargeError(
+          `Usage summary response exceeds the ${responseLimit} byte size limit`
+        );
+      }
+      logger.debug('Usage summary generated', {
+        range,
+        breakdownCount: normalizedBreakdowns.length,
+        bucketCount: response.series.length,
+        groupCount: Object.values(response.grouped ?? {}).reduce(
+          (count, breakdown) => count + (breakdown?.items.length ?? 0),
+          0
+        ),
+        cache: 'MISS',
+        responseBytes,
+        durationMs: Math.round(performance.now() - requestStartedAt),
+        queryDurationMs: Math.round(performance.now() - queryStartedAt),
+        dialect,
       });
+      return response;
+    })();
+
+    for (const [key, entry] of summaryCache) {
+      if (entry.expiresAt <= Date.now()) summaryCache.delete(key);
+    }
+    while (summaryCache.size >= MAX_SUMMARY_CACHE_ENTRIES) {
+      const oldestKey = summaryCache.keys().next().value;
+      if (oldestKey === undefined) break;
+      summaryCache.delete(oldestKey);
+    }
+    summaryCache.set(cacheKey, {
+      expiresAt:
+        Date.now() +
+        (range === 'custom' && rangeEnd.getTime() < now.getTime() - 5 * 60 * 1000
+          ? HISTORICAL_SUMMARY_CACHE_TTL_MS
+          : SUMMARY_CACHE_TTL_MS),
+      promise: summaryPromise,
+    });
+    summaryPromise.catch(() => summaryCache.delete(cacheKey));
+
+    try {
+      const response = await summaryPromise;
+      reply.header('X-Usage-Summary-Cache', 'MISS');
+      return reply.send(response);
     } catch (e: any) {
+      if (e instanceof SummaryResponseTooLargeError) {
+        return reply.code(413).send({ error: e.message });
+      }
       return reply.code(500).send({ error: e.message });
     }
   });

--- a/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/OverallTab.tsx
@@ -9,10 +9,8 @@
  * Data sources (all already force-scoped to the caller's key on the backend):
  *   - `getSelfMe`          → identity (key name, allowedProviders, allowedModels,
  *                             quota assignment, comment)
- *   - `getUsageSummary`    → aggregated totals for the selected time range plus
- *                             an embedded 7-day / today roll-up
- *   - `getUsageByProvider` → per-provider request + token totals
- *   - `getUsageByModel`    → per-model (alias) request + token totals
+ *   - `getUsageSummary`    → aggregated totals and optional provider/model
+ *                             breakdowns for the selected time range
  *   - `getSelfQuota`       → per-quota progress for the caller's key
  *                             (`quotas[]`, most-constrained rendered first)
  *
@@ -29,8 +27,10 @@ import { Card } from '../../ui/Card';
 import { QuotaStatusCard } from '../../quota';
 import { TimeRangeSelector } from '../TimeRangeSelector';
 import { sortMostConstrainedFirst } from '../../../lib/quota';
+import type { CustomDateRange } from '../../../lib/date';
+import { Skeleton } from '../../ui/Skeleton';
 
-type TimeRange = 'hour' | 'day' | 'week' | 'month';
+type TimeRange = 'hour' | 'day' | 'week' | 'month' | 'custom';
 
 interface SelfInfo {
   role: 'admin' | 'limited';
@@ -48,6 +48,7 @@ interface SummaryStats {
   totalTokens: number;
   inputTokens: number;
   outputTokens: number;
+  reasoningTokens: number;
   cachedTokens: number;
   cacheWriteTokens: number;
   todayCost: number;
@@ -116,6 +117,7 @@ const BreakdownList: React.FC<{
 export const OverallTab: React.FC = () => {
   const { currency, rate, symbol } = useCurrency();
   const [timeRange, setTimeRange] = useState<TimeRange>('day');
+  const [customDateRange, setCustomDateRange] = useState<CustomDateRange | null>(null);
   const [info, setInfo] = useState<SelfInfo | null>(null);
   const [summary, setSummary] = useState<SummaryStats | null>(null);
   const [providerData, setProviderData] = useState<PieChartDataPoint[]>([]);
@@ -126,6 +128,15 @@ export const OverallTab: React.FC = () => {
 
   useEffect(() => {
     let cancelled = false;
+    let startDate: string | undefined;
+    let endDate: string | undefined;
+
+    if (timeRange === 'custom') {
+      if (!customDateRange) return;
+      startDate = customDateRange.start.toISOString();
+      endDate = customDateRange.end.toISOString();
+    }
+
     setLoading(true);
     // Clear per-range data so switching time ranges doesn't render stale
     // totals/breakdowns under the new range's label while requests are
@@ -160,55 +171,51 @@ export const OverallTab: React.FC = () => {
 
     // Token + request totals for the selected range. The backend endpoint is
     // auto-scoped to the calling limited user.
-    const summaryPromise = api.getUsageSummary(timeRange, true).then((res) => {
-      if (cancelled || !res) return;
-      // `stats` is a fixed 7-day window; to get totals for the selected range
-      // we sum the per-bucket series instead.
-      const totals = (res.series || []).reduce(
-        (acc, p) => {
-          acc.requests += p.requests || 0;
-          acc.inputTokens += p.inputTokens || 0;
-          acc.outputTokens += p.outputTokens || 0;
-          acc.cachedTokens += p.cachedTokens || 0;
-          acc.cacheWriteTokens += p.cacheWriteTokens || 0;
-          return acc;
-        },
-        { requests: 0, inputTokens: 0, outputTokens: 0, cachedTokens: 0, cacheWriteTokens: 0 }
-      );
-      setSummary({
-        range: timeRange,
-        totalRequests: totals.requests,
-        totalTokens:
-          totals.inputTokens + totals.outputTokens + totals.cachedTokens + totals.cacheWriteTokens,
-        inputTokens: totals.inputTokens,
-        outputTokens: totals.outputTokens,
-        cachedTokens: totals.cachedTokens,
-        cacheWriteTokens: totals.cacheWriteTokens,
-        todayCost: res.today?.totalCost ?? 0,
+    const summaryPromise = api
+      .getUsageSummary(timeRange, true, startDate, endDate, ['provider', 'modelAlias'], 10, [
+        'directModels',
+        'probe',
+      ])
+      .then((res) => {
+        if (cancelled || !res) return;
+        const stats = res.stats;
+        setSummary({
+          range: timeRange,
+          totalRequests: stats.totalRequests,
+          totalTokens: stats.totalTokens,
+          inputTokens: stats.inputTokens,
+          outputTokens: stats.outputTokens,
+          reasoningTokens: stats.reasoningTokens,
+          cachedTokens: stats.cachedTokens,
+          cacheWriteTokens: stats.cacheWriteTokens,
+          todayCost: res.today?.totalCost ?? 0,
+        });
+        setProviderData(
+          (res.grouped?.provider?.items ?? []).map((item) => ({
+            name: item.name,
+            requests: item.requests,
+            tokens: item.totalTokens,
+          }))
+        );
+        setModelData(
+          (res.grouped?.modelAlias?.items ?? [])
+            .filter((item) => !item.name.startsWith('direct/'))
+            .map((item) => ({
+              name: item.name,
+              requests: item.requests,
+              tokens: item.totalTokens,
+            }))
+        );
       });
-    });
 
-    const providerPromise = api.getUsageByProvider(timeRange, true).then((d) => {
-      if (!cancelled) setProviderData(d);
-    });
-    const modelPromise = api.getUsageByModel(timeRange, true).then((d) => {
-      if (!cancelled) setModelData(d);
-    });
-
-    Promise.allSettled([
-      metaPromise,
-      quotaPromise,
-      summaryPromise,
-      providerPromise,
-      modelPromise,
-    ]).then(() => {
+    Promise.allSettled([metaPromise, quotaPromise, summaryPromise]).then(() => {
       if (!cancelled) setLoading(false);
     });
 
     return () => {
       cancelled = true;
     };
-  }, [timeRange]);
+  }, [timeRange, customDateRange]);
 
   const allowedProviders = info?.allowedProviders ?? [];
   const allowedModels = info?.allowedModels ?? [];
@@ -225,9 +232,14 @@ export const OverallTab: React.FC = () => {
         <TimeRangeSelector
           value={timeRange}
           onChange={(r) => {
-            if (r !== 'custom' && r !== 'live') setTimeRange(r);
+            if (r !== 'live') {
+              setTimeRange(r);
+              if (r !== 'custom') setCustomDateRange(null);
+            }
           }}
-          options={['hour', 'day', 'week', 'month']}
+          customRange={customDateRange}
+          onCustomRangeChange={setCustomDateRange}
+          options={['hour', 'day', 'week', 'month', 'custom']}
         />
       </header>
 
@@ -347,7 +359,7 @@ export const OverallTab: React.FC = () => {
         extra={<Activity size={16} className="text-text-muted" />}
       >
         {loading && !summary ? (
-          <p className="text-sm text-text-muted">Loading…</p>
+          <Skeleton height={120} className="w-full" />
         ) : !summary ? (
           <p className="text-sm text-text-muted">No usage recorded in this range.</p>
         ) : (
@@ -385,7 +397,7 @@ export const OverallTab: React.FC = () => {
       >
         <Card title="Requests by provider" className="min-w-0">
           {loading && !providerData.length ? (
-            <p className="text-sm text-text-muted">Loading…</p>
+            <Skeleton height={180} className="w-full" />
           ) : (
             <BreakdownList
               data={providerData}
@@ -397,7 +409,7 @@ export const OverallTab: React.FC = () => {
 
         <Card title="Tokens by provider" className="min-w-0">
           {loading && !providerData.length ? (
-            <p className="text-sm text-text-muted">Loading…</p>
+            <Skeleton height={180} className="w-full" />
           ) : (
             <BreakdownList
               data={providerData}
@@ -409,7 +421,7 @@ export const OverallTab: React.FC = () => {
 
         <Card title="Requests by model alias" className="min-w-0">
           {loading && !modelData.length ? (
-            <p className="text-sm text-text-muted">Loading…</p>
+            <Skeleton height={180} className="w-full" />
           ) : (
             <BreakdownList
               data={modelData}
@@ -421,7 +433,7 @@ export const OverallTab: React.FC = () => {
 
         <Card title="Tokens by model alias" className="min-w-0">
           {loading && !modelData.length ? (
-            <p className="text-sm text-text-muted">Loading…</p>
+            <Skeleton height={180} className="w-full" />
           ) : (
             <BreakdownList
               data={modelData}

--- a/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
+++ b/packages/frontend/src/components/dashboard/tabs/UsageTab.tsx
@@ -28,8 +28,14 @@ import { useEffect, useMemo, useState } from 'react';
  * Each record represents a single (provider, model, timestamp) data point returned
  * from the `GET /v0/management/concurrency?timeRange=...` endpoint.
  */
-import { PieChart as PieChartIcon, BarChart3 } from 'lucide-react';
-import { api, UsageData, PieChartDataPoint, type ConcurrencyData } from '../../../lib/api';
+import { PieChart as PieChartIcon, BarChart3, Loader2 } from 'lucide-react';
+import {
+  api,
+  UsageData,
+  PieChartDataPoint,
+  type ConcurrencyData,
+  type UsageSummaryBreakdown,
+} from '../../../lib/api';
 import {
   formatNumber,
   formatTokens,
@@ -39,6 +45,7 @@ import {
 import { Card } from '../../ui/Card';
 import { TimeRangeSelector } from '../TimeRangeSelector';
 import type { CustomDateRange } from '../../../lib/date';
+import { Skeleton } from '../../ui/Skeleton';
 import {
   AreaChart,
   Area,
@@ -94,7 +101,7 @@ export const UsageTab: React.FC<UsageTabProps> = ({
   timeRange,
   onTimeRangeChange,
   customDateRange,
-  onCustomDateRangeChange: _onCustomDateRangeChange,
+  onCustomDateRangeChange,
 }) => {
   // ---------------------------------------------------------------------------
   // State -- pre-existing usage data
@@ -114,6 +121,8 @@ export const UsageTab: React.FC<UsageTabProps> = ({
    */
   const [concurrencyByProvider, setConcurrencyByProvider] = useState<ConcurrencyData[]>([]);
   const [concurrencyByModel, setConcurrencyByModel] = useState<ConcurrencyData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   // ---------------------------------------------------------------------------
   // Data fetching
@@ -121,10 +130,9 @@ export const UsageTab: React.FC<UsageTabProps> = ({
   /**
    * Fetches all dashboard data whenever the selected time range changes.
    *
-   * All five calls fire in parallel (no `await` chaining) so the network
-   * requests overlap. Each `.then()` independently updates its own state slice,
-   * meaning cards render progressively as responses arrive rather than waiting
-   * for the slowest endpoint.
+   * The summary request owns all completed-usage charts and optional breakdowns.
+   * Concurrency remains on its separate endpoint because it represents in-flight
+   * requests rather than completed usage records.
    *
    * **Concurrency fetch (`getConcurrencyData`):** hits the
    * `GET /v0/management/concurrency?timeRange=<range>` endpoint and returns an
@@ -136,12 +144,15 @@ export const UsageTab: React.FC<UsageTabProps> = ({
    * WebSocket strategy should be added here.
    */
   useEffect(() => {
+    let cancelled = false;
     let startDate: string | undefined;
     let endDate: string | undefined;
 
     if (timeRange === 'custom' && customDateRange) {
       startDate = customDateRange.start.toISOString();
       endDate = customDateRange.end.toISOString();
+    } else if (timeRange === 'custom') {
+      return;
     } else {
       // Calculate date range for non-custom time ranges
       const now = new Date();
@@ -166,18 +177,70 @@ export const UsageTab: React.FC<UsageTabProps> = ({
       endDate = now.toISOString();
     }
 
-    // Use summary endpoint for time-series data (much more efficient)
-    api.getSummaryData(timeRange, true, startDate, endDate).then(setData);
-    api.getUsageByModel(timeRange, true, startDate, endDate).then(setModelData);
-    api.getUsageByProvider(timeRange, true, startDate, endDate).then(setProviderData);
-    api.getUsageByKey(timeRange, true, startDate, endDate).then(setKeyData);
-    // Make two separate calls for provider and model concurrency data
-    api
+    setLoading(true);
+    setError(false);
+    const summaryPromise = api
+      .getUsageSummary(
+        timeRange,
+        true,
+        startDate,
+        endDate,
+        ['provider', 'modelAlias', 'apiKey'] satisfies UsageSummaryBreakdown[],
+        10,
+        ['directModels', 'probe']
+      )
+      .then((summary) => {
+        if (cancelled) return;
+        if (!summary) {
+          setError(true);
+          return;
+        }
+        setData(
+          summary.series.map((point) => ({
+            timestamp: String(point.bucketStartMs),
+            requests: point.requests,
+            tokens: point.tokens,
+            inputTokens: point.inputTokens,
+            outputTokens: point.outputTokens,
+            cachedTokens: point.cachedTokens,
+            cacheWriteTokens: point.cacheWriteTokens,
+          }))
+        );
+        setModelData(
+          (summary.grouped?.modelAlias?.items ?? [])
+            .filter((item) => !item.name.startsWith('direct/'))
+            .map((item) => ({ name: item.name, requests: item.requests, tokens: item.totalTokens }))
+        );
+        setProviderData(
+          (summary.grouped?.provider?.items ?? []).map((item) => ({
+            name: item.name,
+            requests: item.requests,
+            tokens: item.totalTokens,
+          }))
+        );
+        setKeyData(
+          (summary.grouped?.apiKey?.items ?? [])
+            .filter((item) => item.name !== 'probe')
+            .map((item) => ({ name: item.name, requests: item.requests, tokens: item.totalTokens }))
+        );
+      });
+    const providerPromise = api
       .getConcurrencyData(timeRange, 'timeline', 'provider', startDate, endDate)
-      .then(setConcurrencyByProvider);
-    api
+      .then((result) => {
+        if (!cancelled) setConcurrencyByProvider(result);
+      });
+    const modelPromise = api
       .getConcurrencyData(timeRange, 'timeline', 'model', startDate, endDate)
-      .then(setConcurrencyByModel);
+      .then((result) => {
+        if (!cancelled) setConcurrencyByModel(result);
+      });
+    Promise.allSettled([summaryPromise, providerPromise, modelPromise]).then(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [timeRange, customDateRange]);
 
   // ---------------------------------------------------------------------------
@@ -404,7 +467,9 @@ export const UsageTab: React.FC<UsageTabProps> = ({
     return (
       <Card className={className ?? 'min-w-0'} title={title} extra={extra}>
         <div style={{ height: 300, marginTop: '12px' }}>
-          {chartType === 'pie' ? (
+          {loading && data.length === 0 ? (
+            <Skeleton height={260} className="w-full" />
+          ) : chartType === 'pie' ? (
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
                 <Pie
@@ -477,7 +542,26 @@ export const UsageTab: React.FC<UsageTabProps> = ({
       </div>
 
       <div className="mb-4">
-        <TimeRangeSelector value={timeRange} onChange={(r) => onTimeRangeChange(r as TimeRange)} />
+        <TimeRangeSelector
+          value={timeRange}
+          onChange={(r) => onTimeRangeChange(r as TimeRange)}
+          customRange={customDateRange}
+          onCustomRangeChange={onCustomDateRangeChange}
+        />
+        {loading && data.length > 0 && (
+          <span
+            className="ml-3 inline-flex items-center gap-1 text-xs text-text-secondary"
+            role="status"
+          >
+            <Loader2 size={13} className="animate-spin" aria-hidden="true" />
+            Updating analytics…
+          </span>
+        )}
+        {error && (
+          <span className="ml-3 text-xs text-red-400" role="alert">
+            Unable to load usage analytics.
+          </span>
+        )}
       </div>
 
       {/* All Charts in 4-Column Grid */}
@@ -485,32 +569,40 @@ export const UsageTab: React.FC<UsageTabProps> = ({
         {/* Time Series - Requests */}
         <Card className="min-w-0" title="Requests over Time">
           <div style={{ height: 300, marginTop: '12px' }}>
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={data}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-glass)" />
-                <XAxis
-                  dataKey="timestamp"
-                  stroke="var(--color-text-secondary)"
-                  tickFormatter={(v) => formatTimeLabel(String(v))}
-                />
-                <YAxis stroke="var(--color-text-secondary)" tickFormatter={formatNumber} />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'var(--color-bg-card)',
-                    borderColor: 'var(--color-border)',
-                    color: 'var(--color-text)',
-                  }}
-                  labelFormatter={(label) => formatDateTimeLabel(String(label))}
-                  formatter={(value) => formatNumber(value as number)}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="requests"
-                  stroke="var(--color-primary)"
-                  fill="var(--color-glow)"
-                />
-              </AreaChart>
-            </ResponsiveContainer>
+            {loading && data.length === 0 ? (
+              <Skeleton height={280} className="w-full" />
+            ) : error && data.length === 0 ? (
+              <div className="h-full flex items-center justify-center text-red-400 text-sm">
+                Unable to load usage data.
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={data}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-glass)" />
+                  <XAxis
+                    dataKey="timestamp"
+                    stroke="var(--color-text-secondary)"
+                    tickFormatter={(v) => formatTimeLabel(String(v))}
+                  />
+                  <YAxis stroke="var(--color-text-secondary)" tickFormatter={formatNumber} />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'var(--color-bg-card)',
+                      borderColor: 'var(--color-border)',
+                      color: 'var(--color-text)',
+                    }}
+                    labelFormatter={(label) => formatDateTimeLabel(String(label))}
+                    formatter={(value) => formatNumber(value as number)}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="requests"
+                    stroke="var(--color-primary)"
+                    fill="var(--color-glow)"
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            )}
           </div>
         </Card>
 
@@ -541,7 +633,9 @@ export const UsageTab: React.FC<UsageTabProps> = ({
          */}
         <Card className="min-w-0" title="Concurrency by Provider">
           <div style={{ height: 300, marginTop: '12px' }}>
-            {concurrencyByProviderTimeline.length === 0 ? (
+            {loading && concurrencyByProviderTimeline.length === 0 ? (
+              <Skeleton height={280} className="w-full" />
+            ) : concurrencyByProviderTimeline.length === 0 ? (
               <div className="h-full flex items-center justify-center text-text-secondary text-sm">
                 No concurrency data available
               </div>
@@ -595,7 +689,9 @@ export const UsageTab: React.FC<UsageTabProps> = ({
          */}
         <Card className="min-w-0" title="Concurrency by Model">
           <div style={{ height: 300, marginTop: '12px' }}>
-            {concurrencyByModelTimeline.length === 0 ? (
+            {loading && concurrencyByModelTimeline.length === 0 ? (
+              <Skeleton height={280} className="w-full" />
+            ) : concurrencyByModelTimeline.length === 0 ? (
               <div className="h-full flex items-center justify-center text-text-secondary text-sm">
                 No concurrency data available
               </div>
@@ -634,67 +730,75 @@ export const UsageTab: React.FC<UsageTabProps> = ({
         {/* Time Series - Tokens */}
         <Card className="min-w-0" title="Token Usage">
           <div style={{ height: 300, marginTop: '12px' }}>
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={data}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-glass)" />
-                <XAxis
-                  dataKey="timestamp"
-                  stroke="var(--color-text-secondary)"
-                  tickFormatter={(v) => formatTimeLabel(String(v))}
-                />
-                <YAxis stroke="var(--color-text-secondary)" tickFormatter={formatTokens} />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'var(--color-bg-card)',
-                    borderColor: 'var(--color-border)',
-                    color: 'var(--color-text)',
-                  }}
-                  labelFormatter={(label) => formatDateTimeLabel(String(label))}
-                  formatter={(value) => formatTokens(value as number)}
-                />
-                <Legend />
-                <Area
-                  type="monotone"
-                  dataKey="tokens"
-                  name="Total Tokens"
-                  stroke="var(--color-primary)"
-                  fill="var(--color-glow)"
-                  fillOpacity={0.1}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="inputTokens"
-                  name="Input"
-                  stroke="#82ca9d"
-                  fill="#82ca9d"
-                  fillOpacity={0.3}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="outputTokens"
-                  name="Output"
-                  stroke="#ffc658"
-                  fill="#ffc658"
-                  fillOpacity={0.3}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="cachedTokens"
-                  name="Cached"
-                  stroke="#ff7300"
-                  fill="#ff7300"
-                  fillOpacity={0.3}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="cacheWriteTokens"
-                  name="Cache Write"
-                  stroke="#a855f7"
-                  fill="#a855f7"
-                  fillOpacity={0.3}
-                />
-              </AreaChart>
-            </ResponsiveContainer>
+            {loading && data.length === 0 ? (
+              <Skeleton height={280} className="w-full" />
+            ) : error && data.length === 0 ? (
+              <div className="h-full flex items-center justify-center text-red-400 text-sm">
+                Unable to load token data.
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={data}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-glass)" />
+                  <XAxis
+                    dataKey="timestamp"
+                    stroke="var(--color-text-secondary)"
+                    tickFormatter={(v) => formatTimeLabel(String(v))}
+                  />
+                  <YAxis stroke="var(--color-text-secondary)" tickFormatter={formatTokens} />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'var(--color-bg-card)',
+                      borderColor: 'var(--color-border)',
+                      color: 'var(--color-text)',
+                    }}
+                    labelFormatter={(label) => formatDateTimeLabel(String(label))}
+                    formatter={(value) => formatTokens(value as number)}
+                  />
+                  <Legend />
+                  <Area
+                    type="monotone"
+                    dataKey="tokens"
+                    name="Total Tokens"
+                    stroke="var(--color-primary)"
+                    fill="var(--color-glow)"
+                    fillOpacity={0.1}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="inputTokens"
+                    name="Input"
+                    stroke="#82ca9d"
+                    fill="#82ca9d"
+                    fillOpacity={0.3}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="outputTokens"
+                    name="Output"
+                    stroke="#ffc658"
+                    fill="#ffc658"
+                    fillOpacity={0.3}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="cachedTokens"
+                    name="Cached"
+                    stroke="#ff7300"
+                    fill="#ff7300"
+                    fillOpacity={0.3}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="cacheWriteTokens"
+                    name="Cache Write"
+                    stroke="#a855f7"
+                    fill="#a855f7"
+                    fillOpacity={0.3}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            )}
           </div>
         </Card>
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -612,11 +612,44 @@ interface BackendResponse<T> {
 interface UsageSummarySeriesPoint {
   bucketStartMs: number;
   requests: number;
+  errors: number;
   inputTokens: number;
   outputTokens: number;
+  reasoningTokens: number;
   cachedTokens: number;
   cacheWriteTokens: number;
   tokens: number;
+  totalCost: number;
+  avgDurationMs: number;
+  avgTtftMs: number;
+  avgTokensPerSec: number;
+}
+
+export type UsageSummaryBreakdown = 'provider' | 'modelAlias' | 'apiKey' | 'status';
+export type UsageSummaryExclusion = 'directModels' | 'probe';
+
+export interface UsageSummaryGroup {
+  name: string;
+  requests: number;
+  errors: number;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  cachedTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  totalCost: number;
+  avgDurationMs: number;
+  totalDurationMs: number;
+  avgTtftMs: number;
+  avgTokensPerSec: number;
+  successRate: number;
+}
+
+export interface UsageSummaryBreakdownResult {
+  items: UsageSummaryGroup[];
+  totalDimensions: number;
+  truncated: boolean;
 }
 
 export interface UsageSummaryResponse {
@@ -624,11 +657,22 @@ export interface UsageSummaryResponse {
   series: UsageSummarySeriesPoint[];
   stats: {
     totalRequests: number;
+    totalErrors: number;
     totalTokens: number;
+    inputTokens: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    cachedTokens: number;
+    cacheWriteTokens: number;
+    totalCost: number;
     avgDurationMs: number;
     totalDurationMs: number;
+    avgTtftMs: number;
+    avgTokensPerSec: number;
+    successRate: number;
   };
   today: TodayMetrics;
+  grouped?: Partial<Record<UsageSummaryBreakdown, UsageSummaryBreakdownResult>>;
 }
 
 type UsageRecordField = keyof UsageRecord;
@@ -996,7 +1040,10 @@ const fetchUsageSummary = async (
   range: 'hour' | 'day' | 'week' | 'month' | 'custom',
   cache = true,
   startDate?: string,
-  endDate?: string
+  endDate?: string,
+  breakdowns: UsageSummaryBreakdown[] = [],
+  breakdownLimit = 10,
+  exclusions: UsageSummaryExclusion[] = []
 ) => {
   const searchParams = new URLSearchParams();
   searchParams.set('range', range);
@@ -1004,6 +1051,16 @@ const fetchUsageSummary = async (
   if (range === 'custom' && startDate && endDate) {
     searchParams.set('startDate', startDate);
     searchParams.set('endDate', endDate);
+  }
+
+  const normalizedBreakdowns = Array.from(new Set(breakdowns)).sort();
+  if (normalizedBreakdowns.length > 0) {
+    searchParams.set('breakdowns', normalizedBreakdowns.join(','));
+    searchParams.set('breakdownLimit', String(breakdownLimit));
+  }
+  const normalizedExclusions = Array.from(new Set(exclusions)).sort();
+  if (normalizedExclusions.length > 0) {
+    searchParams.set('exclude', normalizedExclusions.join(','));
   }
 
   const queryString = searchParams.toString();
@@ -1378,10 +1435,8 @@ export const api = {
    * Fetch the raw usage-summary response for the current principal.
    *
    * Unlike `getSummaryData` (which reshapes series into chart-ready rows),
-   * this returns the untransformed backend payload including `stats` (7-day
-   * window) and `today` roll-ups. Used by the Overall dashboard tab to
-   * compute range-scoped totals without having to duplicate the endpoint
-   * definition.
+   * this returns the untransformed backend payload including range-scoped
+   * stats, optional grouped breakdowns, and today roll-ups.
    *
    * The backend auto-scopes this endpoint to the calling limited user's
    * key, so admin callers see global totals and api-key callers see only
@@ -1391,10 +1446,21 @@ export const api = {
     range: 'hour' | 'day' | 'week' | 'month' | 'custom' = 'day',
     cache = true,
     startDate?: string,
-    endDate?: string
+    endDate?: string,
+    breakdowns: UsageSummaryBreakdown[] = [],
+    breakdownLimit = 10,
+    exclusions: UsageSummaryExclusion[] = []
   ): Promise<UsageSummaryResponse | null> => {
     try {
-      return await fetchUsageSummary(range, cache, startDate, endDate);
+      return await fetchUsageSummary(
+        range,
+        cache,
+        startDate,
+        endDate,
+        breakdowns,
+        breakdownLimit,
+        exclusions
+      );
     } catch (e) {
       console.error('API Error getUsageSummary', e);
       return null;
@@ -1409,24 +1475,38 @@ export const api = {
     range: 'hour' | 'day' | 'week' | 'month' | 'custom' = 'week',
     cache = true,
     startDate?: string,
-    endDate?: string
+    endDate?: string,
+    breakdowns: UsageSummaryBreakdown[] = [],
+    breakdownLimit = 10,
+    exclusions: UsageSummaryExclusion[] = []
   ): Promise<any[]> => {
     try {
-      const summaryResponse = await fetchUsageSummary(range, cache, startDate, endDate);
+      const summaryResponse = await fetchUsageSummary(
+        range,
+        cache,
+        startDate,
+        endDate,
+        breakdowns,
+        breakdownLimit,
+        exclusions
+      );
       const series = summaryResponse.series || [];
 
-      // Hard limit to prevent memory issues
-      const limitedSeries = series.length > 100 ? series.slice(0, 100) : series;
-
       // Return raw data with minimal transformation
-      return limitedSeries.map((point) => ({
+      return series.map((point) => ({
         timestamp: String(point.bucketStartMs),
         requests: point.requests,
+        errors: point.errors,
         tokens: point.tokens,
         inputTokens: point.inputTokens,
         outputTokens: point.outputTokens,
+        reasoningTokens: point.reasoningTokens,
         cachedTokens: point.cachedTokens,
         cacheWriteTokens: point.cacheWriteTokens,
+        cost: point.totalCost,
+        duration: point.avgDurationMs,
+        ttft: point.avgTtftMs,
+        tps: point.avgTokensPerSec,
       }));
     } catch (e) {
       console.error('API Error getSummaryData', e);
@@ -1526,181 +1606,6 @@ export const api = {
         cacheWriteTokens: 0,
         totalCost: 0,
       };
-    }
-  },
-
-  getUsageByModel: async (
-    range: 'hour' | 'day' | 'week' | 'month' | 'custom' = 'week',
-    cache = true,
-    startDate?: string,
-    endDate?: string
-  ): Promise<PieChartDataPoint[]> => {
-    try {
-      const now = normalizeNow();
-
-      let queryStartDate: Date;
-      let queryEndDate: Date;
-
-      if (range === 'custom' && startDate && endDate) {
-        queryStartDate = new Date(startDate);
-        queryEndDate = new Date(endDate);
-      } else {
-        const { startDate: configStart } = getUsageRangeConfig(
-          range as 'hour' | 'day' | 'week' | 'month',
-          now
-        );
-        queryStartDate = configStart;
-        queryEndDate = now;
-      }
-
-      const usageResponse = await fetchUsageRecords({
-        limit: 5000,
-        startDate: queryStartDate.toISOString(),
-        endDate: queryEndDate.toISOString(),
-        fields: USAGE_PAGE_FIELDS,
-        cache,
-      });
-
-      const records = usageResponse.data || [];
-
-      const aggregated: Record<string, PieChartDataPoint> = {};
-
-      records.forEach((r) => {
-        const name = r.incomingModelAlias || 'Unknown';
-        if (name.startsWith('direct/')) return;
-        if (!aggregated[name]) {
-          aggregated[name] = { name, requests: 0, tokens: 0 };
-        }
-        aggregated[name].requests++;
-        aggregated[name].tokens +=
-          (r.tokensInput || 0) +
-          (r.tokensOutput || 0) +
-          (r.tokensCached || 0) +
-          (r.tokensCacheWrite || 0);
-      });
-
-      return Object.values(aggregated).sort((a, b) => b.requests - a.requests);
-    } catch (e) {
-      console.error('API Error getUsageByModel', e);
-      return [];
-    }
-  },
-
-  getUsageByProvider: async (
-    range: 'hour' | 'day' | 'week' | 'month' | 'custom' = 'week',
-    cache = true,
-    startDate?: string,
-    endDate?: string
-  ): Promise<PieChartDataPoint[]> => {
-    try {
-      const now = normalizeNow();
-
-      let queryStartDate: Date;
-      let queryEndDate: Date;
-
-      if (range === 'custom' && startDate && endDate) {
-        queryStartDate = new Date(startDate);
-        queryEndDate = new Date(endDate);
-      } else {
-        const { startDate: configStart } = getUsageRangeConfig(
-          range as 'hour' | 'day' | 'week' | 'month',
-          now
-        );
-        queryStartDate = configStart;
-        queryEndDate = now;
-      }
-
-      const usageResponse = await fetchUsageRecords({
-        limit: 5000,
-        startDate: queryStartDate.toISOString(),
-        endDate: queryEndDate.toISOString(),
-        fields: USAGE_PAGE_FIELDS,
-        cache,
-      });
-
-      const records = usageResponse.data || [];
-
-      const aggregated: Record<string, PieChartDataPoint> = {};
-
-      records.forEach((r) => {
-        const name = r.provider || 'Unknown';
-        if (!aggregated[name]) {
-          aggregated[name] = { name, requests: 0, tokens: 0 };
-        }
-        aggregated[name].requests++;
-        aggregated[name].tokens +=
-          (r.tokensInput || 0) +
-          (r.tokensOutput || 0) +
-          (r.tokensCached || 0) +
-          (r.tokensCacheWrite || 0);
-      });
-
-      return Object.values(aggregated).sort((a, b) => b.requests - a.requests);
-    } catch (e) {
-      console.error('API Error getUsageByProvider', e);
-      return [];
-    }
-  },
-
-  getUsageByKey: async (
-    range: 'hour' | 'day' | 'week' | 'month' | 'custom' = 'week',
-    cache = true,
-    startDate?: string,
-    endDate?: string
-  ): Promise<PieChartDataPoint[]> => {
-    try {
-      const now = normalizeNow();
-
-      let queryStartDate: Date;
-      let queryEndDate: Date;
-
-      if (range === 'custom' && startDate && endDate) {
-        queryStartDate = new Date(startDate);
-        queryEndDate = new Date(endDate);
-      } else {
-        const { startDate: configStart } = getUsageRangeConfig(
-          range as 'hour' | 'day' | 'week' | 'month',
-          now
-        );
-        queryStartDate = configStart;
-        queryEndDate = now;
-      }
-
-      const usageResponse = await fetchUsageRecords({
-        limit: 5000,
-        startDate: queryStartDate.toISOString(),
-        endDate: queryEndDate.toISOString(),
-        fields: USAGE_PAGE_FIELDS,
-        cache,
-      });
-
-      const records = usageResponse.data || [];
-
-      const aggregated: Record<string, PieChartDataPoint> = {};
-
-      records.forEach((r) => {
-        if (r.apiKey === 'probe') return;
-
-        const name = r.apiKey
-          ? r.apiKey.length > 8
-            ? `${r.apiKey.slice(0, 8)}...`
-            : r.apiKey
-          : 'Unknown';
-        if (!aggregated[name]) {
-          aggregated[name] = { name, requests: 0, tokens: 0 };
-        }
-        aggregated[name].requests++;
-        aggregated[name].tokens +=
-          (r.tokensInput || 0) +
-          (r.tokensOutput || 0) +
-          (r.tokensCached || 0) +
-          (r.tokensCacheWrite || 0);
-      });
-
-      return Object.values(aggregated).sort((a, b) => b.requests - a.requests);
-    } catch (e) {
-      console.error('API Error getUsageByKey', e);
-      return [];
     }
   },
 

--- a/packages/frontend/src/lib/date.ts
+++ b/packages/frontend/src/lib/date.ts
@@ -20,7 +20,6 @@ export function getPresetRange(preset: DateRangePreset): CustomDateRange {
   switch (preset) {
     case 'today':
       start.setHours(0, 0, 0, 0);
-      end.setHours(23, 59, 59, 999);
       break;
 
     case 'this-week':
@@ -28,13 +27,11 @@ export function getPresetRange(preset: DateRangePreset): CustomDateRange {
       const dayOfWeek = start.getDay();
       start.setDate(start.getDate() - dayOfWeek);
       start.setHours(0, 0, 0, 0);
-      end.setHours(23, 59, 59, 999);
       break;
 
     case 'this-month':
       start.setDate(1);
       start.setHours(0, 0, 0, 0);
-      end.setHours(23, 59, 59, 999);
       break;
 
     case 'last-month':
@@ -79,13 +76,8 @@ export function isValidDateRange(start: Date, end: Date): boolean {
   if (isNaN(start.getTime()) || isNaN(end.getTime())) return false;
   if (end < start) return false;
 
-  // Optional: prevent dates too far in the future
   const now = new Date();
-  const tomorrow = new Date(now);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  tomorrow.setHours(23, 59, 59, 999);
-
-  if (end > tomorrow) return false;
+  if (end > now) return false;
 
   return true;
 }

--- a/packages/frontend/src/pages/DetailedUsage.tsx
+++ b/packages/frontend/src/pages/DetailedUsage.tsx
@@ -30,13 +30,13 @@
  *    parsePresetFromQuery() --> initial state (timeRange, chartType, groupBy, etc.)
  *         |
  *         v
- *    loadData() --> api.getLogs(startDate based on timeRange)
+ *    loadData() --> api.getUsageSummary(startDate based on timeRange)
  *         |
  *         v
- *    records[] (raw UsageRecord array)
+ *    summary response + optional recent records for List mode
  *         |
  *         v
- *    aggregateByTime() or aggregateByGroup() --> aggregatedData[]
+ *    server aggregates --> aggregatedData[]
  *         |
  *         v
  *    renderTimeSeriesChart() / renderPieChart() / list table
@@ -44,15 +44,14 @@
  * ## Auto-refresh
  *
  * Data is automatically refreshed every 30 seconds via `setInterval` in a
- * `useEffect` hook. The interval is reset whenever `timeRange` changes (since
- * `loadData` depends on `timeRange` via `useCallback`). A manual "Refresh"
- * button is also available in the chart card header.
+ * `useEffect` hook. The interval is reset whenever the requested view changes.
+ * A manual "Refresh" button is also available in the chart card header.
  *
  * ## Query parameter contract (consumed by parsePresetFromQuery)
  *
  * | Param           | Values                                    | Default     |
  * |-----------------|-------------------------------------------|-------------|
- * | `range`         | live, hour, day, week, month              | day         |
+ * | `range`         | live, hour, day, week, month, custom       | day         |
  * | `chartType`     | line, bar, area, pie, composed             | area        |
  * | `groupBy`       | time, provider, model, apiKey, status      | time        |
  * | `viewMode`      | chart, list                               | chart       |
@@ -62,13 +61,20 @@
  * | `filterModel`   | model name string                         | (none)      |
  * | `filterStatus`  | status string (e.g., "error")             | (none)      |
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Card } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { Button } from '../components/ui/Button';
+import { Skeleton } from '../components/ui/Skeleton';
 import { PageHeader } from '../components/layout/PageHeader';
 import { TimeRangeSelector } from '../components/dashboard/TimeRangeSelector';
-import { api, type UsageRecord } from '../lib/api';
+import {
+  api,
+  type UsageRecord,
+  type UsageSummaryBreakdown,
+  type UsageSummaryGroup,
+  type UsageSummaryResponse,
+} from '../lib/api';
 import { useCurrency } from '../lib/CurrencyContext';
 import { formatCostIn, formatMs, formatNumber, formatTokens, formatTimeAgo } from '../lib/format';
 import type { CustomDateRange } from '../lib/date';
@@ -90,6 +96,7 @@ import {
   Ban,
   Timer,
   Plane,
+  Loader2,
 } from 'lucide-react';
 import {
   ResponsiveContainer,
@@ -201,7 +208,7 @@ interface CostDisplay {
  * When groupBy='time', `name` is a formatted time bucket label (e.g., "14:30").
  * When groupBy is a categorical dimension, `name` is the group key (e.g., "openai", "gpt-4").
  *
- * Numeric fields are aggregated from raw UsageRecord values:
+ * Numeric fields are supplied by the range-scoped usage summary:
  * - `requests`, `errors`, `tokens`, `cost` are summed totals for the bucket/group.
  * - `duration`, `ttft`, `tps` are averaged across records in the bucket/group.
  * - `successRate` is derived: ((requests - errors) / requests) * 100.
@@ -220,12 +227,6 @@ interface AggregatedPoint {
   successRate: number;
   velocity?: number;
   fill?: string;
-}
-
-interface SummaryPoint {
-  timestamp: string;
-  requests: number;
-  tokens: number;
 }
 
 /**
@@ -298,7 +299,7 @@ const LIVE_WINDOW_MINUTES = 5;
 // Validation allowlists for query parameter parsing.
 // Unknown values are replaced with safe defaults (see parsePresetFromQuery).
 // ---------------------------------------------------------------------------
-const ALLOWED_TIME_RANGES: TimeRange[] = ['live', 'hour', 'day', 'week', 'month'];
+const ALLOWED_TIME_RANGES: TimeRange[] = ['live', 'hour', 'day', 'week', 'month', 'custom'];
 const ALLOWED_CHART_TYPES: ChartType[] = ['line', 'bar', 'area', 'pie', 'composed'];
 const ALLOWED_GROUP_BY: GroupBy[] = ['time', 'provider', 'model', 'apiKey', 'status'];
 const ALLOWED_VIEW_MODES: ViewMode[] = ['chart', 'list'];
@@ -495,176 +496,21 @@ const calcVelocity = (data: AggregatedPoint[]): AggregatedPoint[] => {
   }));
 };
 
-/**
- * Aggregate raw usage records into time-series buckets for chart rendering.
- *
- * Process:
- * 1. Each record's date is truncated to its time bucket via `bucketFn`
- * 2. Records falling into the same bucket are summed (requests, errors, tokens, cost)
- *    or averaged (duration, ttft, tps)
- * 3. Buckets are sorted chronologically
- * 4. Velocity is computed as the delta between adjacent buckets
- *
- * @param records - Raw usage records from the API
- * @param range   - Current time range (determines bucket granularity)
- * @returns Sorted array of aggregated data points with velocity computed
- */
-// @ts-expect-error kept for future use (client-side aggregation fallback)
-const aggregateByTime = (
-  records: UsageRecord[],
-  range: TimeRange,
-  customRange?: CustomDateRange | null
-): AggregatedPoint[] => {
-  const { bucketFn } = getRangeConfig(range);
-  const grouped = new Map<
-    number,
-    {
-      requests: number;
-      errors: number;
-      tokens: number;
-      cost: number;
-      duration: number;
-      ttft: number;
-      tps: number;
-      count: number;
-    }
-  >();
-
-  records.forEach((r) => {
-    const timestampMs = new Date(r.date).getTime();
-    if (Number.isNaN(timestampMs)) return;
-    const ms = bucketFn(timestampMs);
-    const ex = grouped.get(ms) || {
-      requests: 0,
-      errors: 0,
-      tokens: 0,
-      cost: 0,
-      duration: 0,
-      ttft: 0,
-      tps: 0,
-      count: 0,
-    };
-    ex.requests++;
-    if (r.responseStatus !== 'success') ex.errors++;
-    ex.tokens +=
-      (r.tokensInput || 0) +
-      (r.tokensOutput || 0) +
-      (r.tokensReasoning || 0) +
-      (r.tokensCached || 0);
-    ex.cost += r.costTotal || 0;
-    ex.duration += r.durationMs || 0;
-    ex.ttft += r.ttftMs || 0;
-    ex.tps += r.tokensPerSec || 0;
-    ex.count++;
-    grouped.set(ms, ex);
-  });
-
-  const data = Array.from(grouped.entries())
-    .sort((a, b) => a[0] - b[0])
-    .map(([ms, v]) => ({
-      name: formatBucketLabel(range, ms, range === 'custom' ? customRange : null),
-      requests: v.requests,
-      errors: v.errors,
-      tokens: v.tokens,
-      cost: v.cost,
-      duration: v.count > 0 ? v.duration / v.count : 0,
-      ttft: v.count > 0 ? v.ttft / v.count : 0,
-      tps: v.count > 0 ? v.tps / v.count : 0,
-      successRate: v.requests > 0 ? ((v.requests - v.errors) / v.requests) * 100 : 0,
-    }));
-
-  return calcVelocity(data);
-};
-
-/**
- * Aggregate raw usage records into categorical groups (provider, model, apiKey, status).
- *
- * Unlike time-series aggregation, this produces one data point per unique group value.
- * Results are sorted by request count (descending) and capped at 10 groups to keep
- * pie charts and tables readable. Each group is assigned a deterministic color based
- * on a hash of its name string.
- *
- * @param records - Raw usage records from the API
- * @param groupBy - The categorical dimension to group by
- * @returns Array of aggregated data points, max 10, sorted by request count descending
- */
-const aggregateByGroup = (records: UsageRecord[], groupBy: GroupBy): AggregatedPoint[] => {
-  const grouped = new Map<
-    string,
-    {
-      requests: number;
-      errors: number;
-      tokens: number;
-      cost: number;
-      duration: number;
-      ttft: number;
-      tps: number;
-      count: number;
-    }
-  >();
-
-  records.forEach((r) => {
-    let key: string;
-    switch (groupBy) {
-      case 'provider':
-        key = r.provider || 'unknown';
-        break;
-      case 'model':
-        key = r.incomingModelAlias || r.selectedModelName || 'unknown';
-        break;
-      case 'apiKey':
-        key = r.apiKey ? `${r.apiKey.slice(0, 8)}...` : 'unknown';
-        break;
-      case 'status':
-        key = r.responseStatus || 'unknown';
-        break;
-      default:
-        key = 'unknown';
-    }
-
-    const ex = grouped.get(key) || {
-      requests: 0,
-      errors: 0,
-      tokens: 0,
-      cost: 0,
-      duration: 0,
-      ttft: 0,
-      tps: 0,
-      count: 0,
-    };
-    ex.requests++;
-    if (r.responseStatus !== 'success') ex.errors++;
-    ex.tokens +=
-      (r.tokensInput || 0) +
-      (r.tokensOutput || 0) +
-      (r.tokensReasoning || 0) +
-      (r.tokensCached || 0);
-    ex.cost += r.costTotal || 0;
-    ex.duration += r.durationMs || 0;
-    ex.ttft += r.ttftMs || 0;
-    ex.tps += r.tokensPerSec || 0;
-    ex.count++;
-    grouped.set(key, ex);
-  });
-
-  return Array.from(grouped.entries())
-    .map(([name, v]) => ({
-      name,
-      requests: v.requests,
-      errors: v.errors,
-      tokens: v.tokens,
-      cost: v.cost,
-      duration: v.count > 0 ? v.duration / v.count : 0,
-      ttft: v.count > 0 ? v.ttft / v.count : 0,
-      tps: v.count > 0 ? v.tps / v.count : 0,
-      successRate: v.requests > 0 ? ((v.requests - v.errors) / v.requests) * 100 : 0,
-      fill: COLORS[
-        Math.abs(name.split('').reduce((a, b) => a + b.charCodeAt(0), 0)) % COLORS.length
-      ],
-    }))
-    .sort((a, b) => b.requests - a.requests)
-    .slice(0, 10);
-};
+const toAggregatedPoint = (group: UsageSummaryGroup): AggregatedPoint => ({
+  name: group.name,
+  requests: group.requests,
+  errors: group.errors,
+  tokens: group.totalTokens,
+  cost: group.totalCost,
+  duration: group.avgDurationMs,
+  ttft: group.avgTtftMs,
+  tps: group.avgTokensPerSec,
+  successRate: group.successRate,
+  fill: COLORS[
+    Math.abs(group.name.split('').reduce((sum, character) => sum + character.charCodeAt(0), 0)) %
+      COLORS.length
+  ],
+});
 
 /**
  * Render a time-series chart (area, line, bar, or composed) using Recharts.
@@ -934,12 +780,14 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
   // and data fetching react to state changes automatically.
   // ---------------------------------------------------------------------------
 
-  /** Raw usage records fetched from the API (used for categorical grouping). */
+  /** Raw usage records fetched only for the recent List-mode preview. */
   const [records, setRecords] = useState<UsageRecord[]>([]);
-  /** Pre-aggregated summary buckets for time-series chart rendering. */
-  const [summaryData, setSummaryData] = useState<SummaryPoint[]>([]);
-  /** Whether a data fetch is currently in progress (shows loading spinner on Refresh button). */
-  const [loading, setLoading] = useState(false);
+  /** Range-scoped, server-aggregated analytics data. */
+  const [summaryResponse, setSummaryResponse] = useState<UsageSummaryResponse | null>(null);
+  /** Whether a data fetch is currently in progress. */
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const requestVersion = useRef(0);
   /** Selected time window -- controls how far back data is fetched and bucket granularity. */
   const [timeRange, setTimeRange] = useState<TimeRange>(preset.timeRange);
   /** Custom date range when timeRange is 'custom' */
@@ -986,16 +834,17 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
   /**
    * Fetch usage data from the API for the currently selected time range.
    *
-   * For time-series views (groupBy='time'), uses the backend summary endpoint
-   * which returns pre-aggregated data, significantly reducing memory usage.
-   *
-   * For categorical views (groupBy!='time'), fetches raw records for client-side aggregation.
+   * Chart analytics always use the range-scoped summary endpoint. Raw records
+   * are fetched only when List mode is selected because that view is intentionally
+   * a recent request preview rather than an aggregate analytics source.
    *
    * The callback is memoized on `timeRange` and `customDateRange` so it re-creates
    * when the user changes the time window, which also resets the auto-refresh interval.
    */
   const loadData = useCallback(async () => {
+    const version = ++requestVersion.current;
     setLoading(true);
+    setLoadError(false);
     try {
       let startDate: string | undefined;
       let endDate: string | undefined;
@@ -1003,37 +852,59 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
       if (timeRange === 'custom' && customDateRange) {
         startDate = customDateRange.start.toISOString();
         endDate = customDateRange.end.toISOString();
-      } else if (timeRange !== 'custom') {
+      } else if (timeRange === 'custom') {
+        return;
+      } else {
         const now = new Date();
         const { minutes } = getRangeConfig(timeRange);
         startDate = new Date(now.getTime() - minutes * 60000).toISOString();
         endDate = now.toISOString();
       }
 
-      // Use backend summary endpoint for time-series views (much more efficient)
-      if (groupBy === 'time') {
-        const [summaryResponse, logsResponse] = await Promise.all([
-          api.getSummaryData(timeRange === 'live' ? 'hour' : timeRange, true, startDate, endDate),
-          api.getLogs(5000, 0, { startDate, endDate }),
+      const summaryRange = timeRange === 'live' ? 'custom' : timeRange;
+      const breakdown: UsageSummaryBreakdown[] =
+        groupBy === 'time' || viewMode === 'list'
+          ? []
+          : [groupBy === 'model' ? 'modelAlias' : (groupBy as UsageSummaryBreakdown)];
+      const summaryPromise = api
+        .getUsageSummary(summaryRange, true, startDate, endDate, breakdown, 10)
+        .then((response) => {
+          if (!response) throw new Error('Usage analytics request failed');
+          return response;
+        });
+
+      if (viewMode === 'list') {
+        const [response, logsResponse] = await Promise.all([
+          summaryPromise,
+          api.getLogs(100, 0, {
+            startDate,
+            endDate,
+            fields:
+              'date,provider,incomingModelAlias,selectedModelName,responseStatus,tokensInput,tokensOutput,costTotal,durationMs,ttftMs,tokensPerSec',
+          }),
         ]);
-        // Limit to max 100 points to prevent memory issues
-        const limitedData = summaryResponse.slice(0, 100) as SummaryPoint[];
-        setSummaryData(limitedData);
-        setRecords(logsResponse.data || []);
+        if (version === requestVersion.current) {
+          setSummaryResponse(response);
+          setRecords(logsResponse.data || []);
+        }
       } else {
-        // For categorical views, fetch raw records with strict limits
-        const logsResponse = await api.getLogs(100, 0, { startDate, endDate });
-        setSummaryData([]);
-        setRecords(logsResponse.data || []);
+        const response = await summaryPromise;
+        if (version === requestVersion.current) {
+          setSummaryResponse(response);
+          setRecords([]);
+        }
       }
 
-      setLastUpdated(new Date());
+      if (version === requestVersion.current) setLastUpdated(new Date());
     } catch (e) {
-      console.error('Failed to load usage data', e);
+      if (version === requestVersion.current) {
+        setLoadError(true);
+        console.error('Failed to load usage data', e);
+      }
     } finally {
-      setLoading(false);
+      if (version === requestVersion.current) setLoading(false);
     }
-  }, [timeRange, customDateRange, groupBy, api]);
+  }, [timeRange, customDateRange, groupBy, viewMode, api]);
 
   /**
    * Auto-refresh mechanism: fetch data immediately on mount and whenever
@@ -1062,42 +933,29 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
   }, [loadData, timeRange]);
 
   /**
-   * Derived aggregated data: re-computed whenever raw records, groupBy dimension,
-   * or timeRange changes.
-   *
-   * For time-series views (groupBy='time'), uses pre-aggregated summary data from backend.
-   * For categorical views, aggregates raw records client-side.
+   * Derived chart data from the server-side range-scoped aggregates.
    */
   const aggregatedData = useMemo(() => {
     if (groupBy === 'time') {
-      // Use pre-aggregated summary data - minimize object creation
       const isCustom = timeRange === 'custom';
       const customRange = isCustom ? customDateRange : null;
-      const { bucketFn } = getRangeConfig(timeRange, customRange);
-      const costByBucket = new Map<number, number>();
-
-      records.forEach((record) => {
-        const timestampMs = new Date(record.date).getTime();
-        if (Number.isNaN(timestampMs)) return;
-        const bucket = bucketFn(timestampMs);
-        costByBucket.set(bucket, (costByBucket.get(bucket) || 0) + (record.costTotal || 0));
-      });
-
-      return summaryData.map((r) => ({
-        name: formatBucketLabel(timeRange, Number(r.timestamp), customRange),
-        requests: r.requests || 0,
-        errors: 0,
-        tokens: r.tokens || 0,
-        cost: costByBucket.get(Number(r.timestamp)) || 0,
-        duration: 0,
-        ttft: 0,
-        tps: 0,
-        successRate: 100,
+      const data = (summaryResponse?.series ?? []).map((point) => ({
+        name: formatBucketLabel(timeRange, point.bucketStartMs, customRange),
+        requests: point.requests,
+        errors: point.errors,
+        tokens: point.tokens,
+        cost: point.totalCost,
+        duration: point.avgDurationMs,
+        ttft: point.avgTtftMs,
+        tps: point.avgTokensPerSec,
+        successRate:
+          point.requests > 0 ? ((point.requests - point.errors) / point.requests) * 100 : 0,
       }));
+      return calcVelocity(data);
     }
-    // For categorical views, aggregate raw records
-    return aggregateByGroup(records, groupBy);
-  }, [summaryData, records, groupBy, timeRange, customDateRange]);
+    const breakdown = groupBy === 'model' ? 'modelAlias' : groupBy;
+    return (summaryResponse?.grouped?.[breakdown]?.items ?? []).map(toAggregatedPoint);
+  }, [summaryResponse, groupBy, timeRange, customDateRange]);
 
   const metrics = useMemo(
     () => createMetrics({ currency, rate, symbol }),
@@ -1109,30 +967,21 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
   );
 
   /**
-   * Summary statistics computed from all raw records in the current time window.
+   * Summary statistics returned by the backend for the complete current window.
    * These are displayed as KPI cards at the top of the page, providing an
    * at-a-glance overview: total requests, errors, tokens, cost, and averages
    * for duration, TTFT (time to first token), TPS (tokens per second), and success rate.
    */
   const stats = useMemo(() => {
-    const total = records.length;
-    const errors = records.filter((r) => r.responseStatus !== 'success').length;
-    const tokens = records.reduce(
-      (acc, r) =>
-        acc +
-        (r.tokensInput || 0) +
-        (r.tokensOutput || 0) +
-        (r.tokensReasoning || 0) +
-        (r.tokensCached || 0),
-      0
-    );
-    const cost = records.reduce((acc, r) => acc + (r.costTotal || 0), 0);
-    const avgDuration =
-      total > 0 ? records.reduce((acc, r) => acc + (r.durationMs || 0), 0) / total : 0;
-    const avgTtft = total > 0 ? records.reduce((acc, r) => acc + (r.ttftMs || 0), 0) / total : 0;
-    const avgTps =
-      total > 0 ? records.reduce((acc, r) => acc + (r.tokensPerSec || 0), 0) / total : 0;
-    const successRate = total > 0 ? ((total - errors) / total) * 100 : 0;
+    const summary = summaryResponse?.stats;
+    const total = summary?.totalRequests || 0;
+    const errors = summary?.totalErrors || 0;
+    const tokens = summary?.totalTokens || 0;
+    const cost = summary?.totalCost || 0;
+    const avgDuration = summary?.avgDurationMs || 0;
+    const avgTtft = summary?.avgTtftMs || 0;
+    const avgTps = summary?.avgTokensPerSec || 0;
+    const successRate = summary?.successRate || 0;
 
     return [
       { label: 'Requests', value: formatNumber(total, 0), icon: Activity },
@@ -1153,7 +1002,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
       { label: 'Avg TPS', value: formatNumber(avgTps, 1), icon: TrendingUp },
       { label: 'Success Rate', value: `${successRate.toFixed(1)}%`, icon: TrendingUp },
     ];
-  }, [currency, rate, records, symbol]);
+  }, [currency, rate, summaryResponse, symbol]);
 
   /** Toggle a metric on or off in the chart. Removes it if already selected, adds it otherwise. */
   const toggleMetric = (key: string) =>
@@ -1204,27 +1053,37 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
           </>
         }
       />
+      {loadError && (
+        <div className="mb-4 text-sm text-red-400" role="alert">
+          Unable to load usage analytics for this selection. Try refreshing or choosing a shorter
+          range.
+        </div>
+      )}
 
       {/* -------------------------------------------------------------------
           KPI Summary Cards Section
-          A responsive grid of 8 summary statistics computed from all records
+          A responsive grid of 8 summary statistics computed over the full range
           in the current time window. Each card shows a label, value, and icon.
           Errors are highlighted in red when count > 0.
       ------------------------------------------------------------------- */}
       <div className="mb-6 grid grid-cols-1 gap-3 min-[420px]:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-8">
-        {stats.map((stat, i) => (
-          <div key={i} className="glass-bg rounded-lg p-3 flex flex-col gap-1">
-            <div className="flex justify-between items-start">
-              <span className="font-body text-xs font-semibold text-text-muted uppercase tracking-wider">
-                {stat.label}
-              </span>
-              <stat.icon size={16} className={`text-text-secondary ${stat.color || ''}`} />
-            </div>
-            <div className={`font-heading text-xl font-bold ${stat.color || 'text-text'}`}>
-              {stat.value}
-            </div>
-          </div>
-        ))}
+        {loading && !summaryResponse
+          ? Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} height={76} className="w-full" />
+            ))
+          : stats.map((stat, i) => (
+              <div key={i} className="glass-bg rounded-lg p-3 flex flex-col gap-1">
+                <div className="flex justify-between items-start">
+                  <span className="font-body text-xs font-semibold text-text-muted uppercase tracking-wider">
+                    {stat.label}
+                  </span>
+                  <stat.icon size={16} className={`text-text-secondary ${stat.color || ''}`} />
+                </div>
+                <div className={`font-heading text-xl font-bold ${stat.color || 'text-text'}`}>
+                  {stat.value}
+                </div>
+              </div>
+            ))}
       </div>
 
       {/* -------------------------------------------------------------------
@@ -1265,6 +1124,7 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
                 { k: 'time', l: 'Time' },
                 { k: 'provider', l: 'Provider' },
                 { k: 'model', l: 'Model' },
+                { k: 'apiKey', l: 'API key' },
                 { k: 'status', l: 'Status' },
               ].map((o) => (
                 <Button
@@ -1366,7 +1226,18 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
             </Button>
           }
         >
-          {aggregatedData.length === 0 ? (
+          {loading && summaryResponse && (
+            <div
+              className="mb-3 inline-flex items-center gap-1 text-xs text-text-secondary"
+              role="status"
+            >
+              <Loader2 size={13} className="animate-spin" aria-hidden="true" />
+              Updating analytics…
+            </div>
+          )}
+          {loading && !summaryResponse ? (
+            <Skeleton height={400} className="w-full" />
+          ) : aggregatedData.length === 0 ? (
             <div className="h-96 flex items-center justify-center text-text-secondary">
               No data available
             </div>
@@ -1379,7 +1250,12 @@ export const DetailedUsage: React.FC<DetailedUsageProps> = ({
       ) : (
         <Card
           title="Raw Request Log"
-          extra={<span className="text-xs text-text-secondary">{records.length} requests</span>}
+          extra={
+            <span className="text-xs text-text-secondary">
+              {records.length} shown of {summaryResponse?.stats.totalRequests ?? records.length}{' '}
+              requests
+            </span>
+          }
         >
           <div className="max-h-125 space-y-3 overflow-y-auto md:hidden">
             {records.slice(0, 100).map((r, i) => (

--- a/scripts/openapi-types.ts
+++ b/scripts/openapi-types.ts
@@ -1615,7 +1615,6 @@ export interface paths {
      *     Each entry contains:
      *     - `target_groups` — Ordered array of target groups; each group has a name, selector, and targets
      *     - `type` — Model capability type (text, embeddings, transcriptions, speech, image)
-     *     - `model_architecture` — Used for energy estimation (kWh calculation)
      *     - `metadata` — Optional enriched data from external catalogs
      *     - `pricing` — Optional pricing configuration
      *
@@ -1651,12 +1650,6 @@ export interface paths {
      * Create or replace a model alias (admin only)
      * @description Creates a new alias or replaces an existing one.
      *
-     *     ## Energy recalculation
-     *
-     *     If you change `model_architecture`, the system recalculates estimated
-     *     energy usage (kWh) for all affected usage records. This happens
-     *     asynchronously after the alias is saved.
-     *
      *     ## Validation
      *
      *     The request body is validated against the `AliasConfig` schema.
@@ -1673,12 +1666,6 @@ export interface paths {
      * Merge updates into a model alias (admin only)
      * @description Merges the request body into the existing alias configuration,
      *     then validates the result.
-     *
-     *     ## Energy recalculation
-     *
-     *     If you change `model_architecture` (or add it if it was previously unset),
-     *     the system recalculates estimated energy usage (kWh) for all affected
-     *     usage records. This happens asynchronously after the update.
      *
      *     ## Merge behavior
      *
@@ -1739,57 +1726,6 @@ export interface paths {
      *     **Admin only** — limited principals receive 403.
      */
     delete: operations['deleteV0ManagementModelsByaliasId'];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/v0/management/models/huggingface/{modelId}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description HuggingFace repo ID, URL-encoded (e.g. `mistralai%2FMixtral-8x7B`). The `/` character must be encoded as `%2F`. */
-        modelId: string;
-      };
-      cookie?: never;
-    };
-    /**
-     * Fetch model architecture from HuggingFace (admin only)
-     * @description Fetches model architecture parameters from HuggingFace for use by the
-     *     energy-usage estimator.
-     *
-     *     ## Use case
-     *
-     *     The energy-usage estimator needs layer count, head count, and parameter
-     *     totals to calculate kWh consumed. This endpoint fetches that data from
-     *     HuggingFace's model card.
-     *
-     *     ## Rate limiting
-     *
-     *     - HuggingFace API has rate limits; repeated calls may be throttled
-     *     - Responses are cached in Plexus to reduce unnecessary calls
-     *
-     *     ## Response fields
-     *
-     *     - `success` — Whether the fetch succeeded
-     *     - `model_id` — The model ID queried
-     *     - `architecture` — Model architecture parameters:
-     *       - `total_params` — Total parameters in billions (estimated)
-     *       - `active_params` — Active (non-quantized) parameters
-     *       - `layers` — Number of transformer layers
-     *       - `heads` — Number of attention heads
-     *       - `kv_lora_rank` — KV quantization rank (if applicable)
-     *       - `qk_rope_head_dim` — QK RoPE head dimension (if applicable)
-     *       - `context_length` — Maximum context window
-     *       - `dtype` — Model data type (e.g. `float16`, `bfloat16`)
-     *
-     *     **Admin only** — limited principals receive 403.
-     */
-    get: operations['getV0ManagementModelsHuggingfaceBymodelId'];
-    put?: never;
-    post?: never;
-    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -2285,8 +2221,9 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Valid built-in quota-checker type strings (admin only)
-     * @description Returns the list of valid quota checker types.
+     * Registered quota-checker type strings (admin only)
+     * @description Returns the list of registered quota checker types, including enabled
+     *     admin-authored custom checkers.
      *
      *     ## Relationship to ProviderConfig
      *
@@ -2362,6 +2299,44 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/v0/management/custom-checkers': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List custom quota checkers (admin only) */
+    get: operations['getV0ManagementCustomCheckers'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/v0/management/custom-checkers/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a custom quota checker (admin only) */
+    get: operations['getV0ManagementCustomCheckersByid'];
+    /** Create or replace a custom quota checker (admin only) */
+    put: operations['putV0ManagementCustomCheckersByid'];
+    /** Test a custom quota checker without persisting a snapshot (admin only) */
+    post: operations['postV0ManagementCustomCheckersByid'];
+    /** Delete a custom quota checker (admin only) */
+    delete: operations['deleteV0ManagementCustomCheckersByid'];
+    options?: never;
+    head?: never;
+    /** Update a custom quota checker (admin only) */
+    patch: operations['patchV0ManagementCustomCheckersByid'];
+    trace?: never;
+  };
   '/v0/management/usage': {
     parameters: {
       query?: never;
@@ -2421,30 +2396,35 @@ export interface paths {
     };
     /**
      * Aggregated usage time-series and totals
-     * @description Returns bucketed series plus 7-day and since-midnight rollups.
+     * @description Returns range-scoped bucketed series and totals plus a since-midnight
+     *     rollup. Optional grouped breakdowns are computed server-side over the
+     *     complete requested range.
      *
      *     ## Scoping
      *
      *     Limited principals see only their own key's data; admins see global data.
      *
-     *     ## Bucket algorithm
+     *     ## Range and bucket algorithm
      *
      *     The endpoint uses adaptive bucketing to ensure meaningful visualizations:
-     *     - `hour` — returns hourly buckets for the last 24 hours
-     *     - `day` — returns daily buckets for the last 30 days
-     *     - `week` — returns weekly buckets for the last 12 weeks
-     *     - `month` — returns monthly buckets for the last 12 months
+     *     - `hour` — the last hour, in one-minute buckets
+     *     - `day` — the last 24 hours, in one-hour buckets
+     *     - `week` — the last 7 days, in one-day buckets
+     *     - `month` — the last 30 days, in one-day buckets
      *     - `custom` — requires `startDate` and `endDate`; buckets are auto-sized
-     *       based on the range duration
+     *       based on the range duration and the range may not exceed 12 months.
      *
      *     ## Response structure
      *
      *     - **series** — Time-bucketed data, where each bucket contains aggregated
      *       counts and token sums
-     *     - **stats** — Fixed 7-day rolling window (always the last 7 days, regardless
-     *       of `range`)
+     *     - **stats** — Aggregation over the requested range, including rich usage
+     *       and performance metrics
      *     - **today** — Aggregation since local midnight (not UTC), giving a
      *       "day-so-far" view
+     *     - **grouped** — Optional top-N grouped aggregates. Request dimensions with
+     *       the comma-separated `breakdowns` parameter. At most three dimensions are
+     *       allowed, and omitted groups are represented by an `Other` item.
      */
     get: operations['getV0ManagementUsageSummary'];
     put?: never;
@@ -4692,6 +4672,121 @@ export interface components {
       /** @description Maximum number of web searches allowed per request. Only honoured when `target` is `"anthropic"` (maps to `max_uses` on the `web_search_20250305` tool entry). Ignored for all other targets. */
       max_uses?: number;
     };
+    /** @description Aggregated usage statistics over time windows. */
+    UsageSummary: {
+      /** @description Requested time range. Both series and stats use this range. */
+      range?: string;
+      series?: {
+        /** @description Start of the time bucket (epoch ms). */
+        bucketStartMs?: number;
+        /** @description Number of requests in this bucket. */
+        requests?: number;
+        /** @description Number of non-success requests in this bucket. */
+        errors?: number;
+        /** @description Sum of input tokens across all requests. */
+        inputTokens?: number;
+        /** @description Sum of output tokens across all requests. */
+        outputTokens?: number;
+        /** @description Sum of reasoning tokens across all requests. */
+        reasoningTokens?: number;
+        /** @description Sum of cached tokens across all requests. */
+        cachedTokens?: number;
+        /** @description Sum of cache-write tokens across all requests. */
+        cacheWriteTokens?: number;
+        /** @description Total token count = inputTokens + outputTokens + reasoningTokens + cachedTokens + cacheWriteTokens. */
+        tokens?: number;
+        /** @description Sum of request costs in the bucket. */
+        totalCost?: number;
+        /** @description Average request duration in milliseconds. */
+        avgDurationMs?: number;
+        /** @description Average time to first token in milliseconds. */
+        avgTtftMs?: number;
+        /** @description Average reported tokens per second. */
+        avgTokensPerSec?: number;
+      }[];
+      /** @description Aggregation over the requested range. */
+      stats?: {
+        /** @description Total requests in the requested range. */
+        totalRequests?: number;
+        /** @description Total non-success requests in the requested range. */
+        totalErrors?: number;
+        /** @description Total tokens (input + output + reasoning + cached + cacheWrite) in the requested range. */
+        totalTokens?: number;
+        /** @description Total uncached input tokens. */
+        inputTokens?: number;
+        /** @description Total output tokens. */
+        outputTokens?: number;
+        /** @description Total reasoning tokens. */
+        reasoningTokens?: number;
+        /** @description Total cached input tokens. */
+        cachedTokens?: number;
+        /** @description Total cache-write tokens. */
+        cacheWriteTokens?: number;
+        /** @description Total request cost in the requested range. */
+        totalCost?: number;
+        /** @description Average request duration in milliseconds. */
+        avgDurationMs?: number;
+        /** @description Sum of all request durations in milliseconds. */
+        totalDurationMs?: number;
+        /** @description Average time to first token in milliseconds. */
+        avgTtftMs?: number;
+        /** @description Average reported tokens per second. */
+        avgTokensPerSec?: number;
+        /** @description Percentage of requests whose status is success. */
+        successRate?: number;
+      };
+      /** @description Optional top-N aggregates for requested dimensions. */
+      grouped?: {
+        provider?: components['schemas']['UsageSummaryBreakdown'];
+        modelAlias?: components['schemas']['UsageSummaryBreakdown'];
+        apiKey?: components['schemas']['UsageSummaryBreakdown'];
+        status?: components['schemas']['UsageSummaryBreakdown'];
+      };
+      /** @description Aggregation since local midnight (time-of-day based, not UTC). */
+      today?: {
+        /** @description Number of requests since midnight. */
+        requests?: number;
+        /** @description Input tokens since midnight. */
+        inputTokens?: number;
+        /** @description Output tokens since midnight. */
+        outputTokens?: number;
+        /** @description Reasoning tokens since midnight. */
+        reasoningTokens?: number;
+        /** @description Cached tokens since midnight. */
+        cachedTokens?: number;
+        /** @description Cache-write tokens since midnight. */
+        cacheWriteTokens?: number;
+        /** @description Total cost in dollars since midnight. */
+        totalCost?: number;
+      };
+    };
+    /** @description Optional top-N aggregates for one requested dimension. */
+    UsageSummaryBreakdown: {
+      items?: components['schemas']['UsageSummaryGroup'][];
+      /** @description Total distinct groups in the requested range. */
+      totalDimensions?: number;
+      /** @description Whether groups were omitted from the named items. */
+      truncated?: boolean;
+    };
+    /** @description Aggregate metrics for one usage dimension value. */
+    UsageSummaryGroup: {
+      /** @description Group label; API-key labels are display-safe prefixes. */
+      name?: string;
+      requests?: number;
+      errors?: number;
+      inputTokens?: number;
+      outputTokens?: number;
+      reasoningTokens?: number;
+      cachedTokens?: number;
+      cacheWriteTokens?: number;
+      totalTokens?: number;
+      totalCost?: number;
+      avgDurationMs?: number;
+      totalDurationMs?: number;
+      avgTtftMs?: number;
+      avgTokensPerSec?: number;
+      successRate?: number;
+    };
     /** @description OpenAI Chat Completions request (pass-through; full OpenAI schema accepted). */
     ChatCompletionRequest: {
       model: string;
@@ -5212,16 +5307,8 @@ export interface components {
           };
       /** @description API key for the provider. Can be a literal string or `$env:VARIABLE_NAME` to reference an environment variable. Required unless `api_base_url` is an `oauth://` URI. */
       api_key?: string;
-      /**
-       * @description OAuth provider identifier. Required when `api_base_url` uses an `oauth://` URI. Determines which OAuth flow is used to obtain credentials. Note: `google-gemini-cli` and `google-antigravity` are deprecated and no longer supported — they remain accepted for backward compatibility but are rejected at request routing.
-       * @enum {string}
-       */
-      oauth_provider?:
-        | 'anthropic'
-        | 'openai-codex'
-        | 'github-copilot'
-        | 'google-gemini-cli'
-        | 'google-antigravity';
+      /** @description OAuth provider identifier. Required when `api_base_url` uses an `oauth://` URI. Determines which OAuth flow is used to obtain credentials. Any OAuth-capable provider bundled with Plexus's pi-ai dependency is accepted (e.g. `anthropic`, `openai-codex`, `github-copilot`, `xai`, `kimi-coding`, `openrouter`) except `radius`, which is not supported. See `GET /v0/management/oauth/providers` for the current list. `google-gemini-cli` and `google-antigravity` are deprecated and no longer supported — they are rejected on write. */
+      oauth_provider?: string;
       /** @description OAuth account identifier. Required when `api_base_url` uses an `oauth://` URI. */
       oauth_account?: string;
       /**
@@ -5347,16 +5434,6 @@ export interface components {
         /** @default 60 */
         intervalMinutes: number;
       };
-      /** @description Named GPU profile (e.g. `H100`, `A100`, `custom`). A display hint used by the frontend; the backend uses the four numeric fields below as the source of truth. */
-      gpu_profile?: string;
-      /** @description GPU RAM in GB. Used for energy estimation when combined with model_architecture. */
-      gpu_ram_gb?: number;
-      /** @description GPU memory bandwidth in TB/s. Used for energy estimation. */
-      gpu_bandwidth_tb_s?: number;
-      /** @description GPU peak FLOPs in teraflops. Used for energy estimation. */
-      gpu_flops_tflop?: number;
-      /** @description GPU TDP in watts. Used for energy estimation. */
-      gpu_power_draw_watts?: number;
       /**
        * @description Adapter name(s) applied to every model under this provider. Adapters rewrite outbound request payloads (preDispatch) and inbound provider responses (postDispatch) to fix provider-specific field-name incompatibilities. Applied before model-level adapters.
        *     Adapters can be specified as bare strings (backward compatible) or as objects with `{ name, options }` for adapters that require configuration.
@@ -5595,20 +5672,6 @@ export interface components {
             /** @description All metadata lives here for custom sources. `name` is required because there is no catalog fallback. */
             overrides: WithRequired<components['schemas']['MetadataOverrides'], 'name'>;
           };
-      /** @description Model architecture details used for inference energy estimation. When modified, triggers async recalculation of kWh for all affected historical usage records. */
-      model_architecture?: {
-        /** @description Total parameter count (billions). */
-        total_params?: number;
-        /** @description Active (non-MoE-gated) parameter count (billions). */
-        active_params?: number;
-        layers?: number;
-        heads?: number;
-        kv_lora_rank?: number;
-        qk_rope_head_dim?: number;
-        context_length?: number;
-        /** @enum {string} */
-        dtype?: 'fp16' | 'bf16' | 'fp8' | 'fp8_e4m3' | 'fp8_e5m2' | 'nvfp4' | 'int4' | 'int8';
-      };
       /** @description Shorthand simple pricing: input price per million tokens. Equivalent to setting `pricing` to `{ source: "simple", input: <value>, output: <output_price_per_million> }`. Only used when `pricing` is not set. */
       input_price_per_million?: number;
       /** @description Shorthand simple pricing: output price per million tokens. See `input_price_per_million`. */
@@ -5920,6 +5983,37 @@ export interface components {
       /** @description Optional utilisation percentage at which the checker gates the provider onto cooldown. */
       exhaustionThreshold?: number | null;
     };
+    CustomQuotaChecker: {
+      id: string;
+      type: string;
+      displayName: string;
+      /** @description JavaScript function body returning an array of quota meters. */
+      code: string;
+      enabled: boolean;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+    };
+    CustomQuotaCheckerInput: {
+      displayName: string;
+      code: string;
+      /** @default true */
+      enabled: boolean;
+    };
+    CustomQuotaCheckerTestInput: {
+      provider: string;
+      options?: {
+        [key: string]: unknown;
+      };
+      /** @description Optional unsaved code to execute instead of the persisted code. */
+      code?: string;
+    };
+    CustomQuotaCheckerPatch: {
+      displayName?: string;
+      code?: string;
+      enabled?: boolean;
+    };
     /** @description Per-request usage record stored in `request_usage`. Populated after each inference request completes (or errors). Fields may be null on error paths. */
     UsageRecord: {
       /**
@@ -5963,7 +6057,7 @@ export interface components {
       retryHistory?: string | null;
       /** @description Model alias as specified in the request (before resolution). */
       incomingModelAlias?: string | null;
-      /** @description Resolved canonical model name. For aliases with `model_architecture`, this is the target; otherwise same as `incomingModelAlias`. */
+      /** @description Resolved canonical model name. */
       canonicalModelName?: string | null;
       /** @description Final model name sent to the upstream provider. May differ from `canonicalModelName` due to provider-specific transformations. */
       selectedModelName?: string | null;
@@ -6018,7 +6112,7 @@ export interface components {
       ttftMs?: number | null;
       /** @description Output tokens per second (throughput). Calculated as `tokensOutput / (durationMs - ttftMs)` for streaming requests. Null for non-streaming or if calculation invalid. */
       tokensPerSec?: number | null;
-      /** @description Estimated energy consumption in kilowatt-hours. Calculated from `model_architecture` token estimates and provider-specific energy coefficients. Requires `model_architecture` to be set on the alias. */
+      /** @description Measured energy consumption in kilowatt-hours reported by the provider (if available). */
       kwhUsed?: number | null;
       /** @description Whether the response was streamed (SSE). */
       isStreamed?: boolean;
@@ -6049,61 +6143,6 @@ export interface components {
       hasDebug?: boolean;
       /** @description Whether error records exist for this request (mirrors presence in `inference_errors` table). */
       hasError?: boolean;
-    };
-    /** @description Aggregated usage statistics over time windows. */
-    UsageSummary: {
-      /** @description Time range for series data. Format depends on query param (e.g. "24h", "7d", custom start/end). Affects only the series field. */
-      range?: string;
-      series?: {
-        /** @description Start of the time bucket (epoch ms). */
-        bucketStartMs?: number;
-        /** @description Number of requests in this bucket. */
-        requests?: number;
-        /** @description Sum of input tokens across all requests. */
-        inputTokens?: number;
-        /** @description Sum of output tokens across all requests. */
-        outputTokens?: number;
-        /** @description Sum of cached tokens across all requests. */
-        cachedTokens?: number;
-        /** @description Sum of cache-write tokens across all requests. */
-        cacheWriteTokens?: number;
-        /** @description Sum of energy usage (kWh) across all requests. */
-        kwhUsed?: number;
-        /** @description Total token count = inputTokens + outputTokens + cachedTokens + cacheWriteTokens. */
-        tokens?: number;
-      }[];
-      /** @description Rolling 7-day aggregation window. */
-      stats?: {
-        /** @description Total requests in the 7-day window. */
-        totalRequests?: number;
-        /** @description Total tokens (input + output + cached + cacheWrite) in the window. */
-        totalTokens?: number;
-        /** @description Total energy usage in the window. */
-        totalKwhUsed?: number;
-        /** @description Average request duration in milliseconds. */
-        avgDurationMs?: number;
-        /** @description Sum of all request durations in milliseconds. */
-        totalDurationMs?: number;
-      };
-      /** @description Aggregation since local midnight (time-of-day based, not UTC). */
-      today?: {
-        /** @description Number of requests since midnight. */
-        requests?: number;
-        /** @description Input tokens since midnight. */
-        inputTokens?: number;
-        /** @description Output tokens since midnight. */
-        outputTokens?: number;
-        /** @description Reasoning tokens since midnight. */
-        reasoningTokens?: number;
-        /** @description Cached tokens since midnight. */
-        cachedTokens?: number;
-        /** @description Cache-write tokens since midnight. */
-        cacheWriteTokens?: number;
-        /** @description Energy usage since midnight. */
-        kwhUsed?: number;
-        /** @description Total cost in dollars since midnight. */
-        totalCost?: number;
-      };
     };
     /** @description Debug capture for an inference request. Can contain request/response snapshots at various transformation stages. Only populated if debug is enabled for the request (via header or key configuration). */
     DebugLog: {
@@ -6675,6 +6714,8 @@ export interface components {
   };
   parameters: {
     ResponseId: string;
+    /** @description Custom quota checker type identifier. */
+    CustomCheckerId: string;
   };
   requestBodies: never;
   headers: never;
@@ -9510,50 +9551,6 @@ export interface operations {
       };
     };
   };
-  getV0ManagementModelsHuggingfaceBymodelId: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description HuggingFace repo ID, URL-encoded (e.g. `mistralai%2FMixtral-8x7B`). The `/` character must be encoded as `%2F`. */
-        modelId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Architecture params. */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': {
-            /** @constant */
-            success?: true;
-            model_id?: string;
-            architecture?: {
-              total_params?: number;
-              active_params?: number;
-              layers?: number;
-              heads?: number;
-              kv_lora_rank?: number | null;
-              qk_rope_head_dim?: number | null;
-              context_length?: number;
-              dtype?: string;
-            };
-          };
-        };
-      };
-      /** @description Model not found on HuggingFace. */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
   postV0ManagementModelsMetadataRefresh: {
     parameters: {
       query?: never;
@@ -10536,6 +10533,203 @@ export interface operations {
       };
     };
   };
+  getV0ManagementCustomCheckers: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Custom quota checkers. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CustomQuotaChecker'][];
+        };
+      };
+      /** @description Authentication required or invalid credentials. */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getV0ManagementCustomCheckersByid: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Custom quota checker type identifier. */
+        id: components['parameters']['CustomCheckerId'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Custom quota checker. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CustomQuotaChecker'];
+        };
+      };
+      /** @description Custom checker not found. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  putV0ManagementCustomCheckersByid: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Custom quota checker type identifier. */
+        id: components['parameters']['CustomCheckerId'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CustomQuotaCheckerInput'];
+      };
+    };
+    responses: {
+      /** @description Saved custom quota checker. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CustomQuotaChecker'];
+        };
+      };
+      /** @description Validation failed. */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Checker type collides with a built-in checker. */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  postV0ManagementCustomCheckersByid: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Custom quota checker type identifier. */
+        id: components['parameters']['CustomCheckerId'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CustomQuotaCheckerTestInput'];
+      };
+    };
+    responses: {
+      /** @description Test result. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Checker execution failed. */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Custom checker not found. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  deleteV0ManagementCustomCheckersByid: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Custom quota checker type identifier. */
+        id: components['parameters']['CustomCheckerId'];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Custom checker deleted. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Custom checker not found. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  patchV0ManagementCustomCheckersByid: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Custom quota checker type identifier. */
+        id: components['parameters']['CustomCheckerId'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CustomQuotaCheckerPatch'];
+      };
+    };
+    responses: {
+      /** @description Updated custom quota checker. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Custom checker not found. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   getV0ManagementUsage: {
     parameters: {
       query?: {
@@ -10617,6 +10811,12 @@ export interface operations {
         startDate?: string;
         /** @description Required with `range=custom`. */
         endDate?: string;
+        /** @description Optional comma-separated dimensions: provider, modelAlias, apiKey, or status. At most three dimensions are allowed. */
+        breakdowns?: string;
+        /** @description Maximum number of named groups returned per dimension. */
+        breakdownLimit?: number;
+        /** @description Optional comma-separated dimension-specific exclusions. `directModels` excludes model aliases beginning with `direct/`; `probe` excludes the internal probe API key from API-key breakdowns. */
+        exclude?: string;
       };
       header?: never;
       path?: never;
@@ -10627,6 +10827,8 @@ export interface operations {
       /** @description Aggregates. */
       200: {
         headers: {
+          /** @description Whether the response was served from the in-memory summary cache. */
+          'X-Usage-Summary-Cache'?: 'HIT' | 'MISS';
           [name: string]: unknown;
         };
         content: {
@@ -10635,6 +10837,13 @@ export interface operations {
       };
       /** @description Invalid `range` or custom-range parameters. */
       400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Requested aggregate response exceeds the response-size limit. */
+      413: {
         headers: {
           [name: string]: unknown;
         };


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Fixes usage analytics range and data-volume issues by moving dashboard and Detailed Usage reporting to complete, server-side aggregates. Preset and Custom ranges now use the requested time window consistently, while grouped analytics are opt-in, bounded, and scoped to the requesting principal. The change also preserves the branch’s backup-restore upload fix for large archives.

## Changes

### Usage summary API

- Removed the fixed seven-day stats window; `stats` now matches the selected Hour, Day, Week, Month, or Custom range.
- Added range-scoped metrics for:
  - Requests and errors
  - Input, output, reasoning, cached, and cache-write tokens
  - Total tokens using the full quota formula
  - Cost
  - Total and average duration
  - Average TTFT and tokens per second
  - Success rate
- Added optional server-side breakdowns for providers, model aliases, API keys, and statuses.
- Added validation for:
  - Custom ranges missing required dates
  - Invalid, reversed, future, or over-12-month Custom ranges
  - Unsupported breakdown dimensions
  - More than three breakdown dimensions
  - Breakdown limits outside 1–50
- Added deterministic top-N grouping with:
  - Exact `Other` aggregates
  - `totalDimensions`
  - `truncated` metadata
  - Display-safe API-key prefixes
- Added dimension-specific exclusions for direct model aliases and the internal probe API key.
- Added principal-scoped in-memory caching with short-lived preset and historical Custom-range TTLs, in-flight request reuse, bounded cache size, and an `X-Usage-Summary-Cache` response header.
- Enforced 16 KiB limits for basic responses and 128 KiB limits for grouped responses, returning `413` when exceeded.
- Added summary telemetry for cache state, selected range, query duration, result cardinality, dialect, bucket/group counts, and serialized response size.

### Dashboard analytics

- Connected Custom date selection to `UsageTab` and `OverallTab`, preserving the selected dates in requests.
- Replaced client-side aggregation of up to 5,000 raw records with summary breakdowns for provider, model, and API-key charts.
- Kept provider/model concurrency requests on the dedicated concurrency endpoint.
- Added cancellation/stale-response guards so earlier range requests cannot overwrite newer selections.
- Added initial skeletons, refresh indicators, and accessible loading/error states while retaining existing charts during refreshes.
- Limited-user Overall analytics now use range-scoped summary totals and optional grouped results instead of separate raw-record breakdown requests.

### Detailed Usage

- Uses complete server-side summary aggregates for KPIs, time-series metrics, and categorical charts.
- Added support for API-key grouping alongside provider, model, and status views.
- Removed analytical aggregation over the client-side raw-record collection.
- List mode now fetches only a projected 100-row raw-request preview and displays the number shown versus the full range total.
- Added Custom-range support, initial loading skeletons, refresh indicators, request-version guards, and explicit load errors.
- Corrected previously incomplete summary-path metrics, including cost, errors, duration, TTFT, TPS, and success rate.

### API and date handling

- Updated the Usage Summary OpenAPI contract and frontend types with the new metrics, grouping response, query parameters, cache header, response limits, and Custom-range semantics.
- Updated date-range validation to reject dates after the current time rather than allowing the prior broader future window.
- Adjusted preset date helpers so their end time remains the current time instead of being forced to the end of the day/month.
- Removed obsolete frontend helpers that aggregated provider, model, and API-key data from truncated raw-record responses.

### Backup restore

- Increased the `/v0/management/restore` route body limit to 100 MiB for full binary archive restores.
- Added a regression test confirming that archives larger than the global request limit are not rejected with `413`.

### Generated API changes

The regenerated OpenAPI types also reflect the current API contract by adding custom quota-checker schemas and CRUD/test operations, broadening the OAuth provider type, and removing stale HuggingFace model-architecture and energy-estimation fields and endpoints.

## Testing

- Added coverage for range-specific totals, valid and invalid Custom ranges, inclusive boundaries, rich metric calculations, quota token totals, breakdown validation, top-N behavior, `Other` rollups, API-key masking, cache hits, response-size bounds, and large restore uploads.
- Existing validation and formatting checks should be run alongside the project test suite and OpenAPI generation/synchronization commands.
<!-- kody-pr-summary:end -->

Fixes #823