### PR TITLE
docs(agents): forbid two Plexus instances on one OAuth grant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This file is a **guardrail**, not general documentation.
 - **NEVER** use `--no-verify` or `LEFTHOOK=0` without user permission.
 - **NEVER** edit or manually create migration files.
 - **NEVER** produce implementation or summary documents unless specifically requested.
+- **NEVER** run two Plexus instances against the same OAuth credential/grant. A refresh-token chain belongs to exactly one live process: providers use single-use rotating refresh tokens, so a second instance sharing the same token rotates and revokes it, 401-ing the whole account pool (caused a full opus outage 2026-08-18). If you must run a second instance, give it its **own** separate `oauth login` (distinct grant) or point it at **API-key-only providers** — never copy one refresh token into two running processes. In-process refresh coalescing gives zero cross-process protection.
 - **DEBUGGING** Plexus instances: read and use the `plexus-cli` skill. The worktree `.env` contains the relevant staging configuration. When the user specifies `staging`, use `PLEXUS_STAGING_URL` for the staging URL and `PLEXUS_ADMIN_KEY` for the admin key.
 - **AVOID** searching library type definitions for documentation. Use context/search skills first when available.
 - **ASK** when requirements are ambiguous.


### PR DESCRIPTION
Adds a Critical-rules guardrail to `AGENTS.md`.

**Why:** Provider OAuth uses single-use *rotating* refresh tokens. Two live Plexus processes sharing one grant rotate and revoke each other's token, 401-ing the entire pooled account set — this caused a full opus outage on 2026-08-18. In-process refresh coalescing only dedupes within a single process; it gives zero cross-process protection.

**Rule:** never run two instances against the same OAuth credential/grant. A second instance must have its own `oauth login` (distinct grant) or use API-key-only providers — never copy one refresh token into two running processes.

Docs-only; one line added to the Critical rules list.