### PR TITLE
fix(providers): fix Anthropic model fetching

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,9 @@
       "bin": {
         "plexuscli": "src/index.ts",
       },
+      "devDependencies": {
+        "typescript": "^7.0.2",
+      },
     },
     "packages/frontend": {
       "name": "frontend",

--- a/docs/openapi/paths/v0_management_providers_fetch-models.yaml
+++ b/docs/openapi/paths/v0_management_providers_fetch-models.yaml
@@ -4,7 +4,7 @@ post:
   summary: Fetch `/v1/models` from an external URL (admin only)
   description: |
     Helper used by the admin UI when adding a new provider. Fetches the
-    target URL (with optional Bearer apiKey), normalizes OpenAI- and
+    target URL (with provider-appropriate optional apiKey authentication), normalizes OpenAI- and
     Ollama-style responses into `{ data: [...] }`, and returns it.
     Blocks localhost and cloud metadata addresses to mitigate SSRF.
   security:
@@ -38,6 +38,8 @@ post:
                   additionalProperties: true
     '400':
       description: Invalid URL, SSRF block, or upstream parse error.
+    '502':
+      description: Upstream provider rejected the request or returned an authorization error.
     '504':
       description: Upstream fetch timed out (10s).
   operationId: postV0ManagementProvidersFetchmodels

--- a/packages/backend/src/assets/openapi.json
+++ b/packages/backend/src/assets/openapi.json
@@ -3900,7 +3900,7 @@
           "Management — Config"
         ],
         "summary": "Fetch `/v1/models` from an external URL (admin only)",
-        "description": "Helper used by the admin UI when adding a new provider. Fetches the\ntarget URL (with optional Bearer apiKey), normalizes OpenAI- and\nOllama-style responses into `{ data: [...] }`, and returns it.\nBlocks localhost and cloud metadata addresses to mitigate SSRF.\n",
+        "description": "Helper used by the admin UI when adding a new provider. Fetches the\ntarget URL (with provider-appropriate optional apiKey authentication), normalizes OpenAI- and\nOllama-style responses into `{ data: [...] }`, and returns it.\nBlocks localhost and cloud metadata addresses to mitigate SSRF.\n",
         "security": [
           {
             "AdminKey": []
@@ -3950,6 +3950,9 @@
           },
           "400": {
             "description": "Invalid URL, SSRF block, or upstream parse error."
+          },
+          "502": {
+            "description": "Upstream provider rejected the request or returned an authorization error."
           },
           "504": {
             "description": "Upstream fetch timed out (10s)."

--- a/packages/backend/src/routes/management/__tests__/providers.test.ts
+++ b/packages/backend/src/routes/management/__tests__/providers.test.ts
@@ -1,0 +1,49 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerProviderRoutes } from '../providers';
+
+describe('management provider routes', () => {
+  let fastify: FastifyInstance;
+
+  beforeEach(async () => {
+    fastify = Fastify();
+    await registerProviderRoutes(fastify);
+    await fastify.ready();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not expose an upstream unauthorized response as a management auth failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ type: 'error', error: { type: 'authentication_error' } }), {
+          status: 401,
+          statusText: 'Unauthorized',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/v0/management/providers/fetch-models',
+      payload: {
+        url: 'https://api.anthropic.com/v1/models',
+        apiKey: 'sk-ant-test',
+      },
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(response.json()).toMatchObject({
+      error: {
+        message: 'Provider returned 401: Unauthorized',
+        type: 'provider_error',
+        code: 401,
+      },
+    });
+  });
+});

--- a/packages/backend/src/routes/management/providers.ts
+++ b/packages/backend/src/routes/management/providers.ts
@@ -11,6 +11,9 @@ const fetchModelsSchema = z.object({
   apiKey: z.string().optional(),
 });
 
