### PR TITLE
fix(responses): finalize terminal stream capture

### DIFF
--- a/.repomap.txt
+++ b/.repomap.txt
@@ -1,0 +1,2514 @@
+
+📁 packages/backend/src/cli/backup.ts:
+  │ [function] generateBackupName (line 28)
+  │ [function] main (line 33)
+
+📁 packages/backend/src/cli/rekey.ts:
+  │ [function] decryptWithKey (line 41)
+  │ [function] deriveKey (line 30)
+  │ [function] encryptWithKey (line 54)
+  │ [function] hashSecret (line 62)
+  │ [function] isEncrypted (line 37)
+  │ [function] main (line 81)
+  │ [function] reEncrypt (line 66)
+  │ [function] reEncryptNullable (line 71)
+
+📁 packages/backend/src/config.ts:
+  │ [function] assertNoAliasRefCycles (line 393)
+  │ [function] buildProviderQuotaConfigs (line 1035)
+  │ [function] findDuplicateAdditionalAliases (line 445)
+  │ [function] findDuplicateAliasTargets (line 366)
+  │ [function] getConfig (line 1103)
+  │ [function] getDatabaseConfig (line 1166)
+  │ [function] getProviderTypes (line 868)
+  │ [function] hydrateConfig (line 931)
+  │ [function] isKeyDisabled (line 851)
+  │ [function] isOAuthProviderConfig (line 909)
+  │ [function] isValidUrlOrOAuth (line 899)
+  │ [function] migrateOAuthAccounts (line 983)
+  │ [function] normalizeKeyConfig (line 735)
+  │ [function] setConfigForTesting (line 1128)
+  │ [function] validateConfig (line 924)
+
+📁 packages/backend/src/db/client.ts:
+  │ [function] closeDatabase (line 247)
+  │ [function] getCurrentDialect (line 240)
+  │ [function] getDatabase (line 226)
+  │ [function] getPostgresDriver (line 54)
+  │ [function] getSchema (line 233)
+  │ [function] initializeDatabase (line 58)
+  │ [function] parseConnectionString (line 23)
+  │ [function] resolvePath (line 45)
+
+📁 packages/backend/src/db/config-repository.ts:
+  │ [class] ConfigRepository (line 268)
+  │ [interface] CustomCheckerRecord (line 29)
+  │ [interface] McpKeyConfig (line 262)
+  │ [interface] OAuthCredentialsData (line 256)
+  │ [method] addMcpServerKey (line 1572)
+  │ [method] addMissingProviderModels (line 603)
+  │ [method] batchInsertMcpKeys (line 1541)
+  │ [method] clearAllData (line 346)
+  │ [method] clearMcpServerKeyCooldown (line 1616)
+  │ [method] db (line 269)
+  │ [function] decryptJsonField (line 120)
+  │ [method] deleteAlias (line 1069)
+  │ [method] deleteAllAliases (line 1074)
+  │ [method] deleteCustomChecker (line 338)
+  │ [method] deleteKey (line 1291)
+  │ [method] deleteMcpServer (line 1498)
+  │ [method] deleteMcpServerKey (line 1600)
+  │ [method] deleteOAuthCredentials (line 1898)
+  │ [method] deleteProvider (line 556)
+  │ [method] deleteUserQuota (line 1376)
+  │ [method] disableTimeBoundKey (line 1297)
+  │ [function] encryptJsonField (line 108)
+  │ [function] fromBool (line 189)
+  │ [method] getAlias (line 780)
+  │ [method] getAllAliases (line 738)
+  │ [method] getAllKeys (line 1151)
+  │ [method] getAllMcpKeys (line 1523)
+  │ [method] getAllMcpServers (line 1385)
+  │ [method] getAllOAuthProviders (line 1910)
+  │ [method] getAllProviders (line 363)
+  │ [method] getAllSettings (line 1718)
+  │ [method] getAllUserQuotas (line 1311)
+  │ [method] getBackgroundExplorationConfig (line 1763)
+  │ [method] getCaptureTraceOnError (line 1749)
+  │ [method] getCompactionConfig (line 1794)
+  │ [method] getCooldownPolicy (line 1753)
+  │ [method] getCustomChecker (line 289)
+  │ [method] getCustomCheckers (line 277)
+  │ [method] getFailoverPolicy (line 1732)
+  │ [method] getKeyBySecret (line 1182)
+  │ [method] getMcpOAuthConfig (line 1776)
+  │ [method] getMcpServerKeys (line 1503)
+  │ [method] getMetadataOverrideRow (line 801)
+  │ [method] getOAuthCredentials (line 1817)
+  │ [method] getProvider (line 390)
+  │ [method] getProviderModels (line 572)
+  │ [method] getSetting (line 1635)
+  │ [method] getStallConfig (line 1798)
+  │ [method] getTimeoutConfig (line 1789)
+  │ [method] getTrustedProxies (line 1759)
+  │ [function] hasAnyOverrideField (line 134)
+  │ [method] hasColumn (line 928)
+  │ [method] migrateLegacyTargetGroups (line 818)
+  │ [method] migrateModelTypes (line 870)
+  │ [function] normalizeAdapterEntries (line 73)
+  │ [function] now (line 195)
+  │ [function] overrideRowToOverrides (line 149)
+  │ [function] parseJson (line 39)
+  │ [function] parseStringArray (line 199)
+  │ [function] quotasFromRow (line 248)
+  │ [method] repairCorruptedAliasFallbackSlugs (line 903)
+  │ [method] rowToModelConfig (line 1082)
+  │ [method] rowToProviderConfig (line 649)
+  │ [method] saveAlias (line 952)
+  │ [method] saveCustomChecker (line 307)
+  │ [method] saveKey (line 1237)
+  │ [method] saveMcpServer (line 1430)
+  │ [method] saveProvider (line 419)
+  │ [method] saveUserQuota (line 1339)
+  │ [method] schema (line 273)
+  │ [method] setOAuthCredentials (line 1853)
+  │ [method] setSetting (line 1664)
+  │ [method] setSettingsBulk (line 1689)
+  │ [function] stringifyQuotaNames (line 234)
+  │ [function] stringifyStringArray (line 217)
+  │ [function] toBool (line 184)
+  │ [function] toJson (line 54)
+
+📁 packages/backend/src/db/encrypt-migration.ts:
+  │ [function] runEncryptionMigration (line 21)
+
+📁 packages/backend/src/db/mcp-key-migration.ts:
+  │ [function] extractLegacyCredential (line 14)
+  │ [function] runMcpKeyMigration (line 50)
+
+📁 packages/backend/src/db/mcp-oauth-repository.ts:
+  │ [interface] McpOauthAuthorizationCodeRecord (line 52)
+  │ [interface] McpOauthClientRecord (line 29)
+  │ [interface] McpOauthClientWithTokensRecord (line 98)
+  │ [class] McpOauthRepository (line 114)
+  │ [interface] McpOauthTokenRecord (line 81)
+  │ [interface] NewMcpOauthAuthorizationCode (line 68)
+  │ [interface] NewMcpOauthClient (line 41)
+  │ [interface] NewMcpOauthToken (line 102)
+  │ [function] arraysEqual (line 454)
+  │ [method] consumeAuthorizationCode (line 296)
+  │ [method] createAuthorizationCode (line 240)
+  │ [method] createClient (line 123)
+  │ [method] createToken (line 311)
+  │ [method] db (line 115)
+  │ [method] deleteClient (line 409)
+  │ [method] findClientByRegistration (line 169)
+  │ [method] getAccessToken (line 340)
+  │ [function] getAffectedRowCount (line 458)
+  │ [method] getAuthorizationCode (line 269)
+  │ [method] getClient (line 146)
+  │ [method] getRefreshToken (line 351)
+  │ [method] listClientsWithActiveTokens (line 186)
+  │ [function] normalizeStringSet (line 450)
+  │ [function] now (line 5)
+  │ [function] parseJsonArray (line 9)
+  │ [method] revokeRefreshToken (line 362)
+  │ [method] revokeTokenById (line 376)
+  │ [method] revokeTokensForClient (line 416)
+  │ [method] revokeTokensForKeyName (line 387)
+  │ [method] rowToToken (line 430)
+  │ [method] schema (line 119)
+  │ [method] setClientStatus (line 401)
+  │ [function] stringifyArray (line 24)
+
+📁 packages/backend/src/db/migrate.ts:
+  │ [interface] MigrationMeta (line 28)
+  │ [function] attemptPostgresDuplicateColumnRepair (line 269)
+  │ [function] attemptSQLiteAlreadyExistsRepair (line 120)
+  │ [function] attemptSQLiteDuplicateColumnRepair (line 196)
+  │ [function] buildMigrations (line 46)
+  │ [function] getSQLiteDuplicateColumnName (line 115)
+  │ [function] isDuplicateColumnError (line 74)
+  │ [function] isSQLiteAlreadyExistsError (line 78)
+  │ [function] isSQLiteDuplicateColumnError (line 83)
+  │ [function] isSQLiteDuplicateColumnName (line 110)
+  │ [function] normalizeSqlStatement (line 70)
+  │ [function] readSql (line 37)
+  │ [function] runMigrations (line 333)
+  │ [function] toIdempotentSQLiteStatement (line 103)
+  │ [function] toIdempotentStatement (line 88)
+
+📁 packages/backend/src/routes/inference/_quota-error.ts:
+  │ [function] saveQuotaBlockedUsage (line 49)
+  │ [function] saveQuotaExceededUsage (line 22)
+
+📁 packages/backend/src/routes/inference/chat.ts:
+  │ [function] registerChatRoute (line 21)
+
+📁 packages/backend/src/routes/inference/completions.ts:
+  │ [function] registerCompletionsRoute (line 21)
+
+📁 packages/backend/src/routes/inference/embeddings.ts:
+  │ [function] registerEmbeddingsRoute (line 15)
+
+📁 packages/backend/src/routes/inference/gemini.ts:
+  │ [function] registerGeminiRoute (line 20)
+
+📁 packages/backend/src/routes/inference/images.ts:
+  │ [function] registerImagesRoute (line 16)
+
+📁 packages/backend/src/routes/inference/index.ts:
+  │ [function] registerInferenceRoutes (line 18)
+
+📁 packages/backend/src/routes/inference/messages.ts:
+  │ [function] registerMessagesRoute (line 21)
+
+📁 packages/backend/src/routes/inference/models.ts:
+  │ [function] registerModelsRoute (line 22)
+
+📁 packages/backend/src/routes/inference/responses.ts:
+  │ [function] detectResponsesApiType (line 27)
+  │ [function] registerResponsesRoute (line 53)
+
+📁 packages/backend/src/routes/inference/speech.ts:
+  │ [function] registerSpeechRoute (line 33)
+
+📁 packages/backend/src/routes/inference/transcriptions.ts:
+  │ [function] registerTranscriptionsRoute (line 15)
+
+📁 packages/backend/src/routes/management.ts:
+  │ [function] registerManagementRoutes (line 33)
+
+📁 packages/backend/src/routes/management/_principal.ts:
+  │ [interface] FastifyRequest (line 44)
+  │ [class] ManagementAuthError (line 12)
+  │ [function] authenticate (line 141)
+  │ [function] constantTimeEquals (line 49)
+  │ [function] constantTimeHashEquals (line 62)
+  │ [method] constructor (line 15)
+  │ [function] isLimited (line 182)
+  │ [function] requireAdmin (line 159)
+  │ [function] resolvePrincipal (line 72)
+  │ [function] scopedKeyName (line 172)
+
+📁 packages/backend/src/routes/management/_quota-response.ts:
+  │ [interface] QuotaSnapshotJson (line 6)
+  │ [function] resolveAttachedQuotaNames (line 69)
+  │ [function] serializeQuotaSnapshot (line 31)
+
+📁 packages/backend/src/routes/management/backup.ts:
+  │ [function] registerBackupRoutes (line 9)
+
+📁 packages/backend/src/routes/management/concurrency.ts:
+  │ [function] registerConcurrencyRoutes (line 7)
+
+📁 packages/backend/src/routes/management/config.ts:
+  │ [function] isRecord (line 27)
+  │ [function] mergeCompactionPatch (line 72)
+  │ [function] registerConfigRoutes (line 101)
+  │ [function] serializeMcpKey (line 58)
+  │ [function] validateProviderQuotaChecker (line 31)
+
+📁 packages/backend/src/routes/management/cooldowns.ts:
+  │ [function] registerCooldownRoutes (line 6)
+
+📁 packages/backend/src/routes/management/custom-checkers.ts:
+  │ [function] registerCustomCheckerRoutes (line 37)
+  │ [function] serializeChecker (line 24)
+
+📁 packages/backend/src/routes/management/debug.ts:
+  │ [function] registerDebugRoutes (line 14)
+
+📁 packages/backend/src/routes/management/errors.ts:
+  │ [function] registerErrorRoutes (line 5)
+
+📁 packages/backend/src/routes/management/logging.ts:
+  │ [function] registerLoggingRoutes (line 19)
+
+📁 packages/backend/src/routes/management/mcp-logs.ts:
+  │ [function] registerMcpLogRoutes (line 4)
+
+📁 packages/backend/src/routes/management/mcp-oauth.ts:
+  │ [function] registerMcpOAuthManagementRoutes (line 17)
+
+📁 packages/backend/src/routes/management/metrics.ts:
+  │ [interface] RequestTimeWindow (line 111)
+  │ [function] computeActiveTimeMs (line 129)
+  │ [function] escLabel (line 36)
+  │ [function] getCacheTtlMs (line 89)
+  │ [function] line (line 55)
+  │ [function] metricBlock (line 65)
+  │ [function] registerMetricsRoutes (line 159)
+  │ [function] renderLabels (line 44)
+
+📁 packages/backend/src/routes/management/models.ts:
+  │ [function] registerModelRoutes (line 13)
+
+📁 packages/backend/src/routes/management/oauth.ts:
+  │ [function] registerOAuthRoutes (line 41)
+
+📁 packages/backend/src/routes/management/performance.ts:
+  │ [function] registerPerformanceRoutes (line 5)
+
+📁 packages/backend/src/routes/management/providers.ts:
+  │ [function] registerProviderRoutes (line 17)
+
+📁 packages/backend/src/routes/management/quota-enforcement.ts:
+  │ [function] registerQuotaEnforcementRoutes (line 11)
+
+📁 packages/backend/src/routes/management/quotas.ts:
+  │ [function] getCheckerType (line 23)
+  │ [function] getOAuthMetadata (line 10)
+  │ [function] registerQuotaRoutes (line 27)
+
+📁 packages/backend/src/routes/management/restart.ts:
+  │ [function] registerRestartRoutes (line 4)
+
+📁 packages/backend/src/routes/management/self.ts:
+  │ [function] generateSecret (line 21)
+  │ [function] registerSelfRoutes (line 35)
+
+📁 packages/backend/src/routes/management/system-logs.ts:
+  │ [function] registerSystemLogRoutes (line 5)
+  │ [function] serializeRecentLog (line 71)
+
+📁 packages/backend/src/routes/management/test.ts:
+  │ [function] registerTestRoutes (line 17)
+
+📁 packages/backend/src/routes/management/usage.ts:
+  │ [class] SummaryResponseTooLargeError (line 163)
+  │ [class] UsageEventsBroadcaster (line 255)
+  │ [method] broadcast (line 295)
+  │ [method] constructor (line 263)
+  │ [method] dispose (line 284)
+  │ [function] registerUsageRoutes (line 303)
+  │ [method] subscribe (line 265)
+
+📁 packages/backend/src/routes/management/user-quotas.ts:
+  │ [function] registerUserQuotaRoutes (line 9)
+
+📁 packages/backend/src/routes/mcp/index.ts:
+  │ [function] authErrorResponse (line 43)
+  │ [function] extractBearerCredential (line 62)
+  │ [function] getStringHeader (line 57)
+  │ [function] mcpOAuthFallbackAuth (line 79)
+  │ [function] oauthUnavailableReply (line 47)
+  │ [function] registerMcpRoutes (line 221)
+  │ [function] requiredScopeForOperation (line 29)
+  │ [function] scopeAllowsOperation (line 39)
+  │ [function] setInitialOAuthChallenge (line 68)
+  │ [function] setInvalidTokenChallenge (line 75)
+  │ [function] streamUpstreamResponse (line 169)
+
+📁 packages/backend/src/routes/mcp/plexus.ts:
+  │ [class] McpToolError (line 130)
+  │ [function] appendQuery (line 1257)
+  │ [function] asObject (line 1384)
+  │ [function] asOptionalString (line 618)
+  │ [function] buildShimHeaders (line 1206)
+  │ [function] callManagementRoute (line 1215)
+  │ [method] constructor (line 134)
+  │ [function] createPlexusMcpServer (line 260)
+  │ [function] encodePathPreservingSlashes (line 1294)
+  │ [function] errorResponse (line 1328)
+  │ [function] getMcpServers (line 1390)
+  │ [function] getToolDescription (line 1394)
+  │ [function] handleConfigTool (line 622)
+  │ [function] handleDebugTool (line 433)
+  │ [function] handleKeyTool (line 786)
+  │ [function] handleMcpGatewayTool (line 978)
+  │ [function] handleModelAliasTool (line 720)
+  │ [function] handleOperationsTool (line 506)
+  │ [function] handlePlexusMcpRequest (line 190)
+  │ [function] handleProviderTool (line 647)
+  │ [function] handleQuotaCheckerTool (line 948)
+  │ [function] handleQuotaTool (line 856)
+  │ [function] handleSettingsTool (line 1074)
+  │ [function] handleSystemLogsTool (line 1143)
+  │ [function] handleToolCall (line 327)
+  │ [function] handleUsageTool (line 374)
+  │ [function] isSensitiveKey (line 1368)
+  │ [function] mapRecordResponse (line 1195)
+  │ [function] redactSecrets (line 1349)
+  │ [function] registerPlexusMcpRoutes (line 141)
+  │ [function] requireDestructiveAck (line 1301)
+  │ [function] requireId (line 1188)
+  │ [function] stripNamedId (line 1200)
+  │ [function] successResponse (line 1324)
+  │ [function] toMcpToolError (line 1268)
+  │ [function] toToolResult (line 1311)
+  │ [function] toWebRequest (line 1425)
+  │ [function] unsupportedOperation (line 1341)
+
+📁 packages/backend/src/routes/openapi.ts:
+  │ [function] registerOpenApiRoute (line 8)
+
+📁 packages/backend/src/routes/raw-passthrough.ts:
+  │ [function] applyObservedUsage (line 87)
+  │ [function] extractRawSuffix (line 42)
+  │ [function] formatDebugBody (line 126)
+  │ [function] inferObservedApiType (line 50)
+  │ [function] isTextualContentType (line 114)
+  │ [function] parseRawJsonBody (line 61)
+  │ [function] registerRawPassthroughRoutes (line 173)
+  │ [function] resolveRawModelPricing (line 73)
+  │ [function] saveCompletedUsage (line 162)
+  │ [function] waitForDrainOrClose (line 137)
+
+📁 packages/backend/src/services/compaction/compaction-service.ts:
+  │ [class] CompactionService (line 84)
+  │ [interface] MaybeCompactOpts (line 21)
+  │ [function] compactContextForSend (line 244)
+  │ [method] constructor (line 87)
+  │ [function] createScopedAbortSignal (line 59)
+  │ [method] getInstance (line 93)
+  │ [method] maybeCompact (line 109)
+  │ [method] resetForTesting (line 105)
+  │ [function] runWithTimeout (line 40)
+
+📁 packages/backend/src/services/compaction/headroom-compactor.ts:
+  │ [interface] AssistantTemplate (line 58)
+  │ [class] HeadroomCompactor (line 250)
+  │ [method] compact (line 255)
+  │ [method] constructor (line 253)
+  │ [function] fromOpenAI (line 163)
+  │ [function] parseToolArguments (line 77)
+  │ [function] toOpenAI (line 93)
+
+📁 packages/backend/src/services/compaction/native-compactor.ts:
+  │ [class] NativeCompactor (line 150)
+  │ [method] compact (line 153)
+  │ [function] compactAssistantMessage (line 96)
+  │ [function] compactJsonValue (line 18)
+  │ [function] compactText (line 41)
+  │ [function] compactToolResultMessage (line 127)
+  │ [function] compactUserMessage (line 64)
+
+📁 packages/backend/src/services/compaction/resolve-settings.ts:
+  │ [function] pick (line 11)
+  │ [function] resolveCompactionSettings (line 26)
+
+📁 packages/backend/src/services/compaction/types.ts:
+  │ [interface] CompactionResult (line 28)
+  │ [interface] CompactionSettings (line 5)
+  │ [interface] CompactionStrategy (line 43)
+  │ [interface] CompactionStrategyContext (line 37)
+  │ [interface] ResolvedCompactionSettings (line 17)
+  │ [method] compact (line 46)
+
+📁 packages/backend/src/services/configuration/backup-service.ts:
+  │ [class] BackupService (line 283)
+  │ [interface] ConfigBackupData (line 43)
+  │ [interface] ConfigBackupEnvelope (line 34)
+  │ [interface] RestoreResult (line 61)
+  │ [function] buildBunArchive (line 167)
+  │ [function] csvEscape (line 72)
+  │ [function] csvValueToDb (line 123)
+  │ [method] exportConfigBackup (line 287)
+  │ [method] exportFullBackup (line 332)
+  │ [method] getSchemaTableMap (line 663)
+  │ [function] normaliseForCsv (line 96)
+  │ [function] readBunArchive (line 172)
+  │ [method] restoreConfigBackup (line 398)
+  │ [method] restoreFromArchive (line 497)
+  │ [method] restoreFullBackup (line 483)
+  │ [function] rowToCsvLine (line 85)
+
+📁 packages/backend/src/services/configuration/config-service.ts:
+  │ [class] ConfigService (line 37)
+  │ [method] buildProviderQuotaConfigs (line 563)
+  │ [method] clearAllData (line 361)
+  │ [method] constructor (line 52)
+  │ [method] deleteAlias (line 250)
+  │ [method] deleteAllAliases (line 256)
+  │ [method] deleteCustomChecker (line 222)
+  │ [method] deleteKey (line 271)
+  │ [method] deleteMcpServer (line 308)
+  │ [method] deleteOAuthCredentials (line 353)
+  │ [method] deleteProvider (line 236)
+  │ [method] deleteUserQuota (line 294)
+  │ [method] disableTimeBoundKey (line 277)
+  │ [method] doRebuild (line 493)
+  │ [method] dropRetiredOAuthProviders (line 156)
+  │ [method] executeRebuild (line 475)
+  │ [method] exportConfig (line 395)
+  │ [method] flush (line 424)
+  │ [method] getAllOAuthProviders (line 357)
+  │ [method] getAllSettings (line 332)
+  │ [method] getConfig (line 190)
+  │ [method] getCustomChecker (line 208)
+  │ [method] getCustomCheckers (line 204)
+  │ [method] getInstance (line 56)
+  │ [method] getOAuthCredentials (line 338)
+  │ [method] getRepository (line 200)
+  │ [method] getSetting (line 328)
+  │ [method] importFromAuthJson (line 371)
+  │ [method] initialize (line 85)
+  │ [method] isOAuthProvider (line 613)
+  │ [method] migrateLegacyTargetGroups (line 97)
+  │ [method] migrateModelTypes (line 116)
+  │ [method] rebuildCache (line 443)
+  │ [method] repairCorruptedAliasFallbackSlugs (line 135)
+  │ [method] resetInstance (line 63)
+  │ [method] saveAlias (line 244)
+  │ [method] saveCustomChecker (line 212)
+  │ [method] saveKey (line 265)
+  │ [method] saveMcpServer (line 302)
+  │ [method] saveProvider (line 230)
+  │ [method] saveUserQuota (line 288)
+  │ [method] setInstanceForTesting (line 72)
+  │ [method] setOAuthCredentials (line 345)
+  │ [method] setSetting (line 316)
+  │ [method] setSettingsBulk (line 322)
+
+📁 packages/backend/src/services/dispatch/adapter-resolver.ts:
+  │ [function] isAnthropicTargetProvider (line 168)
+  │ [function] isGpt5Model (line 214)
+  │ [function] resolveAdapters (line 45)
+  │ [function] resolveImplicitAdapters (line 115)
+  │ [function] selectDispatchUrls (line 200)
+
+📁 packages/backend/src/services/dispatch/attempt-history.ts:
+  │ [function] appendFailureAttempt (line 40)
+  │ [function] appendSkippedAttempt (line 7)
+  │ [function] appendSuccessAttempt (line 24)
+  │ [function] attachAttemptMetadata (line 62)
+  │ [function] buildAllTargetsFailedError (line 155)
+  │ [function] describeAttemptTag (line 101)
+  │ [function] formatAttemptedProvidersSummary (line 123)
+
+📁 packages/backend/src/services/dispatch/dispatcher-auto-compat.ts:
+  │ [interface] AdvisorResultStripResult (line 1055)
+  │ [interface] AdvisorResultStripState (line 1166)
+  │ [interface] DeleteDottedPathResult (line 542)
+  │ [interface] LiteToolStripResult (line 1255)
+  │ [interface] LiteToolStripState (line 1289)
+  │ [interface] ThinkingSignatureStripResult (line 827)
+  │ [interface] ThinkingSignatureStripState (line 937)
+  │ [interface] UnsupportedParamStripState (line 711)
+  │ [function] advisorElidedPlaceholder (line 1051)
+  │ [function] applyRegistryAutoCompat (line 418)
+  │ [function] contentHasBlockType (line 813)
+  │ [function] createAdvisorResultStripState (line 1170)
+  │ [function] createLiteToolStripState (line 1293)
+  │ [function] createThinkingSignatureStripState (line 941)
+  │ [function] createUnsupportedParamStripState (line 716)
+  │ [function] deleteDottedPath (line 605)
+  │ [function] extractGenerationIntent (line 138)
+  │ [function] extractReasoningIntent (line 72)
+  │ [function] hasCodexResponsesExtensions (line 23)
+  │ [function] hasOwn (line 11)
+  │ [function] isAdvisorInvocationBlock (line 1039)
+  │ [function] isAdvisorResultBlock (line 1035)
+  │ [function] isAnthropicMessagesPayload (line 801)
+  │ [function] isCanonicalArrayIndex (line 538)
+  │ [function] isStructuralArrayElementPath (line 703)
+  │ [function] isThinkingBlock (line 805)
+  │ [function] mappedOffValue (line 166)
+  │ [function] mappedThinkingValue (line 160)
+  │ [function] matchAdvisorResultError (line 1030)
+  │ [function] matchLiteUnsupportedToolsError (line 1250)
+  │ [function] matchThinkingSignatureError (line 786)
+  │ [function] matchUnsupportedParameter (line 518)
+  │ [function] normalizeBracketSegments (line 509)
+  │ [function] normalizeReasoningFromUnified (line 55)
+  │ [function] planAdvisorResultStrip (line 1186)
+  │ [function] planLiteToolStrip (line 1308)
+  │ [function] planThinkingSignatureStrip (line 959)
+  │ [function] planUnsupportedParamStrip (line 741)
+  │ [function] projectAnthropicAutoCompat (line 361)
+  │ [function] projectGeminiAutoCompat (line 393)
+  │ [function] projectOpenAiCompletionsAutoCompat (line 175)
+  │ [function] projectResponsesAutoCompat (line 331)
+  │ [function] reasoningElidedPlaceholder (line 823)
+  │ [function] refundAdvisorResultStrip (line 1209)
+  │ [function] refundThinkingSignatureStrip (line 989)
+  │ [function] resolveChatTemplateKwargValue (line 318)
+  │ [function] resolveChatTemplateKwargs (line 306)
+  │ [function] shouldDropTemperature (line 171)
+  │ [function] stripAdvisorResultBlocks (line 1088)
+  │ [function] stripLiteUnsupportedTools (line 1273)
+  │ [function] stripThinkingSignatureBlocks (line 871)
+
+📁 packages/backend/src/services/dispatch/dispatcher-types.ts:
+  │ [interface] RetryAttemptRecord (line 1)
+
+📁 packages/backend/src/services/dispatch/dispatcher.ts:
+  │ [class] Dispatcher (line 70)
+  │ [interface] ParseFailureContext (line 57)
+  │ [interface] RetryHistoryLikeEntry (line 62)
+  │ [method] appendFailureAttempt (line 439)
+  │ [method] appendSkippedAttempt (line 373)
+  │ [method] appendSuccessAttempt (line 431)
+  │ [method] applyGeminiThinkingConfig (line 581)
+  │ [method] applyQuotaFilter (line 398)
+  │ [method] attachAttemptMetadata (line 363)
+  │ [method] buildAllTargetsFailedError (line 456)
+  │ [method] buildCancelledError (line 606)
+  │ [method] buildRequestUrl (line 629)
+  │ [method] buildSseFrameRewriteTransform (line 938)
+  │ [method] buildSseRewriteTransform (line 900)
+  │ [method] buildTimeoutError (line 597)
+  │ [method] compactProviderErrorSummary (line 138)
+  │ [method] createAttemptTimeout (line 589)
+  │ [method] dispatch (line 331)
+  │ [method] dispatchEmbeddings (line 1044)
+  │ [method] dispatchImageEdits (line 1064)
+  │ [method] dispatchImageGenerations (line 1058)
+  │ [method] dispatchSpeech (line 1054)
+  │ [method] dispatchTranscription (line 1048)
+  │ [method] emitRoutingUpdate (line 297)
+  │ [method] enrichResponseWithMetadata (line 822)
+  │ [method] executeProviderRequest (line 651)
+  │ [method] extractFailureReason (line 155)
+  │ [method] extractResponseHeaders (line 811)
+  │ [method] formatClientProviderError (line 150)
+  │ [method] formatFailureReason (line 223)
+  │ [method] getApiMetadata (line 566)
+  │ [method] getMediaDispatcher (line 111)
+  │ [method] getRequestManager (line 75)
+  │ [method] getUsageStorage (line 280)
+  │ [method] handleNonStreamingResponse (line 965)
+  │ [method] handleProviderError (line 695)
+  │ [method] handleStreamingResponse (line 841)
+  │ [method] isPiAiRoute (line 585)
+  │ [method] isQuotaExhaustedError (line 667)
+  │ [method] isRetryableNetworkError (line 350)
+  │ [method] isRetryableStatus (line 346)
+  │ [method] parseJsonResponseBody (line 470)
+  │ [method] probeStreamingStart (line 354)
+  │ [method] recordAttemptMetric (line 241)
+  │ [method] recordStickySession (line 313)
+  │ [method] resolveBaseUrl (line 577)
+  │ [method] saveIntermediateError (line 284)
+  │ [method] selectTargetApiType (line 570)
+  │ [method] setUsageStorage (line 276)
+  │ [method] setupHeaders (line 552)
+  │ [method] transformRequestPayload (line 616)
+
+📁 packages/backend/src/services/dispatch/embeddings-transformer-factory.ts:
+  │ [class] EmbeddingsTransformerFactory (line 12)
+  │ [method] getTransformer (line 30)
+  │ [method] resolveTransformer (line 23)
+
+📁 packages/backend/src/services/dispatch/empty-completion.ts:
+  │ [interface] CompletionVisibilitySignals (line 41)
+  │ [interface] StreamVisibilityTracker (line 200)
+  │ [function] countClientToolCalls (line 143)
+  │ [function] countRawImageGenerationCalls (line 123)
+  │ [function] countTypedImageGenerationCalls (line 104)
+  │ [function] createStreamVisibilityTracker (line 209)
+  │ [function] getResponseVisibilitySignals (line 148)
+  │ [function] hasVisibleText (line 66)
+  │ [function] isEmptyCompletion (line 54)
+  │ [function] isEmptyUnifiedResponse (line 189)
+  │ [function] isRetryableEmptyFinishReason (line 172)
+  │ [function] isStreamEmpty (line 263)
+  │ [function] observeStreamChunk (line 231)
+
+📁 packages/backend/src/services/dispatch/failover-policy.ts:
+  │ [function] isRetryableNetworkError (line 36)
+  │ [function] isRetryableOAuthError (line 6)
+  │ [function] isRetryableStatus (line 1)
+
+📁 packages/backend/src/services/dispatch/image-transformer-factory.ts:
+  │ [class] ImageGenerationTransformerFactory (line 11)
+  │ [method] getTransformer (line 12)
+  │ [method] resolveTransformer (line 30)
+
+📁 packages/backend/src/services/dispatch/media-dispatcher.ts:
+  │ [interface] MediaDispatchHost (line 123)
+  │ [class] MediaDispatcher (line 154)
+  │ [method] appendFailureAttempt (line 142)
+  │ [method] appendSkippedAttempt (line 140)
+  │ [method] appendSuccessAttempt (line 141)
+  │ [function] applyImageProviderPreferences (line 32)
+  │ [method] applyQuotaFilter (line 134)
+  │ [method] attachAttemptMetadata (line 143)
+  │ [method] buildAllTargetsFailedError (line 144)
+  │ [method] constructor (line 155)
+  │ [method] dispatchEmbeddings (line 164)
+  │ [method] dispatchImageEdits (line 1218)
+  │ [method] dispatchImageGenerations (line 968)
+  │ [method] dispatchSpeech (line 667)
+  │ [method] dispatchTranscription (line 421)
+  │ [method] emitRoutingUpdate (line 145)
+  │ [method] executeProviderRequest (line 125)
+  │ [method] extractResponseHeaders (line 133)
+  │ [method] formatFailureReason (line 148)
+  │ [method] handleProviderError (line 131)
+  │ [function] imageRoutingError (line 26)
+  │ [method] isRetryableNetworkError (line 150)
+  │ [method] isRetryableStatus (line 149)
+  │ [function] mergeImagePayload (line 72)
+  │ [method] parseJsonResponseBody (line 132)
+  │ [method] probeStreamingStart (line 151)
+  │ [function] providerImageOptions (line 108)
+  │ [method] recordAttemptMetric (line 146)
+  │ [method] resolveBaseUrl (line 124)
+  │ [method] saveIntermediateError (line 147)
+
+📁 packages/backend/src/services/dispatch/raw-passthrough.ts:
+  │ [function] buildRawUpstreamHeaders (line 64)
+  │ [function] buildRawUpstreamUrl (line 34)
+  │ [function] containsEncodedDotSegment (line 18)
+  │ [function] executeRawUpstreamRequest (line 122)
+  │ [function] filterRawResponseHeaders (line 111)
+  │ [function] validateRawProviderSlug (line 14)
+
+📁 packages/backend/src/services/dispatch/request-manager.ts:
+  │ [class] RequestManager (line 59)
+  │ [interface] RequestManagerHost (line 30)
+  │ [method] appendFailureAttempt (line 31)
+  │ [method] appendSkippedAttempt (line 32)
+  │ [method] appendSuccessAttempt (line 33)
+  │ [method] attachAttemptMetadata (line 34)
+  │ [method] buildAllTargetsFailedError (line 35)
+  │ [method] buildCancelledError (line 36)
+  │ [method] buildRequestUrl (line 37)
+  │ [method] buildTimeoutError (line 38)
+  │ [method] constructor (line 60)
+  │ [method] createAttemptTimeout (line 39)
+  │ [method] dispatch (line 62)
+  │ [method] emitRoutingUpdate (line 40)
+  │ [method] executeProviderRequest (line 41)
+  │ [method] formatFailureReason (line 42)
+  │ [method] getUsageStorage (line 43)
+  │ [method] handleNonStreamingResponse (line 44)
+  │ [method] handleProviderError (line 45)
+  │ [method] handleStreamingResponse (line 46)
+  │ [method] isPiAiRoute (line 47)
+  │ [method] isRetryableNetworkError (line 48)
+  │ [method] isRetryableStatus (line 49)
+  │ [method] probeStreamingStart (line 50)
+  │ [method] recordAttemptMetric (line 51)
+  │ [method] recordStickySession (line 52)
+  │ [method] saveIntermediateError (line 53)
+  │ [method] selectTargetApiType (line 54)
+  │ [method] setupHeaders (line 55)
+  │ [method] transformRequestPayload (line 56)
+
+📁 packages/backend/src/services/dispatch/request-payload-builder.ts:
+  │ [interface] RequestPayload (line 53)
+  │ [function] buildRequestPayload (line 105)
+  │ [function] isNativeOAuthRoute (line 37)
+  │ [function] isOAuthRouteForNative (line 44)
+  │ [function] refreshOAuthRoute (line 355)
+  │ [function] shouldUsePassThrough (line 58)
+
+📁 packages/backend/src/services/dispatch/standard-attempt-request.ts:
+  │ [interface] StandardAttemptContext (line 64)
+  │ [function] deriveProbeStallConfig (line 49)
+  │ [function] executeStandardAttempt (line 88)
+
+📁 packages/backend/src/services/dispatch/transformer-factory.ts:
+  │ [class] TransformerFactory (line 22)
+  │ [method] getTransformer (line 23)
+
+📁 packages/backend/src/services/dispatch/upstream-execution.ts:
+  │ [function] createAttemptTimeout (line 14)
+  │ [function] executeUpstreamRequest (line 36)
+  │ [function] probeStreamingStart (line 51)
+
+📁 packages/backend/src/services/inspectors/base.ts:
+  │ [class] BaseInspector (line 3)
+  │ [method] constructor (line 6)
+  │ [method] createInspector (line 10)
+
+📁 packages/backend/src/services/inspectors/debug-logging.ts:
+  │ [class] DebugLoggingInspector (line 14)
+  │ [method] captureChunk (line 64)
+  │ [method] constructor (line 27)
+  │ [method] createInspector (line 36)
+  │ [method] extractProviderCostFromSSEComments (line 202)
+  │ [method] extractProviderEnergyFromSSEComments (line 226)
+  │ [method] finalize (line 138)
+  │ [method] initializeResponsesTerminalEventDetection (line 103)
+  │ [method] mapOAuthUsage (line 545)
+  │ [method] reconstructChatCompletions (line 245)
+  │ [method] reconstructGemini (line 403)
+  │ [method] reconstructMessages (line 350)
+  │ [method] reconstructOAuth (line 454)
+  │ [method] reconstructResponses (line 297)
+  │ [method] saveRawResponse (line 180)
+  │ [method] saveReconstructedResponse (line 188)
+  │ [method] updateChatCompletionsSnapshot (line 710)
+  │ [method] updateGeminiSnapshot (line 560)
+  │ [method] updateMessagesSnapshot (line 625)
+  │ [method] updateResponsesSnapshot (line 785)
+
+📁 packages/backend/src/services/inspectors/stall-inspector.ts:
+  │ [interface] ByteSample (line 28)
+  │ [interface] StallConfig (line 41)
+  │ [class] StallInspector (line 67)
+  │ [method] _destroy (line 191)
+  │ [method] _flush (line 196)
+  │ [method] _transform (line 144)
+  │ [method] checkThroughput (line 296)
+  │ [method] constructor (line 88)
+  │ [method] consumeResponseBlock (line 230)
+  │ [method] consumeResponseChunk (line 210)
+  │ [method] getConfig (line 140)
+  │ [method] isResponsesStream (line 206)
+  │ [method] onGracePeriodEnd (line 273)
+  │ [method] setProgressApiType (line 132)
+  │ [method] setRequestId (line 127)
+  │ [method] transitionToGracePeriod (line 256)
+  │ [method] updateConfig (line 111)
+
+📁 packages/backend/src/services/inspectors/usage-logging.ts:
+  │ [interface] ExtractedObservedUsage (line 18)
+  │ [class] UsageInspector (line 92)
+  │ [method] _destroy (line 333)
+  │ [method] _flush (line 149)
+  │ [method] _transform (line 140)
+  │ [method] constructor (line 112)
+  │ [method] deepSearchToolCalls (line 573)
+  │ [method] extractResponseMetadataFromReconstructed (line 418)
+  │ [function] extractUsageFromReconstructed (line 26)
+  │ [method] finalize (line 154)
+  │ [method] readObservedUsage (line 404)
+
+📁 packages/backend/src/services/mcp-local/mcp-process-manager.ts:
+  │ [interface] LocalMcpRuntimeStatus (line 6)
+  │ [interface] LocalProcessState (line 16)
+  │ [class] McpProcessManager (line 41)
+  │ [method] appendLog (line 311)
+  │ [method] buildChildEnv (line 258)
+  │ [method] consumeStream (line 283)
+  │ [method] ensureRunning (line 49)
+  │ [method] getConfigFingerprint (line 270)
+  │ [method] getLocalUrl (line 44)
+  │ [method] getLogs (line 133)
+  │ [method] getState (line 316)
+  │ [method] getStatus (line 120)
+  │ [method] restart (line 115)
+  │ [method] start (line 85)
+  │ [method] startInternal (line 141)
+  │ [method] stop (line 91)
+  │ [method] stopAll (line 137)
+  │ [method] waitForReady (line 226)
+
+📁 packages/backend/src/services/mcp-oauth/plexus-idp-provider.ts:
+  │ [class] PlexusIdpProvider (line 200)
+  │ [function] appendQuery (line 187)
+  │ [function] constrainScopes (line 117)
+  │ [method] constructor (line 201)
+  │ [function] getBodyOrQuery (line 145)
+  │ [method] getCurrentApiKeySecretHash (line 596)
+  │ [method] getDiscoveryMetadata (line 203)
+  │ [method] getProtectedResourceMetadata (line 219)
+  │ [function] getSingleValue (line 141)
+  │ [method] handleAuthorizationCodeGrant (line 430)
+  │ [method] handleAuthorize (line 290)
+  │ [method] handleRefreshTokenGrant (line 489)
+  │ [method] handleRegister (line 229)
+  │ [method] handleToken (line 386)
+  │ [function] htmlEscape (line 132)
+  │ [method] isApiKeyCurrentlyValid (line 611)
+  │ [function] isLoopbackRedirectUri (line 156)
+  │ [method] isTokenBoundToCurrentApiKeySecret (line 602)
+  │ [method] issueToken (line 550)
+  │ [function] oauthError (line 183)
+  │ [function] randomToken (line 96)
+  │ [function] redirectUriMatches (line 169)
+  │ [method] renderConsent (line 627)
+  │ [method] resolveAuthorizationKey (line 852)
+  │ [method] resourceMatchesMcpServer (line 617)
+  │ [function] splitScopes (line 100)
+  │ [function] toScopeString (line 108)
+  │ [function] validatePkce (line 178)
+  │ [method] validateToken (line 407)
+  │ [method] wantsJsonResponse (line 841)
+
+📁 packages/backend/src/services/mcp-oauth/provider-factory.ts:
+  │ [function] getMcpAuthProvider (line 12)
+  │ [function] isMcpOAuthEnabled (line 8)
+  │ [function] resetMcpAuthProviderForTesting (line 29)
+
+📁 packages/backend/src/services/mcp-oauth/types.ts:
+  │ [interface] AuthProvider (line 23)
+  │ [interface] OAuthDiscoveryMetadata (line 3)
+  │ [interface] ProtectedResourceMetadata (line 16)
+  │ [method] getDiscoveryMetadata (line 24)
+  │ [method] getProtectedResourceMetadata (line 25)
+  │ [method] handleAuthorize (line 26)
+  │ [method] handleRegister (line 28)
+  │ [method] handleToken (line 27)
+  │ [method] validateToken (line 29)
+
+📁 packages/backend/src/services/mcp-oauth/url.ts:
+  │ [function] getMcpProtectedResourceMetadataUrl (line 39)
+  │ [function] getMcpResourceUrl (line 33)
+  │ [function] getMcpServerNameFromRequest (line 26)
+  │ [function] getMcpServerNameFromResource (line 45)
+  │ [function] getRequestBaseUrl (line 10)
+  │ [function] isAllowedRedirectUri (line 80)
+  │ [function] normalizeBaseUrl (line 4)
+  │ [function] resourceMatchesExpected (line 69)
+
+📁 packages/backend/src/services/mcp-proxy/mcp-proxy-service.ts:
+  │ [interface] McpKey (line 29)
+  │ [interface] McpServerKeyConfig (line 34)
+  │ [function] cooldownMcpKey (line 108)
+  │ [function] extractJsonRpcMethod (line 235)
+  │ [function] extractJsonRpcMethods (line 226)
+  │ [function] extractToolName (line 333)
+  │ [function] filterClientAuthHeaders (line 211)
+  │ [function] filterHopByHopHeaders (line 155)
+  │ [function] getActiveMcpKeys (line 70)
+  │ [function] getEffectiveUpstreamUrl (line 148)
+  │ [function] getMcpServerConfig (line 118)
+  │ [function] injectMcpKeyAuth (line 51)
+  │ [function] mergeUpstreamHeaders (line 181)
+  │ [function] proxyMcpRequest (line 353)
+  │ [function] redactSensitiveHeaders (line 196)
+  │ [function] requestsToolsList (line 239)
+  │ [function] sanitizeToolsListTtlStream (line 272)
+  │ [function] selectMcpKeyRoundRobin (line 41)
+  │ [function] stripZeroTtlFromToolsListResult (line 255)
+  │ [function] validateServerName (line 143)
+
+📁 packages/backend/src/services/mcp-proxy/mcp-usage-storage.ts:
+  │ [interface] McpDebugLogRecord (line 28)
+  │ [interface] McpRequestUsageRecord (line 8)
+  │ [class] McpUsageStorageService (line 37)
+  │ [method] constructor (line 40)
+  │ [method] ensureDb (line 42)
+  │ [method] getLogs (line 113)
+  │ [method] getMcpSchema (line 49)
+  │ [method] saveDebugLog (line 92)
+  │ [method] saveRequest (line 58)
+
+📁 packages/backend/src/services/models/enforce-limits.ts:
+  │ [interface] ContextLengthExceededDetails (line 29)
+  │ [class] ContextLengthExceededError (line 43)
+  │ [interface] ContextLimitOptions (line 136)
+  │ [interface] EnforceRouteInfo (line 146)
+  │ [method] constructor (line 46)
+  │ [function] enforceContextLimit (line 68)
+  │ [function] enforceContextLimitForContext (line 176)
+  │ [function] enforceContextLimitForRoute (line 156)
+  │ [function] resolveContextLength (line 130)
+  │ [function] resolveMetadata (line 17)
+
+📁 packages/backend/src/services/models/model-autosync-scheduler.ts:
+  │ [interface] AutosyncConfig (line 8)
+  │ [class] ModelAutosyncScheduler (line 14)
+  │ [method] constructor (line 22)
+  │ [method] getInstance (line 24)
+  │ [method] initialize (line 35)
+  │ [method] isInitialized (line 114)
+  │ [method] reload (line 44)
+  │ [method] resetInstance (line 31)
+  │ [method] runSyncNow (line 79)
+  │ [method] schedule (line 129)
+  │ [method] stop (line 118)
+  │ [method] unschedule (line 138)
+
+📁 packages/backend/src/services/models/model-behaviors.ts:
+  │ [interface] BehaviorContext (line 20)
+  │ [function] applyBehavior (line 49)
+  │ [function] applyModelBehaviors (line 31)
+  │ [function] applyStripAdaptiveThinking (line 78)
+
+📁 packages/backend/src/services/models/model-metadata-manager.ts:
+  │ [interface] AutomaticModelIdentity (line 982)
+  │ [interface] CatwalkModel (line 173)
+  │ [interface] CatwalkProvider (line 187)
+  │ [interface] MetadataCatalogSources (line 11)
+  │ [interface] MetadataSourceRefreshSummary (line 17)
+  │ [class] ModelMetadataManager (line 343)
+  │ [interface] ModelMetadataRefreshResult (line 24)
+  │ [interface] ModelsDevModel (line 143)
+  │ [interface] ModelsDevProvider (line 167)
+  │ [interface] NormalizedModelMetadata (line 48)
+  │ [interface] OpenRouterRawModel (line 93)
+  │ [interface] OpenRouterResponse (line 137)
+  │ [interface] ResolvedModelMetadata (line 85)
+  │ [function] applyConfiguredModelType (line 936)
+  │ [method] constructor (line 361)
+  │ [method] fetchOrReadJson (line 647)
+  │ [method] findExactMetadata (line 714)
+  │ [method] getAllIds (line 777)
+  │ [method] getInstance (line 363)
+  │ [method] getMap (line 682)
+  │ [method] getMetadata (line 707)
+  │ [method] getOpenRouterAuxiliarySources (line 627)
+  │ [function] getProviderModelConfig (line 954)
+  │ [function] humanizeModelName (line 873)
+  │ [function] inferArchitecture (line 898)
+  │ [function] inferModelType (line 886)
+  │ [function] inferOpenRouterArchitecture (line 210)
+  │ [function] inferProviderFromModel (line 962)
+  │ [method] isAnyInitialized (line 699)
+  │ [method] isInitialized (line 695)
+  │ [method] loadAll (line 380)
+  │ [method] loadCatwalk (line 586)
+  │ [method] loadModelsDev (line 528)
+  │ [method] loadOpenRouter (line 474)
+  │ [function] mergeOverrides (line 813)
+  │ [function] normalizeCatalogProvider (line 971)
+  │ [function] normalizeCatwalkModel (line 305)
+  │ [function] normalizeModelsDevModel (line 258)
+  │ [function] normalizeOpenRouterModel (line 229)
+  │ [function] normalizeTopProvider (line 197)
+  │ [function] positiveNumber (line 193)
+  │ [method] refreshAll (line 384)
+  │ [method] resetForTesting (line 371)
+  │ [function] resolveAutomaticModelIdentity (line 988)
+  │ [function] resolveModelMetadata (line 1027)
+  │ [function] resolvePreferredApi (line 1081)
+  │ [method] search (line 733)
+  │ [method] startAutoRefresh (line 441)
+  │ [method] stopAutoRefresh (line 465)
+  │ [method] toSourceSummary (line 781)
+
+📁 packages/backend/src/services/oauth/codex-version-service.ts:
+  │ [class] CodexVersionService (line 10)
+  │ [interface] GitHubRelease (line 6)
+  │ [method] constructor (line 14)
+  │ [method] fetchVersion (line 29)
+  │ [method] getInstance (line 18)
+  │ [method] getUserAgent (line 69)
+  │ [method] getVersion (line 65)
+  │ [method] resetForTesting (line 25)
+
+📁 packages/backend/src/services/oauth/oauth-auth-manager.ts:
+  │ [interface] GetApiKeyOptions (line 60)
+  │ [class] OAuthAuthManager (line 67)
+  │ [method] constructor (line 81)
+  │ [method] deleteCredentials (line 456)
+  │ [method] forceRefresh (line 340)
+  │ [method] getApiKey (line 225)
+  │ [method] getCredentials (line 439)
+  │ [method] getInstance (line 85)
+  │ [method] hasProvider (line 447)
+  │ [method] initialize (line 96)
+  │ [method] loadFromDatabaseAsync (line 100)
+  │ [method] refreshCredentials (line 348)
+  │ [method] reload (line 486)
+  │ [method] resetForTesting (line 92)
+  │ [method] resolveAccountId (line 178)
+  │ [method] runProviderRefresh (line 401)
+  │ [method] saveToDatabase (line 155)
+  │ [method] setCredentials (line 201)
+  │ [function] waitForDelay (line 16)
+  │ [function] waitForPromise (line 34)
+
+📁 packages/backend/src/services/oauth/oauth-dispatcher.ts:
+  │ [function] isClaudeMaskingApiKeyRoute (line 27)
+  │ [function] isOAuthRoute (line 18)
+  │ [function] isPiAiRoute (line 49)
+
+📁 packages/backend/src/services/oauth/oauth-error-handler.ts:
+  │ [class] OAuthErrorHandler (line 1)
+  │ [method] handleAuthError (line 2)
+
+📁 packages/backend/src/services/oauth/oauth-login-session.ts:
+  │ [class] OAuthLoginSessionManager (line 81)
+  │ [method] cancel (line 201)
+  │ [method] cleanupExpired (line 360)
+  │ [method] constructor (line 86)
+  │ [method] createSession (line 121)
+  │ [method] dispose (line 100)
+  │ [method] findActiveSession (line 230)
+  │ [method] getInstance (line 93)
+  │ [method] getInternal (line 239)
+  │ [method] getSession (line 115)
+  │ [method] listProviders (line 111)
+  │ [method] releaseSession (line 220)
+  │ [method] runLogin (line 267)
+  │ [method] startCleanup (line 355)
+  │ [method] stripInternal (line 248)
+  │ [method] submitManualCode (line 186)
+  │ [method] submitPrompt (line 170)
+  │ [method] touch (line 263)
+
+📁 packages/backend/src/services/oauth/oauth-native-request.ts:
+  │ [interface] PreparedOAuthRequest (line 56)
+  │ [function] adornCodexResponsesBody (line 311)
+  │ [function] adornCopilotBody (line 481)
+  │ [function] buildCopilotDynamicHeaders (line 465)
+  │ [function] buildFrameReverser (line 210)
+  │ [function] copilotEndpoint (line 399)
+  │ [function] copilotWireApiType (line 621)
+  │ [function] extractChatgptAccountId (line 291)
+  │ [function] genericOAuthApiType (line 661)
+  │ [function] hasCopilotVisionInput (line 448)
+  │ [function] inferCopilotInitiator (line 435)
+  │ [function] isCodexCliShapedBody (line 250)
+  │ [function] isNativeOAuthProvider (line 580)
+  │ [function] mergeBetas (line 112)
+  │ [function] nativeOAuthApiType (line 607)
+  │ [function] prepareAnthropicOAuthRequest (line 130)
+  │ [function] prepareCodexOAuthRequest (line 332)
+  │ [function] prepareCopilotOAuthRequest (line 495)
+  │ [function] prepareGenericOAuthDispatch (line 673)
+  │ [function] prepareNativeOAuthDispatch (line 732)
+  │ [function] prepareOAuthNativeRequest (line 537)
+  │ [function] resolveCopilotBaseUrl (line 417)
+  │ [function] resolveOAuthBaseUrl (line 84)
+
+📁 packages/backend/src/services/oauth/oauth-providers.ts:
+  │ [interface] OAuthProviderDescriptor (line 25)
+  │ [function] getOAuthProviderAuth (line 60)
+  │ [function] isKnownOAuthProviderId (line 73)
+  │ [function] listOAuthProviders (line 65)
+  │ [function] toDescriptor (line 46)
+
+📁 packages/backend/src/services/observability/debug-manager.ts:
+  │ [interface] DebugLogRecord (line 7)
+  │ [class] DebugManager (line 31)
+  │ [method] addRawResponse (line 287)
+  │ [method] addReconstructedRawResponse (line 294)
+  │ [method] addResponseMeta (line 315)
+  │ [method] addTransformedRequest (line 280)
+  │ [method] addTransformedResponse (line 301)
+  │ [method] addTransformedResponseSnapshot (line 309)
+  │ [method] constructor (line 42)
+  │ [method] disableForAlias (line 133)
+  │ [method] disableForKey (line 84)
+  │ [method] discardEphemeral (line 417)
+  │ [method] enableForAlias (line 128)
+  │ [method] enableForKey (line 79)
+  │ [method] ensureLog (line 267)
+  │ [method] flush (line 339)
+  │ [method] getEnabledAliases (line 145)
+  │ [method] getEnabledKeys (line 116)
+  │ [method] getInstance (line 44)
+  │ [method] getPendingLog (line 439)
+  │ [method] getProviderFilter (line 173)
+  │ [method] getReconstructedRawResponse (line 405)
+  │ [method] getRequestModelAlias (line 246)
+  │ [method] isAliasDimensionEnabled (line 154)
+  │ [method] isCaptureEnabled (line 104)
+  │ [method] isCaptureOnError (line 74)
+  │ [method] isEnabled (line 61)
+  │ [method] isEnabledForAlias (line 149)
+  │ [method] isEnabledForKey (line 89)
+  │ [method] isEphemeral (line 398)
+  │ [method] isKeyDimensionEnabled (line 95)
+  │ [method] isProviderDimensionEnabled (line 183)
+  │ [method] markEphemeral (line 390)
+  │ [method] markForcePersist (line 380)
+  │ [method] resetForTesting (line 430)
+  │ [method] setCaptureOnError (line 69)
+  │ [method] setEnabled (line 56)
+  │ [method] setEnabledAliases (line 138)
+  │ [method] setEnabledKeys (line 120)
+  │ [method] setEnabledProviders (line 164)
+  │ [method] setModelAliasForRequest (line 195)
+  │ [method] setProviderFilter (line 160)
+  │ [method] setProviderForRequest (line 188)
+  │ [method] setStorage (line 51)
+  │ [method] shouldCapturePayloadAtStart (line 252)
+  │ [method] shouldCapturePayloadForRequest (line 262)
+  │ [method] shouldLogProvider (line 178)
+  │ [method] shouldPersistLog (line 329)
+  │ [method] startLog (line 213)
+
+📁 packages/backend/src/services/observability/pricing-manager.ts:
+  │ [interface] OpenRouterPricing (line 6)
+  │ [class] PricingManager (line 25)
+  │ [method] constructor (line 28)
+  │ [method] getAllModelSlugs (line 53)
+  │ [method] getInstance (line 30)
+  │ [method] getPricing (line 41)
+  │ [method] isInitialized (line 49)
+  │ [method] metadataManager (line 37)
+  │ [method] searchModelSlugs (line 57)
+
+📁 packages/backend/src/services/observability/request-context.ts:
+  │ [interface] RequestContext (line 10)
+  │ [function] enterRequestContext (line 22)
+  │ [function] getCurrentKeyName (line 36)
+  │ [function] getCurrentRequestId (line 43)
+  │ [function] getRequestContext (line 29)
+  │ [function] runInRequestContext (line 65)
+  │ [function] setCurrentRequestId (line 55)
+
+📁 packages/backend/src/services/observability/usage-storage.ts:
+  │ [interface] PaginationOptions (line 47)
+  │ [interface] ProgressUpdate (line 11)
+  │ [interface] UsageFilters (line 25)
+  │ [class] UsageStorageService (line 64)
+  │ [method] constructor (line 100)
+  │ [method] deleteAllDebugLogs (line 547)
+  │ [method] deleteAllErrors (line 453)
+  │ [method] deleteAllUsageLogs (line 772)
+  │ [method] deleteDebugLog (line 535)
+  │ [method] deleteError (line 441)
+  │ [method] deletePerformanceByModel (line 790)
+  │ [method] deleteUsageLog (line 760)
+  │ [method] deregisterInFlight (line 83)
+  │ [method] emitStarted (line 208)
+  │ [method] emitStartedAsync (line 185)
+  │ [method] emitUpdated (line 253)
+  │ [method] emitUpdatedAsync (line 189)
+  │ [method] enqueueTelemetryTask (line 193)
+  │ [method] ensureDb (line 104)
+  │ [method] getDb (line 112)
+  │ [method] getDebugLog (line 504)
+  │ [method] getDebugLogOwner (line 427)
+  │ [method] getDebugLogs (line 464)
+  │ [method] getErrorOwner (line 413)
+  │ [method] getErrors (line 388)
+  │ [method] getPerformanceRetentionLimit (line 116)
+  │ [method] getProgressUpdates (line 87)
+  │ [method] getProviderPerformance (line 949)
+  │ [method] getUsage (line 558)
+  │ [method] normalizeErrorDetails (line 312)
+  │ [method] recordFailedAttempt (line 911)
+  │ [method] recordSuccessfulAttempt (line 873)
+  │ [method] registerInFlight (line 74)
+  │ [method] saveDebugLog (line 281)
+  │ [method] saveError (line 337)
+  │ [method] saveRequest (line 127)
+  │ [method] updatePerformanceMetrics (line 806)
+
+📁 packages/backend/src/services/pi-ai/catalog.ts:
+  │ [interface] CatalogRefreshResult (line 248)
+  │ [class] FileModelsStore (line 155)
+  │ [class] MemoryModelsStore (line 133)
+  │ [interface] ModelCatalog (line 255)
+  │ [interface] ModelCatalogDeps (line 238)
+  │ [method] constructor (line 160)
+  │ [function] createDefaultStore (line 458)
+  │ [function] createModelCatalog (line 281)
+  │ [function] defaultModelsStorePath (line 215)
+  │ [method] delete (line 145)
+  │ [method] delete (line 172)
+  │ [method] dispose (line 264)
+  │ [function] fetchPiDevCatalog (line 74)
+  │ [function] getCatalogModel (line 464)
+  │ [function] getCatalogModels (line 469)
+  │ [method] getModel (line 276)
+  │ [function] getModelCatalog (line 445)
+  │ [method] getModels (line 278)
+  │ [method] init (line 262)
+  │ [function] initModelCatalog (line 478)
+  │ [method] load (line 177)
+  │ [function] parseCatalog (line 51)
+  │ [method] persist (line 193)
+  │ [method] read (line 136)
+  │ [method] read (line 162)
+  │ [method] refresh (line 270)
+  │ [function] resetModelCatalogForTesting (line 453)
+  │ [function] withRemoteCatalog (line 104)
+  │ [method] write (line 141)
+  │ [method] write (line 167)
+
+📁 packages/backend/src/services/pi-ai/generation.ts:
+  │ [interface] GenerationIntent (line 24)
+  │ [function] normalizeVerbosity (line 38)
+
+📁 packages/backend/src/services/pi-ai/reasoning.ts:
+  │ [interface] ReasoningIntent (line 43)
+  │ [function] budgetToEffort (line 117)
+  │ [function] clampEffortToWindow (line 285)
+  │ [function] effortToBudget (line 106)
+  │ [function] getReasoningLogValue (line 176)
+  │ [function] intentToEffort (line 315)
+  │ [function] normalizeEffort (line 128)
+  │ [function] normalizeVisibility (line 259)
+  │ [function] reasoningIntentToLogValue (line 156)
+  │ [function] splitReasoningSuffix (line 333)
+
+📁 packages/backend/src/services/pi-ai/registry.ts:
+  │ [function] buildEnabledOptions (line 172)
+  │ [function] buildGenerationOptions (line 280)
+  │ [function] buildReasoningOptionsForModel (line 123)
+  │ [function] isOpenAiFamily (line 321)
+  │ [function] isPlaceholderThinkingSignature (line 362)
+  │ [function] modelSupportsDisable (line 117)
+  │ [function] resolveBaseUrl (line 52)
+  │ [function] resolvePiAiModel (line 334)
+
+📁 packages/backend/src/services/probes/probe-request.ts:
+  │ [function] buildProbeChatRequest (line 103)
+
+📁 packages/backend/src/services/probes/probe-service.ts:
+  │ [interface] ProbeResult (line 35)
+  │ [class] ProbeService (line 99)
+  │ [interface] RunProbeArgs (line 27)
+  │ [function] buildSecondaryRequest (line 52)
+  │ [method] constructor (line 100)
+  │ [method] runProbe (line 105)
+
+📁 packages/backend/src/services/probes/stream-probe.ts:
+  │ [function] concatChunks (line 4)
+  │ [function] parseInitialStreamError (line 22)
+  │ [function] probeStreamingStart (line 158)
+  │ [function] probeStreamingStartWithStallCheck (line 295)
+
+📁 packages/backend/src/services/providers/provider-api-selection.ts:
+  │ [function] applyGeminiThinkingConfig (line 180)
+  │ [function] getApiMetadata (line 23)
+  │ [function] resolveImageProviderBaseUrl (line 99)
+  │ [function] resolveProviderBaseUrl (line 115)
+  │ [function] selectTargetApiType (line 32)
+  │ [function] stripTrailingApiVersion (line 19)
+
+📁 packages/backend/src/services/providers/provider-cooldown.ts:
+  │ [function] parseCooldownDurationForProvider (line 30)
+  │ [function] resolveCooldownProviderType (line 6)
+
+📁 packages/backend/src/services/providers/provider-model-discovery.ts:
+  │ [interface] DiscoveredModel (line 5)
+  │ [function] deriveModelsUrl (line 152)
+  │ [function] discoverProviderModelIds (line 185)
+  │ [function] discoverProviderModels (line 172)
+  │ [function] fetchModelsFromUrl (line 92)
+  │ [function] getOAuthProviderModels (line 138)
+  │ [function] isAnthropicApiUrl (line 18)
+  │ [function] normalizeModelsResponse (line 61)
+  │ [function] validateUrlSafety (line 26)
+
+📁 packages/backend/src/services/providers/provider-request-headers.ts:
+  │ [function] setupProviderHeaders (line 8)
+
+📁 packages/backend/src/services/quota/checker-registry.ts:
+  │ [interface] AllowanceParams (line 37)
+  │ [interface] BalanceParams (line 25)
+  │ [interface] CheckerDefinition (line 55)
+  │ [interface] MeterContext (line 13)
+  │ [method] allowance (line 22)
+  │ [method] balance (line 21)
+  │ [method] check (line 59)
+  │ [function] defineChecker (line 79)
+  │ [method] fetch (line 20)
+  │ [function] getCheckerDefinition (line 94)
+  │ [function] getCheckerDefinitions (line 90)
+  │ [function] getCheckerTypes (line 86)
+  │ [method] getOption (line 17)
+  │ [function] isCheckerRegistered (line 98)
+  │ [function] registerCheckerDefinition (line 67)
+  │ [method] requestHeaders (line 19)
+  │ [method] requireOption (line 18)
+  │ [function] validateCheckerOptions (line 102)
+
+📁 packages/backend/src/services/quota/checkers/apertis-checker.ts:
+  │ [interface] ApertisBillingCreditsResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/claude-code-checker.ts:
+  │ [interface] ScopedLimit (line 37)
+  │ [function] isSameLimit (line 60)
+  │ [function] legacyScopedLimits (line 130)
+  │ [function] normalizeName (line 53)
+  │ [function] parseIsoDate (line 161)
+  │ [function] reconcileScopedLimits (line 66)
+  │ [function] resolveApiKey (line 171)
+  │ [function] scopedLimitFromEntry (line 100)
+  │ [function] scopedLimitFromLegacy (line 87)
+  │ [function] scopedLimitsFromResponse (line 139)
+  │ [function] scopedWindowKey (line 118)
+  │ [function] uniqueWindowKey (line 122)
+
+📁 packages/backend/src/services/quota/checkers/cline-checker.ts:
+  │ [interface] ClineApiEnvelope (line 36)
+  │ [interface] ClineBalanceResponse (line 8)
+  │ [interface] ClineSubscriptionPlan (line 13)
+  │ [interface] ClineUserCurrentPlan (line 24)
+  │ [function] clineRequest (line 42)
+
+📁 packages/backend/src/services/quota/checkers/copilot-checker.ts:
+  │ [interface] CopilotUsageResponse (line 7)
+  │ [function] resolveApiKey (line 18)
+
+📁 packages/backend/src/services/quota/checkers/crof-checker.ts:
+  │ [interface] CrofUsageResponse (line 4)
+
+📁 packages/backend/src/services/quota/checkers/deepseek-checker.ts:
+  │ [interface] DeepSeekBalanceInfo (line 5)
+  │ [interface] DeepSeekBalanceResponse (line 12)
+
+📁 packages/backend/src/services/quota/checkers/devpass-checker.ts:
+  │ [interface] DevPassUsageResponse (line 5)
+  │ [function] addMonths (line 31)
+  │ [function] toNumber (line 25)
+
+📁 packages/backend/src/services/quota/checkers/exedev-checker.ts:
+  │ [interface] ExeDevCreditsResponse (line 5)
+  │ [function] parseResetTimestamp (line 27)
+
+📁 packages/backend/src/services/quota/checkers/hyper-checker.ts:
+  │ [interface] HyperCreditsResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/kilo-checker.ts:
+  │ [interface] KiloBalanceResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/kimi-code-checker.ts:
+  │ [interface] KimiLimit (line 12)
+  │ [interface] KimiUsage (line 5)
+  │ [interface] KimiUsageResponse (line 17)
+  │ [function] resolvePeriod (line 22)
+
+📁 packages/backend/src/services/quota/checkers/minimax-checker.ts:
+  │ [interface] MiniMaxBalanceResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/minimax-coding-checker.ts:
+  │ [interface] MiniMaxCodingModelRemain (line 5)
+  │ [interface] MiniMaxCodingResponse (line 14)
+
+📁 packages/backend/src/services/quota/checkers/moonshot-checker.ts:
+  │ [interface] MoonshotBalanceResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/naga-checker.ts:
+  │ [interface] NagaBalanceResponse (line 4)
+
+📁 packages/backend/src/services/quota/checkers/nanogpt-checker.ts:
+  │ [interface] NanoGPTQuotaResponse (line 11)
+  │ [interface] NanoGPTUsageWindow (line 5)
+  │ [function] normalizeApiKey (line 26)
+
+📁 packages/backend/src/services/quota/checkers/neuralwatt-checker.ts:
+  │ [interface] NeuralwattQuotaResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/novita-checker.ts:
+  │ [interface] NovitaBalanceResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/ollama-checker.ts:
+  │ [function] extractUsage (line 5)
+
+📁 packages/backend/src/services/quota/checkers/openai-codex-checker.ts:
+  │ [interface] CodexRateLimitInfo (line 16)
+  │ [interface] CodexUsageResponse (line 23)
+  │ [interface] CodexUsageWindow (line 10)
+  │ [interface] OAuthCredentialsBlob (line 32)
+  │ [function] buildMeterFromWindow (line 75)
+  │ [function] extractChatGPTAccountId (line 49)
+  │ [function] parseAccessToken (line 36)
+  │ [function] resolveApiKey (line 95)
+  │ [function] resolveCodexAccountId (line 129)
+  │ [function] windowPeriod (line 65)
+
+📁 packages/backend/src/services/quota/checkers/opencode-go-checker.ts:
+  │ [interface] OpenCodeGoWindow (line 10)
+  │ [function] parseWindowUsage (line 15)
+
+📁 packages/backend/src/services/quota/checkers/openrouter-checker.ts:
+  │ [interface] OpenRouterCreditsResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/poe-checker.ts:
+  │ [interface] PoeBalanceResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/routing-run-checker.ts:
+  │ [interface] RoutingRunRequestsResponse (line 4)
+  │ [function] requireNumber (line 17)
+
+📁 packages/backend/src/services/quota/checkers/sakana-checker.ts:
+  │ [interface] UsageWindow (line 8)
+  │ [function] extractCreditBalance (line 38)
+  │ [function] extractUsageWindow (line 13)
+
+📁 packages/backend/src/services/quota/checkers/synthetic-checker.ts:
+  │ [interface] SyntheticQuotaResponse (line 4)
+  │ [function] parseCredits (line 25)
+
+📁 packages/backend/src/services/quota/checkers/wafer-checker.ts:
+  │ [interface] WaferQuotaResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/wisdomgate-checker.ts:
+  │ [interface] WisdomGateUsageResponse (line 5)
+
+📁 packages/backend/src/services/quota/checkers/zai-checker.ts:
+  │ [interface] ZAILimit (line 5)
+  │ [interface] ZAIQuotaResponse (line 14)
+
+📁 packages/backend/src/services/quota/checkers/zenmux-checker.ts:
+  │ [interface] ZenmuxQuotaResponse (line 5)
+
+📁 packages/backend/src/services/quota/custom-checker-runtime.ts:
+  │ [class] CustomCheckerError (line 58)
+  │ [function] buildCustomCheckerHeaders (line 12)
+  │ [method] constructor (line 59)
+  │ [function] createCustomCheckerFetch (line 35)
+  │ [function] getOptionString (line 7)
+  │ [function] isMeterMarker (line 76)
+  │ [function] materializeMeters (line 95)
+  │ [function] normalizeMeters (line 82)
+  │ [function] runCustomChecker (line 101)
+  │ [function] validateCustomCheckerCode (line 68)
+
+📁 packages/backend/src/services/quota/custom-checker-worker.ts:
+  │ [function] createContext (line 25)
+  │ [function] requestHeaders (line 3)
+
+📁 packages/backend/src/services/quota/quota-enforcer.ts:
+  │ [interface] QuotaCandidate (line 54)
+  │ [interface] QuotaCheckSnapshot (line 27)
+  │ [interface] QuotaContext (line 46)
+  │ [class] QuotaEnforcer (line 90)
+  │ [interface] QuotaStateRow (line 59)
+  │ [interface] UsageRecord (line 15)
+  │ [method] alignToPeriodStart (line 155)
+  │ [method] clearQuota (line 517)
+  │ [method] computeSnapshot (line 168)
+  │ [method] computeUsageValue (line 363)
+  │ [method] constructor (line 96)
+  │ [method] filterCandidates (line 323)
+  │ [method] getWindowEnd (line 144)
+  │ [method] getWindowStart (line 129)
+  │ [method] keysAttachingQuota (line 551)
+  │ [method] loadQuotaContext (line 251)
+  │ [method] recomputeQuota (line 568)
+  │ [method] recordUsage (line 487)
+  │ [function] resolveQuotaNames (line 77)
+  │ [method] scopeOf (line 112)
+  │ [method] selectHeaderQuota (line 352)
+  │ [method] toMs (line 107)
+  │ [method] upsertQuotaState (line 382)
+
+📁 packages/backend/src/services/quota/quota-middleware.ts:
+  │ [interface] QuotaCheckResult (line 15)
+  │ [interface] QuotaUsageRecord (line 6)
+  │ [function] attachQuotaContext (line 120)
+  │ [function] buildQuotaExceededBody (line 28)
+  │ [function] buildQuotaExceededError (line 64)
+  │ [function] buildQuotaHeaders (line 88)
+  │ [function] checkQuotaMiddleware (line 153)
+  │ [function] recordQuotaUsage (line 183)
+
+📁 packages/backend/src/services/quota/quota-scheduler.ts:
+  │ [class] QuotaScheduler (line 36)
+  │ [method] applyCooldownsFromResult (line 205)
+  │ [method] constructor (line 46)
+  │ [method] ensureDb (line 55)
+  │ [method] getCheckerIds (line 372)
+  │ [method] getExhaustionThreshold (line 189)
+  │ [method] getInstance (line 48)
+  │ [method] getLatestQuota (line 380)
+  │ [method] getLatestQuotaForProvider (line 458)
+  │ [method] getQuotaHistory (line 477)
+  │ [method] getStrictestThresholdForProvider (line 269)
+  │ [method] initialize (line 63)
+  │ [method] isInitialized (line 376)
+  │ [method] persistResult (line 283)
+  │ [method] reload (line 521)
+  │ [method] runCheckNow (line 98)
+  │ [method] runCheckerWithSpacing (line 154)
+  │ [method] stop (line 510)
+  │ [function] toIso (line 32)
+  │ [function] toMs (line 25)
+
+📁 packages/backend/src/services/responses/response-handler.ts:
+  │ [function] finalizeUsage (line 780)
+  │ [function] formatClientError (line 46)
+  │ [function] getHeaderValue (line 28)
+  │ [function] handleResponse (line 84)
+  │ [function] hasValidAdminKey (line 33)
+  │ [function] shouldIncludePlaygroundRouting (line 42)
+
+📁 packages/backend/src/services/responses/responses-storage.ts:
+  │ [class] ResponsesStorageService (line 6)
+  │ [method] cleanupOldResponses (line 280)
+  │ [method] deleteResponse (line 184)
+  │ [method] ensureDb (line 71)
+  │ [method] formatStoredConversation (line 398)
+  │ [method] formatStoredResponse (line 344)
+  │ [method] getConversation (line 260)
+  │ [method] getResponse (line 165)
+  │ [method] startCleanupJob (line 29)
+  │ [method] stopCleanupJob (line 63)
+  │ [method] storeResponse (line 88)
+  │ [method] updateConversation (line 207)
+
+📁 packages/backend/src/services/routing/background-explorer.ts:
+  │ [class] BackgroundExplorer (line 24)
+  │ [interface] TargetState (line 8)
+  │ [method] constructor (line 33)
+  │ [method] getInstance (line 44)
+  │ [method] initialize (line 37)
+  │ [method] keyFor (line 116)
+  │ [method] maybeTrigger (line 59)
+  │ [method] pumpWorkers (line 120)
+  │ [method] resetForTesting (line 48)
+  │ [method] worker (line 133)
+
+📁 packages/backend/src/services/routing/key-access-policy.ts:
+  │ [interface] PolicyRequest (line 15)
+  │ [function] applyKeyAccessPolicy (line 44)
+  │ [function] buildAccessDeniedError (line 24)
+  │ [function] getKeyAccessPolicy (line 35)
+
+📁 packages/backend/src/services/routing/route-candidates.ts:
+  │ [function] resolveRouteCandidates (line 16)
+
+📁 packages/backend/src/services/routing/router.ts:
+  │ [interface] RouteResult (line 23)
+  │ [class] Router (line 460)
+  │ [function] buildGroupCandidates (line 383)
+  │ [function] dedupeCandidates (line 371)
+  │ [function] filterGroupTargets (line 59)
+  │ [function] findAlias (line 43)
+  │ [function] isImageApiType (line 19)
+  │ [method] resolve (line 561)
+  │ [method] resolveCandidates (line 461)
+  │ [method] resolveDirect (line 653)
+  │ [function] selectOrderedTargets (line 335)
+  │ [function] tryParseDirectGroup (line 32)
+  │ [function] withVisited (line 365)
+
+📁 packages/backend/src/services/routing/scope-match.ts:
+  │ [interface] ScopeLists (line 15)
+  │ [function] isGlobalScope (line 47)
+  │ [function] listAllows (line 23)
+  │ [function] scopeMatches (line 39)
+
+📁 packages/backend/src/services/routing/selectors/base.ts:
+  │ [interface] CandidateStats (line 13)
+  │ [interface] EnrichedModelTarget (line 7)
+  │ [class] Selector (line 19)
+  │ [method] select (line 25)
+
+📁 packages/backend/src/services/routing/selectors/cost.ts:
+  │ [class] CostSelector (line 61)
+  │ [function] calculatePriceForTarget (line 4)
+  │ [method] select (line 62)
+
+📁 packages/backend/src/services/routing/selectors/e2e-performance.ts:
+  │ [class] E2EPerformanceSelector (line 6)
+  │ [method] constructor (line 9)
+  │ [method] select (line 14)
+
+📁 packages/backend/src/services/routing/selectors/factory.ts:
+  │ [class] SelectorFactory (line 13)
+  │ [method] getSelector (line 25)
+  │ [method] setQuotaScheduler (line 21)
+  │ [method] setUsageStorage (line 17)
+
+📁 packages/backend/src/services/routing/selectors/in-order.ts:
+  │ [class] InOrderSelector (line 4)
+  │ [method] select (line 5)
+
+📁 packages/backend/src/services/routing/selectors/latency.ts:
+  │ [class] LatencySelector (line 7)
+  │ [method] constructor (line 10)
+  │ [method] select (line 15)
+
+📁 packages/backend/src/services/routing/selectors/performance.ts:
+  │ [class] PerformanceSelector (line 6)
+  │ [method] constructor (line 9)
+  │ [method] select (line 14)
+
+📁 packages/backend/src/services/routing/selectors/quota.ts:
+  │ [class] QuotaSelector (line 112)
+  │ [interface] QuotaSnapshotProvider (line 8)
+  │ [interface] ScoredTarget (line 12)
+  │ [method] constructor (line 116)
+  │ [function] getBurnDownScore (line 67)
+  │ [method] getLatestQuotaForProvider (line 9)
+  │ [method] getSnapshot (line 153)
+  │ [function] getUtilization (line 19)
+  │ [method] select (line 121)
+
+📁 packages/backend/src/services/routing/selectors/random.ts:
+  │ [class] RandomSelector (line 4)
+  │ [method] select (line 5)
+
+📁 packages/backend/src/services/routing/selectors/usage.ts:
+  │ [class] UsageSelector (line 6)
+  │ [method] constructor (line 9)
+  │ [method] select (line 14)
+
+📁 packages/backend/src/services/routing/sticky-session-manager.ts:
+  │ [interface] StickyEntry (line 3)
+  │ [class] StickySessionManager (line 20)
+  │ [method] clear (line 87)
+  │ [method] computeSessionKey (line 42)
+  │ [method] get (line 57)
+  │ [method] getInstance (line 26)
+  │ [method] makeKey (line 53)
+  │ [method] set (line 67)
+  │ [method] size (line 92)
+
+📁 packages/backend/src/services/runtime/concurrency-tracker.ts:
+  │ [interface] ConcurrencySnapshot (line 4)
+  │ [class] ConcurrencyTracker (line 9)
+  │ [method] acquire (line 33)
+  │ [method] constructor (line 14)
+  │ [method] getInstance (line 16)
+  │ [method] getProviderCount (line 98)
+  │ [method] getSnapshot (line 106)
+  │ [method] getTargetCount (line 102)
+  │ [method] release (line 81)
+  │ [method] resetForTesting (line 24)
+
+📁 packages/backend/src/services/runtime/cooldown-manager.ts:
+  │ [interface] CooldownEntry (line 14)
+  │ [class] CooldownManager (line 20)
+  │ [interface] Target (line 9)
+  │ [method] calculateCooldownDuration (line 159)
+  │ [method] clearCooldown (line 386)
+  │ [method] constructor (line 26)
+  │ [method] ensureDb (line 40)
+  │ [method] filterHealthyTargets (line 331)
+  │ [method] getCooldowns (line 348)
+  │ [method] getInstance (line 28)
+  │ [method] isCooldownDisabledForProvider (line 82)
+  │ [method] isProviderHealthy (line 284)
+  │ [method] isStallCooldownEnabledForProvider (line 91)
+  │ [method] loadFromStorage (line 48)
+  │ [method] makeCooldownKey (line 78)
+  │ [method] markProviderFailure (line 183)
+  │ [method] markProviderStallFailure (line 101)
+  │ [method] markProviderSuccess (line 251)
+  │ [method] pruneDisabledProviders (line 115)
+  │ [method] removeCooldowns (line 344)
+  │ [method] resetForTesting (line 36)
+  │ [method] resetInstance (line 146)
+
+📁 packages/backend/src/services/runtime/cooldown-parsers.ts:
+  │ [interface] CooldownParser (line 7)
+  │ [class] CooldownParserRegistry (line 20)
+  │ [method] getParser (line 96)
+  │ [method] parseCooldown (line 107)
+  │ [method] parseCooldownDuration (line 13)
+  │ [method] register (line 86)
+
+📁 packages/backend/src/services/runtime/provider-admission.ts:
+  │ [function] admitProvider (line 13)
+
+📁 packages/backend/src/services/vision/vision-descriptor-service.ts:
+  │ [class] VisionDescriptorService (line 17)
+  │ [method] _cacheGet (line 26)
+  │ [method] _cacheKey (line 21)
+  │ [method] _cacheSet (line 35)
+  │ [method] clearCache (line 46)
+  │ [method] describeImage (line 128)
+  │ [method] extractImages (line 104)
+  │ [method] hasImages (line 90)
+  │ [method] injectDescriptions (line 282)
+  │ [method] process (line 60)
+
+📁 packages/backend/src/services/vision/vision-request-preprocessor.ts:
+  │ [function] preprocessVisionRequest (line 10)
+
+📁 packages/backend/src/transformers/adapters/model-override.adapter.ts:
+  │ [function] evaluateCondition (line 82)
+  │ [function] resolveDottedPath (line 102)
+
+📁 packages/backend/src/transformers/adapters/normalize-anthropic-tool-ids.adapter.ts:
+  │ [function] coerceToolIdToString (line 79)
+  │ [function] normalizeAnthropicToolIds (line 140)
+  │ [function] sanitizeAnthropicToolId (line 101)
+
+📁 packages/backend/src/transformers/adapters/reasoning-rewrite.adapter.ts:
+  │ [function] computeTargetValue (line 155)
+  │ [function] evaluateCondition (line 120)
+  │ [function] removeDottedPath (line 226)
+  │ [function] setDottedPath (line 199)
+
+📁 packages/backend/src/transformers/adapters/strip-unsupported-tool-search.adapter.ts:
+  │ [function] isToolSearchShorthand (line 71)
+
+📁 packages/backend/src/transformers/adapters/suppress-unsupported-gpt5-options.adapter.ts:
+  │ [function] stripUnsupportedGpt5Options (line 29)
+
+📁 packages/backend/src/transformers/adapters/web-search-coercion.adapter.ts:
+  │ [function] buildTargetTool (line 94)
+  │ [function] isWebSearchTool (line 86)
+
+📁 packages/backend/src/transformers/anthropic/content-mapper.ts:
+  │ [function] convertAnthropicContent (line 11)
+
+📁 packages/backend/src/transformers/anthropic/index.ts:
+  │ [class] AnthropicTransformer (line 24)
+  │ [method] extractUsage (line 55)
+  │ [method] formatResponse (line 40)
+  │ [method] formatStream (line 48)
+  │ [method] parseRequest (line 28)
+  │ [method] transformRequest (line 32)
+  │ [method] transformResponse (line 36)
+  │ [method] transformStream (line 44)
+
+📁 packages/backend/src/transformers/anthropic/request-builder.ts:
+  │ [function] buildAnthropicRequest (line 13)
+
+📁 packages/backend/src/transformers/anthropic/request-parser.ts:
+  │ [function] parseAnthropicRequest (line 16)
+
+📁 packages/backend/src/transformers/anthropic/response-formatter.ts:
+  │ [function] formatAnthropicResponse (line 13)
+
+📁 packages/backend/src/transformers/anthropic/response-transformer.ts:
+  │ [function] transformAnthropicResponse (line 13)
+
+📁 packages/backend/src/transformers/anthropic/stream-formatter.ts:
+  │ [function] formatAnthropicStream (line 19)
+
+📁 packages/backend/src/transformers/anthropic/stream-transformer.ts:
+  │ [function] transformAnthropicStream (line 21)
+
+📁 packages/backend/src/transformers/anthropic/tool-mapper.ts:
+  │ [function] convertAnthropicToolsToUnified (line 12)
+  │ [function] convertUnifiedToolsToAnthropic (line 54)
+
+📁 packages/backend/src/transformers/completions.ts:
+  │ [class] OpenAICompletionTransformer (line 82)
+  │ [function] buildFimUserPrompt (line 49)
+  │ [method] extractUsage (line 339)
+  │ [method] formatResponse (line 199)
+  │ [method] formatStream (line 287)
+  │ [function] normalizeFimResponse (line 69)
+  │ [method] parseRequest (line 88)
+  │ [function] removeCompleteMarkdownFence (line 53)
+  │ [method] transformRequest (line 136)
+  │ [method] transformResponse (line 178)
+  │ [method] transformStream (line 233)
+  │ [function] truncateAtFimProtocolToken (line 60)
+
+📁 packages/backend/src/transformers/embeddings/gemini.ts:
+  │ [class] GeminiEmbeddingsTransformer (line 4)
+  │ [method] getAuthHeaders (line 16)
+  │ [method] getEndpoint (line 8)
+  │ [method] transformRequest (line 20)
+  │ [method] transformResponse (line 41)
+
+📁 packages/backend/src/transformers/embeddings/openai.ts:
+  │ [class] OpenAIEmbeddingsTransformer (line 4)
+  │ [method] extractUsage (line 34)
+  │ [method] formatResponse (line 25)
+  │ [method] transformRequest (line 8)
+  │ [method] transformResponse (line 15)
+
+📁 packages/backend/src/transformers/gemini/index.ts:
+  │ [class] GeminiTransformer (line 25)
+  │ [method] extractUsage (line 71)
+  │ [method] formatResponse (line 56)
+  │ [method] formatStream (line 64)
+  │ [method] getEndpoint (line 35)
+  │ [method] parseRequest (line 44)
+  │ [method] transformRequest (line 48)
+  │ [method] transformResponse (line 52)
+  │ [method] transformStream (line 60)
+
+📁 packages/backend/src/transformers/gemini/part-mapper.ts:
+  │ [function] convertGeminiPartsToUnified (line 15)
+  │ [function] convertUnifiedPartsToGemini (line 55)
+
+📁 packages/backend/src/transformers/gemini/request-builder.ts:
+  │ [interface] GenerateContentRequest (line 20)
+  │ [function] buildGeminiRequest (line 56)
+
+📁 packages/backend/src/transformers/gemini/request-parser.ts:
+  │ [function] parseGeminiRequest (line 16)
+
+📁 packages/backend/src/transformers/gemini/response-formatter.ts:
+  │ [function] formatGeminiResponse (line 14)
+
+📁 packages/backend/src/transformers/gemini/response-transformer.ts:
+  │ [function] transformGeminiResponse (line 16)
+
+📁 packages/backend/src/transformers/gemini/stream-formatter.ts:
+  │ [function] buildGeminiFunctionCallPart (line 52)
+  │ [function] formatGeminiStream (line 89)
+  │ [function] getToolCallKeys (line 14)
+  │ [function] resolveToolCallArguments (line 32)
+
+📁 packages/backend/src/transformers/gemini/stream-transformer.ts:
+  │ [function] transformGeminiStream (line 21)
+
+📁 packages/backend/src/transformers/gemini/utils/json-schema.ts:
+  │ [function] normalizeJsonSchemaTypes (line 7)
+
+📁 packages/backend/src/transformers/gemini/utils/model-tail.ts:
+  │ [function] appendUserAfterTextOnlyModelTail (line 38)
+  │ [function] ensureContentsEndWithUser (line 50)
+  │ [function] isTextOnlyModelContent (line 19)
+
+📁 packages/backend/src/transformers/gemini/utils/thought-signature.ts:
+  │ [function] isValidThoughtSignature (line 16)
+  │ [function] sanitizeThoughtSignature (line 33)
+
+📁 packages/backend/src/transformers/image-rendering.ts:
+  │ [function] composeContentWithImageMarkdown (line 112)
+  │ [function] imageGenerationCallMarkdown (line 95)
+  │ [function] renderImageResultMarkdown (line 75)
+  │ [function] sniffImageMimeSubtype (line 37)
+
+📁 packages/backend/src/transformers/image.ts:
+  │ [class] ImageRequestValidationError (line 64)
+  │ [class] ImageTransformer (line 506)
+  │ [function] appendFormValue (line 445)
+  │ [function] buildOpenAIGenerationRequest (line 482)
+  │ [function] buildOpenAIReferenceRequest (line 449)
+  │ [method] constructor (line 67)
+  │ [function] formatOpenRouterImageResponse (line 381)
+  │ [method] formatResponse (line 630)
+  │ [method] getEndpoint (line 510)
+  │ [function] isUnsafeRemoteImageHost (line 94)
+  │ [function] normalizeImageUsage (line 358)
+  │ [method] parseEditRequest (line 577)
+  │ [method] parseGenerationRequest (line 516)
+  │ [function] parseImageDataUrl (line 82)
+  │ [method] parseOpenRouterGenerationRequest (line 541)
+  │ [function] requireNonEmptyString (line 165)
+  │ [function] resolutionTierForSize (line 246)
+  │ [function] resolveImageReference (line 107)
+  │ [function] resolveOpenAISize (line 425)
+  │ [method] transformEditRequest (line 589)
+  │ [method] transformEditResponse (line 615)
+  │ [method] transformGenerationRequest (line 552)
+  │ [method] transformGenerationResponse (line 559)
+  │ [function] validateOpenRouterRequest (line 282)
+  │ [function] validateProviderPreferences (line 209)
+  │ [function] validateReference (line 172)
+  │ [function] validateSizeAndAspectRatio (line 257)
+
+📁 packages/backend/src/transformers/images/gemini.ts:
+  │ [class] GeminiImageTransformer (line 66)
+  │ [method] getAuthHeaders (line 77)
+  │ [method] getEndpoint (line 70)
+  │ [function] imagePartFromReference (line 32)
+  │ [function] prefixModel (line 15)
+  │ [function] resolutionFromSize (line 20)
+  │ [method] transformGenerationRequest (line 81)
+  │ [method] transformGenerationResponse (line 110)
+  │ [function] unsupportedOptions (line 45)
+
+📁 packages/backend/src/transformers/images/openrouter.ts:
+  │ [class] OpenRouterImageTransformer (line 8)
+  │ [method] getEndpoint (line 12)
+  │ [method] transformGenerationRequest (line 19)
+  │ [method] transformGenerationResponse (line 56)
+
+📁 packages/backend/src/transformers/oauth/masking/apply-masking.ts:
+  │ [interface] ClaudeCodeMaskingResult (line 54)
+  │ [function] applyClaudeCodeMasking (line 72)
+
+📁 packages/backend/src/transformers/oauth/masking/cc-billing.ts:
+  │ [function] buildBillingHeaderText (line 58)
+  │ [function] computeBuildHash (line 25)
+  │ [function] extractFirstUserText (line 38)
+
+📁 packages/backend/src/transformers/oauth/masking/cc-collision-shape.ts:
+  │ [function] requiredParamsOf (line 36)
+
+📁 packages/backend/src/transformers/oauth/masking/cc-headers.ts:
+  │ [function] getStainlessHeaders (line 25)
+
+📁 packages/backend/src/transformers/oauth/masking/cc-identity.ts:
+  │ [function] injectClaudeCodeIdentity (line 169)
+  │ [function] prependToFirstUserMessage (line 116)
+  │ [function] sanitizeForwardedSystemPrompt (line 99)
+
+📁 packages/backend/src/transformers/oauth/masking/cc-metadata.ts:
+  │ [function] injectClaudeCodeMetadata (line 34)
+
+📁 packages/backend/src/transformers/oauth/masking/cc-reference-tools.ts:
+  │ [function] matchesReferenceShape (line 74)
+  │ [function] sortedUnique (line 64)
+
+📁 packages/backend/src/transformers/oauth/masking/cc-tools.ts:
+  │ [function] stripDescriptionsAndInjectSyntheticTools (line 49)
+
+📁 packages/backend/src/transformers/oauth/masking/dedupe.ts:
+  │ [function] dedupeSyntheticToolCollisions (line 28)
+
+📁 packages/backend/src/transformers/oauth/masking/mcp-shape.ts:
+  │ [function] firstUnderscoreSplit (line 47)
+
+📁 packages/backend/src/transformers/oauth/masking/registry.ts:
+  │ [function] buildToolRenamePairs (line 28)
+
+📁 packages/backend/src/transformers/oauth/masking/rename-apply.ts:
+  │ [function] applyToolRenames (line 49)
+  │ [function] toRenameMap (line 39)
+
+📁 packages/backend/src/transformers/oauth/masking/reverse-rename.ts:
+  │ [function] escapeForRegex (line 31)
+  │ [function] reverseToolRenames (line 41)
+
+📁 packages/backend/src/transformers/oauth/masking/sign-billing.ts:
+  │ [function] signBillingHeader (line 53)
+
+📁 packages/backend/src/transformers/oauth/masking/types.ts:
+  │ [interface] ToolDescriptor (line 65)
+  │ [interface] ToolShape (line 76)
+  │ [method] detect (line 86)
+
+📁 packages/backend/src/transformers/oauth/oauth-claude.ts:
+  │ [interface] ClaudeOAuthConfig (line 321)
+  │ [interface] ClaudeOAuthContext (line 643)
+  │ [function] applyClaudeOAuthTransform (line 664)
+  │ [function] canonicalizeOAuthToolName (line 60)
+  │ [function] computeFingerprint (line 388)
+  │ [function] computeSHA256Truncated (line 411)
+  │ [function] computeSimpleHash (line 374)
+  │ [function] generateBillingHeader (line 336)
+  │ [function] injectClaudeCodeSystemPrompt (line 482)
+  │ [function] isClaudeOAuthToken (line 653)
+  │ [function] prependToFirstUserMessage (line 439)
+  │ [function] remapOAuthToolNames (line 79)
+  │ [function] reverseRemapOAuthToolNames (line 163)
+  │ [function] reverseRemapOAuthToolNamesFromStreamLine (line 204)
+  │ [function] reverseRemapToolName (line 68)
+  │ [function] sanitizeForwardedSystemPrompt (line 426)
+  │ [function] shouldRemapToolName (line 53)
+  │ [function] signAnthropicMessagesBody (line 603)
+  │ [function] xxHash64 (line 586)
+
+📁 packages/backend/src/transformers/ollama.ts:
+  │ [class] OllamaTransformer (line 16)
+  │ [method] extractUsage (line 296)
+  │ [method] extractUsageFromResponse (line 314)
+  │ [method] formatResponse (line 146)
+  │ [method] formatStream (line 245)
+  │ [function] parseOllamaChunk (line 337)
+  │ [method] parseRequest (line 20)
+  │ [method] transformRequest (line 44)
+  │ [method] transformResponse (line 118)
+  │ [method] transformStream (line 185)
+
+📁 packages/backend/src/transformers/openai.ts:
+  │ [class] OpenAITransformer (line 12)
+  │ [method] parseRequest (line 16)
+
+📁 packages/backend/src/transformers/responses.ts:
+  │ [class] ResponsesTransformer (line 190)
+  │ [method] buildToolOutputItem (line 1083)
+  │ [function] clientToolCallKey (line 82)
+  │ [method] convertChatResponseToOutputItems (line 1005)
+  │ [method] convertToolChoiceForChatCompletions (line 989)
+  │ [method] customToolArgumentsForModel (line 932)
+  │ [method] customToolInput (line 945)
+  │ [function] isClientExecutedToolItem (line 63)
+  │ [function] normalizeCompositeResponsesCallIds (line 93)
+  │ [function] normalizeResponsesFunctionCallItemIds (line 134)
+  │ [function] normalizeResponsesReasoningContent (line 160)
+  │ [method] parseRequest (line 205)
+  │ [function] toUnifiedImageGenerationCall (line 38)
+  │ [method] transformRequest (line 301)
+  │ [method] transformResponse (line 479)
+
+📁 packages/backend/src/transformers/speech.ts:
+  │ [class] SpeechTransformer (line 3)
+  │ [method] extractUsage (line 62)
+  │ [method] formatResponse (line 43)
+  │ [method] getMimeType (line 50)
+  │ [method] parseRequest (line 7)
+  │ [method] transformRequest (line 19)
+  │ [method] transformResponse (line 30)
+
+📁 packages/backend/src/transformers/transcriptions.ts:
+  │ [class] TranscriptionsTransformer (line 10)
+  │ [method] extractUsage (line 146)
+  │ [method] formatResponse (line 112)
+  │ [method] parseRequest (line 17)
+  │ [method] transformRequest (line 39)
+  │ [method] transformResponse (line 71)
+
+📁 packages/backend/src/transformers/utils.ts:
+  │ [function] countTokens (line 34)
+  │ [function] projectReasoningForResponses (line 3)
+
+📁 packages/backend/src/types/embeddings-transformer.ts:
+  │ [interface] EmbeddingsTransformer (line 11)
+  │ [method] extractUsage (line 28)
+  │ [method] formatResponse (line 26)
+  │ [method] getAuthHeaders (line 17)
+  │ [method] getEndpoint (line 15)
+  │ [method] transformRequest (line 19)
+  │ [method] transformResponse (line 21)
+
+📁 packages/backend/src/types/image-transformer.ts:
+  │ [interface] ImageGenerationTransformer (line 10)
+  │ [method] getAuthHeaders (line 16)
+  │ [method] getEndpoint (line 14)
+  │ [method] transformGenerationRequest (line 18)
+  │ [method] transformGenerationResponse (line 20)
+
+📁 packages/backend/src/types/mcp.ts:
+  │ [interface] LocalHttpMcpServerConfig (line 13)
+  │ [interface] McpDebugLog (line 46)
+  │ [interface] McpProxyRequest (line 56)
+  │ [interface] McpProxyResponse (line 65)
+  │ [interface] McpRequestUsage (line 26)
+  │ [interface] RemoteHttpMcpServerConfig (line 6)
+
+📁 packages/backend/src/types/meter.ts:
+  │ [interface] Meter (line 11)
+  │ [interface] MeterCheckResult (line 41)
+
+📁 packages/backend/src/types/provider-adapter.ts:
+  │ [interface] ProviderAdapter (line 27)
+  │ [interface] ResolvedAdapter (line 7)
+  │ [method] postDispatch (line 43)
+  │ [method] postDispatchStreamChunk (line 57)
+  │ [method] preDispatch (line 36)
+  │ [method] preDispatchStreamChunk (line 50)
+
+📁 packages/backend/src/types/responses.ts:
+  │ [interface] Annotation (line 116)
+  │ [interface] ResponsesBuiltInToolCallItem (line 350)
+  │ [interface] ResponsesCodeInterpreterTool (line 148)
+  │ [interface] ResponsesCompletedEvent (line 460)
+  │ [interface] ResponsesComputerUseTool (line 152)
+  │ [interface] ResponsesContentPartAddedEvent (line 399)
+  │ [interface] ResponsesContentPartDoneEvent (line 407)
+  │ [interface] ResponsesCreatedEvent (line 377)
+  │ [interface] ResponsesCustomTool (line 187)
+  │ [interface] ResponsesCustomToolCallItem (line 92)
+  │ [interface] ResponsesCustomToolCallOutputItem (line 100)
+  │ [interface] ResponsesFailedEvent (line 465)
+  │ [interface] ResponsesFileSearchTool (line 143)
+  │ [interface] ResponsesFunctionCallArgumentsDeltaEvent (line 431)
+  │ [interface] ResponsesFunctionCallArgumentsDoneEvent (line 438)
+  │ [interface] ResponsesFunctionCallItem (line 70)
+  │ [interface] ResponsesFunctionCallOutputItem (line 83)
+  │ [interface] ResponsesFunctionTool (line 131)
+  │ [interface] ResponsesImageGenerationTool (line 156)
+  │ [interface] ResponsesInProgressEvent (line 382)
+  │ [interface] ResponsesIncompleteEvent (line 471)
+  │ [interface] ResponsesInputAudioPart (line 47)
+  │ [interface] ResponsesInputImagePart (line 41)
+  │ [interface] ResponsesInputItem (line 10)
+  │ [interface] ResponsesInputTextPart (line 36)
+  │ [interface] ResponsesMCPTool (line 169)
+  │ [interface] ResponsesMessageItem (line 21)
+  │ [interface] ResponsesNamespaceTool (line 179)
+  │ [interface] ResponsesOutputItemAddedEvent (line 387)
+  │ [interface] ResponsesOutputItemDoneEvent (line 393)
+  │ [interface] ResponsesOutputTextDeltaEvent (line 415)
+  │ [interface] ResponsesOutputTextDoneEvent (line 423)
+  │ [interface] ResponsesOutputTextPart (line 53)
+  │ [interface] ResponsesReasoningItem (line 107)
+  │ [interface] ResponsesReasoningSummaryTextDeltaEvent (line 446)
+  │ [interface] ResponsesReasoningSummaryTextDoneEvent (line 453)
+  │ [interface] ResponsesReasoningTextPart (line 65)
+  │ [interface] ResponsesStreamEvent (line 371)
+  │ [interface] ResponsesSummaryTextPart (line 60)
+  │ [interface] ResponsesWebSearchTool (line 139)
+  │ [interface] UnifiedResponsesRequest (line 209)
+  │ [interface] UnifiedResponsesResponse (line 273)
+
+📁 packages/backend/src/types/transformer.ts:
+  │ [interface] Transformer (line 3)
+  │ [method] extractUsage (line 36)
+  │ [method] formatResponse (line 23)
+  │ [method] formatStream (line 31)
+  │ [method] getEndpoint (line 11)
+  │ [method] parseRequest (line 14)
+  │ [method] transformRequest (line 17)
+  │ [method] transformResponse (line 20)
+  │ [method] transformStream (line 27)
+
+📁 packages/backend/src/types/unified.ts:
+  │ [interface] Annotation (line 185)
+  │ [interface] CacheRoutingHeaders (line 174)
+  │ [interface] ImageContent (line 11)
+  │ [interface] KeyAccessPolicy (line 83)
+  │ [interface] PlexusMetadata (line 92)
+  │ [interface] TextContent (line 3)
+  │ [interface] UnifiedChatRequest (line 105)
+  │ [interface] UnifiedChatResponse (line 251)
+  │ [interface] UnifiedChatStreamChunk (line 339)
+  │ [interface] UnifiedClientError (line 312)
+  │ [interface] UnifiedClientToolCall (line 243)
+  │ [interface] UnifiedEmbeddingsRequest (line 399)
+  │ [interface] UnifiedEmbeddingsResponse (line 412)
+  │ [interface] UnifiedImageEditRequest (line 614)
+  │ [interface] UnifiedImageEditResponse (line 636)
+  │ [interface] UnifiedImageGenerationCall (line 224)
+  │ [interface] UnifiedImageGenerationRequest (line 555)
+  │ [interface] UnifiedImageGenerationResponse (line 584)
+  │ [interface] UnifiedImageProviderPreferences (line 546)
+  │ [interface] UnifiedImageReference (line 538)
+  │ [interface] UnifiedMessage (line 24)
+  │ [interface] UnifiedSpeechRequest (line 499)
+  │ [interface] UnifiedSpeechResponse (line 514)
+  │ [interface] UnifiedTool (line 66)
+  │ [interface] UnifiedToolConfig (line 76)
+  │ [interface] UnifiedToolFunction (line 52)
+  │ [interface] UnifiedTranscriptionRequest (line 437)
+  │ [interface] UnifiedTranscriptionResponse (line 457)
+  │ [interface] UnifiedUsage (line 196)
+
+📁 packages/backend/src/types/usage.ts:
+  │ [interface] UsageRecord (line 1)
+
+📁 packages/backend/src/utils/api-format.ts:
+  │ [interface] ApiFormat (line 1)
+  │ [function] apiAccessToKey (line 8)
+  │ [function] getApiBaseType (line 21)
+  │ [function] getApiSubtype (line 25)
+  │ [function] isApiSubtype (line 31)
+  │ [function] normalizeApiAccessList (line 16)
+
+📁 packages/backend/src/utils/auth.ts:
+  │ [interface] PlexusApiKeyAuthResult (line 68)
+  │ [function] attachKeyAccessPolicy (line 9)
+  │ [function] attachPlexusApiKeyAuth (line 140)
+  │ [function] createAuthHook (line 147)
+  │ [function] isRequestIpAllowed (line 59)
+  │ [function] splitApiKeyAttribution (line 74)
+  │ [function] validatePlexusApiKey (line 88)
+
+📁 packages/backend/src/utils/cache-routing-headers.ts:
+  │ [function] getCacheRoutingHeaders (line 10)
+  │ [function] getHeaderValue (line 5)
+
+📁 packages/backend/src/utils/calculate-costs.ts:
+  │ [function] calculateCosts (line 4)
+
+📁 packages/backend/src/utils/client-request-id.ts:
+  │ [function] getClientRequestId (line 10)
+
+📁 packages/backend/src/utils/encryption.ts:
+  │ [function] decrypt (line 88)
+  │ [function] decryptField (line 170)
+  │ [function] decryptJson (line 137)
+  │ [function] encrypt (line 69)
+  │ [function] encryptField (line 162)
+  │ [function] encryptJson (line 128)
+  │ [function] getEncryptionKey (line 21)
+  │ [function] hashSecret (line 120)
+  │ [function] isEncrypted (line 60)
+  │ [function] isEncryptionEnabled (line 53)
+  │ [function] resetEncryptionKeyCache (line 45)
+
+📁 packages/backend/src/utils/estimate-tokens.ts:
+  │ [interface] ImageDimensions (line 150)
+  │ [interface] NormalizedImage (line 317)
+  │ [function] __setEncoderFailedForTests (line 32)
+  │ [function] claudeImageTokens (line 338)
+  │ [function] dimensionsFor (line 325)
+  │ [function] estimateContextTokens (line 642)
+  │ [function] estimateImageTokens (line 381)
+  │ [function] estimateInputTokens (line 520)
+  │ [function] estimateTokens (line 67)
+  │ [function] estimateTokensFromReconstructed (line 800)
+  │ [function] estimateTokensHeuristic (line 102)
+  │ [function] extractChatContent (line 709)
+  │ [function] extractGeminiContent (line 752)
+  │ [function] extractMessagesContent (line 729)
+  │ [function] extractOAuthContent (line 781)
+  │ [function] getEncoder (line 20)
+  │ [function] getImageDimensionsFromBuffer (line 189)
+  │ [function] getImageDimensionsFromDataUri (line 162)
+  │ [function] looksRepetitive (line 46)
+  │ [function] openaiImageTokens (line 344)
+  │ [function] tokensForStringOrJson (line 393)
+  │ [function] walkAnthropicContent (line 439)
+  │ [function] walkGeminiPart (line 474)
+  │ [function] walkMessagesArray (line 493)
+  │ [function] walkOpenAIContent (line 409)
+
+📁 packages/backend/src/utils/gemini-malformed-function-call.ts:
+  │ [interface] GeminiMalformedFunctionCall (line 7)
+  │ [function] detectGeminiMalformedFunctionCall (line 14)
+  │ [function] rewriteGeminiMalformedFunctionCallStream (line 34)
+
+📁 packages/backend/src/utils/ip-match.ts:
+  │ [interface] IpRange (line 28)
+  │ [interface] ParsedIp (line 23)
+  │ [function] ipToBigInt (line 138)
+  │ [function] ipv4ToBigInt (line 63)
+  │ [function] ipv6ToBigInt (line 77)
+  │ [function] isIpAllowed (line 233)
+  │ [function] isValidIpRule (line 223)
+  │ [function] mappedIpv4Value (line 121)
+  │ [function] normalizeClientIp (line 160)
+  │ [function] parseRule (line 169)
+  │ [function] stripAddrDecorations (line 43)
+
+📁 packages/backend/src/utils/ip.ts:
+  │ [function] getClientIp (line 14)
+  │ [function] getTrustedClientIp (line 77)
+
+📁 packages/backend/src/utils/logger.ts:
+  │ [class] StreamTransport (line 35)
+  │ [function] appendRecentLog (line 16)
+  │ [method] log (line 36)
+
+📁 packages/backend/src/utils/normalize.ts:
+  │ [function] toBoolean (line 5)
+  │ [function] toDbBoolean (line 18)
+  │ [function] toDbTimestamp (line 58)
+  │ [function] toDbTimestampMs (line 78)
+  │ [function] toEpochMs (line 22)
+  │ [function] toIsoString (line 43)
+
+📁 packages/backend/src/utils/provider-cost.ts:
+  │ [function] applyProviderReportedCost (line 13)
+  │ [function] applyUsageCostDetails (line 78)
+
+📁 packages/backend/src/utils/sanitize-headers.ts:
+  │ [function] maskSecret (line 34)
+  │ [function] sanitizeHeaders (line 11)
+
+📁 packages/backend/src/utils/stall.ts:
+  │ [function] getGlobalStallConfig (line 81)
+  │ [function] resolveStallConfig (line 28)
+  │ [function] wireStallDetection (line 122)
+
+📁 packages/backend/src/utils/timeout.ts:
+  │ [function] wireEarlyDisconnectDetection (line 52)
+  │ [function] wireUpstreamTimeout (line 27)
+
+📁 packages/backend/src/utils/usage-normalizer.ts:
+  │ [interface] ProviderCostDetails (line 26)
+  │ [interface] UsageWithCostDetails (line 43)
+  │ [function] extractUsageCostDetails (line 52)
+  │ [function] normalizeAnthropicUsage (line 204)
+  │ [function] normalizeGeminiUsage (line 181)
+  │ [function] normalizeOAuthUsage (line 220)
+  │ [function] normalizeOpenAIChatUsage (line 127)
+  │ [function] normalizeOpenAIResponsesUsage (line 152)
+
+📁 packages/backend/test/test-utils.ts:
+  │ [interface] TrackedSpy (line 26)
+  │ [function] createTrackedMock (line 87)
+  │ [function] getTrackedSpyCount (line 73)
+  │ [function] registerSpy (line 39)
+  │ [function] restoreAllSpies (line 59)
+  │ [function] unregisterSpy (line 49)
+
+📁 packages/backend/test/vitest.global-setup.ts:
+  │ [function] copyDirectory (line 7)
+  │ [function] globalSetup (line 147)
+  │ [function] setupTestDatabase (line 22)
+
+📁 packages/backend/test/vitest.postgres.global-setup.ts:
+  │ [function] globalSetup (line 3)
+
+📁 packages/backend/test/vitest.setup.ts:
+  │ [function] copyDirectory (line 8)
+
+📁 packages/backend/test/vitest.sqlite.global-setup.ts:
+  │ [function] globalSetup (line 3)
+
+📁 packages/cli/src/cli.ts:
+  │ [class] CliError (line 48)
+  │ [interface] OpenApiOperation (line 11)
+  │ [interface] OpenApiParameter (line 21)
+  │ [interface] Operation (line 28)
+  │ [interface] ParsedArgs (line 35)
+  │ [interface] Runtime (line 327)
+  │ [function] buildRequest (line 177)
+  │ [method] constructor (line 49)
+  │ [function] discoverOperations (line 114)
+  │ [function] fallbackId (line 155)
+  │ [function] fetchAllPages (line 258)
+  │ [function] formatCell (line 246)
+  │ [function] formatOutput (line 298)
+  │ [function] getPaginatedData (line 251)
+  │ [function] isRisky (line 173)
+  │ [function] isStreamOperation (line 165)
+  │ [function] parseArgs (line 65)
+  │ [function] parseJsonLiteral (line 57)
+  │ [function] run (line 336)
+  │ [function] table (line 226)
+  │ [function] yaml (line 205)
+
+📁 packages/frontend/src/components/quota/checker-presentation.ts:
+  │ [function] getCheckerDisplayName (line 1)
+
+📁 packages/frontend/src/hooks/useBodyScrollLock.ts:
+  │ [function] useBodyScrollLock (line 10)
+
+📁 packages/frontend/src/hooks/useCardPositions.ts:
+  │ [interface] UseCardPositionsReturn (line 56)
+  │ [function] useCardPositions (line 82)
+
+📁 packages/frontend/src/hooks/useMetadataEditor.ts:
+  │ [function] useMetadataEditor (line 19)
+
+📁 packages/frontend/src/hooks/useModels.ts:
+  │ [interface] AliasMatch (line 6)
+  │ [interface] AliasSearchEntry (line 19)
+  │ [interface] OrphanGroup (line 11)
+
+📁 packages/frontend/src/hooks/useNow.ts:
+  │ [function] useNow (line 7)
+
+📁 packages/frontend/src/hooks/useSSEStream.ts:
+  │ [interface] SSEOptions (line 3)
+  │ [function] useSSEStream (line 24)
+
+📁 packages/frontend/src/lib/api.ts:
+  │ [interface] Alias (line 498)
+  │ [interface] AliasTargetGroup (line 484)
+  │ [interface] BackendResponse (line 607)
+  │ [interface] CompactionSettings (line 1260)
+  │ [interface] ConcurrencyData (line 168)
+  │ [interface] Cooldown (line 536)
+  │ [interface] CustomQuotaChecker (line 719)
+  │ [interface] DashboardData (line 179)
+  │ [interface] InferenceError (line 515)
+  │ [interface] KeyConfig (line 1112)
+  │ [interface] LocalMcpRuntimeStatus (line 293)
+  │ [interface] LocalMcpServer (line 270)
+  │ [interface] LoggingLevelState (line 357)
+  │ [interface] McpLogRecord (line 303)
+  │ [interface] McpOAuthClientRecord (line 344)
+  │ [interface] McpOAuthSettings (line 323)
+  │ [interface] McpOAuthTokenRecord (line 329)
+  │ [interface] McpServerKey (line 286)
+  │ [interface] MetadataOverrides (line 390)
+  │ [interface] Model (line 368)
+  │ [interface] ModelMetadataRefreshResult (line 447)
+  │ [interface] ModelMetadataRefreshSourceSummary (line 440)
+  │ [interface] ModelResolutionPreview (line 1271)
+  │ [interface] ModuleFilterState (line 364)
+  │ [interface] NormalizedModelMetadata (line 416)
+  │ [interface] OAuthAuthInfo (line 1222)
+  │ [interface] OAuthCredentialStatus (line 1246)
+  │ [interface] OAuthPrompt (line 1227)
+  │ [interface] OAuthProviderInfo (line 1216)
+  │ [interface] OAuthSession (line 1233)
+  │ [interface] PieChartDataPoint (line 186)
+  │ [interface] Provider (line 210)
+  │ [interface] ProviderPerformanceData (line 193)
+  │ [interface] QuotaCheckerType (line 713)
+  │ [interface] QuotaCheckersResponse (line 783)
+  │ [interface] QuotaConfig (line 1188)
+  │ [interface] QuotaScope (line 1147)
+  │ [interface] QuotaStatusEntry (line 1173)
+  │ [interface] RemoteMcpServer (line 260)
+  │ [interface] Stat (line 132)
+  │ [interface] StripAdaptiveThinkingBehavior (line 380)
+  │ [interface] TodayMetrics (line 149)
+  │ [interface] UsageData (line 139)
+  │ [interface] UsageQueryParams (line 681)
+  │ [interface] UsageRecord (line 547)
+  │ [interface] UsageSummaryBreakdownResult (line 650)
+  │ [interface] UsageSummaryGroup (line 632)
+  │ [interface] UsageSummaryResponse (line 656)
+  │ [interface] UsageSummarySeriesPoint (line 613)
+  │ [interface] UserQuota (line 1154)
+  │ [function] aliasToConfigPayload (line 1286)
+  │ [function] deleteCustomQuotaChecker (line 754)
+  │ [function] fetchCustomQuotaCheckers (line 729)
+  │ [function] fetchQuotaCheckers (line 788)
+  │ [function] inferProviderTypes (line 16)
+  │ [function] normalizeQuotaCheckerInfo (line 125)
+  │ [function] saveCustomQuotaChecker (line 735)
+  │ [function] testCustomQuotaChecker (line 764)
+  │ [function] verifyAdminKey (line 69)
+
+📁 packages/frontend/src/lib/apiFormats.ts:
+  │ [interface] ApiFormat (line 1)
+  │ [function] apiAccessToKey (line 8)
+  │ [function] formatApiTypeLabel (line 46)
+  │ [function] getApiBaseType (line 15)
+  │ [function] getApiSubtype (line 19)
+  │ [function] hasApiAccess (line 25)
+  │ [function] normalizeApiAccessList (line 42)
+  │ [function] toggleApiAccess (line 30)
+
+📁 packages/frontend/src/lib/currency.ts:
+  │ [function] fetchRates (line 144)
+  │ [function] getCachedRates (line 110)
+  │ [function] getCurrency (line 174)
+  │ [function] getSelectedCurrency (line 178)
+  │ [function] getStorage (line 67)
+  │ [function] isCurrencyRateCacheFresh (line 137)
+  │ [function] isRecord (line 63)
+  │ [function] normalizeRates (line 76)
+  │ [function] setSelectedCurrency (line 194)
+  │ [function] toCurrencyRates (line 91)
+  │ [function] writeCachedRates (line 99)
+
+📁 packages/frontend/src/lib/date.ts:
+  │ [interface] CustomDateRange (line 7)
+  │ [function] formatDateRange (line 54)
+  │ [function] formatISODate (line 100)
+  │ [function] getPresetRange (line 15)
+  │ [function] getTimeRangeBounds (line 107)
+  │ [function] isValidDateRange (line 74)
+  │ [function] parseISODate (line 88)
+
+📁 packages/frontend/src/lib/format.ts:
+  │ [interface] ResetCountdown (line 63)
+  │ [function] countdownTickMs (line 120)
+  │ [function] formatBytes (line 234)
+  │ [function] formatCost (line 147)
+  │ [function] formatCostIn (line 167)
+  │ [function] formatDateTimeLabel (line 271)
+  │ [function] formatDuration (line 6)
+  │ [function] formatMs (line 224)
+  │ [function] formatNumber (line 127)
+  │ [function] formatPercent (line 251)
+  │ [function] formatPoints (line 202)
+  │ [function] formatPointsFull (line 217)
+  │ [function] formatResetCountdown (line 78)
+  │ [function] formatResetsIn (line 48)
+  │ [function] formatTPS (line 243)
+  │ [function] formatTimeAgo (line 34)
+  │ [function] formatTimeLabel (line 261)
+  │ [function] formatTokens (line 138)
+  │ [function] getEstimatedBytesPerToken (line 312)
+  │ [function] parseTimestamp (line 285)
+  │ [function] toTitleCase (line 299)
+
+📁 packages/frontend/src/lib/normalize.ts:
+  │ [function] toBoolean (line 4)
+  │ [function] toEpochMs (line 17)
+  │ [function] toIsoString (line 38)
+
+📁 packages/frontend/src/lib/quota.ts:
+  │ [function] formatQuotaValue (line 30)
+  │ [function] quotaUsagePercent (line 50)
+  │ [function] statusForPercent (line 18)
+
+📁 packages/frontend/src/types/card.ts:
+  │ [interface] CardPosition (line 61)
+
+📁 packages/frontend/src/types/quota.ts:
+  │ [interface] Meter (line 5)
+  │ [interface] QuotaCheckResult (line 44)
+  │ [interface] QuotaCheckerInfo (line 23)
+  │ [interface] QuotaWindow (line 35)
+
+📁 packages/shared/src/format-time.ts:
+  │ [function] formatMinutesToMinSec (line 16)
+  │ [function] formatMsToMinSec (line 48)
+
+📁 packages/shared/src/quota-ranking.ts:
+  │ [interface] QuotaRatioFields (line 9)
+  │ [function] constrainedRatio (line 20)
+  │ [function] mostConstrained (line 26)
+  │ [function] sortMostConstrainedFirst (line 33)

