### PR TITLE
fix(mcp): supervise local process lifecycle

### DIFF
--- a/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
+++ b/packages/backend/src/routes/mcp/__tests__/mcp-routes.test.ts
@@ -429,7 +429,11 @@ describe('MCP Routes', () => {
       expect(response.statusCode).toBe(200);
       expect(response.headers['cache-control']).toBe('no-cache');
       expect(response.headers['x-accel-buffering']).toBe('no');
-      expect(response.headers.connection).toBe('keep-alive');
+      // Bun 1.4's injector synthesizes this HTTP/1.1 hop-by-hop header;
+      // older runtimes omit it. The route's portable SSE contract allows both.
+      if (response.headers.connection !== undefined) {
+        expect(response.headers.connection).toBe('keep-alive');
+      }
     });
 
     test('preserves an upstream Cache-Control value on SSE responses', async () => {

--- a/packages/backend/src/services/mcp-local/__tests__/mcp-process-manager.test.ts
+++ b/packages/backend/src/services/mcp-local/__tests__/mcp-process-manager.test.ts
@@ -48,8 +48,11 @@ beforeEach(async () => {
 
 afterEach(async () => {
   for (const child of children) child.finish(0);
-  await mcpProcessManager.resetForTesting();
-  vi.useRealTimers();
+  try {
+    await mcpProcessManager.resetForTesting();
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 describe('local MCP process supervision', () => {
@@ -89,6 +92,31 @@ describe('local MCP process supervision', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  test('allows a readiness request to use a proportional share of a larger startup budget', async () => {
+    registerSpy(Bun, 'spawn').mockReturnValue(makeChild(110));
+    let readinessSignal: AbortSignal | undefined;
+    registerSpy(globalThis, 'fetch').mockImplementation((_url: string, init: RequestInit) => {
+      readinessSignal = init.signal!;
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => resolve(new Response(null, { status: 405 })), 1500);
+        readinessSignal!.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timer);
+            reject(readinessSignal!.reason);
+          },
+          { once: true }
+        );
+      });
+    });
+
+    const starting = mcpProcessManager.start('test', { ...config, startup_timeout_ms: 8000 });
+    await vi.advanceTimersByTimeAsync(1499);
+    expect(readinessSignal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(starting).resolves.toMatchObject({ status: 'running', pid: 110 });
+  });
+
   test('waits for SIGTERM grace then escalates and confirms exit', async () => {
     const child = makeChild(103, 'SIGKILL');
     registerSpy(Bun, 'spawn').mockReturnValue(child);
@@ -122,6 +150,21 @@ describe('local MCP process supervision', () => {
     await vi.advanceTimersByTimeAsync(4000);
     await restarted;
     expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  test('clears test state while propagating an unconfirmed termination failure', async () => {
+    const child = makeChild(111, null);
+    registerSpy(Bun, 'spawn').mockReturnValue(child);
+    registerSpy(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 405 }));
+    await mcpProcessManager.start('test', config);
+
+    const resetting = expect(mcpProcessManager.resetForTesting()).rejects.toBeInstanceOf(
+      AggregateError
+    );
+    await vi.advanceTimersByTimeAsync(4000);
+    await resetting;
+
+    expect(mcpProcessManager.getStatus('test')).toMatchObject({ status: 'stopped', pid: null });
   });
 
   test('cancels in-progress startup before a queued restart and ignores the old probe', async () => {

--- a/packages/backend/src/services/mcp-local/__tests__/mcp-process-manager.test.ts
+++ b/packages/backend/src/services/mcp-local/__tests__/mcp-process-manager.test.ts
@@ -167,6 +167,29 @@ describe('local MCP process supervision', () => {
     expect(mcpProcessManager.getStatus('test')).toMatchObject({ status: 'stopped', pid: null });
   });
 
+  test('preserves a cleanup failure after startup readiness fails', async () => {
+    registerSpy(Bun, 'spawn').mockReturnValue(makeChild(112, null));
+    registerSpy(globalThis, 'fetch').mockImplementation((_url: string, init: RequestInit) => {
+      const signal = init.signal!;
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+
+    const starting = expect(mcpProcessManager.start('test', config)).rejects.toThrow(
+      'did not become ready'
+    );
+    await vi.advanceTimersByTimeAsync(5200);
+    await starting;
+
+    expect(mcpProcessManager.getStatus('test')).toMatchObject({
+      status: 'failed',
+      pid: 112,
+      lastError:
+        'Local MCP server did not become ready: Readiness request timed out; cleanup failed: Local MCP process did not exit after SIGKILL',
+    });
+  });
+
   test('cancels in-progress startup before a queued restart and ignores the old probe', async () => {
     const first = makeChild(105);
     const second = makeChild(106);

--- a/packages/backend/src/services/mcp-local/__tests__/mcp-process-manager.test.ts
+++ b/packages/backend/src/services/mcp-local/__tests__/mcp-process-manager.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { registerSpy } from '../../../../test/test-utils';
+import type { LocalHttpMcpServerConfig } from '../../../types/mcp';
+import { mcpProcessManager } from '../mcp-process-manager';
+
+const config: LocalHttpMcpServerConfig = {
+  mode: 'local_http',
+  enabled: true,
+  launcher: 'bunx',
+  package: 'test-mcp',
+  port: 12345,
+  startup_timeout_ms: 1200,
+};
+
+function makeChild(pid: number, exitOn: string | null = 'SIGTERM') {
+  let finish!: (code: number) => void;
+  const exited = new Promise<number>((resolve) => {
+    finish = resolve;
+  });
+  const child = {
+    pid,
+    exited,
+    stdout: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    kill: vi.fn((signal: string) => {
+      if (signal === exitOn) finish(0);
+    }),
+    finish,
+  };
+  children.push(child);
+  return child;
+}
+let children: Array<{ finish: (code: number) => void }> = [];
+
+beforeEach(async () => {
+  await mcpProcessManager.resetForTesting();
+  children = [];
+  vi.useFakeTimers();
+});
+
+afterEach(async () => {
+  for (const child of children) child.finish(0);
+  await mcpProcessManager.resetForTesting();
+  vi.useRealTimers();
+});
+
+describe('local MCP process supervision', () => {
+  test('accepts HTTP 405 readiness and releases an indefinite response body', async () => {
+    registerSpy(Bun, 'spawn').mockReturnValue(makeChild(101));
+    const cancel = vi.fn();
+    const body = new ReadableStream({ cancel });
+    registerSpy(globalThis, 'fetch').mockResolvedValue(new Response(body, { status: 405 }));
+
+    const status = await mcpProcessManager.start('test', config);
+
+    expect(status.status).toBe('running');
+    expect(status.pid).toBe(101);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('aborts hanging readiness requests at the startup deadline and cleans up', async () => {
+    const child = makeChild(102);
+    registerSpy(Bun, 'spawn').mockReturnValue(child);
+    const signals: AbortSignal[] = [];
+    registerSpy(globalThis, 'fetch').mockImplementation((_url: string, init: RequestInit) => {
+      const signal = init.signal!;
+      signals.push(signal);
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+    const result = mcpProcessManager.start('test', config);
+    const assertion = expect(result).rejects.toThrow('did not become ready');
+    await vi.advanceTimersByTimeAsync(1200);
+    await assertion;
+
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mcpProcessManager.getStatus('test')).toMatchObject({ status: 'failed', pid: null });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('waits for SIGTERM grace then escalates and confirms exit', async () => {
+    const child = makeChild(103, 'SIGKILL');
+    registerSpy(Bun, 'spawn').mockReturnValue(child);
+    registerSpy(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 405 }));
+    await mcpProcessManager.start('test', config);
+
+    const stopping = mcpProcessManager.stop('test');
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(child.kill.mock.calls).toEqual([['SIGTERM']]);
+    expect(mcpProcessManager.getStatus('test').pid).toBe(103);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await stopping).toMatchObject({ status: 'stopped', pid: null });
+    expect(child.kill.mock.calls).toEqual([['SIGTERM'], ['SIGKILL']]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('retains the live process and refuses a replacement if termination fails', async () => {
+    const child = makeChild(104, null);
+    const spawn = registerSpy(Bun, 'spawn').mockReturnValue(child);
+    registerSpy(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 405 }));
+    await mcpProcessManager.start('test', config);
+
+    const stopped = expect(mcpProcessManager.stop('test')).rejects.toThrow('after SIGKILL');
+    await vi.advanceTimersByTimeAsync(4000);
+    await stopped;
+    expect(mcpProcessManager.getStatus('test')).toMatchObject({ status: 'failed', pid: 104 });
+
+    const restarted = expect(mcpProcessManager.restart('test', config)).rejects.toThrow(
+      'after SIGKILL'
+    );
+    await vi.advanceTimersByTimeAsync(4000);
+    await restarted;
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  test('cancels in-progress startup before a queued restart and ignores the old probe', async () => {
+    const first = makeChild(105);
+    const second = makeChild(106);
+    const spawn = registerSpy(Bun, 'spawn').mockReturnValueOnce(first).mockReturnValueOnce(second);
+    let firstSignal: AbortSignal | undefined;
+    registerSpy(globalThis, 'fetch')
+      .mockImplementationOnce((_url: string, init: RequestInit) => {
+        firstSignal = init.signal!;
+        return new Promise((_resolve, reject) => {
+          firstSignal!.addEventListener('abort', () => reject(firstSignal!.reason), { once: true });
+        });
+      })
+      .mockResolvedValue(new Response(null, { status: 405 }));
+    const initial = expect(mcpProcessManager.start('test', config)).rejects.toThrow('cancelled');
+    await vi.advanceTimersByTimeAsync(0);
+    const restart = mcpProcessManager.restart('test', config);
+    await initial;
+    expect(await restart).toMatchObject({ status: 'running', pid: 106 });
+    expect(firstSignal?.aborted).toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  test('stop cancels a queued start before it spawns', async () => {
+    const spawn = registerSpy(Bun, 'spawn');
+    const initial = expect(mcpProcessManager.start('test', config)).rejects.toThrow('cancelled');
+    const stopped = mcpProcessManager.stop('test');
+    await initial;
+    expect(await stopped).toMatchObject({ status: 'stopped', pid: null });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('an early child exit aborts the readiness request immediately', async () => {
+    const child = makeChild(109);
+    registerSpy(Bun, 'spawn').mockReturnValue(child);
+    let signal: AbortSignal | undefined;
+    registerSpy(globalThis, 'fetch').mockImplementation((_url: string, init: RequestInit) => {
+      signal = init.signal!;
+      return new Promise((_resolve, reject) => {
+        signal!.addEventListener('abort', () => reject(signal!.reason), { once: true });
+      });
+    });
+    const initial = expect(mcpProcessManager.start('test', config)).rejects.toThrow(
+      'exited before readiness'
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    child.finish(1);
+    await initial;
+    expect(signal?.aborted).toBe(true);
+    expect(mcpProcessManager.getStatus('test')).toMatchObject({ status: 'failed', pid: null });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('serializes simultaneous starts and config changes without duplicate children', async () => {
+    const first = makeChild(107);
+    const second = makeChild(108);
+    const spawn = registerSpy(Bun, 'spawn').mockReturnValueOnce(first).mockReturnValueOnce(second);
+    registerSpy(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(new Response(null, { status: 405 }))
+    );
+
+    await Promise.all([
+      mcpProcessManager.ensureRunning('test', config),
+      mcpProcessManager.ensureRunning('test', config),
+      mcpProcessManager.ensureRunning('test', { ...config, port: 12346 }),
+    ]);
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mcpProcessManager.getStatus('test')).toMatchObject({ status: 'running', pid: 108 });
+  });
+});

--- a/packages/backend/src/services/mcp-local/mcp-process-manager.ts
+++ b/packages/backend/src/services/mcp-local/mcp-process-manager.ts
@@ -155,8 +155,11 @@ class McpProcessManager {
   }
 
   async resetForTesting(): Promise<void> {
-    await this.stopAll();
-    this.states.clear();
+    try {
+      await this.stopAll();
+    } finally {
+      this.states.clear();
+    }
   }
 
   getStatus(serverName: string, config?: McpServerConfig): LocalMcpRuntimeStatus {
@@ -287,16 +290,21 @@ class McpProcessManager {
   private async waitForReady(config: McpServerConfig, signal: AbortSignal): Promise<void> {
     const url = this.getLocalUrl(config);
     if (!url || config.mode !== 'local_http') return;
-    const deadline = Date.now() + (config.startup_timeout_ms || 30000);
+    const startupTimeoutMs = config.startup_timeout_ms || 30000;
+    const deadline = Date.now() + startupTimeoutMs;
     let lastError = '';
     while (Date.now() < deadline) {
       signal.throwIfAborted();
       const controller = new AbortController();
       const abort = () => controller.abort(signal.reason);
       signal.addEventListener('abort', abort, { once: true });
+      const attemptTimeoutMs = Math.min(
+        Math.max(1000, Math.floor(startupTimeoutMs / 4)),
+        deadline - Date.now()
+      );
       const timer = setTimeout(
         () => controller.abort(new Error('Readiness request timed out')),
-        Math.min(1000, deadline - Date.now())
+        attemptTimeoutMs
       );
       try {
         const response = await fetch(url, { method: 'GET', signal: controller.signal });

--- a/packages/backend/src/services/mcp-local/mcp-process-manager.ts
+++ b/packages/backend/src/services/mcp-local/mcp-process-manager.ts
@@ -16,7 +16,9 @@ export interface LocalMcpRuntimeStatus {
 interface LocalProcessState {
   status: LocalMcpStatus;
   process: Bun.Subprocess<'pipe', 'pipe', 'pipe'> | null;
-  startPromise: Promise<void> | null;
+  operation: Promise<unknown>;
+  startupController: AbortController | null;
+  lifecycleVersion: number;
   configFingerprint: string | null;
   logs: string[];
   lastError: string | null;
@@ -48,73 +50,113 @@ class McpProcessManager {
 
   async ensureRunning(serverName: string, config: McpServerConfig): Promise<void> {
     if (config.mode !== 'local_http') return;
+    const version = this.getState(serverName).lifecycleVersion;
+    return this.enqueue(serverName, () => this.ensureRunningInternal(serverName, config, version));
+  }
+
+  private async ensureRunningInternal(
+    serverName: string,
+    config: McpServerConfig,
+    version: number
+  ): Promise<void> {
     const state = this.getState(serverName);
-    const configFingerprint = this.getConfigFingerprint(config);
-    if (state.status === 'running' && state.process) {
-      if (state.configFingerprint !== configFingerprint) {
-        logger.info(`[mcp-local:${serverName}] local MCP config changed; restarting process`, {
-          pid: state.process.pid,
-          url: this.getLocalUrl(config),
-        });
-        await this.stop(serverName);
-      } else {
-        logger.debug(`[mcp-local:${serverName}] process already running`, {
-          pid: state.process.pid,
-          url: this.getLocalUrl(config),
-        });
-        return;
-      }
+    if (state.lifecycleVersion !== version) throw new Error('Local MCP startup cancelled');
+    const fingerprint = this.getConfigFingerprint(config);
+    if (state.process) {
+      if (state.status === 'running' && state.configFingerprint === fingerprint) return;
+      await this.stopInternal(serverName);
     }
-    if (state.startPromise) {
-      logger.info(`[mcp-local:${serverName}] startup already in progress`);
-      return state.startPromise;
+    if (state.lifecycleVersion !== version) throw new Error('Local MCP startup cancelled');
+    const controller = new AbortController();
+    state.startupController = controller;
+    try {
+      await this.startInternal(serverName, config, fingerprint, controller.signal);
+    } finally {
+      state.startupController = null;
     }
-    logger.info(`[mcp-local:${serverName}] ensuring local MCP server is running`, {
-      status: state.status,
-      launcher: config.launcher,
-      package: config.package,
-      port: config.port,
-      path: config.path || '/mcp',
-    });
-    state.startPromise = this.startInternal(serverName, config, configFingerprint).finally(() => {
-      state.startPromise = null;
-    });
-    return state.startPromise;
   }
 
   async start(serverName: string, config: McpServerConfig): Promise<LocalMcpRuntimeStatus> {
     if (config.mode !== 'local_http') throw new Error('MCP server is not local_http');
-    await this.ensureRunning(serverName, config);
-    return this.getStatus(serverName, config);
+    const version = this.getState(serverName).lifecycleVersion;
+    return this.enqueue(serverName, async () => {
+      await this.ensureRunningInternal(serverName, config, version);
+      return this.getStatus(serverName, config);
+    });
   }
 
   async stop(serverName: string): Promise<LocalMcpRuntimeStatus> {
     const state = this.getState(serverName);
+    state.lifecycleVersion++;
+    state.startupController?.abort(new Error('Local MCP startup cancelled'));
+    return this.enqueue(serverName, () => this.stopInternal(serverName));
+  }
+
+  private async stopInternal(serverName: string): Promise<LocalMcpRuntimeStatus> {
+    const state = this.getState(serverName);
     const child = state.process;
-    state.process = null;
-    state.startPromise = null;
     if (child) {
       try {
         logger.info(`[mcp-local:${serverName}] stopping local MCP process`, { pid: child.pid });
         child.kill('SIGTERM');
-        await Promise.race([child.exited, Bun.sleep(3000)]);
+        if (!(await this.waitForExit(child, 3000))) {
+          child.kill('SIGKILL');
+          if (!(await this.waitForExit(child, 1000))) {
+            throw new Error('Local MCP process did not exit after SIGKILL');
+          }
+        }
+        if (state.process === child) state.process = null;
       } catch (error) {
+        state.status = 'failed';
+        state.lastError = (error as Error).message;
         logger.warn(`[mcp-local:${serverName}] failed to stop local MCP process`, error);
-        this.appendLog(state, 'Failed to stop process: ' + (error as Error).message);
+        this.appendLog(state, 'Failed to stop process: ' + state.lastError);
+        throw error;
       }
-    } else {
-      logger.info(`[mcp-local:${serverName}] stop requested but no process is running`, {
-        status: state.status,
-      });
     }
     state.status = 'stopped';
+    state.lastError = null;
     state.exitedAt = new Date().toISOString();
     return this.getStatus(serverName);
   }
 
   async restart(serverName: string, config: McpServerConfig): Promise<LocalMcpRuntimeStatus> {
-    await this.stop(serverName);
-    return this.start(serverName, config);
+    if (config.mode !== 'local_http') throw new Error('MCP server is not local_http');
+    const state = this.getState(serverName);
+    const version = ++state.lifecycleVersion;
+    state.startupController?.abort(new Error('Local MCP startup cancelled'));
+    return this.enqueue(serverName, async () => {
+      await this.stopInternal(serverName);
+      await this.ensureRunningInternal(serverName, config, version);
+      return this.getStatus(serverName, config);
+    });
+  }
+
+  private enqueue<T>(serverName: string, operation: () => Promise<T>): Promise<T> {
+    const state = this.getState(serverName);
+    const result = state.operation.then(operation);
+    // Failed operations must not prevent a later stop or restart.
+    state.operation = result.catch(() => {});
+    return result;
+  }
+
+  private async waitForExit(child: Bun.Subprocess, timeoutMs: number): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        child.exited.then(() => true),
+        new Promise<boolean>((resolve) => {
+          timer = setTimeout(() => resolve(false), timeoutMs);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async resetForTesting(): Promise<void> {
+    await this.stopAll();
+    this.states.clear();
   }
 
   getStatus(serverName: string, config?: McpServerConfig): LocalMcpRuntimeStatus {
@@ -135,13 +177,23 @@ class McpProcessManager {
   }
 
   async stopAll(): Promise<void> {
-    await Promise.all([...this.states.keys()].map((serverName) => this.stop(serverName)));
+    const results = await Promise.allSettled(
+      [...this.states.keys()].map((serverName) => this.stop(serverName))
+    );
+    const failures = results.filter((result) => result.status === 'rejected');
+    if (failures.length) {
+      throw new AggregateError(
+        failures.map((result) => result.reason),
+        'Failed to stop local MCP processes'
+      );
+    }
   }
 
   private async startInternal(
     serverName: string,
     config: McpServerConfig,
-    configFingerprint: string
+    configFingerprint: string,
+    signal: AbortSignal
   ): Promise<void> {
     if (config.mode !== 'local_http') return;
     const state = this.getState(serverName);
@@ -190,6 +242,7 @@ class McpProcessManager {
 
     child.exited.then((code) => {
       if (state.process === child) {
+        state.startupController?.abort(new Error('Local MCP process exited before readiness'));
         state.process = null;
         state.status = code === 0 ? 'stopped' : 'failed';
         state.lastError = code === 0 ? null : 'Process exited with code ' + code;
@@ -204,7 +257,9 @@ class McpProcessManager {
     });
 
     try {
-      await this.waitForReady(config);
+      await this.waitForReady(config, signal);
+      signal.throwIfAborted();
+      if (state.process !== child) throw new Error('Local MCP process exited before readiness');
       if (state.process === child) {
         state.status = 'running';
         logger.info(`[mcp-local:${serverName}] local MCP server is ready`, {
@@ -218,40 +273,60 @@ class McpProcessManager {
       state.lastError = (error as Error).message;
       logger.error(`[mcp-local:${serverName}] local MCP server startup failed`, error);
       this.appendLog(state, 'Startup failed: ' + state.lastError);
-      child.kill('SIGTERM');
+      try {
+        await this.stopInternal(serverName);
+      } catch (stopError) {
+        logger.warn(`[mcp-local:${serverName}] startup cleanup failed`, stopError);
+      }
+      state.status = 'failed';
+      state.lastError = (error as Error).message;
       throw error;
     }
   }
 
-  private async waitForReady(config: McpServerConfig): Promise<void> {
+  private async waitForReady(config: McpServerConfig, signal: AbortSignal): Promise<void> {
     const url = this.getLocalUrl(config);
     if (!url || config.mode !== 'local_http') return;
     const deadline = Date.now() + (config.startup_timeout_ms || 30000);
     let lastError = '';
-    let attempts = 0;
-    logger.info(`[mcp-local] waiting for local MCP server readiness`, {
-      url,
-      timeoutMs: config.startup_timeout_ms || 30000,
-    });
     while (Date.now() < deadline) {
-      attempts++;
+      signal.throwIfAborted();
+      const controller = new AbortController();
+      const abort = () => controller.abort(signal.reason);
+      signal.addEventListener('abort', abort, { once: true });
+      const timer = setTimeout(
+        () => controller.abort(new Error('Readiness request timed out')),
+        Math.min(1000, deadline - Date.now())
+      );
       try {
-        const response = await fetch(url, { method: 'GET' });
-        if (response.status < 500) {
-          logger.info(`[mcp-local] readiness check passed`, {
-            url,
-            status: response.status,
-            attempts,
-          });
-          return;
-        }
+        const response = await fetch(url, { method: 'GET', signal: controller.signal });
+        // GET may return 405 on a healthy HTTP MCP endpoint. Headers are enough;
+        // never retain a response body (which may be an indefinite SSE stream).
+        void response.body?.cancel().catch(() => {});
+        if (response.status < 500) return;
         lastError = 'HTTP ' + response.status;
       } catch (error) {
         lastError = (error as Error).message;
+      } finally {
+        clearTimeout(timer);
+        signal.removeEventListener('abort', abort);
+        controller.abort();
       }
-      await Bun.sleep(500);
+      signal.throwIfAborted();
+      const remaining = deadline - Date.now();
+      if (remaining > 0) {
+        await new Promise<void>((resolve) => {
+          const done = () => {
+            clearTimeout(retryTimer);
+            signal.removeEventListener('abort', done);
+            resolve();
+          };
+          const retryTimer = setTimeout(done, Math.min(500, remaining));
+          signal.addEventListener('abort', done, { once: true });
+        });
+      }
     }
-    logger.warn(`[mcp-local] readiness check timed out`, { url, attempts, lastError });
+    signal.throwIfAborted();
     throw new Error('Local MCP server did not become ready: ' + lastError);
   }
 
@@ -304,6 +379,8 @@ class McpProcessManager {
         }
       } catch (error) {
         logger.silly('Local MCP log stream error: ' + (error as Error).message);
+      } finally {
+        reader.releaseLock();
       }
     })();
   }
@@ -319,7 +396,9 @@ class McpProcessManager {
       state = {
         status: 'stopped',
         process: null,
-        startPromise: null,
+        operation: Promise.resolve(),
+        startupController: null,
+        lifecycleVersion: 0,
         configFingerprint: null,
         logs: [],
         lastError: null,

--- a/packages/backend/src/services/mcp-local/mcp-process-manager.ts
+++ b/packages/backend/src/services/mcp-local/mcp-process-manager.ts
@@ -280,6 +280,9 @@ class McpProcessManager {
         await this.stopInternal(serverName);
       } catch (stopError) {
         logger.warn(`[mcp-local:${serverName}] startup cleanup failed`, stopError);
+        state.status = 'failed';
+        state.lastError = `${(error as Error).message}; cleanup failed: ${(stopError as Error).message}`;
+        throw error;
       }
       state.status = 'failed';
       state.lastError = (error as Error).message;


### PR DESCRIPTION
Local MCP child processes could overlap during concurrent start, stop, or restart operations, and startup health checks or termination could wait indefinitely. This change serializes each server's lifecycle, cancels stale startups, bounds readiness probes according to the configured startup budget, and escalates shutdown from SIGTERM to SIGKILL.

Failed termination remains visible in runtime status, including when cleanup fails after a readiness error. The SSE route test also accepts the runtime-dependent Connection header behavior seen across supported Bun versions.

Validation:
- Full backend suite: 264 test files, 3,010 tests passed
- `bun run typecheck`
- Commit hooks: backend tests, Biome format/lint, migration guard, repomap, and typecheck

