### PR TITLE
fix(logs): preserve Responses tool metadata

### DIFF
--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -467,5 +467,78 @@ describe('DebugLoggingInspector Reconstruction', () => {
         output_tokens_details: { reasoning_tokens: 0 },
       });
     });
+
+    test('response.completed preserves output items when its output array is empty', async () => {
+      const completedRequestId = 'test-responses-completed-empty-output';
+      const inspector = new DebugLoggingInspector(completedRequestId, 'raw');
+      const stream = inspector.createInspector('responses');
+
+      writeEvents(stream, [
+        {
+          type: 'response.created',
+          response: {
+            id: 'resp_tools',
+            object: 'response',
+            status: 'in_progress',
+            model: 'gpt-5-codex',
+            output: [],
+          },
+        },
+        {
+          type: 'response.output_item.added',
+          output_index: 0,
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'lookup',
+            arguments: '',
+          },
+        },
+        {
+          type: 'response.function_call_arguments.delta',
+          output_index: 0,
+          delta: '{}',
+        },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'lookup',
+            arguments: '{}',
+            status: 'completed',
+          },
+        },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_tools',
+            object: 'response',
+            status: 'completed',
+            model: 'gpt-5-codex',
+            output: [],
+            usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+          },
+        },
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const snapshot = DebugManager.getInstance().getReconstructedRawResponse(completedRequestId);
+      expect(snapshot.output).toEqual([
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{}',
+          status: 'completed',
+        },
+      ]);
+      expect(snapshot.usage).toEqual({ input_tokens: 10, output_tokens: 5, total_tokens: 15 });
+    });
   });
 });

--- a/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
@@ -375,6 +375,39 @@ describe('UsageInspector Metadata Robustness', () => {
       expect(record?.tokensInput).toBe(42);
       expect(record?.tokensOutput).toBe(20);
     });
+
+    it('should map completed Responses API tool calls to finishReason "tool_calls"', async () => {
+      const requestId = 'responses-completed-tool-call-stream';
+      const snapshot = {
+        id: 'resp_tools',
+        object: 'response',
+        status: 'completed',
+        model: 'gpt-5-codex',
+        output: [
+          {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'lookup',
+            arguments: '{}',
+            status: 'completed',
+          },
+          {
+            id: 'ct_1',
+            type: 'custom_tool_call',
+            call_id: 'call_2',
+            name: 'apply_patch',
+            input: '*** Begin Patch',
+            status: 'completed',
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      };
+
+      const record = await runInspector(requestId, 'responses', snapshot);
+      expect(record?.toolCallsCount).toBe(2);
+      expect(record?.finishReason).toBe('tool_calls');
+    });
   });
 
   describe('usage fallback to the transformed-mode snapshot', () => {

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -808,7 +808,16 @@ export class DebugLoggingInspector extends BaseInspector {
       case 'response.completed':
         // Final response state
         if (event.response) {
+          const accumulatedOutput = acc.output;
           Object.assign(acc, event.response);
+          if (
+            Array.isArray(accumulatedOutput) &&
+            accumulatedOutput.length > 0 &&
+            Array.isArray(event.response.output) &&
+            event.response.output.length === 0
+          ) {
+            acc.output = accumulatedOutput;
+          }
         }
         break;
 

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -472,11 +472,11 @@ export class UsageInspector extends PassThrough {
         return { toolCallsCount: toolCallsCount > 0 ? toolCallsCount : null, finishReason };
       }
       case 'responses': {
-        // Responses API format: function_call items in output array
+        // Responses API format: function_call/custom_tool_call items in output array
         let toolCallsCount = 0;
         if (reconstructed.output && Array.isArray(reconstructed.output)) {
           toolCallsCount = reconstructed.output.filter(
-            (item: any) => item.type === 'function_call'
+            (item: any) => item.type === 'function_call' || item.type === 'custom_tool_call'
           ).length;
         }
         // Responses API doesn't have a direct finish_reason, use status instead.
@@ -488,7 +488,9 @@ export class UsageInspector extends PassThrough {
         // 'length', matching the OpenAI-compatible finish reason vocabulary.
         const finishReason =
           reconstructed.status === 'completed'
-            ? 'stop'
+            ? toolCallsCount > 0
+              ? 'tool_calls'
+              : 'stop'
             : reconstructed.status === 'failed'
               ? 'error'
               : reconstructed.status === 'incomplete'

--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -1052,7 +1052,7 @@ const DesktopLogRow = React.memo(
                   <CirclePause size={12} className="text-yellow-500" />
                 ) : log.finishReason === 'stop' ? (
                   <Octagon size={12} className="text-red-500" />
-                ) : log.finishReason === 'tool_calls' ? (
+                ) : log.finishReason === 'tool_calls' || log.finishReason === 'tool_use' ? (
                   <Hammer size={12} className="text-purple-500" />
                 ) : log.finishReason === 'length' || log.finishReason === 'max_tokens' ? (
                   <RulerDimensionLine size={12} className="text-pink-400" />


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Preserve Responses API tool-call metadata when reconstructing streamed responses and correctly represent it in usage logs.

## Changes

- Retain accumulated output items when `response.completed` provides an empty `output` array.
- Count both `function_call` and `custom_tool_call` Responses output items.
- Report `tool_calls` instead of `stop` when a completed Responses request contains tool calls.
- Display the same hammer icon for Messages API `tool_use` and Responses API `tool_calls`, while preserving their distinct finish reasons.
- Add regression tests covering empty terminal output, standard and custom tool calls, and finish-reason mapping.
<!-- kody-pr-summary:end -->