### PR TITLE
feat(models): expose reasoning_options and honor max effort

### DIFF
--- a/packages/backend/src/routes/inference/__tests__/models.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/models.test.ts
@@ -145,6 +145,68 @@ describe('GET /v1/models', () => {
   });
 });
 
+// ─── Reasoning options from the pi-ai catalog ──────────────
+
+describe('GET /v1/models – reasoning_options', () => {
+  it('exposes canonical effort levels for auto-identified reasoning models', async () => {
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+
+    setConfigForTesting({
+      models: {
+        // Auto-identifies to the pi-ai catalog (openai / gpt-5.6-luna), which
+        // is reasoning-capable with a gpt-5.6 thinkingLevelMap.
+        'gpt-5.6-luna': { targets: [] },
+      },
+    } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({ method: 'GET', url: '/v1/models' });
+    expect(response.statusCode).toBe(200);
+
+    const model = response.json().data[0];
+    expect(model.reasoning_options).toEqual([
+      {
+        type: 'effort',
+        values: ['off', 'low', 'medium', 'high', 'xhigh', 'max'],
+      },
+    ]);
+  });
+
+  it('omits reasoning_options when the resolved pi model is not reasoning-capable', async () => {
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+
+    setConfigForTesting({
+      models: {
+        'claude-alias': {
+          targets: [],
+          pi_model: { provider: 'anthropic', model_id: 'claude-test' },
+        },
+      },
+    } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({ method: 'GET', url: '/v1/models' });
+    const model = response.json().data[0];
+    expect(model.pi_model).toBe('claude-test');
+    expect(model.reasoning_options).toBeUndefined();
+  });
+
+  it('omits reasoning_options when no pi model can be resolved', async () => {
+    const fastify = Fastify();
+    await registerModelsRoute(fastify);
+
+    setConfigForTesting({
+      models: {
+        'plain-model': { targets: [] },
+      },
+    } as unknown as PlexusConfig);
+
+    const response = await fastify.inject({ method: 'GET', url: '/v1/models' });
+    const model = response.json().data[0];
+    expect(model.reasoning_options).toBeUndefined();
+  });
+});
+
 // ─── Vision fallthrough modality injection ──────────────
 
 describe('GET /v1/models – vision fallthrough modalities', () => {

--- a/packages/backend/src/routes/inference/models.ts
+++ b/packages/backend/src/routes/inference/models.ts
@@ -1,5 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import crypto from 'crypto';
+import { getSupportedThinkingLevels } from '@earendil-works/pi-ai';
+import type { Api, Model as PiAiModel } from '@earendil-works/pi-ai';
 import { getConfig } from '../../config';
 import { PricingManager } from '../../services/observability/pricing-manager';
 import {
@@ -47,6 +49,7 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
 
       // Look up pi compat options if a pi model reference is configured.
       let piOptions: Record<string, unknown> | undefined;
+      let piModel: PiAiModel<Api> | null = null;
       if (!piModelConfig && automaticIdentity.provider) {
         const inferred = getCatalogModel(automaticIdentity.provider, automaticIdentity.model);
         if (inferred) {
@@ -57,11 +60,25 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
         }
       }
       if (piModelConfig) {
-        const piModel = getCatalogModel(piModelConfig.provider, piModelConfig.model_id);
+        piModel = getCatalogModel(piModelConfig.provider, piModelConfig.model_id);
         if (piModel?.compat && Object.keys(piModel.compat).length > 0) {
           piOptions = piModel.compat as Record<string, unknown>;
         }
       }
+
+      // Canonical reasoning effort levels from the pi-ai model record
+      // (thinkingLevelMap). Exposed so clients can offer a real effort picker
+      // (e.g. OpenCode) instead of relying on fallback behavior. Values use
+      // pi's canonical vocabulary ('off' | 'minimal' | 'low' | 'medium' |
+      // 'high' | 'xhigh' | 'max'); clients map them to provider-native values.
+      const reasoningOptions = piModel?.reasoning
+        ? [
+            {
+              type: 'effort' as const,
+              values: [...getSupportedThinkingLevels(piModel)],
+            },
+          ]
+        : undefined;
 
       const base = {
         id: aliasId,
@@ -72,6 +89,7 @@ export async function registerModelsRoute(fastify: FastifyInstance) {
         ...(piModelConfig && { pi_provider: piModelConfig.provider }),
         ...(piModelConfig && { pi_model: piModelConfig.model_id }),
         ...(piOptions !== undefined && { pi_options: piOptions }),
+        ...(reasoningOptions !== undefined && { reasoning_options: reasoningOptions }),
       };
 
       const enriched = resolveModelMetadata(

--- a/packages/backend/src/services/pi-ai/__tests__/build-reasoning-for-model.test.ts
+++ b/packages/backend/src/services/pi-ai/__tests__/build-reasoning-for-model.test.ts
@@ -2,17 +2,18 @@ import { describe, it, expect, vi } from 'vitest';
 import type { ReasoningIntent } from '../reasoning';
 
 // buildReasoningOptionsForModel calls into pi-ai's clampThinkingLevel /
-// getSupportedThinkingLevels. The global mock in test/vitest.setup.ts does NOT
-// provide those, so mock them locally with faithful re-implementations that
-// honour thinkingLevelMap (mirroring pi-ai's real models.ts).
+// getSupportedThinkingLevels. The global mock in test/vitest.setup.ts provides
+// a shared implementation, but this suite pins its own faithful copies that
+// honour thinkingLevelMap (mirroring pi-ai's real models.ts) so the tests stay
+// independent of the global mock's shape.
 vi.mock('@earendil-works/pi-ai', () => {
-  const LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+  const LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
   const getSupportedThinkingLevels = (model: any) => {
     if (!model.reasoning) return ['off'];
     return LEVELS.filter((level) => {
       const mapped = model.thinkingLevelMap?.[level];
       if (mapped === null) return false;
-      if (level === 'xhigh') return mapped !== undefined;
+      if (level === 'xhigh' || level === 'max') return mapped !== undefined;
       return true;
     });
   };
@@ -81,6 +82,39 @@ describe('buildReasoningOptionsForModel', () => {
         intent({ effort: 'high', enabled: true, visibility: 'summary', summaryDetail: 'detailed' })
       );
       expect(opts.reasoningSummary).toBe('detailed');
+    });
+  });
+
+  describe("canonical 'max' effort", () => {
+    // gpt-5.6-style model: thinkingLevelMap explicitly supports max
+    const gpt56 = {
+      api: 'openai-responses',
+      reasoning: true,
+      thinkingLevelMap: {
+        off: 'none',
+        minimal: null,
+        low: 'low',
+        medium: 'medium',
+        high: 'high',
+        xhigh: 'xhigh',
+        max: 'max',
+      },
+    } as any;
+
+    it('round-trips a client max effort to a max egress level', () => {
+      const opts = buildReasoningOptionsForModel(gpt56, intent({ effort: 'max', enabled: true }));
+      expect(opts.reasoningEffort).toBe('max');
+      expect(opts.reasoning).toBe('max');
+    });
+
+    it('clamps max down when the model has no max level', () => {
+      const model = {
+        api: 'openai-responses',
+        reasoning: true,
+        thinkingLevelMap: { off: 'none', low: 'low', high: 'high', xhigh: 'xhigh' },
+      } as any;
+      const opts = buildReasoningOptionsForModel(model, intent({ effort: 'max', enabled: true }));
+      expect(opts.reasoningEffort).toBe('xhigh');
     });
   });
 

--- a/packages/backend/src/services/pi-ai/__tests__/reasoning.test.ts
+++ b/packages/backend/src/services/pi-ai/__tests__/reasoning.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeEffort,
+  budgetToEffort,
+  effortToBudget,
+  splitReasoningSuffix,
+} from '../reasoning';
+
+describe('normalizeEffort', () => {
+  it.each([
+    ['none', 'off'],
+    ['off', 'off'],
+    ['disabled', 'off'],
+    ['minimal', 'minimal'],
+    ['low', 'low'],
+    ['medium', 'medium'],
+    ['high', 'high'],
+    ['xhigh', 'xhigh'],
+    // 'max' is its own canonical level, not a synonym of 'xhigh'
+    ['max', 'max'],
+    ['maximum', 'max'],
+    ['MAX', 'max'],
+  ])('normalizes %s → %s', (raw, expected) => {
+    expect(normalizeEffort(raw)).toBe(expected);
+  });
+
+  it('returns undefined for unknown values and non-strings', () => {
+    expect(normalizeEffort('turbo')).toBeUndefined();
+    expect(normalizeEffort(42)).toBeUndefined();
+    expect(normalizeEffort(undefined)).toBeUndefined();
+  });
+});
+
+describe('budgetToEffort', () => {
+  it('maps budget bands up through xhigh', () => {
+    expect(budgetToEffort(0)).toBe('off');
+    expect(budgetToEffort(1024)).toBe('minimal');
+    expect(budgetToEffort(2048)).toBe('low');
+    expect(budgetToEffort(8192)).toBe('medium');
+    expect(budgetToEffort(16384)).toBe('high');
+    expect(budgetToEffort(32768)).toBe('xhigh');
+  });
+
+  it('maps budgets above the xhigh band to max', () => {
+    expect(budgetToEffort(32769)).toBe('max');
+    expect(budgetToEffort(65536)).toBe('max');
+  });
+
+  it('round-trips stably through effortToBudget', () => {
+    for (const budget of [1024, 2048, 8192, 16384, 32768, 65536]) {
+      const effort = budgetToEffort(budget);
+      expect(effort).not.toBe('off');
+      expect(effortToBudget(effort as Exclude<typeof effort, 'off'>)).toBe(budget);
+    }
+  });
+});
+
+describe('splitReasoningSuffix', () => {
+  it('splits a :max suffix into a max-effort intent (not xhigh)', () => {
+    const { alias, intent } = splitReasoningSuffix('gpt-5.6-luna:max');
+    expect(alias).toBe('gpt-5.6-luna');
+    expect(intent).toEqual({ effort: 'max', enabled: true, source: 'client' });
+  });
+
+  it('leaves unknown suffixes intact', () => {
+    expect(splitReasoningSuffix('my-model:custom')).toEqual({ alias: 'my-model:custom' });
+  });
+});

--- a/packages/backend/src/services/pi-ai/reasoning.ts
+++ b/packages/backend/src/services/pi-ai/reasoning.ts
@@ -27,7 +27,7 @@
  */
 
 /** pi-ai's thinking vocabulary. "off" means thinking disabled. */
-export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+export type ReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 /**
  * Unified reasoning-output visibility, normalized across protocols:
@@ -85,6 +85,7 @@ export const EFFORT_LADDER: readonly ReasoningEffort[] = [
   'medium',
   'high',
   'xhigh',
+  'max',
 ] as const;
 
 /**
@@ -99,6 +100,7 @@ const EFFORT_TO_BUDGET: Record<ReasoningEffort, number> = {
   medium: 8192,
   high: 16384,
   xhigh: 32768,
+  max: 65536,
 };
 
 export function effortToBudget(effort: ReasoningEffort): number {
@@ -118,7 +120,8 @@ export function budgetToEffort(budget: number): ReasoningEffort | 'off' {
   if (budget <= 2048) return 'low';
   if (budget <= 8192) return 'medium';
   if (budget <= 16384) return 'high';
-  return 'xhigh';
+  if (budget <= 32768) return 'xhigh';
+  return 'max';
 }
 
 /** Normalize an arbitrary client effort string to our vocabulary, if possible. */
@@ -139,9 +142,10 @@ export function normalizeEffort(raw: unknown): ReasoningEffort | 'off' | undefin
     case 'high':
       return 'high';
     case 'xhigh':
+      return 'xhigh';
     case 'max':
     case 'maximum':
-      return 'xhigh';
+      return 'max';
     default:
       return undefined;
   }

--- a/packages/backend/src/transformers/gemini/__tests__/request-builder.test.ts
+++ b/packages/backend/src/transformers/gemini/__tests__/request-builder.test.ts
@@ -237,6 +237,20 @@ describe('Gemini Request Builder', () => {
       expect(result.generationConfig?.thinkingConfig?.includeThoughts).toBe(true);
     });
 
+    it('clamps xhigh and max efforts to HIGH (valid Gemini ThinkingLevel)', async () => {
+      // Gemini has no level above HIGH; forwarding 'XHIGH'/'MAX' would be
+      // rejected upstream.
+      for (const effort of ['xhigh', 'max'] as const) {
+        const request: UnifiedChatRequest = {
+          messages: [{ role: 'user', content: 'Think' }],
+          model: 'gemini-2.5-flash',
+          reasoning: { enabled: true, effort },
+        };
+        const result = await buildGeminiRequest(request);
+        expect(result.generationConfig?.thinkingConfig?.thinkingLevel).toBe('HIGH');
+      }
+    });
+
     it('should emit camelCase thinkingBudget from max_tokens', async () => {
       const request: UnifiedChatRequest = {
         messages: [{ role: 'user', content: 'Think' }],

--- a/packages/backend/src/transformers/gemini/request-builder.ts
+++ b/packages/backend/src/transformers/gemini/request-builder.ts
@@ -1,6 +1,20 @@
 import { Content, Part, Tool } from '@google/genai';
-import { UnifiedChatRequest, GoogleBuiltInToolType } from '../../types/unified';
+import { UnifiedChatRequest, GoogleBuiltInToolType, ThinkLevel } from '../../types/unified';
 import { convertUnifiedPartsToGemini } from './part-mapper';
+
+/**
+ * Unified ThinkLevel → Gemini ThinkingLevel enum. Gemini has no level above
+ * HIGH, so the extended canonical efforts (xhigh, max) clamp to HIGH.
+ */
+const GEMINI_THINKING_LEVEL: Record<ThinkLevel, string> = {
+  none: 'NONE',
+  minimal: 'MINIMAL',
+  low: 'LOW',
+  medium: 'MEDIUM',
+  high: 'HIGH',
+  xhigh: 'HIGH',
+  max: 'HIGH',
+};
 
 export interface GenerateContentRequest {
   contents: Content[];
@@ -212,8 +226,12 @@ export async function buildGeminiRequest(
     generationConfig.thinkingConfig = {
       includeThoughts: request.reasoning.enabled,
       thinkingBudget: request.reasoning.max_tokens,
-      // Map unified effort back to Gemini's ThinkingLevel enum values (MINIMAL/LOW/MEDIUM/HIGH)
-      thinkingLevel: request.reasoning.effort ? request.reasoning.effort.toUpperCase() : undefined,
+      // Map unified effort to Gemini's ThinkingLevel enum values
+      // (MINIMAL/LOW/MEDIUM/HIGH). Gemini has no level above HIGH, so the
+      // extended canonical efforts (xhigh, max) clamp to HIGH.
+      thinkingLevel: request.reasoning.effort
+        ? GEMINI_THINKING_LEVEL[request.reasoning.effort]
+        : undefined,
     };
   }
 

--- a/packages/backend/src/types/responses.ts
+++ b/packages/backend/src/types/responses.ts
@@ -236,7 +236,7 @@ export interface UnifiedResponsesRequest {
     verbosity?: 'low' | 'medium' | 'high';
   };
   reasoning?: {
-    effort?: 'low' | 'medium' | 'high' | 'minimal' | 'xhigh';
+    effort?: 'low' | 'medium' | 'high' | 'minimal' | 'xhigh' | 'max';
     summary?: 'auto' | 'concise' | 'detailed';
     max_tokens?: number;
   };

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -77,7 +77,7 @@ export interface UnifiedToolConfig {
   functionCallingPreference?: string;
 }
 
-export type ThinkLevel = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+export type ThinkLevel = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export interface KeyAccessPolicy {
   allowedModels?: string[];

--- a/packages/backend/test/vitest.setup.ts
+++ b/packages/backend/test/vitest.setup.ts
@@ -178,6 +178,27 @@ const mockGetModel = (provider: string, modelId: string) => {
     else if (modelId === 'gpt-5.4' || modelId.includes('responses')) api = 'openai-responses';
     else api = 'openai-completions';
   }
+  // GPT-5.6-style reasoning model with a gpt-5.6 thinkingLevelMap, mirroring
+  // the real pi-ai openai-responses catalog (minimal unsupported, off = none).
+  if (modelId.startsWith('gpt-5.6')) {
+    return {
+      id: modelId,
+      name: modelId,
+      contextWindow: 400000,
+      provider,
+      api: 'openai-responses',
+      reasoning: true,
+      thinkingLevelMap: {
+        off: 'none',
+        minimal: null,
+        low: 'low',
+        medium: 'medium',
+        high: 'high',
+        xhigh: 'xhigh',
+        max: 'max',
+      },
+    };
+  }
   return {
     id: modelId,
     name: modelId,
@@ -194,6 +215,20 @@ const mockGetModel = (provider: string, modelId: string) => {
 };
 
 const mockGetProviders = () => ['anthropic', 'openai-codex', 'openai', 'google'];
+
+// Faithful port of pi-ai's getSupportedThinkingLevels: honours model.reasoning
+// and thinkingLevelMap ('null' = unsupported; xhigh/max require an explicit
+// entry) so reasoning-capability assertions track the model record under test.
+const EXTENDED_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
+const mockGetSupportedThinkingLevels = (model: any) => {
+  if (!model?.reasoning) return ['off'];
+  return EXTENDED_THINKING_LEVELS.filter((level) => {
+    const mapped = model.thinkingLevelMap?.[level];
+    if (mapped === null) return false;
+    if (level === 'xhigh' || level === 'max') return mapped !== undefined;
+    return true;
+  });
+};
 
 // @earendil-works/pi-ai — single authoritative mock for the whole worker.
 //
@@ -220,7 +255,7 @@ vi.mock('@earendil-works/pi-ai', async (importOriginal) => {
     stream: mockModels.stream,
     calculateCost: vi.fn(() => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 })),
     clampThinkingLevel: (_m: any, l: string) => l,
-    getSupportedThinkingLevels: () => ['off', 'low', 'medium', 'high'],
+    getSupportedThinkingLevels: mockGetSupportedThinkingLevels,
     // The model catalog overlay delegates merge/restore/persist to pi-ai's
     // real createProvider — keep it real so catalog tests exercise genuine
     // library semantics.


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

- Exposes `reasoning_options` in `GET /v1/models` using supported effort levels from the pi-ai catalog.
- Adds canonical `max` reasoning effort support across unified request types and reasoning utilities.
- Maps reasoning budgets above `xhigh` to `max`, while preserving `max` during normalization and provider translation.
- Clamps `xhigh` and `max` to Gemini’s supported `HIGH` thinking level.
- Adds coverage for model capability detection, effort normalization, budget conversion, suffix parsing, and provider behavior.
<!-- kody-pr-summary:end -->