### PR TITLE
fix(logs): stop truncating long key names and clipping AM/PM times

### DIFF
--- a/packages/frontend/src/pages/Logs.tsx
+++ b/packages/frontend/src/pages/Logs.tsx
@@ -96,8 +96,7 @@ const SSE_HEARTBEAT_TIMEOUT_MS = 30_000;
 const LIVE_DURATION_UPDATE_INTERVAL_MS = 500;
 const DESKTOP_LOGS_MEDIA_QUERY = '(min-width: 1024px)';
 const DESKTOP_STATUS_COLUMN_WIDTH = '32px';
-const DESKTOP_DATE_COLUMN_WIDTH = '78px';
-const DESKTOP_KEY_COLUMN_WIDTH = '82px';
+const DESKTOP_DATE_COLUMN_WIDTH = '96px';
 const DESKTOP_API_COLUMN_WIDTH = '58px';
 const DESKTOP_TOKENS_COLUMN_WIDTH = '144px';
 const DESKTOP_COST_COLUMN_WIDTH = '86px';
@@ -694,7 +693,7 @@ const DesktopLogRow = React.memo(
         <td
           className="min-w-0 overflow-hidden px-1 py-1.5 text-left border-b border-border-glass text-text align-middle"
           title={log.sourceIp ? `IP: ${log.sourceIp}` : undefined}
-          style={{ width: DESKTOP_KEY_COLUMN_WIDTH, ...(log.sourceIp ? { cursor: 'help' } : {}) }}
+          style={log.sourceIp ? { cursor: 'help' } : undefined}
         >
           <div className="flex min-w-0 flex-col">
             <span
@@ -2077,7 +2076,7 @@ export const Logs = () => {
                 <colgroup>
                   <col style={{ width: DESKTOP_STATUS_COLUMN_WIDTH }} />
                   <col style={{ width: DESKTOP_DATE_COLUMN_WIDTH }} />
-                  <col style={{ width: DESKTOP_KEY_COLUMN_WIDTH }} />
+                  <col />
                   <col style={{ width: DESKTOP_API_COLUMN_WIDTH }} />
                   <col />
                   <col style={{ width: DESKTOP_TOKENS_COLUMN_WIDTH }} />
@@ -2101,10 +2100,7 @@ export const Logs = () => {
                     >
                       {renderSortableHeader('Date', 'date')}
                     </th>
-                    <th
-                      className="px-1 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap"
-                      style={{ width: DESKTOP_KEY_COLUMN_WIDTH }}
-                    >
+                    <th className="px-1 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
                       {renderSortableHeader('Key', 'apiKey')}
                     </th>
                     <th


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR modifies the desktop Logs table layout to resolve two truncation problems, and — as visible in the diff — carries a much wider set of changes to the Logs page and several unrelated subsystems.

### Logs table (the stated fix, plus more)

The desktop table was reworked well beyond the two-column tweak described:

- **Fixed column widths introduced as named constants** (`DESKTOP_STATUS_COLUMN_WIDTH`, `DESKTOP_DATE_COLUMN_WIDTH = 96px`, `DESKTOP_API_COLUMN_WIDTH`, `DESKTOP_TOKENS_COLUMN_WIDTH`, `DESKTOP_COST_COLUMN_WIDTH`, `DESKTOP_PERF_COLUMN_WIDTH`, `DESKTOP_DELETE_COLUMN_WIDTH`) with `table-fixed`, a `<colgroup>`, and a `768px` table min-width. The Date column is widened to 96px as described; Key/Model/Meta become flexible and truncate with `title` tooltips.\n- **New leading status column** consolidating status, error, debug, and retry indicators into compact icon buttons, replacing the previous wide Status cell and separate action buttons.\n- **Cost and Tokens columns condensed**: the four-way cost breakdown moved out of the cell and into a `CostToolTip` (extended with a new `costBreakdown` prop); tokens are regrouped into two rows with cache read/write shown inline.\n- **Perf column condensed** behind a new `PerformanceToolTip` component that exposes duration, semantic/raw bytes, throughput, and estimated tokens/sec on hover.\n- **Meta column hidden below 1150px**; some API/streaming icon rows are similarly gated.\n- **Mobile rows redesigned** into a denser 4-column icon grid and now receive `liveNow`/`progress` so in-flight requests show live duration and estimated tok/s.\n- **Filters moved into a mobile `Drawer`** with an active-filter count and clear action; the desktop filter bar is compacted to a 3-column grid.\n- **`Tooltip` now renders through a portal** with fixed positioning recalculated on scroll/resize, so tooltips are no longer clipped by table overflow.\n- A new `reasoningEffort` field is surfaced per row.

### Unrelated changes bundled in this branch

The diff also contains substantial work outside the Logs page:

- **Custom quota checkers**: new `custom_checkers` table (SQLite + Postgres), worker-isolated JS execution runtime with 10s timeout, management CRUD/test endpoints, admin UI page and provider config editor, plus docs.
- **Checker type de-enumeration**: `quota_checker_type` and `oauth_provider_type` Postgres enums dropped in favour of text; option validation moves from a `config.ts` discriminated union to registry-backed `optionsSchema` checks at save time.
- **Usage summary overhaul**: range-scoped stats (removing the fixed 7-day window), rich metrics, opt-in server-side breakdowns with bounds/caching/telemetry, and frontend rewiring of Usage/Detailed Usage/Overall tabs to stop aggregating 5,000-row client samples.
- **Energy estimation removal**: `kwhUsed` synthetic estimation, GPU profiles, `model_architecture`, and the HuggingFace fetcher are deleted (schema columns retained as deprecated).
- **New `quota` routing selector** with burn-down scoring, plus generic OAuth dispatch for any pi-ai OAuth provider except `radius`.
- Misc: Bun pinned to 1.4.0 in CI/Docker, backup service switched to `Bun.Archive`, `reasoning_effort` logging, `max` reasoning level, CC_VERSION bump to 2.1.258, repomap pre-push hook, React Compiler enabled.
<!-- kody-pr-summary:end -->