### PR TITLE
fix(oauth): update Claude Code identity version

### DIFF
--- a/packages/backend/src/services/oauth/__tests__/oauth-native-request-betas.test.ts
+++ b/packages/backend/src/services/oauth/__tests__/oauth-native-request-betas.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { REQUIRED_BETAS } from '../../../transformers/oauth/masking';
+import { CC_VERSION, REQUIRED_BETAS } from '../../../transformers/oauth/masking';
 import { prepareOAuthNativeRequest } from '../oauth-native-request';
 
 const AUTH = { mode: 'oauth', token: 'oauth-token-for-test' } as const;
@@ -74,5 +74,23 @@ describe('prepareOAuthNativeRequest — anthropic-beta merging', () => {
   it('emits exactly REQUIRED_BETAS when the caller sent no header', () => {
     expect(betasFor(undefined)).toEqual([...REQUIRED_BETAS]);
     expect(betasFor('')).toEqual([...REQUIRED_BETAS]);
+  });
+});
+
+describe('prepareOAuthNativeRequest — Claude Code identity', () => {
+  // The version gate applies to both the HTTP identity and billing identity.
+  it('uses the current shared version in the user agent and billing header', () => {
+    const prepared = prepareOAuthNativeRequest(
+      'anthropic',
+      'claude-sonnet-4-5',
+      AUTH,
+      nativeBody(),
+      false
+    );
+    const sentBody = prepared.body;
+    const billingHeader = sentBody.system[0].text as string;
+
+    expect(prepared.headers['user-agent']).toBe(`claude-cli/${CC_VERSION} (external, cli)`);
+    expect(billingHeader).toContain(`cc_version=${CC_VERSION}.`);
   });
 });

--- a/packages/backend/src/services/oauth/oauth-native-request.ts
+++ b/packages/backend/src/services/oauth/oauth-native-request.ts
@@ -41,6 +41,7 @@ import {
 import type { RenamePair } from '../../transformers/oauth/masking/types';
 import { CodexVersionService } from './codex-version-service';
 import { stripUnsupportedGpt5Options } from '../../transformers/adapters/suppress-unsupported-gpt5-options.adapter';
+import { CC_VERSION } from '../../transformers/oauth/masking/cc-constants';
 
 /**
  * Auth for a native Anthropic request. Two modes, mirroring the old executor:
@@ -149,7 +150,7 @@ function prepareAnthropicOAuthRequest(
   // canon-only variant, which drops the system relocation). We do NOT reuse
   // their internal rename bookkeeping for the response — see reversal below.
   const { payload: transformed } = applyClaudeOAuthTransform(nativeBody, maskingToken, {
-    version: '2.1.63',
+    version: CC_VERSION,
     entrypoint: 'cli',
     workload: '',
     oauthMode: true,

--- a/packages/backend/src/transformers/oauth/masking/cc-constants.ts
+++ b/packages/backend/src/transformers/oauth/masking/cc-constants.ts
@@ -30,7 +30,7 @@
  * inspect a genuine Claude Code session's `user-agent` header
  * (`claude-cli/<version> (external, cli)`).
  */
-export const CC_VERSION = '2.1.207';
+export const CC_VERSION = '2.1.258';
 
 /**
  * Billing fingerprint salt + character-index selection, used to compute the

--- a/packages/backend/src/transformers/oauth/masking/index.ts
+++ b/packages/backend/src/transformers/oauth/masking/index.ts
@@ -5,5 +5,5 @@ export { signBillingHeader } from './sign-billing';
 export { applyClaudeCodeMasking, type ClaudeCodeMaskingResult } from './apply-masking';
 export { getStainlessHeaders } from './cc-headers';
 export { reverseToolRenames } from './reverse-rename';
-export { REQUIRED_BETAS } from './cc-constants';
+export { CC_VERSION, REQUIRED_BETAS } from './cc-constants';
 export type { RenamePair, ToolDescriptor, ToolShape } from './types';


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
{
  "name": "Grep",
  "input": {
    "pattern": "2\\.1\\.(63|207|258)",
    "output_mode": "content",
    "-n": true,
    "path": "packages/backend/src"
  }
}
<!-- kody-pr-summary:end -->