### PR TITLE
fix(logs): align cost placeholders

### DIFF
--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -1017,24 +1017,25 @@ const DesktopLogRow = React.memo(
           style={{ width: DESKTOP_COST_COLUMN_WIDTH }}
         >
           {log.costTotal !== undefined && log.costTotal !== null ? (
-            <CostToolTip
-              source={log.costSource}
-              costMetadata={log.costMetadata}
-              costBreakdown={costBreakdown}
-            >
-              <span className="block truncate" style={{ fontWeight: '500', cursor: 'help' }}>
-                {log.costTotal === 0
-                  ? '-'
-                  : formatCostIn(log.costTotal, { currency, rate, symbol, decimals: 6 })}
-              </span>
-            </CostToolTip>
+            <div className={log.costTotal === 0 ? 'text-center' : undefined}>
+              <CostToolTip
+                source={log.costSource}
+                costMetadata={log.costMetadata}
+                costBreakdown={costBreakdown}
+              >
+                <span className="block truncate" style={{ fontWeight: '500', cursor: 'help' }}>
+                  {log.costTotal === 0
+                    ? '-'
+                    : formatCostIn(log.costTotal, { currency, rate, symbol, decimals: 6 })}
+                </span>
+              </CostToolTip>
+            </div>
           ) : (
             <span
               style={{
                 color: 'var(--color-text-secondary)',
                 fontSize: '1.2em',
                 display: 'block',
-                textAlign: 'center',
               }}
             >
               -


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
What would you like me to do with this change?

One thing I noticed: the diff removes `textAlign: 'center'` from the null/undefined branch while adding `text-center` for the `costTotal === 0` case — so the fallback `-` is now left-aligned. Want me to restore centering there?
<!-- kody-pr-summary:end -->