+const PROVIDER_AUTH_FAILURE_STATUS_CODES = new Set([401, 403]);
+const PROVIDER_GATEWAY_ERROR_STATUS = 502;
+
 export async function registerProviderRoutes(fastify: FastifyInstance) {
   fastify.post('/v0/management/providers/fetch-models', async (request, reply) => {
     const parsed = fetchModelsSchema.safeParse(request.body);
@@ -56,12 +59,15 @@ export async function registerProviderRoutes(fastify: FastifyInstance) {
           });
         }
         logger.error(`Fetch error: ${error.message}`);
-        const statusCode = (error as any).statusCode ?? 500;
-        return reply.code(statusCode).send({
+        const providerStatusCode = (error as any).statusCode ?? 500;
+        const responseStatusCode = PROVIDER_AUTH_FAILURE_STATUS_CODES.has(providerStatusCode)
+          ? PROVIDER_GATEWAY_ERROR_STATUS
+          : providerStatusCode;
+        return reply.code(responseStatusCode).send({
           error: {
             message: error.message,
-            type: statusCode === 500 ? 'fetch_error' : 'provider_error',
-            code: statusCode,
+            type: providerStatusCode === 500 ? 'fetch_error' : 'provider_error',
+            code: providerStatusCode,
             details: (error as any).details,
           },
         });

--- a/packages/backend/src/services/__tests__/provider-model-discovery.test.ts
+++ b/packages/backend/src/services/__tests__/provider-model-discovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   deriveModelsUrl,
   discoverProviderModels,
+  fetchModelsFromUrl,
   normalizeModelsResponse,
   validateUrlSafety,
 } from '../providers/provider-model-discovery';
@@ -24,6 +25,20 @@ describe('provider model discovery', () => {
     };
 
     expect(deriveModelsUrl(provider)).toBe('https://api.example.com/v1/models');
+  });
+
+  it('derives /models URLs from Anthropic messages URLs', () => {
+    const provider: ProviderConfig = {
+      api_base_url: 'https://api.anthropic.com/v1/messages',
+      api_key: 'sk-test',
+      disable_cooldown: false,
+      stall_cooldown: false,
+      allow_100_percent_utilization: false,
+      estimateTokens: false,
+      useClaudeMasking: false,
+    };
+
+    expect(deriveModelsUrl(provider)).toBe('https://api.anthropic.com/v1/models');
   });
 
   it('uses the Ollama catalog endpoint for native Ollama providers', () => {
@@ -87,5 +102,42 @@ describe('provider model discovery', () => {
         headers: { Accept: 'application/json' },
       })
     );
+  });
+
+  it('uses Anthropic API-key authentication for Anthropic model endpoints', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'claude-sonnet-4-20250514' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchModelsFromUrl('https://api.anthropic.com/v1/models', 'sk-ant-test');
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(request.headers).toEqual({
+      Accept: 'application/json',
+      'x-api-key': 'sk-ant-test',
+      'anthropic-version': '2023-06-01',
+    });
+  });
+
+  it('uses Bearer authentication for non-Anthropic model endpoints', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'gpt-5' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchModelsFromUrl('https://api.example.com/v1/models', 'sk-test');
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(request.headers).toEqual({
+      Accept: 'application/json',
+      Authorization: 'Bearer sk-test',
+    });
   });
 });

--- a/packages/backend/src/services/providers/provider-model-discovery.ts
+++ b/packages/backend/src/services/providers/provider-model-discovery.ts
@@ -13,6 +13,16 @@ export interface DiscoveredModel {
   pricing?: { prompt?: string; completion?: string };
 }
 
