### PR TITLE
fix(transformers): preserve tool strict flags

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,8 @@
       "!!packages/backend/src/assets/openapi.json",
       "!!packages/cli/src/skill.ts",
       "!!packages/backend/src/transformers/oauth/__tests__/golden-fixtures/**",
-      "!!.claude/**"
+      "!!.claude/**",
+      "!!.cora/**"
     ]
   },
   "formatter": {

--- a/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-request-roundtrip.test.ts
@@ -655,3 +655,50 @@ describe('transformRequest stream-field hygiene (no phantom `stream: undefined`)
     expect(built.stream).toBe(false);
   });
 });
+
+describe('transformRequest tool strict-field hygiene', () => {
+  const MINIMAL_REQUEST = {
+    model: 'gpt-4o',
+    input: [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'Hello' }],
+      },
+    ],
+  };
+
+  const functionTool = (strict?: boolean) => ({
+    type: 'function',
+    name: 'get_weather',
+    description: 'Get the weather',
+    parameters: { type: 'object', properties: { city: { type: 'string' } } },
+    ...(strict !== undefined ? { strict } : {}),
+  });
+
+  it('preserves an explicit strict:false in Responses and Chat payloads', async () => {
+    const unified = await new ResponsesTransformer().parseRequest({
+      ...MINIMAL_REQUEST,
+      tools: [functionTool(false)],
+    });
+
+    const responsesPayload = await new ResponsesTransformer().transformRequest(unified);
+    const chatPayload = await new OpenAITransformer().transformRequest(unified);
+
+    expect(responsesPayload.tools[0].strict).toBe(false);
+    expect(chatPayload.tools[0].function.strict).toBe(false);
+  });
+
+  it('does not add strict when the client omits it', async () => {
+    const unified = await new ResponsesTransformer().parseRequest({
+      ...MINIMAL_REQUEST,
+      tools: [functionTool()],
+    });
+
+    const responsesPayload = await new ResponsesTransformer().transformRequest(unified);
+    const chatPayload = await new OpenAITransformer().transformRequest(unified);
+
+    expect(Object.hasOwn(responsesPayload.tools[0], 'strict')).toBe(false);
+    expect(Object.hasOwn(chatPayload.tools[0].function, 'strict')).toBe(false);
+  });
+});

--- a/packages/backend/src/transformers/openai.ts
+++ b/packages/backend/src/transformers/openai.ts
@@ -101,6 +101,7 @@ export class OpenAITransformer implements Transformer {
                 name: fn.name,
                 description: fn.description,
                 parameters,
+                ...(fn.strict !== undefined ? { strict: fn.strict } : {}),
               },
             };
           })

--- a/packages/backend/src/transformers/responses.ts
+++ b/packages/backend/src/transformers/responses.ts
@@ -374,11 +374,13 @@ export class ResponsesTransformer implements Transformer {
     // the HTTP call is made.
     const tools = request.tools?.map((tool: any) => {
       if (tool.type !== 'function' || !tool.function) return tool;
+      const strict = tool.function?.strict;
       return {
         type: 'function',
         name: tool.function?.name ?? '',
         description: tool.function?.description ?? '',
         parameters: tool.function?.parameters ?? {},
+        ...(strict !== undefined ? { strict } : {}),
       };
     });
 

--- a/packages/backend/src/types/unified.ts
+++ b/packages/backend/src/types/unified.ts
@@ -60,6 +60,7 @@ export interface UnifiedToolFunction {
     $schema?: string;
   };
   parametersJsonSchema?: any; // Newer format supporting full JSON Schema (anyOf, oneOf, const)
+  strict?: boolean;
 }
 
 export interface UnifiedTool {

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "vercel-labs/agent-browser",
       "sourceType": "github",
       "skillPath": "skills/agent-browser/SKILL.md",
-      "computedHash": "a674b7d81066e3cc471a7512ddb4ae724418cbfefa75cbb050b0dc430e4d57a0"
+      "computedHash": "80161e6836b3b40f4e83730a290deb40ac14d877d38c97ad5f6d71be37ce74c3"
     },
     "batch-grill-me": {
       "source": "mattpocock/skills",


### PR DESCRIPTION
## Summary
Preserve explicit function-tool `strict` values when transforming requests between Responses and OpenAI Chat formats. This prevents `strict: false` from being silently dropped while still omitting the field when the client did not provide it.

## Changes
- **Responses transformer**: retain function-tool `strict` values in Responses payloads.
- **OpenAI transformer**: retain function-tool `strict` values in Chat Completions payloads.
- **Unified types and tests**: model the field and cover explicit `strict: false` plus omitted-field behavior across both outbound formats.
- **Tooling**: exclude Cora-generated history from Biome formatting checks.

## Testing
- Added regression coverage for Responses and Chat payloads.
- Verified Cora reviews report no issues.
- Verified repository formatting checks pass.

## Notes
This branch also includes the pre-existing `skills-lock.json` refresh commit (`36252ff6`), as requested.
