### PR TITLE
chore(cora): trigger model smoke test

### DIFF
--- a/.github/workflows/cora-review.yml
+++ b/.github/workflows/cora-review.yml
@@ -1,4 +1,5 @@
 name: Cora AI Code Review
+# Temporary smoke-test change for the Cora model configuration.
 run-name: "Cora Review: PR #${{ github.event.pull_request.number }}"
 
 on:


### PR DESCRIPTION
## Summary
Create a temporary pull request to trigger Cora using the current workflow on `main`.

## Why
The previous rerun reused an older workflow definition that still referenced the deleted `LLM_MODEL_ID` variable. This PR provides a fresh event to verify that the current workflow passes `kimi-k3`.

## Changes
- Add one temporary comment to the Cora workflow.

## Testing
Commit hooks passed: Biome lint, migration guard, repomap generation, typecheck, and workflow YAML validation.

This PR is intended to be closed after the Cora run is verified.
