### PR TITLE
fix(gemini): append synthetic user turn after text-only model tail

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-gemini-model-tail.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-gemini-model-tail.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
+import { Dispatcher } from '../dispatch/dispatcher';
+import { setConfigForTesting } from '../../config';
+import type { UnifiedChatRequest } from '../../types/unified';
+
+const fetchMock: any = vi.fn(async (): Promise<any> => {
+  throw new Error('fetch mock not configured for test');
+});
+
+global.fetch = fetchMock as any;
+
+function makeGeminiConfig() {
+  return {
+    providers: {
+      g1: {
+        type: 'gemini',
+        api_base_url: 'https://generativelanguage.googleapis.com',
+        api_key: 'test-key-g1',
+        models: { 'gemini-3.8-flash': {} },
+      },
+    },
+    models: {
+      'test-alias': {
+        targets: [{ provider: 'g1', model: 'gemini-3.8-flash' }],
+      },
+    },
+    keys: {},
+  } as any;
+}
+
+function geminiSuccessResponse(model: string) {
+  return new Response(
+    JSON.stringify({
+      candidates: [
+        {
+          content: { role: 'model', parts: [{ text: 'ok' }] },
+          finishReason: 'STOP',
+          index: 0,
+        },
+      ],
+      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+      modelVersion: model,
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+describe('Dispatcher Gemini model-tail normalization', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('native gemini->gemini pass-through appends a user turn after a text-only model tail', async () => {
+    setConfigForTesting(makeGeminiConfig());
+    fetchMock.mockResolvedValue(geminiSuccessResponse('gemini-3.8-flash'));
+    const dispatcher = new Dispatcher();
+
+    const request: UnifiedChatRequest = {
+      model: 'test-alias',
+      messages: [
+        { role: 'user', content: 'Remember cobalt' },
+        { role: 'assistant', content: 'stored' },
+      ],
+      incomingApiType: 'gemini',
+      stream: false,
+      originalBody: {
+        contents: [
+          { role: 'user', parts: [{ text: 'Remember cobalt' }] },
+          { role: 'model', parts: [{ text: 'stored' }] },
+        ],
+      },
+    } as any;
+
+    await dispatcher.dispatch(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.contents).toHaveLength(3);
+    expect(body.contents[2]).toEqual({ role: 'user', parts: [{ text: '.' }] });
+  });
+
+  test('native gemini->gemini pass-through leaves tool-call tails alone', async () => {
+    setConfigForTesting(makeGeminiConfig());
+    fetchMock.mockResolvedValue(geminiSuccessResponse('gemini-3.8-flash'));
+    const dispatcher = new Dispatcher();
+
+    const request: UnifiedChatRequest = {
+      model: 'test-alias',
+      messages: [{ role: 'user', content: 'Look up cobalt' }],
+      incomingApiType: 'gemini',
+      stream: false,
+      originalBody: {
+        contents: [
+          { role: 'user', parts: [{ text: 'Look up cobalt' }] },
+          { role: 'model', parts: [{ functionCall: { name: 'lookup', args: {} } }] },
+        ],
+      },
+    } as any;
+
+    await dispatcher.dispatch(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.contents).toHaveLength(2);
+    expect(body.contents[1].role).toBe('model');
+  });
+
+  test('cross-format (chat->gemini) transform appends a user turn after an assistant tail', async () => {
+    setConfigForTesting(makeGeminiConfig());
+    fetchMock.mockResolvedValue(geminiSuccessResponse('gemini-3.8-flash'));
+    const dispatcher = new Dispatcher();
+
+    const request: UnifiedChatRequest = {
+      model: 'test-alias',
+      messages: [
+        { role: 'user', content: 'Remember cobalt' },
+        { role: 'assistant', content: 'stored' },
+      ],
+      incomingApiType: 'chat',
+      stream: false,
+    };
+
+    await dispatcher.dispatch(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.contents).toHaveLength(3);
+    expect(body.contents[2]).toEqual({ role: 'user', parts: [{ text: '.' }] });
+  });
+});

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -19,6 +19,7 @@ import {
   hasCodexResponsesExtensions,
   stripLiteUnsupportedTools,
 } from './dispatcher-auto-compat';
+import { appendUserAfterTextOnlyModelTail } from '../../transformers/gemini/utils/model-tail';
 
 /** Symbol stash for the native OAuth prep, read by the standard dispatch seams. */
 export const NATIVE_OAUTH_STASH = Symbol('nativeOAuthPrep');
@@ -149,6 +150,19 @@ export async function buildRequestPayload(
     payload = JSON.parse(JSON.stringify(request.originalBody));
     payload.model = route.model;
 
+    // Native Gemini pass-through forwards `contents` verbatim, so a client
+    // history ending on a text-only model turn would 400 upstream
+    // ("Requests ending with a model turn are not supported", LiteLLM
+    // #38537 / PR #38652). Normalize the tail the same way the transform
+    // path does. Tool-call / media tails are left untouched.
+    if (getApiBaseType(targetApiType) === 'gemini' && Array.isArray((payload as any)?.contents)) {
+      const before = (payload as any).contents.length;
+      (payload as any).contents = appendUserAfterTextOnlyModelTail((payload as any).contents);
+      if ((payload as any).contents.length !== before) {
+        logger.debug('Auto-compat: appended synthetic user turn after text-only model tail');
+      }
+    }
+
     if (request.metadata) {
       const apiMetadata = getApiMetadata(request.metadata);
       if (Object.keys(apiMetadata).length > 0) payload.metadata = apiMetadata;
@@ -170,6 +184,14 @@ export async function buildRequestPayload(
         }
       : request;
     payload = await transformer.transformRequest(requestWithOAuthProvider);
+  }
+
+  // Defense in depth: non-Gemini-transformer paths (cross-format routing to
+  // a Gemini target, adapters that rewrite contents) can still produce a
+  // trailing text-only model turn. Normalize unconditionally for Gemini
+  // targets — the helper is a no-op unless the tail matches.
+  if (getApiBaseType(targetApiType) === 'gemini' && Array.isArray((payload as any)?.contents)) {
+    (payload as any).contents = appendUserAfterTextOnlyModelTail((payload as any).contents);
   }
 
   payload = applyGeminiThinkingConfig(route, targetApiType, payload);

--- a/packages/backend/src/transformers/gemini/__tests__/model-tail.test.ts
+++ b/packages/backend/src/transformers/gemini/__tests__/model-tail.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { buildGeminiRequest } from '../request-builder';
+import {
+  appendUserAfterTextOnlyModelTail,
+  ensureContentsEndWithUser,
+  isTextOnlyModelContent,
+} from '../utils/model-tail';
+import type { UnifiedChatRequest } from '../../../types/unified';
+
+describe('Gemini model-tail normalization', () => {
+  describe('isTextOnlyModelContent', () => {
+    it('returns true for a text-only model turn', () => {
+      expect(isTextOnlyModelContent({ role: 'model', parts: [{ text: 'stored' }] })).toBe(true);
+    });
+
+    it('returns true for text plus thought metadata', () => {
+      expect(
+        isTextOnlyModelContent({
+          role: 'model',
+          parts: [{ text: 'stored', thought: true, thoughtSignature: 'aGVsbG8=' }],
+        })
+      ).toBe(true);
+    });
+
+    it('returns false for non-model roles', () => {
+      expect(isTextOnlyModelContent({ role: 'user', parts: [{ text: 'hi' }] })).toBe(false);
+    });
+
+    it('returns false for empty parts', () => {
+      expect(isTextOnlyModelContent({ role: 'model', parts: [] })).toBe(false);
+    });
+
+    it('returns false for functionCall tails', () => {
+      expect(
+        isTextOnlyModelContent({
+          role: 'model',
+          parts: [{ functionCall: { name: 'lookup', args: {} } }],
+        })
+      ).toBe(false);
+    });
+
+    it('returns false for media tails', () => {
+      expect(
+        isTextOnlyModelContent({
+          role: 'model',
+          parts: [{ inlineData: { mimeType: 'image/png', data: 'abcd' } }],
+        })
+      ).toBe(false);
+    });
+
+    it('returns false for text parts with disallowed keys', () => {
+      expect(
+        isTextOnlyModelContent({
+          role: 'model',
+          parts: [{ text: 'stored', media_resolution: 'low' }],
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('appendUserAfterTextOnlyModelTail', () => {
+    it('appends a "." user turn after a text-only model tail', () => {
+      const contents = [
+        { role: 'user', parts: [{ text: 'Remember cobalt' }] },
+        { role: 'model', parts: [{ text: 'stored' }] },
+      ];
+      const result = appendUserAfterTextOnlyModelTail(contents);
+      expect(result).toHaveLength(3);
+      expect(result[2]).toEqual({ role: 'user', parts: [{ text: '.' }] });
+      // Does not mutate the input
+      expect(contents).toHaveLength(2);
+    });
+
+    it('leaves user tails unchanged', () => {
+      const contents = [
+        { role: 'user', parts: [{ text: 'hi' }] },
+        { role: 'model', parts: [{ text: 'stored' }] },
+        { role: 'user', parts: [{ text: 'what was it?' }] },
+      ];
+      expect(appendUserAfterTextOnlyModelTail(contents)).toBe(contents);
+    });
+
+    it('leaves functionCall tails unchanged', () => {
+      const contents = [
+        { role: 'user', parts: [{ text: 'Look up cobalt' }] },
+        { role: 'model', parts: [{ functionCall: { name: 'lookup', args: {} } }] },
+      ];
+      expect(appendUserAfterTextOnlyModelTail(contents)).toBe(contents);
+    });
+  });
+
+  describe('ensureContentsEndWithUser', () => {
+    it('mutates in place and returns true when appended', () => {
+      const contents: any[] = [{ role: 'model', parts: [{ text: 'stored' }] }];
+      expect(ensureContentsEndWithUser(contents)).toBe(true);
+      expect(contents).toHaveLength(2);
+      expect(contents[1]).toEqual({ role: 'user', parts: [{ text: '.' }] });
+    });
+
+    it('returns false for user tails', () => {
+      const contents: any[] = [{ role: 'user', parts: [{ text: 'hi' }] }];
+      expect(ensureContentsEndWithUser(contents)).toBe(false);
+      expect(contents).toHaveLength(1);
+    });
+  });
+
+  describe('buildGeminiRequest', () => {
+    it('appends a synthetic user turn when messages end on an assistant turn', async () => {
+      const request: UnifiedChatRequest = {
+        messages: [
+          { role: 'user', content: 'Remember cobalt' },
+          { role: 'assistant', content: 'stored' },
+        ],
+        model: 'gemini-3.8-flash',
+      };
+      const result = await buildGeminiRequest(request);
+      expect(result.contents).toHaveLength(3);
+      expect(result.contents[2]!.role).toBe('user');
+      expect(result.contents[2]!.parts).toEqual([{ text: '.' }]);
+    });
+
+    it('leaves user-final histories unchanged', async () => {
+      const request: UnifiedChatRequest = {
+        messages: [{ role: 'user', content: 'hello' }],
+        model: 'gemini-3.8-flash',
+      };
+      const result = await buildGeminiRequest(request);
+      expect(result.contents).toHaveLength(1);
+      expect(result.contents[0]!.role).toBe('user');
+    });
+
+    it('leaves tool-call tails unchanged', async () => {
+      const request: UnifiedChatRequest = {
+        messages: [
+          { role: 'user', content: 'Look up cobalt' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call-1',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' },
+              },
+            ],
+          },
+        ],
+        model: 'gemini-3.8-flash',
+      };
+      const result = await buildGeminiRequest(request);
+      const last = result.contents[result.contents.length - 1]!;
+      expect(last.role).toBe('model');
+      expect(last.parts!.some((p: any) => p.functionCall)).toBe(true);
+    });
+  });
+});

--- a/packages/backend/src/transformers/gemini/request-builder.ts
+++ b/packages/backend/src/transformers/gemini/request-builder.ts
@@ -1,6 +1,7 @@
 import { Content, Part, Tool } from '@google/genai';
 import { UnifiedChatRequest, GoogleBuiltInToolType, ThinkLevel } from '../../types/unified';
 import { convertUnifiedPartsToGemini } from './part-mapper';
+import { ensureContentsEndWithUser } from './utils/model-tail';
 
 /**
  * Unified ThinkLevel → Gemini ThinkingLevel enum. Gemini has no level above
@@ -135,6 +136,14 @@ export async function buildGeminiRequest(
 
     if (role && parts.length > 0) contents.push({ role, parts });
   }
+
+  // Gemini 3+ rejects histories ending on a model turn ("Requests ending
+  // with a model turn are not supported", LiteLLM #38537 / PR #38652).
+  // Agent loops replaying conversation state hit this when the last message
+  // is a text-only assistant turn. Append a minimal synthetic user turn so
+  // the request is accepted upstream. Tool-call / media tails are left
+  // alone — a user turn there would break functionCall pairing.
+  ensureContentsEndWithUser(contents);
 
   // Gap 4 & 5: Transform Unified tools to Gemini function declarations or built-in tools
   if (request.tools && request.tools.length > 0) {

--- a/packages/backend/src/transformers/gemini/utils/index.ts
+++ b/packages/backend/src/transformers/gemini/utils/index.ts
@@ -1,2 +1,7 @@
 export { isValidThoughtSignature, sanitizeThoughtSignature } from './thought-signature';
 export { normalizeJsonSchemaTypes } from './json-schema';
+export {
+  appendUserAfterTextOnlyModelTail,
+  ensureContentsEndWithUser,
+  isTextOnlyModelContent,
+} from './model-tail';

--- a/packages/backend/src/transformers/gemini/utils/model-tail.ts
+++ b/packages/backend/src/transformers/gemini/utils/model-tail.ts
@@ -1,0 +1,55 @@
+import type { Content } from '@google/genai';
+
+/**
+ * Keys allowed on a text-only model part. Mirrors LiteLLM PR #38652
+ * (`_TEXT_ONLY_MODEL_PART_KEYS`): a trailing model turn is only eligible
+ * for the synthetic user-turn placeholder when every part carries `text`
+ * plus optional thought metadata. Tool calls (`functionCall`), tool
+ * results (`functionResponse`), server-side tools (`toolCall` /
+ * `toolResponse`, `executableCode` / `codeExecutionResult`), and media
+ * (`inlineData` / `fileData`) tails are left alone — inserting a user turn
+ * there would break functionCall → functionResponse pairing.
+ */
+const TEXT_ONLY_MODEL_PART_KEYS = new Set(['text', 'thought', 'thoughtSignature']);
+
+/**
+ * Returns true when `content` is a model turn whose parts are text/thought
+ * metadata only. Empty-parts model turns return false (nothing to continue).
+ */
+export function isTextOnlyModelContent(content: any): boolean {
+  if (!content || content.role !== 'model') return false;
+  const parts = content.parts;
+  if (!Array.isArray(parts) || parts.length === 0) return false;
+  return parts.every((part: any) => {
+    if (!part || typeof part !== 'object' || !('text' in part)) return false;
+    return Object.keys(part).every((key) => TEXT_ONLY_MODEL_PART_KEYS.has(key));
+  });
+}
+
+/**
+ * Gemini 3+ rejects histories ending on a model turn
+ * (`Requests ending with a model turn are not supported`, LiteLLM #38537 /
+ * PR #38652). When the last entry of `contents` is a text-only model turn,
+ * append a minimal `user` turn (`"."`) so the request is accepted upstream.
+ * Tool-call, media, and empty tails are returned unchanged.
+ *
+ * Returns the (possibly new) contents array. Does not mutate the input.
+ */
+export function appendUserAfterTextOnlyModelTail<T extends { role?: string }>(contents: T[]): T[] {
+  if (!Array.isArray(contents) || contents.length === 0) return contents;
+  if (!isTextOnlyModelContent(contents[contents.length - 1])) return contents;
+  const placeholder = { role: 'user', parts: [{ text: '.' }] } as unknown as T;
+  return [...contents, placeholder];
+}
+
+/**
+ * Mutating variant used by the request builder: appends the placeholder in
+ * place when the trailing turn is a text-only model turn. Returns true when
+ * a turn was appended.
+ */
+export function ensureContentsEndWithUser(contents: Content[]): boolean {
+  if (!Array.isArray(contents) || contents.length === 0) return false;
+  if (!isTextOnlyModelContent(contents[contents.length - 1])) return false;
+  contents.push({ role: 'user', parts: [{ text: '.' }] });
+  return true;
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
What would you like me to do with these changes — review, test, or something else?
<!-- kody-pr-summary:end -->