### PR TITLE
fix(providers): persist auto-compat setting

### DIFF
--- a/packages/frontend/src/hooks/useProviderForm.tsx
+++ b/packages/frontend/src/hooks/useProviderForm.tsx
@@ -386,7 +386,7 @@ export function useProviderForm() {
   const handleToggleEnabled = async (provider: Provider, newState: boolean) => {
     setProviders(providers.map((p) => (p.id === provider.id ? { ...p, enabled: newState } : p)));
     try {
-      await api.saveProvider({ ...provider, enabled: newState }, provider.id);
+      await api.updateProviderEnabled(provider.id, newState);
     } catch (e) {
       console.error('Toggle error', e);
       toast.error('Failed to update provider status: ' + e);

--- a/packages/frontend/src/lib/__tests__/api.test.ts
+++ b/packages/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api, type Provider } from '../api';
+
+describe('provider auto-compat persistence', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends and reloads provider-level auto_compat', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            test: {
+              api_base_url: 'https://api.example.com/v1',
+              api_key: 'test-key',
+              enabled: true,
+              auto_compat: true,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('localStorage', { getItem: vi.fn(() => 'test-admin-key') });
+    vi.stubGlobal('window', { location: { pathname: '/ui/providers' } });
+
+    const provider: Provider = {
+      id: 'test',
+      name: 'Test',
+      type: ['chat'],
+      apiBaseUrl: 'https://api.example.com/v1',
+      apiKey: 'test-key',
+      enabled: true,
+      auto_compat: true,
+    };
+
+    await api.saveProvider(provider, 'test');
+
+    const saveRequest = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(saveRequest.body as string)).toMatchObject({ auto_compat: true });
+
+    const [reloadedProvider] = await api.getProviders();
+    expect(reloadedProvider?.auto_compat).toBe(true);
+  });
+});

--- a/packages/frontend/src/lib/__tests__/api.test.ts
+++ b/packages/frontend/src/lib/__tests__/api.test.ts
@@ -73,4 +73,21 @@ describe('provider auto-compat persistence', () => {
       auto_compat: false,
     });
   });
+
+  it('patches only enabled when updating provider status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('localStorage', { getItem: vi.fn(() => 'test-admin-key') });
+    vi.stubGlobal('window', { location: { pathname: '/ui/providers' } });
+
+    await api.updateProviderEnabled('provider/with-slash', false);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v0/management/providers/provider/with-slash',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ enabled: false }),
+      })
+    );
+  });
 });

--- a/packages/frontend/src/lib/__tests__/api.test.ts
+++ b/packages/frontend/src/lib/__tests__/api.test.ts
@@ -45,4 +45,24 @@ describe('provider auto-compat persistence', () => {
     const [reloadedProvider] = await api.getProviders();
     expect(reloadedProvider?.auto_compat).toBe(true);
   });
+
+  it('sends false when disabling provider-level auto_compat', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('localStorage', { getItem: vi.fn(() => 'test-admin-key') });
+    vi.stubGlobal('window', { location: { pathname: '/ui/providers' } });
+
+    await api.saveProvider({
+      id: 'test',
+      name: 'Test',
+      type: ['chat'],
+      apiBaseUrl: 'https://api.example.com/v1',
+      apiKey: 'test-key',
+      enabled: true,
+      auto_compat: false,
+    });
+
+    const saveRequest = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(saveRequest.body as string)).toMatchObject({ auto_compat: false });
+  });
 });

--- a/packages/frontend/src/lib/__tests__/api.test.ts
+++ b/packages/frontend/src/lib/__tests__/api.test.ts
@@ -46,7 +46,7 @@ describe('provider auto-compat persistence', () => {
     expect(reloadedProvider?.auto_compat).toBe(true);
   });
 