+const ANTHROPIC_API_HOST = 'api.anthropic.com';
+
+function isAnthropicApiUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname.toLowerCase() === ANTHROPIC_API_HOST;
+  } catch {
+    return false;
+  }
+}
+
 export function validateUrlSafety(url: string): { valid: boolean; error?: string } {
   let parsedUrl: URL;
   try {
@@ -89,7 +99,14 @@ export async function fetchModelsFromUrl(
   }
 
   const requestHeaders: Record<string, string> = { Accept: 'application/json' };
-  if (apiKey) requestHeaders.Authorization = `Bearer ${apiKey}`;
+  if (apiKey) {
+    if (isAnthropicApiUrl(url)) {
+      requestHeaders['x-api-key'] = apiKey;
+      requestHeaders['anthropic-version'] = '2023-06-01';
+    } else {
+      requestHeaders.Authorization = `Bearer ${apiKey}`;
+    }
+  }
 
   logger.debug(`Fetching models from ${url}`);
 
@@ -135,15 +152,20 @@ export function getOAuthProviderModels(providerId: string): DiscoveredModel[] {
 export function deriveModelsUrl(provider: ProviderConfig): string | null {
   if (typeof provider.api_base_url === 'string') {
     const types = getProviderTypes(provider);
-    if (types.length === 1 && types[0] === 'chat') {
-      return `${provider.api_base_url.replace(/\/chat\/completions\/?$/, '')}/models`;
+    if (types.length === 1 && (types[0] === 'chat' || types[0] === 'messages')) {
+      return `${provider.api_base_url.replace(/\/(?:chat\/completions|messages)\/?$/, '')}/models`;
     }
     return null;
   }
 
   const apiBaseUrl = provider.api_base_url as Record<string, string>;
   if (apiBaseUrl.ollama) return 'https://ollama.com/api/tags';
-  if (apiBaseUrl.chat) return `${apiBaseUrl.chat.replace(/\/chat\/completions\/?$/, '')}/models`;
+  if (apiBaseUrl.chat) {
+    return `${apiBaseUrl.chat.replace(/\/(?:chat\/completions|messages)\/?$/, '')}/models`;
+  }
+  if (apiBaseUrl.messages) {
+    return `${apiBaseUrl.messages.replace(/\/(?:chat\/completions|messages)\/?$/, '')}/models`;
+  }
   return null;
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,9 @@
     "typecheck": "bun x tsc --noEmit",
     "test": "bunx --bun vitest run"
   },
+  "devDependencies": {
+    "typescript": "^7.0.2"
+  },
   "engines": {
     "bun": ">=1.4.0"
   }

--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -698,8 +698,14 @@ export function useProviderForm() {
     const ollamaUrl = getApiUrlValue('ollama');
     if (ollamaUrl) return 'https://ollama.com/api/tags';
     const chatUrl = getApiUrlValue('chat');
-    if (!chatUrl) return '';
-    return `${chatUrl.replace(/\/chat\/completions\/?$/, '')}/models`;
+    if (chatUrl) {
+      return `${chatUrl.replace(/\/(?:chat\/completions|messages)\/?$/, '')}/models`;
+    }
+    const messagesUrl = getApiUrlValue('messages');
+    if (messagesUrl) {
+      return `${messagesUrl.replace(/\/(?:chat\/completions|messages)\/?$/, '')}/models`;
+    }
+    return '';
   };
 
   const handleOpenFetchModels = () => {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Fix Anthropic model discovery when configuring providers through the management UI. Anthropic model requests now use the authentication headers required by `api.anthropic.com`, while other providers continue using Bearer authentication. Provider authorization failures are also isolated from Plexus management-session authentication.

## Changes

- **Anthropic authentication**
  - Requests to `api.anthropic.com` now send:
    - `x-api-key`
    - `anthropic-version: 2023-06-01`
  - Non-Anthropic provider requests continue to use `Authorization: Bearer`.

- **Model endpoint discovery**
  - Backend and frontend URL derivation now support providers configured with `/v1/messages` endpoints.
  - Message-based URLs are normalized to their corresponding `/v1/models` endpoint.
  - Support applies to both string-based provider URLs and provider URL maps.

- **Provider error handling**
  - Upstream `401` and `403` responses are returned to the management UI as `502` gateway errors instead of being treated as Plexus authentication failures.
  - The original provider status code remains available in the response body, along with the provider error classification and message.
  - Other upstream status codes retain their existing response behavior.

- **API documentation**
  - Updated the fetch-models OpenAPI description to document provider-specific authentication.
  - Added the `502` response for upstream provider authorization failures.

- **Regression coverage**
  - Added route coverage verifying that an Anthropic `401` becomes a `502` without triggering management-session failure handling.
  - Added discovery tests for:
    - Anthropic `/messages` to `/models` URL conversion.
    - Anthropic API-key headers.
    - Bearer authentication for non-Anthropic providers.
<!-- kody-pr-summary:end -->