### PR TITLE
fix(chat): normalize max_completion_tokens into unified max_tokens

### DIFF
--- a/docs/openapi/components/schemas/ChatCompletionRequest.yaml
+++ b/docs/openapi/components/schemas/ChatCompletionRequest.yaml
@@ -39,6 +39,9 @@ properties:
     type: number
   max_tokens:
     type: integer
+    deprecated: true
+  max_completion_tokens:
+    type: integer
   tools:
     type: array
     items:

--- a/packages/backend/src/assets/openapi.json
+++ b/packages/backend/src/assets/openapi.json
@@ -10744,6 +10744,10 @@
             "type": "number"
           },
           "max_tokens": {
+            "type": "integer",
+            "deprecated": true
+          },
+          "max_completion_tokens": {
             "type": "integer"
           },
           "tools": {

--- a/packages/backend/src/transformers/__tests__/openai-max-completion-tokens.test.ts
+++ b/packages/backend/src/transformers/__tests__/openai-max-completion-tokens.test.ts
@@ -121,6 +121,18 @@ describe('same-format emission (chat -> chat, non-bypass transform path)', () =>
     });
     expect('max_tokens' in unified).toBe(false);
   });
+
+  it('passes an invalid caller budget through untouched so the upstream 400s', async () => {
+    const unified = await parse({
+      model: 'alias-B',
+      messages: MESSAGES,
+      max_completion_tokens: 'lots' as any,
+    });
+    const transformer = new OpenAITransformer();
+    const out = await transformer.transformRequest(unified);
+    expect(out.max_completion_tokens).toBe('lots');
+    expect('max_tokens' in out).toBe(false);
+  });
 });
 
 describe('enforce-limits pickup', () => {

--- a/packages/backend/src/transformers/__tests__/openai-max-completion-tokens.test.ts
+++ b/packages/backend/src/transformers/__tests__/openai-max-completion-tokens.test.ts
@@ -99,6 +99,28 @@ describe('same-format emission (chat -> chat, non-bypass transform path)', () =>
     expect('max_tokens' in out).toBe(false);
     expect('max_completion_tokens' in out).toBe(false);
   });
+
+  it('emits only max_completion_tokens when the caller sent both spellings', async () => {
+    const unified = await parse({
+      model: 'alias-B',
+      messages: MESSAGES,
+      max_tokens: 100,
+      max_completion_tokens: 200,
+    });
+    const transformer = new OpenAITransformer();
+    const out = await transformer.transformRequest(unified);
+    expect(out.max_completion_tokens).toBe(200);
+    expect('max_tokens' in out).toBe(false);
+  });
+
+  it('ignores non-numeric budget values at parse time', async () => {
+    const unified = await parse({
+      model: 'alias-B',
+      messages: MESSAGES,
+      max_completion_tokens: 'lots' as any,
+    });
+    expect('max_tokens' in unified).toBe(false);
+  });
 });
 
 describe('enforce-limits pickup', () => {

--- a/packages/backend/src/transformers/__tests__/openai-max-completion-tokens.test.ts
+++ b/packages/backend/src/transformers/__tests__/openai-max-completion-tokens.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { OpenAITransformer } from '../openai';
+import { buildAnthropicRequest } from '../anthropic/request-builder';
+import type { UnifiedChatRequest } from '../../types/unified';
+
+/**
+ * Regression tests for https://github.com/mcowger/plexus/issues/849:
+ * `max_completion_tokens` (the non-deprecated Chat Completions spelling,
+ * required by o-series/GPT-5-style reasoning models) was silently dropped by
+ * OpenAITransformer.parseRequest, so cross-format routes lost the caller's
+ * output budget (Anthropic fell back to `max_tokens: 4096`).
+ */
+
+const MESSAGES = [{ role: 'user', content: 'hi' }];
+
+async function parse(body: any) {
+  const transformer = new OpenAITransformer();
+  const unified = await transformer.parseRequest(body);
+  unified.incomingApiType = 'chat';
+  unified.originalBody = body;
+  return unified;
+}
+
+describe('parseRequest max_completion_tokens normalization', () => {
+  it('normalizes max_completion_tokens-only into unified max_tokens', async () => {
+    const unified = await parse({
+      model: 'alias-A',
+      messages: MESSAGES,
+      max_completion_tokens: 393216,
+    });
+    expect(unified.max_tokens).toBe(393216);
+  });
+
+  it('keeps unified max_tokens absent when the caller sent neither spelling', async () => {
+    const unified = await parse({ model: 'alias-A', messages: MESSAGES });
+    expect(unified.max_tokens).toBeUndefined();
+    expect('max_tokens' in unified).toBe(false);
+  });
+
+  it('prefers max_completion_tokens when both spellings are present', async () => {
+    const unified = await parse({
+      model: 'alias-A',
+      messages: MESSAGES,
+      max_tokens: 100,
+      max_completion_tokens: 200,
+    });
+    expect(unified.max_tokens).toBe(200);
+  });
+
+  it('still reads legacy max_tokens', async () => {
+    const unified = await parse({ model: 'alias-A', messages: MESSAGES, max_tokens: 512 });
+    expect(unified.max_tokens).toBe(512);
+  });
+});
+
+describe('cross-format emission (chat -> messages)', () => {
+  it('forwards the max_completion_tokens budget instead of defaulting to 4096', async () => {
+    const unified = await parse({
+      model: 'alias-A',
+      messages: MESSAGES,
+      max_completion_tokens: 393216,
+    });
+    const out = await buildAnthropicRequest({ ...unified, model: 'upstream-A' });
+    expect(out.max_tokens).toBe(393216);
+  });
+
+  it('still defaults to 4096 when the caller sent no budget', async () => {
+    const unified = await parse({ model: 'alias-A', messages: MESSAGES });
+    const out = await buildAnthropicRequest({ ...unified, model: 'upstream-A' });
+    expect(out.max_tokens).toBe(4096);
+  });
+});
+
+describe('same-format emission (chat -> chat, non-bypass transform path)', () => {
+  it('emits max_completion_tokens (not max_tokens) when the caller sent only that spelling', async () => {
+    const unified = await parse({
+      model: 'alias-B',
+      messages: MESSAGES,
+      max_completion_tokens: 131072,
+    });
+    const transformer = new OpenAITransformer();
+    const out = await transformer.transformRequest(unified);
+    expect(out.max_completion_tokens).toBe(131072);
+    expect('max_tokens' in out).toBe(false);
+  });
+
+  it('emits max_tokens when the caller sent only the legacy spelling', async () => {
+    const unified = await parse({ model: 'alias-B', messages: MESSAGES, max_tokens: 512 });
+    const transformer = new OpenAITransformer();
+    const out = await transformer.transformRequest(unified);
+    expect(out.max_tokens).toBe(512);
+    expect('max_completion_tokens' in out).toBe(false);
+  });
+
+  it('emits no budget key when the caller sent neither', async () => {
+    const unified = await parse({ model: 'alias-B', messages: MESSAGES });
+    const transformer = new OpenAITransformer();
+    const out = await transformer.transformRequest(unified);
+    expect('max_tokens' in out).toBe(false);
+    expect('max_completion_tokens' in out).toBe(false);
+  });
+});
+
+describe('enforce-limits pickup', () => {
+  it('reserves the normalized budget (covered via unified max_tokens)', async () => {
+    // enforceContextLimit reads request.max_tokens; entrance normalization
+    // means max_completion_tokens callers are enforced against their real
+    // budget rather than the 4096 fallback.
+    const unified = await parse({
+      model: 'alias-A',
+      messages: MESSAGES,
+      max_completion_tokens: 800,
+    });
+    expect(unified.max_tokens).toBe(800);
+    const unifiedRecord = unified as UnifiedChatRequest;
+    expect(typeof unifiedRecord.max_tokens).toBe('number');
+  });
+});

--- a/packages/backend/src/transformers/__tests__/openai-max-completion-tokens.test.ts
+++ b/packages/backend/src/transformers/__tests__/openai-max-completion-tokens.test.ts
@@ -122,6 +122,16 @@ describe('same-format emission (chat -> chat, non-bypass transform path)', () =>
     expect('max_tokens' in unified).toBe(false);
   });
 
+  it('ignores a garbage mct without dropping a valid legacy max_tokens', async () => {
+    const unified = await parse({
+      model: 'alias-B',
+      messages: MESSAGES,
+      max_tokens: 512,
+      max_completion_tokens: '1024' as any,
+    });
+    expect(unified.max_tokens).toBe(512);
+  });
+
   it('passes an invalid caller budget through untouched so the upstream 400s', async () => {
     const unified = await parse({
       model: 'alias-B',

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -48,10 +48,19 @@ export class OpenAITransformer implements Transformer {
         })
       : input.messages;
 
+    // `max_completion_tokens` is the non-deprecated Chat Completions spelling
+    // (required by o-series/GPT-5-style reasoning models); `max_tokens` is the
+    // legacy spelling. They are mutually exclusive upstream (sending both
+    // 400s), so normalize either into unified `max_tokens`, preferring
+    // `max_completion_tokens` when both are present. Conditional spread keeps
+    // the key absent (not `max_tokens: undefined`) when the caller sent
+    // neither — downstream `in`-checks must not see a phantom key.
+    const maxTokens = input.max_completion_tokens ?? input.max_tokens;
+
     return {
       messages,
       model: input.model,
-      max_tokens: input.max_tokens,
+      ...(maxTokens !== undefined ? { max_tokens: maxTokens } : {}),
       temperature: input.temperature,
       stream: input.stream,
       tools: input.tools,
@@ -100,7 +109,24 @@ export class OpenAITransformer implements Transformer {
     // Override with explicitly-transformed fields
     out.model = request.model;
     out.messages = messages;
-    out.max_tokens = request.max_tokens;
+    // `max_tokens` and `max_completion_tokens` are mutually exclusive
+    // upstream (sending both 400s). Mirror the caller's spelling: a caller
+    // that sent only `max_completion_tokens` must not gain a `max_tokens`
+    // key from the overlay (the spread above preserved their spelling).
+    // Callers that sent both keep both — that request is invalid and the
+    // upstream 400 explains why.
+    const callerSentMct = request.originalBody?.max_completion_tokens !== undefined;
+    const callerSentMaxTokens = request.originalBody?.max_tokens !== undefined;
+    if (request.max_tokens !== undefined) {
+      if (callerSentMct && !callerSentMaxTokens) {
+        delete out.max_tokens;
+        out.max_completion_tokens = request.max_tokens;
+      } else {
+        out.max_tokens = request.max_tokens;
+      }
+    } else {
+      delete out.max_tokens;
+    }
     out.temperature = request.temperature;
     out.stream = request.stream;
     out.tools = normalizedTools && normalizedTools.length > 0 ? normalizedTools : undefined;

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -60,7 +60,7 @@ export class OpenAITransformer implements Transformer {
     return {
       messages,
       model: input.model,
-      ...(maxTokens !== undefined ? { max_tokens: maxTokens } : {}),
+      ...(typeof maxTokens === 'number' && maxTokens > 0 ? { max_tokens: maxTokens } : {}),
       temperature: input.temperature,
       stream: input.stream,
       tools: input.tools,
@@ -110,22 +110,26 @@ export class OpenAITransformer implements Transformer {
     out.model = request.model;
     out.messages = messages;
     // `max_tokens` and `max_completion_tokens` are mutually exclusive
-    // upstream (sending both 400s). Mirror the caller's spelling: a caller
-    // that sent only `max_completion_tokens` must not gain a `max_tokens`
-    // key from the overlay (the spread above preserved their spelling).
-    // Callers that sent both keep both — that request is invalid and the
-    // upstream 400 explains why.
+    // upstream (sending both 400s), so emit exactly one spelling. Mirror the
+    // caller's spelling when they sent only one; when they sent both, the
+    // unified value already prefers `max_completion_tokens` (see
+    // parseRequest), so emit that alone rather than a contradictory pair.
     const callerSentMct = request.originalBody?.max_completion_tokens !== undefined;
     const callerSentMaxTokens = request.originalBody?.max_tokens !== undefined;
+    delete out.max_tokens;
+    delete out.max_completion_tokens;
     if (request.max_tokens !== undefined) {
       if (callerSentMct && !callerSentMaxTokens) {
-        delete out.max_tokens;
+        out.max_completion_tokens = request.max_tokens;
+      } else if (callerSentMaxTokens && !callerSentMct) {
+        out.max_tokens = request.max_tokens;
+      } else if (callerSentMct && callerSentMaxTokens) {
         out.max_completion_tokens = request.max_tokens;
       } else {
+        // No caller spelling to mirror (unified value came from middleware
+        // or a default): use the legacy key this wire format defaults to.
         out.max_tokens = request.max_tokens;
       }
-    } else {
-      delete out.max_tokens;
     }
     out.temperature = request.temperature;
     out.stream = request.stream;

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -55,12 +55,23 @@ export class OpenAITransformer implements Transformer {
     // `max_completion_tokens` when both are present. Conditional spread keeps
     // the key absent (not `max_tokens: undefined`) when the caller sent
     // neither — downstream `in`-checks must not see a phantom key.
-    const maxTokens = input.max_completion_tokens ?? input.max_tokens;
+    // First valid number wins (`max_completion_tokens` preferred): a garbage
+    // value in one spelling must not shadow a good value in the other via a
+    // bare `??` (e.g. `{max_tokens: 512, max_completion_tokens: "1024"}` must
+    // still normalize to 512 rather than dropping the budget entirely).
+    const mct = input.max_completion_tokens;
+    const legacy = input.max_tokens;
+    const maxTokens =
+      typeof mct === 'number' && mct > 0
+        ? mct
+        : typeof legacy === 'number' && legacy > 0
+          ? legacy
+          : undefined;
 
     return {
       messages,
       model: input.model,
-      ...(typeof maxTokens === 'number' && maxTokens > 0 ? { max_tokens: maxTokens } : {}),
+      ...(maxTokens !== undefined ? { max_tokens: maxTokens } : {}),
       temperature: input.temperature,
       stream: input.stream,
       tools: input.tools,

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -116,9 +116,13 @@ export class OpenAITransformer implements Transformer {
     // parseRequest), so emit that alone rather than a contradictory pair.
     const callerSentMct = request.originalBody?.max_completion_tokens !== undefined;
     const callerSentMaxTokens = request.originalBody?.max_tokens !== undefined;
-    delete out.max_tokens;
-    delete out.max_completion_tokens;
     if (request.max_tokens !== undefined) {
+      // Only clear the keys when a unified budget exists to re-emit: an
+      // invalid caller value (e.g. a non-numeric budget the parse-time guard
+      // rejected) must pass through untouched so the upstream still 400s on
+      // it instead of silently running uncapped.
+      delete out.max_tokens;
+      delete out.max_completion_tokens;
       if (callerSentMct && !callerSentMaxTokens) {
         out.max_completion_tokens = request.max_tokens;
       } else if (callerSentMaxTokens && !callerSentMct) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
I see a diff adding `max_completion_tokens` support to the OpenAI transformer, but no request. What would you like me to do — review it, run the tests, or something else?
<!-- kody-pr-summary:end -->