-  it('sends false when disabling provider-level auto_compat', async () => {
+  it('sends false when disabling provider boolean settings', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
     vi.stubGlobal('localStorage', { getItem: vi.fn(() => 'test-admin-key') });
@@ -59,10 +59,18 @@ describe('provider auto-compat persistence', () => {
       apiBaseUrl: 'https://api.example.com/v1',
       apiKey: 'test-key',
       enabled: true,
+      disableCooldown: false,
+      stallCooldown: false,
+      allow100PercentUtilization: false,
       auto_compat: false,
     });
 
     const saveRequest = fetchMock.mock.calls[0]?.[1] as RequestInit;
-    expect(JSON.parse(saveRequest.body as string)).toMatchObject({ auto_compat: false });
+    expect(JSON.parse(saveRequest.body as string)).toMatchObject({
+      disable_cooldown: false,
+      stall_cooldown: false,
+      allow_100_percent_utilization: false,
+      auto_compat: false,
+    });
   });
 });

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1914,7 +1914,7 @@ export const api = {
       stall_cooldown: provider.stallCooldown === true ? true : undefined,
       allow_100_percent_utilization:
         provider.allow100PercentUtilization === true ? true : undefined,
-      auto_compat: provider.auto_compat === true ? true : undefined,
+      auto_compat: provider.auto_compat === true,
       discount: provider.discount,
       headers: provider.headers,
       extraBody: provider.extraBody,

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1860,6 +1860,7 @@ export const api = {
           disableCooldown: val.disable_cooldown === true,
           stallCooldown: val.stall_cooldown === true,
           allow100PercentUtilization: val.allow_100_percent_utilization === true,
+          auto_compat: val.auto_compat === true,
           discount: val.discount,
           headers: val.headers,
           extraBody:
@@ -1913,6 +1914,7 @@ export const api = {
       stall_cooldown: provider.stallCooldown === true ? true : undefined,
       allow_100_percent_utilization:
         provider.allow100PercentUtilization === true ? true : undefined,
+      auto_compat: provider.auto_compat === true ? true : undefined,
       discount: provider.discount,
       headers: provider.headers,
       extraBody: provider.extraBody,

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1973,6 +1973,21 @@ export const api = {
     }
   },
 
+  updateProviderEnabled: async (providerId: string, enabled: boolean): Promise<void> => {
+    const res = await fetchWithAuth(
+      `${API_BASE}/v0/management/providers/${encodePathPreservingSlashes(providerId)}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      }
+    );
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Failed to update provider status');
+    }
+  },
+
   getVisionFallthroughConfig: async (): Promise<{
     descriptor_model?: string;
     default_prompt?: string;

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1910,10 +1910,9 @@ export const api = {
       estimateTokens: provider.estimateTokens,
       useClaudeMasking: provider.useClaudeMasking,
       geminiThinkingEnabled: provider.geminiThinkingEnabled,
-      disable_cooldown: provider.disableCooldown === true ? true : undefined,
-      stall_cooldown: provider.stallCooldown === true ? true : undefined,
-      allow_100_percent_utilization:
-        provider.allow100PercentUtilization === true ? true : undefined,
+      disable_cooldown: provider.disableCooldown === true,
+      stall_cooldown: provider.stallCooldown === true,
+      allow_100_percent_utilization: provider.allow100PercentUtilization === true,
       auto_compat: provider.auto_compat === true,
       discount: provider.discount,
       headers: provider.headers,


### PR DESCRIPTION
## Summary
Persist the Provider modal's Auto Compat setting so enabling or disabling it survives save and reopen. The frontend now sends the setting to the management API, restores it from provider responses, and keeps status-only updates isolated from other provider settings.

## Why / Context
The backend already accepted and stored `auto_compat`, but the frontend omitted it from both the save payload and provider response mapping, so the modal always reopened with Auto Compat disabled. Provider PATCH updates also needed to preserve explicit false values without allowing status-only updates to overwrite unrelated settings.

## Changes
- **Provider API client**: include provider-level `auto_compat` when saving providers and map it from management API responses.
- **Provider API client**: preserve explicit false values for provider cooldown and utilization boolean settings.
- **Provider status updates**: use a dedicated `{ enabled }` PATCH so status toggles cannot overwrite unrelated provider configuration.
- **Regression coverage**: verify enabled and disabled boolean payloads, reload mapping, and status-only updates.

## Testing
- Focused Vitest regression tests pass (3 tests).
- Manually enabled Auto Compat in the Provider modal, saved, reopened it, and confirmed it remained enabled.
- Pre-commit hooks passed formatting, lint, frontend build, typecheck, and migration checks.


<!-- kody-pr-summary:start -->
## Description

Fixes an issue where the provider-level **auto-compat** setting was not being persisted or restored correctly, and where toggling a provider's enabled state could silently overwrite other provider settings.

## Changes

**`packages/frontend/src/lib/api.ts`**

- `getProviders()` now reads the `auto_compat` flag from the backend response and maps it onto the provider object, so the saved value is reflected in the UI after a reload.
- `saveProvider()` now includes `auto_compat` in the request payload.
- Boolean provider flags (`disable_cooldown`, `stall_cooldown`, `allow_100_percent_utilization`, and the new `auto_compat`) are now always sent as explicit `true`/`false` values instead of being omitted (`undefined`) when disabled. Previously, disabling one of these settings sent no value at all, so the backend would keep the old `true` value and the change would appear to be lost.
- Added a new `updateProviderEnabled(providerId, enabled)` method that issues a targeted `PATCH` request containing only the `enabled` field (with path-preserving encoding for provider IDs that contain slashes).

**`packages/frontend/src/hooks/useProviderForm.tsx`**

- The enable/disable toggle now calls `api.updateProviderEnabled()` instead of performing a full `saveProvider()` write, so flipping a provider on or off no longer risks re-submitting (and potentially corrupting) the rest of the provider's configuration.

**`packages/frontend/src/lib/__tests__/api.test.ts`** (new)

- Adds tests covering: `auto_compat` round-tripping through save and reload, explicit `false` values being sent for all provider boolean settings, and the enabled toggle issuing a `PATCH` with only the `enabled` field.

## Impact

Users can now successfully enable **and disable** auto-compat (and the other provider boolean options) and have the change stick after a page reload. Toggling provider availability is also now a minimal, isolated update.
<!-- kody-pr-summary:end -->