--- a/packages/backend/src/routes/inference/chat.ts
+++ b/packages/backend/src/routes/inference/chat.ts
@@ -109,7 +109,7 @@ export async function registerChatRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController, requestId);
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,

--- a/packages/backend/src/routes/inference/completions.ts
+++ b/packages/backend/src/routes/inference/completions.ts
@@ -100,7 +100,7 @@ export async function registerCompletionsRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController, requestId);
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,

--- a/packages/backend/src/routes/inference/gemini.ts
+++ b/packages/backend/src/routes/inference/gemini.ts
@@ -112,7 +112,7 @@ export async function registerGeminiRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController, requestId);
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,

--- a/packages/backend/src/routes/inference/messages.ts
+++ b/packages/backend/src/routes/inference/messages.ts
@@ -105,7 +105,7 @@ export async function registerMessagesRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController, requestId);
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,

--- a/packages/backend/src/routes/inference/responses.ts
+++ b/packages/backend/src/routes/inference/responses.ts
@@ -244,7 +244,12 @@ export async function registerResponsesRoute(
 
       const abortController = new AbortController();
       const { signal: dispatchSignal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-      earlyDisconnect = wireEarlyDisconnectDetection(request, abortController);
+      earlyDisconnect = wireEarlyDisconnectDetection(
+        request,
+        abortController,
+        requestId,
+        incomingApiType === 'responses:lite'
+      );
       const stallDetectionResult = wireStallDetection(abortController, getGlobalStallConfig());
       const unifiedResponse = await dispatcher.dispatch(
         unifiedRequest,

--- a/packages/backend/src/routes/raw-passthrough.ts
+++ b/packages/backend/src/routes/raw-passthrough.ts
@@ -346,7 +346,11 @@ export async function registerRawPassthroughRoutes(
         }
 
         const abortController = new AbortController();
-        const disconnectDetection = wireEarlyDisconnectDetection(request, abortController);
+        const disconnectDetection = wireEarlyDisconnectDetection(
+          request,
+          abortController,
+          requestId
+        );
         const timeoutMs = provider.timeoutMs ?? (getConfig().timeout?.defaultSeconds ?? 300) * 1000;
         const timeout = setTimeout(() => {
           abortController.abort(new DOMException('Upstream request timed out', 'TimeoutError'));

--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -1,5 +1,5 @@
 import { once } from 'node:events';
-import { describe, expect, test, beforeEach } from 'vitest';
+import { describe, expect, test, beforeEach, vi } from 'vitest';
 import { registerSpy } from '../../../test/test-utils';
 import { DebugLoggingInspector } from '../inspectors/debug-logging';
 import { DebugManager } from '../observability/debug-manager';
@@ -177,6 +177,39 @@ describe('DebugLoggingInspector Reconstruction', () => {
       }
       stream.end();
     };
+
+    test('finalizes a completed Responses stream before the transport ends', () => {
+      const completedRequestId = 'test-responses-completed-before-end';
+      const onResponsesTerminal = vi.fn();
+      const inspector = new DebugLoggingInspector(completedRequestId, 'raw', onResponsesTerminal);
+      const stream = inspector.createInspector('responses');
+      const completedEvent = `data: ${JSON.stringify({
+        type: 'response.completed',
+        response: {
+          id: 'resp_completed',
+          object: 'response',
+          status: 'completed',
+          model: 'gpt-4o',
+          output: [],
+          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+        },
+      })}\n\n`;
+
+      stream.write(Buffer.from(completedEvent.slice(0, 40)));
+      expect(DebugManager.getInstance().getReconstructedRawResponse(completedRequestId)).toBeNull();
+
+      stream.write(Buffer.from(completedEvent.slice(40)));
+
+      const log = DebugManager.getInstance().getPendingLog(completedRequestId);
+      expect(onResponsesTerminal).toHaveBeenCalledTimes(1);
+      expect(log?.rawResponse).toBe(completedEvent);
+      expect(log?.rawResponseSnapshot).toMatchObject({
+        id: 'resp_completed',
+        status: 'completed',
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      });
+      stream.destroy();
+    });
 
     test('response.failed captures status, error, and usage (mid-stream failure)', async () => {
       const failedRequestId = 'test-responses-failed';

--- a/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
+++ b/packages/backend/src/services/__tests__/usage-logging-metadata.test.ts
@@ -65,6 +65,49 @@ describe('UsageInspector Metadata Robustness', () => {
     return capturedRecord;
   };
 
+  it('finalizes usage before a completed Responses transport is closed', () => {
+    const requestId = 'responses-completed-before-transport-close';
+    const usageRecord: Partial<UsageRecord> = { requestId, responseStatus: 'success' };
+    const inspector = new UsageInspector(
+      requestId,
+      mockStorage,
+      usageRecord,
+      mockPricing,
+      undefined,
+      Date.now(),
+      false,
+      'responses',
+      'responses'
+    );
+    const dm = DebugManager.getInstance();
+    dm.startLog(requestId, {});
+    dm.addReconstructedRawResponse(requestId, {
+      id: 'resp_completed',
+      status: 'completed',
+      output: [],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      },
+    });
+
+    inspector.finalize();
+    inspector.destroy();
+
+    expect(mockStorage.saveRequest).toHaveBeenCalledTimes(1);
+    expect(mockStorage.saveRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId,
+        responseStatus: 'success',
+        tokensInput: 10,
+        tokensOutput: 5,
+      })
+    );
+  });
+
   it('should extract tool call count from OpenAI non-streaming choices[0].message.tool_calls', async () => {
     const requestId = 'openai-nonstream-tools';
     const snapshot = {

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -1,9 +1,15 @@
 import { PassThrough } from 'stream';
+import { createParser } from 'eventsource-parser';
 import { logger } from '../../utils/logger';
 import { BaseInspector } from './base';
 import { DebugManager } from '../observability/debug-manager';
 
 const MAX_DEBUG_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB
+const RESPONSES_TERMINAL_EVENT_TYPES = new Set([
+  'response.completed',
+  'response.failed',
+  'response.incomplete',
+]);
 
 export class DebugLoggingInspector extends BaseInspector {
   private debugManager = DebugManager.getInstance();
@@ -16,14 +22,20 @@ export class DebugLoggingInspector extends BaseInspector {
   private totalSize = 0;
   private truncated = false;
   private finalized = false;
+  private responsesEventParser: ReturnType<typeof createParser> | null = null;
 
-  constructor(requestId: string, mode: 'raw' | 'transformed' = 'raw') {
+  constructor(
+    requestId: string,
+    mode: 'raw' | 'transformed' = 'raw',
+    private readonly onResponsesTerminal?: () => void
+  ) {
     super(requestId);
     this.mode = mode;
   }
 
   createInspector(providerApiType: string): PassThrough {
     this.providerApiType = providerApiType;
+    this.initializeResponsesTerminalEventDetection();
 
     // Capture happens synchronously in the transform hook (i.e. at write()
     // time), NOT in a 'data' listener: 'data' emission for the very first
@@ -85,6 +97,29 @@ export class DebugLoggingInspector extends BaseInspector {
 
     this.totalSize = newSize;
     this.bodyChunks.push(chunkStr);
+    this.responsesEventParser?.feed(chunkStr);
+  }
+
+  private initializeResponsesTerminalEventDetection(): void {
+    if (this.providerApiType !== 'responses') return;
+
+    this.responsesEventParser = createParser({
+      onEvent: (event) => {
+        try {
+          const responseEvent = JSON.parse(event.data);
+          if (RESPONSES_TERMINAL_EVENT_TYPES.has(responseEvent.type) && !this.finalized) {
+            // Codex may close its HTTP connection immediately after receiving
+            // this terminal event. Finalize before the chunk continues to the
+            // client so the completed response and usage are available during
+            // teardown.
+            this.finalize();
+            this.onResponsesTerminal?.();
+          }
+        } catch {
+          // Non-JSON SSE frames cannot be Responses terminal events.
+        }
+      },
+    });
   }
 
   /**

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -147,6 +147,12 @@ export class UsageInspector extends PassThrough {
   }
 
   override _flush(callback: Function) {
+    this.finalize();
+    callback();
+  }
+
+  finalize(): void {
+    if (this._flushed) return;
     this._flushed = true;
     const stats = {
       inputTokens: 0,
@@ -319,10 +325,8 @@ export class UsageInspector extends PassThrough {
 
       logger.debug(`Request ${this.usageRecord.requestId} usage analysis complete.`);
       DebugManager.getInstance().flush(this.usageRecord.requestId!);
-      callback();
     } catch (err) {
       logger.error(`Error analyzing usage for ${this.usageRecord.requestId}:`, err);
-      callback();
     }
   }
 

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -415,11 +415,27 @@ export async function handleResponse(
         : observedUnifiedStream;
     }
 
+    const usageInspector = new UsageInspector(
+      usageRecord.requestId!,
+      usageStorage,
+      usageRecord,
+      pricing,
+      providerDiscount,
+      startTime,
+      shouldEstimateTokens,
+      providerApiType,
+      apiType,
+      originalRequest,
+      quotaEnforcer,
+      keyName
+    );
+
     // TAP THE TRANSFORMED STREAM for debugging
     // This captures what is actually sent to the client
     const transformedDebugLogging = new DebugLoggingInspector(
       usageRecord.requestId!,
-      'transformed'
+      'transformed',
+      () => usageInspector.finalize()
     );
     const transformedLogInspector = transformedDebugLogging.createInspector(apiType);
 
@@ -443,21 +459,6 @@ export async function handleResponse(
     /**
      * Build the linear stream pipeline.
      */
-
-    const usageInspector = new UsageInspector(
-      usageRecord.requestId!,
-      usageStorage,
-      usageRecord,
-      pricing,
-      providerDiscount,
-      startTime,
-      shouldEstimateTokens,
-      providerApiType,
-      apiType,
-      originalRequest,
-      quotaEnforcer,
-      keyName
-    );
 
     // Convert Web Stream to Node Stream for piping
     const nodeStream = Readable.fromWeb(finalClientStream as any);
@@ -513,18 +514,13 @@ export async function handleResponse(
     // request.signal abort on disconnect. But Fastify runs on node:http, not
     // Bun.serve(), so we can't use that here without a much larger refactor.
     //
-    // THE SOLUTION — bunHandle.closed
-    // --------------------------------
-    // Bun's Node.js Socket wraps an internal Bun TCP socket handle. It is stored
-    // under Symbol(handle) on the Socket object. This handle has a .closed boolean
-    // property that transitions false → true when the underlying TCP connection
-    // closes, even when all the Node.js-layer signals above are broken.
+    // DEFERRED SOCKET-CLOSE SIGNAL — bunHandle.closed
+    // -------------------------------------------------
+    // Bun's Node.js Socket exposes its internal TCP handle under Symbol(handle).
+    // Its .closed flag is useful telemetry, but Codex Responses Lite traffic has
+    // shown that it is not reliable enough to abort an upstream stream by itself.
+    // We log the observation and wait for a confirmed stream error or timeout.
     //
-    // Discovery: we enumerated Object.getOwnPropertySymbols() on the Socket at
-    // runtime, found Symbol(handle), and verified with polling tests that its
-    // .closed property updates correctly within ~250ms of a client disconnect.
-    //
-    // If Bun ever fixes the node:http disconnect signals, we can simplify this.
     // Track: https://github.com/oven-sh/bun/issues/25919
     //        https://github.com/oven-sh/bun/issues/14697
     //
@@ -570,6 +566,7 @@ export async function handleResponse(
       ? Object.getOwnPropertySymbols(rawSocket).find((s) => s.toString() === 'Symbol(handle)')
       : undefined;
     const bunHandle = symHandle ? (rawSocket as any)[symHandle] : null;
+    const deferSocketClose = usageRecord.incomingApiType === 'responses:lite';
 
     const onDisconnect = (source: string) => {
       if (disconnected) return;
@@ -586,7 +583,7 @@ export async function handleResponse(
         source === 'stall' ||
         (abortController?.signal?.reason?.name === 'TimeoutError' &&
           abortController?.signal?.reason?.message?.includes('stalled'));
-      logger.debug(
+      logger.info(
         `${isStall ? 'Stream stalled' : isTimeout ? 'Upstream timeout' : 'Client disconnected'} for request ${usageRecord.requestId} (detected via ${source}), aborting upstream`
       );
       const timeoutErr = isStall
@@ -645,10 +642,22 @@ export async function handleResponse(
         once: true,
       });
 
-      // Poll bunHandle.closed every 250ms — the only reliable client-disconnect
-      // signal available in Bun's node:http layer for POST requests (see above).
+      // Record a socket-close observation, but do not abort on it alone.
       disconnectPoll = setInterval(() => {
-        if (bunHandle?.closed) onDisconnect('bunHandle.closed');
+        if (bunHandle?.closed) {
+          if (deferSocketClose) {
+            logger.info(
+              `Socket close observed for request ${usageRecord.requestId} ` +
+                '(source=bunHandle.closed); deferring upstream cancellation'
+            );
+            if (disconnectPoll) {
+              clearInterval(disconnectPoll);
+              disconnectPoll = null;
+            }
+          } else {
+            onDisconnect('bunHandle.closed');
+          }
+        }
         if (pipeline.destroyed || pipeline.readableEnded) {
           if (disconnectPoll) {
             clearInterval(disconnectPoll);

--- a/packages/backend/src/utils/__tests__/timeout.test.ts
+++ b/packages/backend/src/utils/__tests__/timeout.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test, vi } from 'vitest';
+import { registerSpy } from '../../../test/test-utils';
+import { logger } from '../logger';
 
 vi.mock('../../config', () => ({
   getConfig: () => ({ timeout: { defaultSeconds: 4 } }),
 }));
 
-import { wireUpstreamTimeout } from '../timeout';
+import { wireEarlyDisconnectDetection, wireUpstreamTimeout } from '../timeout';
 
 describe('wireUpstreamTimeout', () => {
   test('per-provider timeout can be longer than global timeout', () => {
@@ -20,5 +22,53 @@ describe('wireUpstreamTimeout', () => {
     const { resolveTimeoutMs } = wireUpstreamTimeout(abortController);
 
     expect(resolveTimeoutMs(null)).toBe(4_000);
+  });
+
+  test('defers cancellation when bunHandle.closed is observed before dispatch', () => {
+    vi.useFakeTimers();
+    try {
+      const infoSpy = registerSpy(logger, 'info');
+      infoSpy.mockClear();
+      const abortController = new AbortController();
+      const socket = { [Symbol('handle')]: { closed: true } };
+      const { cleanup } = wireEarlyDisconnectDetection(
+        { raw: { socket } },
+        abortController,
+        'request-with-deferred-socket-close',
+        true
+      );
+
+      vi.advanceTimersByTime(1_000);
+
+      expect(abortController.signal.aborted).toBe(false);
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy).toHaveBeenCalledWith(
+        'Socket close observed for request request-with-deferred-socket-close before dispatch ' +
+          '(source=bunHandle.closed); deferring upstream cancellation'
+      );
+      cleanup();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('keeps aborting on bunHandle.closed when cancellation is not deferred', () => {
+    vi.useFakeTimers();
+    try {
+      const abortController = new AbortController();
+      const socket = { [Symbol('handle')]: { closed: true } };
+      const { cleanup } = wireEarlyDisconnectDetection(
+        { raw: { socket } },
+        abortController,
+        'request-with-immediate-socket-close'
+      );
+
+      vi.advanceTimersByTime(250);
+
+      expect(abortController.signal.aborted).toBe(true);
+      cleanup();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/backend/src/utils/timeout.ts
+++ b/packages/backend/src/utils/timeout.ts
@@ -39,28 +39,21 @@ export function wireUpstreamTimeout(
 }
 
 /**
- * Start early client-disconnect detection before dispatch.
+ * Observe an early socket closure before dispatch.
  *
- * Bun's node:http layer does NOT reliably fire close/abort events when a
- * client disconnects during streaming POST responses. The only working
- * detection mechanism is polling `bunHandle.closed` on the Socket object.
- *
- * The response-handler's polling only starts after the dispatcher returns,
- * so there's a gap: if the client disconnects while fetch() is still
- * pending (upstream hasn't responded yet), nothing detects the disconnect.
- * The fetch keeps running, wasting upstream API quota.
- *
- * This function starts the bunHandle.closed polling BEFORE the dispatch,
- * and aborts the route's AbortController when the client disconnects.
- * This propagates through the route signal to fetch(), causing it to
- * throw AbortError and the dispatcher to stop waiting.
+ * Bun's node:http close/abort events are unreliable for streaming POST
+ * responses. `bunHandle.closed` is useful telemetry, but it has produced
+ * false positives for Codex Responses Lite traffic. That route can defer
+ * cancellation while all other callers retain the existing abort behavior.
  *
  * Callers must call cleanup() after the dispatch completes (whether success
  * or failure) to stop the polling interval.
  */
 export function wireEarlyDisconnectDetection(
   request: any,
-  abortController: AbortController
+  abortController: AbortController,
+  requestId: string,
+  deferSocketClose = false
 ): { cleanup: () => void } {
   const rawSocket = request?.raw?.socket;
   const symHandle = rawSocket
@@ -77,8 +70,16 @@ export function wireEarlyDisconnectDetection(
   let poll: ReturnType<typeof setInterval> | null = setInterval(() => {
     if (cleanedUp) return;
     if (bunHandle.closed) {
-      if (!abortController.signal.aborted) {
-        logger.debug(`Early disconnect detected (bunHandle.closed), aborting upstream fetch`);
+      if (deferSocketClose) {
+        logger.info(
+          `Socket close observed for request ${requestId} before dispatch ` +
+            '(source=bunHandle.closed); deferring upstream cancellation'
+        );
+      } else if (!abortController.signal.aborted) {
+        logger.info(
+          `Client disconnect observed for request ${requestId} before dispatch ` +
+            '(source=bunHandle.closed); aborting upstream fetch'
+        );
         abortController.abort(new DOMException('Client disconnected', 'AbortError'));
       }
       cleanedUp = true;


### PR DESCRIPTION
## Summary
Plexus now persists Responses stream captures and usage as soon as it forwards a terminal Responses event. Codex can close the connection immediately after `response.completed` without turning a completed request into a cancelled one or losing its trace.

## Context
Codex correctly closes its stream after `response.completed`. Plexus previously waited for the transport to finish before finalizing the inspectors, so the client close could destroy the pipeline first.

## Changes
- Detect terminal Responses SSE events in the debug inspector and finalize raw and transformed captures before forwarding them to the client.
- Finalize usage from the transformed terminal event. Later stream teardown cannot overwrite the completed usage record.
- Defer the Bun socket-close abort only for `responses:lite` requests, while retaining the existing behavior for other API types.
- Log socket-close observations and confirmed cancellation sources with the request ID.
- Add regressions for terminal capture, usage finalization, and the Lite socket-close policy.

## Testing
- Added tests that hold the transport open after `response.completed` and verify both trace data and usage have already finalized.
