### PR TITLE
feat(runtime): drain work during graceful shutdown

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -44,6 +44,7 @@ import { BackgroundExplorer } from './services/routing/background-explorer';
 import { CooldownManager } from './services/runtime/cooldown-manager';
 import { DebugManager } from './services/observability/debug-manager';
 import { ModelMetadataManager } from './services/models/model-metadata-manager';
+import { ModelAutosyncScheduler } from './services/models/model-autosync-scheduler';
 import { CodexVersionService } from './services/oauth/codex-version-service';
 import { SelectorFactory } from './services/routing/selectors/factory';
 import { QuotaScheduler } from './services/quota/quota-scheduler';
@@ -57,7 +58,10 @@ import { registerMcpRoutes } from './routes/mcp';
 import { registerOpenApiRoute } from './routes/openapi';
 import { McpUsageStorageService } from './services/mcp-proxy/mcp-usage-storage';
 import { QuotaEnforcer } from './services/quota/quota-enforcer';
-import { initModelCatalog } from './services/pi-ai/catalog';
+import { getModelCatalog, initModelCatalog } from './services/pi-ai/catalog';
+import { OAuthLoginSessionManager } from './services/oauth/oauth-login-session';
+import { createShutdown } from './services/runtime/shutdown';
+import { trackRequestHandlers } from './services/runtime/request-lifecycle';
 import { initializeDatabase } from './db/client';
 import { runMigrations } from './db/migrate';
 import { runEncryptionMigration } from './db/encrypt-migration';
@@ -97,6 +101,7 @@ const fastify = Fastify({
   bodyLimit: 30 * 1024 * 1024, // 30MB to accommodate 25MB audio files + metadata
   forceCloseConnections: true, // Destroy all open sockets on shutdown (fixes SSE hang)
 });
+const requestHandlers = trackRequestHandlers(fastify);
 
 // --- Plugin Registration ---
 
@@ -324,6 +329,41 @@ await registerOpenApiRoute(fastify);
 const responsesStorage = new ResponsesStorageService();
 responsesStorage.startCleanupJob(1, 7);
 
+const shutdown = createShutdown({
+  closeServer: async () => {
+    try {
+      await fastify.close();
+    } finally {
+      await requestHandlers.drain();
+    }
+  },
+  stopBackground: async () => {
+    getModelCatalog().dispose();
+    OAuthLoginSessionManager.instance?.dispose();
+    const results = await Promise.allSettled([
+      ConfigService.getInstance().shutdown(),
+      quotaScheduler.shutdown(),
+      ModelAutosyncScheduler.getInstance().shutdown(),
+      ModelMetadataManager.getInstance().shutdown(),
+      responsesStorage.shutdown(),
+      BackgroundExplorer.getInstance()?.shutdown(),
+    ]);
+    const failures = results.flatMap((result) =>
+      result.status === 'rejected' ? [result.reason] : []
+    );
+    if (failures.length) throw new AggregateError(failures, 'Background shutdown failed');
+  },
+  stopProcesses: () => mcpProcessManager.stopAll(),
+  drainTelemetry: async () => {
+    await usageStorage.drain();
+    await DebugManager.getInstance().drain();
+  },
+  closeStorage: async () => {
+    const { closeDatabase } = await import('./db/client');
+    await closeDatabase();
+  },
+});
+
 // --- Management API (v0) ---
 await registerManagementRoutes(
   fastify,
@@ -332,7 +372,8 @@ await registerManagementRoutes(
   probeService,
   quotaScheduler,
   mcpUsageStorage,
-  quotaEnforcer
+  quotaEnforcer,
+  shutdown
 );
 
 // Health check endpoint for container orchestration
@@ -450,19 +491,22 @@ const start = async () => {
     await fastify.listen({ port, host });
     logger.info(`Server listening on http://localhost:${port}`);
 
-    const shutdown = async (signal: string) => {
+    const onShutdownSignal = (signal: string) => {
       logger.info(`Received ${signal}, shutting down gracefully...`);
-      quotaScheduler.stop();
-      await mcpProcessManager.stopAll();
-      await fastify.close();
-      const { closeDatabase } = await import('./db/client');
-      await closeDatabase();
-      logger.info('Shutdown complete');
-      process.exit(0);
+      void shutdown().then(
+        () => {
+          logger.info('Shutdown complete');
+          process.exit(0);
+        },
+        (error) => {
+          logger.error('Shutdown failed', error);
+          process.exit(1);
+        }
+      );
     };
 
-    process.on('SIGTERM', () => shutdown('SIGTERM'));
-    process.on('SIGINT', () => shutdown('SIGINT'));
+    process.on('SIGTERM', () => onShutdownSignal('SIGTERM'));
+    process.on('SIGINT', () => onShutdownSignal('SIGINT'));
   } catch (err) {
     logger.error('Fatal error during server startup', err);
     process.exit(1);

--- a/packages/backend/src/routes/inference/__tests__/auth.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/auth.test.ts
@@ -26,6 +26,7 @@ describe('Auth Middleware', () => {
     } as unknown as Dispatcher;
 
     mockUsageStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(),
       saveError: vi.fn(),
       updatePerformanceMetrics: vi.fn(),
@@ -251,6 +252,7 @@ describe('Key Attribution', () => {
     } as unknown as Dispatcher;
 
     mockUsageStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(),
       saveError: vi.fn(),
       updatePerformanceMetrics: vi.fn(),
@@ -486,6 +488,7 @@ describe('Key Access Policy Propagation', () => {
     } as unknown as Dispatcher;
 
     mockUsageStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(),
       saveError: vi.fn(),
       updatePerformanceMetrics: vi.fn(),
@@ -596,6 +599,7 @@ describe('Key Access Policy Exclusion Propagation', () => {
     } as unknown as Dispatcher;
 
     mockUsageStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(),
       saveError: vi.fn(),
       updatePerformanceMetrics: vi.fn(),
@@ -674,6 +678,7 @@ describe('Key IP Allowlist', () => {
     } as unknown as Dispatcher;
 
     mockUsageStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(),
       saveError: vi.fn(),
       updatePerformanceMetrics: vi.fn(),
@@ -792,6 +797,7 @@ describe('Trusted Proxy Header Handling', () => {
     } as unknown as Dispatcher;
 
     mockUsageStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(),
       saveError: vi.fn(),
       updatePerformanceMetrics: vi.fn(),

--- a/packages/backend/src/routes/inference/__tests__/completions.test.ts
+++ b/packages/backend/src/routes/inference/__tests__/completions.test.ts
@@ -76,6 +76,7 @@ describe('Completions Endpoint', () => {
     } as unknown as Dispatcher;
 
     mockUsageStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(),
       saveError: vi.fn(),
       saveDebugLog: vi.fn(),

--- a/packages/backend/src/routes/inference/images.ts
+++ b/packages/backend/src/routes/inference/images.ts
@@ -140,7 +140,7 @@ export async function registerImagesRoute(
     const startTime = Date.now();
     const abortController = new AbortController();
     const { signal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-    const disconnect = wireEarlyDisconnectDetection(request, abortController);
+    const disconnect = wireEarlyDisconnectDetection(request, abortController, requestId);
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,
@@ -307,7 +307,7 @@ export async function registerImagesRoute(
     const startTime = Date.now();
     const abortController = new AbortController();
     const { signal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-    const disconnect = wireEarlyDisconnectDetection(request, abortController);
+    const disconnect = wireEarlyDisconnectDetection(request, abortController, requestId);
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,

--- a/packages/backend/src/routes/management.ts
+++ b/packages/backend/src/routes/management.ts
@@ -37,7 +37,8 @@ export async function registerManagementRoutes(
   probeService: ProbeService,
   quotaScheduler?: QuotaScheduler,
   mcpUsageStorage?: McpUsageStorageService,
-  quotaEnforcer?: QuotaEnforcer
+  quotaEnforcer?: QuotaEnforcer,
+  shutdown?: () => Promise<void>
 ) {
   // Encapsulate all management routes in their own scope so the management
   // error handler doesn't collide with the global one (avoids FSTWRN004).
@@ -103,7 +104,7 @@ export async function registerManagementRoutes(
       await registerTestRoutes(adminOnly, probeService);
       await registerOAuthRoutes(adminOnly);
       await registerLoggingRoutes(adminOnly);
-      await registerRestartRoutes(adminOnly);
+      await registerRestartRoutes(adminOnly, shutdown);
       await registerProviderRoutes(adminOnly);
       await registerMetricsRoutes(adminOnly, usageStorage);
       await registerPerformanceRoutes(adminOnly, usageStorage);

--- a/packages/backend/src/routes/management/__tests__/restart.test.ts
+++ b/packages/backend/src/routes/management/__tests__/restart.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import Fastify from 'fastify';
+import { registerSpy } from '../../../../test/test-utils';
+import { registerRestartRoutes } from '../restart';
+
+afterEach(() => vi.useRealTimers());
+
+describe('management restart', () => {
+  test.each([false, true])(
+    'awaits application shutdown before exiting (failure=%s)',
+    async (fails) => {
+      const app = Fastify();
+      const stopped = Promise.withResolvers<void>();
+      const shutdown = vi.fn(() => stopped.promise);
+      const exit = registerSpy(process, 'exit').mockImplementation((() => undefined) as never);
+      await registerRestartRoutes(app, shutdown);
+      await app.ready();
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+      try {
+        const response = await app.inject({ method: 'POST', url: '/v0/management/restart' });
+        expect(response.statusCode).toBe(200);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(shutdown).toHaveBeenCalledTimes(1);
+        expect(exit).not.toHaveBeenCalled();
+        if (fails) stopped.reject(new Error('cleanup failed'));
+        else stopped.resolve();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(exit).toHaveBeenCalledWith(1);
+      } finally {
+        vi.useRealTimers();
+        await app.close();
+      }
+    }
+  );
+});

--- a/packages/backend/src/routes/management/restart.ts
+++ b/packages/backend/src/routes/management/restart.ts
@@ -1,7 +1,10 @@
 import { FastifyInstance } from 'fastify';
 import { logger } from '../../utils/logger';
 
-export async function registerRestartRoutes(fastify: FastifyInstance) {
+export async function registerRestartRoutes(
+  fastify: FastifyInstance,
+  shutdown: () => Promise<void> = () => fastify.close()
+) {
   /**
    * POST /v0/management/restart
    * Gracefully restart the application by closing the server and exiting.
@@ -20,9 +23,14 @@ export async function registerRestartRoutes(fastify: FastifyInstance) {
       // Give the response time to be sent before closing
       setTimeout(async () => {
         logger.info('[RESTART] Closing server gracefully');
-        await fastify.close();
-        logger.info('[RESTART] Server closed, exiting process');
-        process.exit(1);
+        try {
+          await shutdown();
+          logger.info('[RESTART] Shutdown complete, exiting process');
+        } catch (error) {
+          logger.error('[RESTART] Shutdown failed', error);
+        } finally {
+          process.exit(1);
+        }
       }, 100);
     } catch (error: any) {
       logger.error('[RESTART] Error during restart:', error);

--- a/packages/backend/src/services/__tests__/dispatcher-oauth-passthrough.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-oauth-passthrough.test.ts
@@ -429,6 +429,7 @@ describe('Dispatcher OAuth pass-through — cross-format Anthropic response tran
     const clientTransformer = TransformerFactory.getTransformer('chat');
     const usageRecord: Partial<UsageRecord> = { requestId: 'req-e2e-cross-format' };
     const usageStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(),
       saveError: vi.fn(),
       updatePerformanceMetrics: vi.fn(),

--- a/packages/backend/src/services/__tests__/model-autosync-scheduler.test.ts
+++ b/packages/backend/src/services/__tests__/model-autosync-scheduler.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ProviderConfig } from '../../config';
 import { registerSpy } from '../../../test/test-utils';
 import { ModelAutosyncScheduler } from '../models/model-autosync-scheduler';
+import * as discovery from '../providers/provider-model-discovery';
+import { ConfigRepository } from '../../db/config-repository';
 
 const makeProvider = (intervalMinutes: number): ProviderConfig => ({
   api_base_url: 'https://api.example.com/v1',
@@ -15,6 +17,43 @@ const makeProvider = (intervalMinutes: number): ProviderConfig => ({
 });
 
 describe('ModelAutosyncScheduler', () => {
+  it('waits for persistence and the models-changed callback, then refuses new work', async () => {
+    vi.useFakeTimers();
+    const persisted = Promise.withResolvers<number>();
+    const callbackDone = Promise.withResolvers<void>();
+    const discover = registerSpy(discovery, 'discoverProviderModelIds').mockResolvedValue([
+      'new-model',
+    ]);
+    const save = registerSpy(
+      ConfigRepository.prototype,
+      'addMissingProviderModels'
+    ).mockReturnValue(persisted.promise);
+    const changed = vi.fn(() => callbackDone.promise);
+    const scheduler = ModelAutosyncScheduler.getInstance();
+    scheduler.initialize({ wafer: makeProvider(1) }, changed);
+    await Promise.resolve();
+    expect(save).toHaveBeenCalledOnce();
+
+    let stopped = false;
+    const shutdown = scheduler.shutdown().then(() => {
+      stopped = true;
+    });
+    expect(await scheduler.runSyncNow('wafer')).toBe(0);
+    scheduler.reload({ other: makeProvider(1) });
+    scheduler.initialize({ another: makeProvider(1) });
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(discover).toHaveBeenCalledOnce();
+    expect(stopped).toBe(false);
+
+    persisted.resolve(1);
+    await Promise.resolve();
+    expect(changed).toHaveBeenCalledOnce();
+    expect(stopped).toBe(false);
+    callbackDone.resolve();
+    await shutdown;
+    expect(stopped).toBe(true);
+  });
+
   afterEach(() => {
     ModelAutosyncScheduler.getInstance().stop();
     ModelAutosyncScheduler.resetInstance();

--- a/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
+++ b/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
@@ -334,6 +334,7 @@ describe('handleResponse cancellation records usage from live captures (no pre-s
     const usageRecord: Partial<UsageRecord> = { requestId: 'req-cancel-e2e' };
     const savedRecords: UsageRecord[] = [];
     const mockStorage = {
+      trackFinalization: <T>(task: Promise<T>) => task,
       saveRequest: vi.fn(async (record: UsageRecord) => {
         savedRecords.push(record);
       }),

--- a/packages/backend/src/services/configuration/config-service.ts
+++ b/packages/backend/src/services/configuration/config-service.ts
@@ -48,6 +48,7 @@ export class ConfigService {
   private rebuildPromise: Promise<void> | null = null;
   /** Delay (ms) before a coalesced rebuild fires. */
   private readonly COALESCE_MS = 100;
+  private shuttingDown = false;
 
   constructor(repo?: ConfigRepository) {
     this.repo = repo ?? new ConfigRepository();
@@ -422,6 +423,7 @@ export class ConfigService {
    * Useful in tests or operations that need immediate consistency.
    */
   async flush(): Promise<void> {
+    if (this.shuttingDown) return;
     if (this.coalesceTimer) {
       clearTimeout(this.coalesceTimer);
       this.coalesceTimer = null;
@@ -433,6 +435,16 @@ export class ConfigService {
     await this.executeRebuild();
   }
 
+  /** Writes are already persisted; stop cache rebuilds that could restart schedulers. */
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    if (this.coalesceTimer) {
+      clearTimeout(this.coalesceTimer);
+      this.coalesceTimer = null;
+    }
+    await this.rebuildPromise;
+  }
+
   // ─── Internal ────────────────────────────────────────────────────
 
   /**
@@ -441,6 +453,7 @@ export class ConfigService {
    * final call in a burst actually hits the database.
    */
   private rebuildCache(): void {
+    if (this.shuttingDown) return;
     if (this.coalesceTimer) {
       clearTimeout(this.coalesceTimer);
       this.coalesceTimer = null;
@@ -535,6 +548,7 @@ export class ConfigService {
     // changes saved via the UI take effect without a restart.
     // Only reload if the scheduler has already been initialized;
     // on startup, index.ts calls quotaScheduler.initialize() explicitly after this.
+    if (this.shuttingDown) return;
     const scheduler = QuotaScheduler.getInstance();
     if (scheduler.isInitialized()) {
       try {

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -278,22 +278,26 @@ export class UsageInspector extends PassThrough {
       // Record quota usage after costs are calculated (fire-and-forget) —
       // against the FINAL attempt's resolved provider/model.
       if (this.quotaEnforcer && this.keyName) {
-        recordQuotaUsage(
-          this.keyName,
-          this.usageRecord.finalAttemptProvider,
-          this.usageRecord.finalAttemptModel,
-          {
-            tokensInput: this.usageRecord.tokensInput,
-            tokensOutput: this.usageRecord.tokensOutput,
-            tokensCached: this.usageRecord.tokensCached,
-            tokensCacheWrite: this.usageRecord.tokensCacheWrite,
-            tokensReasoning: this.usageRecord.tokensReasoning,
-            costTotal: this.usageRecord.costTotal,
-          },
-          this.quotaEnforcer
-        ).catch((err) => {
-          logger.error(`Failed to record quota usage for ${this.keyName}:`, err);
-        });
+        this.usageStorage
+          .trackFinalization(
+            recordQuotaUsage(
+              this.keyName,
+              this.usageRecord.finalAttemptProvider,
+              this.usageRecord.finalAttemptModel,
+              {
+                tokensInput: this.usageRecord.tokensInput,
+                tokensOutput: this.usageRecord.tokensOutput,
+                tokensCached: this.usageRecord.tokensCached,
+                tokensCacheWrite: this.usageRecord.tokensCacheWrite,
+                tokensReasoning: this.usageRecord.tokensReasoning,
+                costTotal: this.usageRecord.costTotal,
+              },
+              this.quotaEnforcer
+            )
+          )
+          .catch((err) => {
+            logger.error(`Failed to record quota usage for ${this.keyName}:`, err);
+          });
       }
 
       if (

--- a/packages/backend/src/services/models/model-autosync-scheduler.ts
+++ b/packages/backend/src/services/models/model-autosync-scheduler.ts
@@ -2,6 +2,7 @@ import type { ProviderConfig } from '../../config';
 import { ConfigRepository } from '../../db/config-repository';
 import { logger } from '../../utils/logger';
 import { discoverProviderModelIds } from '../providers/provider-model-discovery';
+import { PendingTasks } from '../runtime/pending-tasks';
 
 type ModelsChangedCallback = () => void | Promise<void>;
 
@@ -17,6 +18,8 @@ export class ModelAutosyncScheduler {
   private intervals: Map<string, ReturnType<typeof setInterval>> = new Map();
   private runningProviders: Set<string> = new Set();
   private initialized = false;
+  private shuttingDown = false;
+  private readonly pendingTasks = new PendingTasks();
   private onModelsChanged?: ModelsChangedCallback;
 
   private constructor(private repo: ConfigRepository = new ConfigRepository()) {}
@@ -36,12 +39,14 @@ export class ModelAutosyncScheduler {
     providers: Record<string, ProviderConfig>,
     onModelsChanged?: ModelsChangedCallback
   ): void {
+    if (this.shuttingDown) return;
     this.initialized = true;
     this.onModelsChanged = onModelsChanged;
     this.reload(providers, onModelsChanged);
   }
 
   reload(providers: Record<string, ProviderConfig>, onModelsChanged?: ModelsChangedCallback): void {
+    if (this.shuttingDown) return;
     if (onModelsChanged) this.onModelsChanged = onModelsChanged;
 
     const nextConfigs = new Map<string, AutosyncConfig>();
@@ -76,7 +81,12 @@ export class ModelAutosyncScheduler {
     }
   }
 
-  async runSyncNow(providerId: string): Promise<number> {
+  runSyncNow(providerId: string): Promise<number> {
+    if (this.shuttingDown) return Promise.resolve(0);
+    return this.pendingTasks.track(this.runSync(providerId));
+  }
+
+  private async runSync(providerId: string): Promise<number> {
     const config = this.configs.get(providerId);
     if (!config) {
       logger.warn(`Model autosync config for provider '${providerId}' not found`);
@@ -115,12 +125,23 @@ export class ModelAutosyncScheduler {
     return this.initialized;
   }
 
-  stop(): void {
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    this.clearIntervals();
+    await this.pendingTasks.drain();
+    this.stop();
+  }
+
+  private clearIntervals(): void {
     for (const [providerId, intervalId] of this.intervals) {
       clearInterval(intervalId);
       logger.info(`Stopped model autosync for provider '${providerId}'`);
     }
     this.intervals.clear();
+  }
+
+  stop(): void {
+    this.clearIntervals();
     this.configs.clear();
     this.runningProviders.clear();
     this.initialized = false;

--- a/packages/backend/src/services/models/model-metadata-manager.ts
+++ b/packages/backend/src/services/models/model-metadata-manager.ts
@@ -356,6 +356,7 @@ export class ModelMetadataManager {
   private autoRefreshIntervalMinutes = 60;
   private autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
   private inFlightRefresh: Promise<ModelMetadataRefreshResult> | null = null;
+  private shuttingDown = false;
   private fetchCache = new Map<string, { etag: string; data: unknown }>();
 
   private constructor() {}
@@ -385,6 +386,7 @@ export class ModelMetadataManager {
     sources?: Partial<MetadataCatalogSources>,
     trigger: 'startup' | 'scheduled' | 'manual' = 'manual'
   ): Promise<ModelMetadataRefreshResult> {
+    if (this.shuttingDown) throw new Error('Model metadata manager is shutting down');
     if (sources) {
       this.sourceConfig = {
         ...this.sourceConfig,
@@ -439,6 +441,7 @@ export class ModelMetadataManager {
   }
 
   public startAutoRefresh(intervalMinutes = 60, sources?: Partial<MetadataCatalogSources>): void {
+    if (this.shuttingDown) return;
     if (sources) {
       this.sourceConfig = {
         ...this.sourceConfig,
@@ -467,6 +470,12 @@ export class ModelMetadataManager {
       clearInterval(this.autoRefreshTimer);
       this.autoRefreshTimer = null;
     }
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    this.stopAutoRefresh();
+    await this.inFlightRefresh;
   }
 
   // ─── Loaders ────────────────────────────────────

--- a/packages/backend/src/services/observability/__tests__/telemetry-drain.test.ts
+++ b/packages/backend/src/services/observability/__tests__/telemetry-drain.test.ts
@@ -1,0 +1,133 @@
+import { UsageInspector } from '../../inspectors/usage-logging';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { registerSpy } from '../../../../test/test-utils';
+import { UsageStorageService } from '../usage-storage';
+import { DebugManager } from '../debug-manager';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  DebugManager.getInstance().resetForTesting();
+  DebugManager.getInstance().setEnabled(false);
+});
+afterEach(() => vi.useRealTimers());
+
+describe('telemetry drain', () => {
+  test('waits for usage writes queued by a pending event', async () => {
+    const storage = new UsageStorageService();
+    const started = deferred();
+    const updated = deferred();
+    registerSpy(storage, 'emitStarted').mockImplementation(async () => {
+      await started.promise;
+      storage.emitUpdatedAsync({ requestId: 'one' });
+    });
+    const update = registerSpy(storage, 'emitUpdated').mockImplementation(() => updated.promise);
+    storage.emitStartedAsync({ requestId: 'one' });
+    let drained = false;
+    const draining = storage.drain().then(() => {
+      drained = true;
+    });
+    started.resolve();
+    await vi.waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(drained).toBe(false);
+    updated.resolve();
+    await draining;
+  });
+
+  test('waits for a direct fire-and-forget usage upsert and writes from its completion listener', async () => {
+    const storage = new UsageStorageService();
+    const write = deferred();
+    const errorWrite = deferred();
+    const values = vi.fn(() => ({ onConflictDoUpdate: () => write.promise }));
+    const errorValues = vi.fn(() => errorWrite.promise);
+    (storage as any).db = {
+      insert: vi.fn().mockReturnValueOnce({ values }).mockReturnValueOnce({ values: errorValues }),
+    };
+    (storage as any).schema = { requestUsage: { requestId: 'request_id' }, inferenceErrors: {} };
+    storage.on('completed', () => {
+      void storage.saveError('one', new Error('late error'), undefined, 'test-key');
+    });
+    void storage.saveRequest({ requestId: 'one' } as any);
+    let drained = false;
+    const draining = storage.drain().then(() => {
+      drained = true;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    write.resolve();
+    await vi.waitFor(() => expect(errorValues).toHaveBeenCalledOnce());
+    expect(drained).toBe(false);
+    errorWrite.resolve();
+    await draining;
+    expect(drained).toBe(true);
+  });
+
+  test('waits for detached streaming quota accounting after the stream finishes', async () => {
+    const storage = new UsageStorageService();
+    registerSpy(storage, 'saveRequest').mockResolvedValue(undefined);
+    registerSpy(storage, 'updatePerformanceMetrics').mockResolvedValue(undefined);
+    const quota = deferred();
+    const recordUsage = vi.fn(() => quota.promise);
+    const inspector = new UsageInspector(
+      'stream',
+      storage,
+      { requestId: 'stream' },
+      undefined,
+      undefined,
+      Date.now(),
+      false,
+      'chat',
+      'chat',
+      undefined,
+      { recordUsage },
+      'test-key'
+    );
+    inspector.resume();
+    const finished = new Promise<void>((resolve) => inspector.on('finish', resolve));
+    inspector.end();
+    await finished;
+    expect(recordUsage).toHaveBeenCalledOnce();
+    let drained = false;
+    const draining = storage.drain().then(() => {
+      drained = true;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    quota.resolve();
+    await draining;
+    expect(drained).toBe(true);
+  });
+
+  test('waits for prior debug writes and flushes remaining eligible traces', async () => {
+    vi.useFakeTimers();
+    const manager = DebugManager.getInstance();
+    const storage = new UsageStorageService();
+    const prior = deferred();
+    const remaining = deferred();
+    const save = registerSpy(storage, 'saveDebugLog')
+      .mockImplementationOnce(() => prior.promise)
+      .mockImplementationOnce(() => remaining.promise);
+    manager.setStorage(storage);
+    manager.setEnabled(true);
+    manager.startLog('prior', { model: 'test' });
+    manager.flush('prior');
+    manager.startLog('remaining', { model: 'test' });
+    let drained = false;
+    const draining = manager.drain().then(() => {
+      drained = true;
+    });
+    expect(save).toHaveBeenCalledTimes(2);
+    remaining.resolve();
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    prior.resolve();
+    await draining;
+    expect(manager.getPendingLog('remaining')).toBeUndefined();
+  });
+});

--- a/packages/backend/src/services/observability/debug-manager.ts
+++ b/packages/backend/src/services/observability/debug-manager.ts
@@ -3,6 +3,7 @@ import { logger } from '../../utils/logger';
 import { createParser, EventSourceMessage } from 'eventsource-parser';
 import { encode } from 'eventsource-encoder';
 import { getCurrentKeyName, setCurrentRequestId } from './request-context';
+import { PendingTasks } from '../runtime/pending-tasks';
 
 export interface DebugLogRecord {
   requestId: string;
@@ -38,6 +39,7 @@ export class DebugManager {
   private enabledProviders: Set<string> = new Set();
   private pendingLogs: Map<string, DebugLogRecord> = new Map();
   private ephemeralRequests: Set<string> = new Set();
+  private writes = new PendingTasks();
 
   private constructor() {}
 
@@ -365,10 +367,18 @@ export class DebugManager {
 
     logger.debug(`Flushing debug log for ${requestId}`);
     if (typeof this.storage.saveDebugLog === 'function') {
-      this.storage.saveDebugLog(log);
+      this.writes.track(Promise.resolve(this.storage.saveDebugLog(log))).catch((error) => {
+        logger.error(`Failed to flush debug log for ${requestId}`, error);
+      });
     }
     this.pendingLogs.delete(requestId);
     this.ephemeralRequests.delete(requestId);
+  }
+
+  /** Flush eligible traces and wait for writes that previous flushes started. */
+  async drain(): Promise<void> {
+    for (const requestId of this.pendingLogs.keys()) this.flush(requestId);
+    await this.writes.drain();
   }
 
   /**

--- a/packages/backend/src/services/observability/usage-storage.ts
+++ b/packages/backend/src/services/observability/usage-storage.ts
@@ -1,3 +1,4 @@
+import { PendingTasks } from '../runtime/pending-tasks';
 import { logger } from '../../utils/logger';
 import { UsageRecord } from '../../types/usage';
 import { getDatabase, getSchema } from '../../db/client';
@@ -65,6 +66,7 @@ export class UsageStorageService extends EventEmitter {
   private db: ReturnType<typeof getDatabase> | null = null;
   private schema: any = null;
   private readonly defaultPerformanceRetentionLimit = 100;
+  private readonly pendingWrites = new PendingTasks();
   private telemetryQueue: Promise<void> = Promise.resolve();
   private inFlightRegistry = new Map<
     string,
@@ -124,7 +126,11 @@ export class UsageStorageService extends EventEmitter {
     return parsed;
   }
 
-  async saveRequest(record: NewRequestUsage | UsageRecord) {
+  saveRequest(record: NewRequestUsage | UsageRecord) {
+    return this.pendingWrites.track(this.saveRequestInternal(record));
+  }
+
+  private async saveRequestInternal(record: NewRequestUsage | UsageRecord) {
     try {
       const isStreamedValue =
         typeof record.isStreamed === 'boolean' ? (record.isStreamed ? 1 : 0) : record.isStreamed;
@@ -191,13 +197,25 @@ export class UsageStorageService extends EventEmitter {
   }
 
   private enqueueTelemetryTask(task: () => Promise<void>): void {
-    this.telemetryQueue = this.telemetryQueue
-      .then(async () => {
-        await task();
-      })
-      .catch((error) => {
-        logger.error('Telemetry queue task failed', error);
-      });
+    this.telemetryQueue = this.pendingWrites.track(
+      this.telemetryQueue
+        .then(async () => {
+          await task();
+        })
+        .catch((error) => {
+          logger.error('Telemetry queue task failed', error);
+        })
+    );
+  }
+
+  /** Include a detached response finalizer, including writes it schedules after awaits. */
+  trackFinalization<T>(task: Promise<T>): Promise<T> {
+    return this.pendingWrites.track(task);
+  }
+
+  /** Wait for queued events, direct writes, and complete response finalizers. */
+  async drain(): Promise<void> {
+    await this.pendingWrites.drain();
   }
 
   /**
@@ -205,7 +223,11 @@ export class UsageStorageService extends EventEmitter {
    * This allows the frontend to show in-flight requests immediately.
    * The record is inserted with durationMs=null to indicate it's still in-flight.
    */
-  async emitStarted(record: Partial<UsageRecord>): Promise<void> {
+  emitStarted(record: Partial<UsageRecord>): Promise<void> {
+    return this.pendingWrites.track(this.emitStartedInternal(record));
+  }
+
+  private async emitStartedInternal(record: Partial<UsageRecord>): Promise<void> {
     try {
       // Insert pending record with durationMs=null to indicate in-flight status
       await this.ensureDb()
@@ -250,7 +272,11 @@ export class UsageStorageService extends EventEmitter {
    * Also updates the pending DB record with provider/model info so the concurrency
    * endpoint can group in-flight requests by provider.
    */
-  async emitUpdated(record: Partial<UsageRecord>): Promise<void> {
+  emitUpdated(record: Partial<UsageRecord>): Promise<void> {
+    return this.pendingWrites.track(this.emitUpdatedInternal(record));
+  }
+
+  private async emitUpdatedInternal(record: Partial<UsageRecord>): Promise<void> {
     // Update the pending record in DB if we have provider/model info
     if (
       record.requestId &&
@@ -278,7 +304,11 @@ export class UsageStorageService extends EventEmitter {
     this.emit('updated', record);
   }
 
-  async saveDebugLog(record: DebugLogRecord) {
+  saveDebugLog(record: DebugLogRecord) {
+    return this.pendingWrites.track(this.saveDebugLogInternal(record));
+  }
+
+  private async saveDebugLogInternal(record: DebugLogRecord) {
     try {
       const serialize = (data: any): string | null => {
         if (!data) return null;
@@ -334,7 +364,16 @@ export class UsageStorageService extends EventEmitter {
     return JSON.stringify(normalized);
   }
 
-  async saveError(requestId: string, error: any, details?: any, apiKey?: string | null) {
+  saveError(requestId: string, error: any, details?: any, apiKey?: string | null) {
+    return this.pendingWrites.track(this.saveErrorInternal(requestId, error, details, apiKey));
+  }
+
+  private async saveErrorInternal(
+    requestId: string,
+    error: any,
+    details?: any,
+    apiKey?: string | null
+  ) {
     try {
       // Resolve the owning key name in preference order:
       //   1. Explicit caller-supplied apiKey (most accurate).
@@ -803,7 +842,31 @@ export class UsageStorageService extends EventEmitter {
     }
   }
 
-  async updatePerformanceMetrics(
+  updatePerformanceMetrics(
+    provider: string,
+    model: string,
+    canonicalModelName: string | null,
+    timeToFirstTokenMs: number | null,
+    outputTokens: number | null,
+    durationMs: number,
+    requestId: string,
+    success: boolean = true
+  ) {
+    return this.pendingWrites.track(
+      this.updatePerformanceMetricsInternal(
+        provider,
+        model,
+        canonicalModelName,
+        timeToFirstTokenMs,
+        outputTokens,
+        durationMs,
+        requestId,
+        success
+      )
+    );
+  }
+
+  private async updatePerformanceMetricsInternal(
     provider: string,
     model: string,
     canonicalModelName: string | null,
@@ -870,7 +933,23 @@ export class UsageStorageService extends EventEmitter {
     }
   }
 
-  async recordSuccessfulAttempt(
+  recordSuccessfulAttempt(
+    provider: string,
+    model: string,
+    canonicalModelName: string | null,
+    requestId: string,
+    metadata?: {
+      isVisionFallthrough?: boolean;
+      isDescriptorRequest?: boolean;
+      visionFallthroughModel?: string;
+    }
+  ) {
+    return this.pendingWrites.track(
+      this.recordSuccessfulAttemptInternal(provider, model, canonicalModelName, requestId, metadata)
+    );
+  }
+
+  private async recordSuccessfulAttemptInternal(
     provider: string,
     model: string,
     canonicalModelName: string | null,
@@ -908,7 +987,23 @@ export class UsageStorageService extends EventEmitter {
     );
   }
 
-  async recordFailedAttempt(
+  recordFailedAttempt(
+    provider: string,
+    model: string,
+    canonicalModelName: string | null,
+    requestId: string,
+    metadata?: {
+      isVisionFallthrough?: boolean;
+      isDescriptorRequest?: boolean;
+      visionFallthroughModel?: string;
+    }
+  ) {
+    return this.pendingWrites.track(
+      this.recordFailedAttemptInternal(provider, model, canonicalModelName, requestId, metadata)
+    );
+  }
+
+  private async recordFailedAttemptInternal(
     provider: string,
     model: string,
     canonicalModelName: string | null,

--- a/packages/backend/src/services/quota/__tests__/quota-scheduler-shutdown.test.ts
+++ b/packages/backend/src/services/quota/__tests__/quota-scheduler-shutdown.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { QuotaConfig } from '../../../config';
+import { QuotaScheduler } from '../quota-scheduler';
+import * as registry from '../checker-registry';
+import { registerSpy } from '../../../../test/test-utils';
+
+vi.mock('../checker-registry', () => ({
+  loadAllCheckers: vi.fn(async () => {}),
+  loadCustomCheckers: vi.fn(async () => {}),
+  getCheckerDefinition: vi.fn(() => ({ check: async () => [] })),
+  createMeterContext: vi.fn(() => ({})),
+}));
+
+const config: QuotaConfig = {
+  id: 'shutdown-checker',
+  provider: 'test',
+  type: 'synthetic',
+  enabled: true,
+  intervalMinutes: 1,
+  options: {},
+};
+
+describe('QuotaScheduler shutdown', () => {
+  beforeEach(() => {
+    QuotaScheduler.resetForTesting();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    QuotaScheduler.resetForTesting();
+    vi.useRealTimers();
+  });
+
+  it('waits for result persistence and cooldown updates while refusing new checks', async () => {
+    const scheduler = QuotaScheduler.getInstance();
+    const persisted = Promise.withResolvers<void>();
+    const persistenceStarted = Promise.withResolvers<void>();
+    const cooldownDone = Promise.withResolvers<void>();
+    const persist = registerSpy(scheduler as any, 'persistResult').mockImplementation(() => {
+      persistenceStarted.resolve();
+      return persisted.promise;
+    });
+    const cooldown = registerSpy(scheduler as any, 'applyCooldownsFromResult').mockReturnValue(
+      cooldownDone.promise
+    );
+    await scheduler.initialize([config]);
+    await persistenceStarted.promise;
+    expect(persist).toHaveBeenCalledOnce();
+
+    let stopped = false;
+    const shutdown = scheduler.shutdown().then(() => {
+      stopped = true;
+    });
+    expect(await scheduler.runCheckNow(config.id)).toBeNull();
+    await scheduler.reload([config]);
+    await scheduler.initialize([config]);
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(persist).toHaveBeenCalledOnce();
+    expect(stopped).toBe(false);
+
+    persisted.resolve();
+    await Promise.resolve();
+    expect(cooldown).toHaveBeenCalledOnce();
+    expect(stopped).toBe(false);
+    cooldownDone.resolve();
+    await shutdown;
+    expect(scheduler.getCheckerIds()).toEqual([]);
+  });
+
+  it.each(['initialize', 'reload'] as const)(
+    'does not schedule after an in-flight %s finishes',
+    async (method) => {
+      const scheduler = QuotaScheduler.getInstance();
+      const loaded = Promise.withResolvers<void>();
+      registerSpy(registry, 'loadAllCheckers').mockReturnValueOnce(loaded.promise);
+      const check = registerSpy(scheduler, 'runCheckNow').mockResolvedValue(null);
+      const loading = scheduler[method]([config]);
+      let stopped = false;
+      const shutdown = scheduler.shutdown().then(() => {
+        stopped = true;
+      });
+      await Promise.resolve();
+      expect(stopped).toBe(false);
+      loaded.resolve();
+      await loading;
+      await shutdown;
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(check).not.toHaveBeenCalled();
+      expect(scheduler.getCheckerIds()).toEqual([]);
+    }
+  );
+});

--- a/packages/backend/src/services/quota/quota-scheduler.ts
+++ b/packages/backend/src/services/quota/quota-scheduler.ts
@@ -12,6 +12,7 @@ import { toDbTimestampMs } from '../../utils/normalize';
 import { eq, desc, gte, and } from 'drizzle-orm';
 import { CooldownManager } from '../runtime/cooldown-manager';
 import { INDEFINITE_COOLDOWN_MS } from '@plexus/shared';
+import { PendingTasks } from '../runtime/pending-tasks';
 
 const DEFAULT_EXHAUSTION_THRESHOLD = 99;
 const MAX_STALE_QUOTA_CHECK_INTERVALS = 2;
@@ -40,6 +41,8 @@ export class QuotaScheduler {
   private checkerRunTails: Map<string, Promise<void>> = new Map();
   private lastCheckerRunAt: Map<string, number> = new Map();
   private checkersLoaded = false;
+  private shuttingDown = false;
+  private readonly pendingTasks = new PendingTasks();
   private db: ReturnType<typeof getDatabase> | null = null;
   private schema: ReturnType<typeof getSchema> | null = null;
 
@@ -52,6 +55,11 @@ export class QuotaScheduler {
     return QuotaScheduler.instance;
   }
 
+  static resetForTesting(): void {
+    QuotaScheduler.instance?.stop();
+    QuotaScheduler.instance = undefined as any;
+  }
+
   private ensureDb() {
     if (!this.db) {
       this.db = getDatabase();
@@ -60,13 +68,20 @@ export class QuotaScheduler {
     return { db: this.db, schema: this.schema! };
   }
 
-  async initialize(quotaConfigs: QuotaConfig[]): Promise<void> {
+  initialize(quotaConfigs: QuotaConfig[]): Promise<void> {
+    if (this.shuttingDown) return Promise.resolve();
+    return this.pendingTasks.track(this.initializeCheckers(quotaConfigs));
+  }
+
+  private async initializeCheckers(quotaConfigs: QuotaConfig[]): Promise<void> {
     if (!this.checkersLoaded) {
       await loadAllCheckers();
       this.checkersLoaded = true;
     } else {
       await loadCustomCheckers();
     }
+
+    if (this.shuttingDown) return;
 
     for (const config of quotaConfigs) {
       if (!config.enabled) {
@@ -95,7 +110,12 @@ export class QuotaScheduler {
     }
   }
 
-  async runCheckNow(checkerId: string): Promise<MeterCheckResult | null> {
+  runCheckNow(checkerId: string): Promise<MeterCheckResult | null> {
+    if (this.shuttingDown) return Promise.resolve(null);
+    return this.pendingTasks.track(this.runCheck(checkerId));
+  }
+
+  private async runCheck(checkerId: string): Promise<MeterCheckResult | null> {
     const config = this.configs.get(checkerId);
     if (!config) {
       logger.warn(`Quota checker '${checkerId}' not found`);
@@ -507,24 +527,42 @@ export class QuotaScheduler {
     }
   }
 
-  stop(): void {
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    this.clearIntervals();
+    await this.pendingTasks.drain();
+    this.stop();
+  }
+
+  private clearIntervals(): void {
     for (const [id, intervalId] of this.intervals) {
       clearInterval(intervalId);
       logger.info(`Stopped quota checker '${id}'`);
     }
     this.intervals.clear();
+  }
+
+  stop(): void {
+    this.clearIntervals();
     this.configs.clear();
     this.checkerRunTails.clear();
     this.lastCheckerRunAt.clear();
   }
 
-  async reload(quotaConfigs: QuotaConfig[]): Promise<void> {
+  reload(quotaConfigs: QuotaConfig[]): Promise<void> {
+    if (this.shuttingDown) return Promise.resolve();
+    return this.pendingTasks.track(this.reloadCheckers(quotaConfigs));
+  }
+
+  private async reloadCheckers(quotaConfigs: QuotaConfig[]): Promise<void> {
     if (!this.checkersLoaded) {
       await loadAllCheckers();
       this.checkersLoaded = true;
     } else {
       await loadCustomCheckers();
     }
+
+    if (this.shuttingDown) return;
 
     const existingIds = new Set(this.configs.keys());
     const activeConfigs = quotaConfigs.filter((c) => c.enabled && getCheckerDefinition(c.type));

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -755,16 +755,22 @@ export async function handleResponse(
     }
 
     // Record the usage.
-    finalizeUsage(
-      usageRecord,
-      unifiedResponse,
-      usageStorage,
-      startTime,
-      pricing,
-      providerDiscount,
-      quotaEnforcer,
-      keyName
-    );
+    void usageStorage
+      .trackFinalization(
+        finalizeUsage(
+          usageRecord,
+          unifiedResponse,
+          usageStorage,
+          startTime,
+          pricing,
+          providerDiscount,
+          quotaEnforcer,
+          keyName
+        )
+      )
+      .catch((error) => {
+        logger.error('Failed to finalize response usage', error);
+      });
 
     logger.debug(`Outgoing ${apiType} Response`, responseBody);
     return reply.send(responseBody);

--- a/packages/backend/src/services/responses/responses-storage.ts
+++ b/packages/backend/src/services/responses/responses-storage.ts
@@ -2,11 +2,14 @@ import { getDatabase, getSchema } from '../../db/client';
 import { eq, sql, lt, inArray } from 'drizzle-orm';
 import { logger } from '../../utils/logger';
 import { UnifiedResponsesResponse } from '../../types/responses';
+import { PendingTasks } from '../runtime/pending-tasks';
 
 export class ResponsesStorageService {
   private db: ReturnType<typeof getDatabase> | null = null;
   private schema: any = null;
   private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+  private cleanupTasks = new PendingTasks();
+  private shuttingDown = false;
 
   /**
    * Response Storage with Automatic TTL Cleanup
@@ -27,21 +30,22 @@ export class ResponsesStorageService {
    * - Logs statistics when deletions occur
    */
   startCleanupJob(intervalHours: number = 24, ttlDays: number = 7): void {
+    if (this.shuttingDown) return;
     if (this.cleanupInterval) {
       logger.warn('Response cleanup job already running');
       return;
     }
 
     // Run initial cleanup
-    this.cleanupOldResponses(ttlDays).catch((err) =>
-      logger.error('Initial response cleanup failed:', err)
-    );
+    this.cleanupTasks
+      .track(this.cleanupOldResponses(ttlDays))
+      .catch((err) => logger.error('Initial response cleanup failed:', err));
 
     // Schedule periodic cleanup
     this.cleanupInterval = setInterval(
       async () => {
         try {
-          const result = await this.cleanupOldResponses(ttlDays);
+          const result = await this.cleanupTasks.track(this.cleanupOldResponses(ttlDays));
           if (result.deletedResponses > 0) {
             logger.debug(
               `Scheduled cleanup: deleted ${result.deletedResponses} responses, ${result.deletedItems} items, ${result.deletedConversations} conversations`
@@ -66,6 +70,12 @@ export class ResponsesStorageService {
       this.cleanupInterval = null;
       logger.debug('Response cleanup job stopped');
     }
+  }
+
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    this.stopCleanupJob();
+    await this.cleanupTasks.drain();
   }
 
   private ensureDb() {

--- a/packages/backend/src/services/routing/background-explorer.ts
+++ b/packages/backend/src/services/routing/background-explorer.ts
@@ -8,6 +8,7 @@ import {
 } from '../../config';
 import { CooldownManager } from '../runtime/cooldown-manager';
 import { ProbeService } from '../probes/probe-service';
+import { PendingTasks } from '../runtime/pending-tasks';
 
 type TargetKey = `${string}:${string}`;
 type ModelKind = NonNullable<ModelConfig['type']>;
@@ -55,6 +56,8 @@ export class BackgroundExplorer {
   private state = new Map<TargetKey, TargetState>();
   private queue: Array<{ provider: string; model: string }> = [];
   private activeWorkers = 0;
+  private shuttingDown = false;
+  private tasks = new PendingTasks();
   private readonly processStartTime = Date.now();
 
   private constructor(probeService: ProbeService) {
@@ -87,6 +90,7 @@ export class BackgroundExplorer {
    * Non-blocking. Returns immediately. Safe to call on every live request.
    */
   maybeTrigger(group: ModelTargetGroup, aliasType?: ModelKind): void {
+    if (this.shuttingDown) return;
     const config = getConfig();
     const bg = config.backgroundExploration;
     if (!bg || bg.enabled !== true) {
@@ -136,22 +140,24 @@ export class BackgroundExplorer {
       // we don't want to block the live-request path waiting on it. The
       // worker re-checks cooldown right before probing as well.
       const captured = st;
-      cooldownMgr
-        .isProviderHealthy(target.provider, target.model)
-        .then((healthy) => {
-          if (!healthy) return;
-          if (captured.inFlight) return;
-          // Re-check staleness in case another trigger raced us.
-          if (Date.now() - captured.lastProbedAt < thresholdMs) return;
+      this.tasks.track(
+        cooldownMgr
+          .isProviderHealthy(target.provider, target.model)
+          .then((healthy) => {
+            if (!healthy || this.shuttingDown) return;
+            if (captured.inFlight) return;
+            // Re-check staleness in case another trigger raced us.
+            if (Date.now() - captured.lastProbedAt < thresholdMs) return;
 
-          this.queue.push({ provider: target.provider!, model: target.model! });
-          this.pumpWorkers();
-        })
-        .catch((err) => {
-          logger.debug(
-            `BackgroundExplorer: cooldown check failed for ${target.provider}/${target.model}: ${err?.message ?? err}`
-          );
-        });
+            this.queue.push({ provider: target.provider!, model: target.model! });
+            this.pumpWorkers();
+          })
+          .catch((err) => {
+            logger.debug(
+              `BackgroundExplorer: cooldown check failed for ${target.provider}/${target.model}: ${err?.message ?? err}`
+            );
+          })
+      );
     }
   }
 
@@ -160,6 +166,7 @@ export class BackgroundExplorer {
   }
 
   private pumpWorkers(): void {
+    if (this.shuttingDown) return;
     const config = getConfig();
     const bg = config.backgroundExploration;
     if (!bg || bg.enabled !== true) return;
@@ -168,13 +175,13 @@ export class BackgroundExplorer {
     while (this.activeWorkers < concurrency && this.queue.length > 0) {
       this.activeWorkers++;
       // Fire and forget; the worker manages its own lifecycle.
-      void this.worker();
+      void this.tasks.track(this.worker());
     }
   }
 
   private async worker(): Promise<void> {
     try {
-      while (this.queue.length > 0) {
+      while (!this.shuttingDown && this.queue.length > 0) {
         const next = this.queue.shift();
         if (!next) break;
 
@@ -188,7 +195,7 @@ export class BackgroundExplorer {
         const healthy = await CooldownManager.getInstance()
           .isProviderHealthy(next.provider, next.model)
           .catch(() => false);
-        if (!healthy) {
+        if (!healthy || this.shuttingDown) {
           logger.debug(
             `BackgroundExplorer: skipping probe for ${next.provider}/${next.model} — on cooldown`
           );
@@ -217,5 +224,12 @@ export class BackgroundExplorer {
     } finally {
       this.activeWorkers--;
     }
+  }
+
+  /** Discard queued probes and wait for probes already producing usage records. */
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true;
+    this.queue.length = 0;
+    await this.tasks.drain();
   }
 }

--- a/packages/backend/src/services/runtime/__tests__/background-drain.test.ts
+++ b/packages/backend/src/services/runtime/__tests__/background-drain.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { registerSpy } from '../../../../test/test-utils';
+import { ResponsesStorageService } from '../../responses/responses-storage';
+import { ConfigService } from '../../configuration/config-service';
+import { ConfigRepository } from '../../../db/config-repository';
+import { BackgroundExplorer } from '../../routing/background-explorer';
+import { CooldownManager } from '../cooldown-manager';
+import type { ProbeService } from '../../probes/probe-service';
+import { setConfigForTesting, type ModelTargetGroup } from '../../../config';
+
+beforeEach(() => BackgroundExplorer.resetForTesting());
+afterEach(() => vi.useRealTimers());
+
+describe('background drain', () => {
+  test('waits for response cleanup and never schedules another sweep', async () => {
+    vi.useFakeTimers();
+    const storage = new ResponsesStorageService();
+    const sweep = Promise.withResolvers<{
+      deletedResponses: number;
+      deletedItems: number;
+      deletedConversations: number;
+    }>();
+    const cleanup = registerSpy(storage, 'cleanupOldResponses').mockReturnValue(sweep.promise);
+    storage.startCleanupJob(1, 7);
+    let drained = false;
+    const draining = storage.shutdown().then(() => {
+      drained = true;
+    });
+    storage.startCleanupJob(1, 7);
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(drained).toBe(false);
+    sweep.resolve({ deletedResponses: 1, deletedItems: 1, deletedConversations: 1 });
+    await draining;
+  });
+
+  test('keeps persisted config changes without restarting cache refresh during shutdown', async () => {
+    vi.useFakeTimers();
+    const repo = new ConfigRepository();
+    const save = registerSpy(repo, 'setSetting').mockResolvedValue(undefined);
+    const load = registerSpy(repo, 'getAllProviders').mockResolvedValue([]);
+    const config = new ConfigService(repo);
+    await config.setSetting('test', 1);
+    await config.shutdown();
+    // An already-admitted request may finish its write after shutdown begins.
+    await config.setSetting('test', 2);
+    await config.flush();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  test('drains an active probe but discards queued targets', async () => {
+    const started = Promise.withResolvers<void>();
+    const finished = Promise.withResolvers<void>();
+    const runProbe = vi.fn(async () => {
+      started.resolve();
+      await finished.promise;
+      return { success: true, durationMs: 1, apiType: 'chat', response: 'ok' };
+    });
+    registerSpy(CooldownManager.getInstance(), 'isProviderHealthy').mockResolvedValue(true);
+    setConfigForTesting({
+      providers: {
+        p: { api_base_url: 'https://example.test', api_key: 'test', models: ['one', 'two'] },
+      },
+      models: {},
+      keys: {},
+      quotas: [],
+      backgroundExploration: { enabled: true, stalenessThresholdSeconds: 0, workerConcurrency: 1 },
+    } as any);
+    const explorer = BackgroundExplorer.initialize({ runProbe } as unknown as ProbeService);
+    const group = {
+      name: 'test',
+      selector: 'latency',
+      targets: [
+        { provider: 'p', model: 'one' },
+        { provider: 'p', model: 'two' },
+      ],
+    } as ModelTargetGroup;
+    explorer.maybeTrigger(group);
+    await started.promise;
+    let drained = false;
+    const draining = explorer.shutdown().then(() => {
+      drained = true;
+    });
+    explorer.maybeTrigger(group);
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    finished.resolve();
+    await draining;
+    expect(runProbe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/services/runtime/__tests__/request-lifecycle.test.ts
+++ b/packages/backend/src/services/runtime/__tests__/request-lifecycle.test.ts
@@ -1,0 +1,249 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, test } from 'vitest';
+import { trackRequestHandlers } from '../request-lifecycle';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const servers: FastifyInstance[] = [];
+const gates: ReturnType<typeof deferred>[] = [];
+function gate() {
+  const result = deferred();
+  gates.push(result);
+  return result;
+}
+function setup() {
+  const server = Fastify({ forceCloseConnections: true });
+  servers.push(server);
+  return { server, tasks: trackRequestHandlers(server) };
+}
+async function listen(server: FastifyInstance) {
+  return server.listen({ host: '127.0.0.1', port: 0 });
+}
+async function nextTurn() {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+afterEach(async () => {
+  for (const pending of gates.splice(0)) pending.resolve();
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+});
+
+describe('request lifecycle shutdown drain', () => {
+  test('waits for a handler after Fastify destroys its socket', async () => {
+    const { server, tasks } = setup();
+    const entered = gate();
+    const finish = gate();
+    let completed = false;
+    server.get('/', async () => {
+      entered.resolve();
+      await finish.promise;
+      completed = true;
+      return 'ok';
+    });
+    const url = await listen(server);
+    const request = fetch(url).catch(() => undefined);
+    await entered.promise;
+    await server.close();
+    let drained = false;
+    const drain = tasks.drain().then(() => {
+      drained = true;
+    });
+    await nextTurn();
+    expect(completed).toBe(false);
+    expect(drained).toBe(false);
+    finish.resolve();
+    await drain;
+    await request;
+    expect(completed).toBe(true);
+  });
+
+  test.each(['async', 'callback'])(
+    'waits through an inherited %s preHandler and its later handler',
+    async (style) => {
+      const { server, tasks } = setup();
+      const hookEntered = gate();
+      const hookFinish = gate();
+      const handlerEntered = gate();
+      const handlerFinish = gate();
+      let completed = false;
+      let nestedInstance: FastifyInstance;
+      await server.register(async (plugin) => {
+        if (style === 'async') {
+          plugin.addHook('preHandler', async function () {
+            expect(this).toBe(nestedInstance);
+            hookEntered.resolve();
+            await hookFinish.promise;
+          });
+        } else {
+          plugin.addHook('preHandler', function (_request, _reply, done) {
+            expect(this).toBe(nestedInstance);
+            hookEntered.resolve();
+            void hookFinish.promise.then(() => done());
+          });
+        }
+        await plugin.register(async (nested) => {
+          nestedInstance = nested;
+          nested.get('/', async () => {
+            handlerEntered.resolve();
+            await handlerFinish.promise;
+            completed = true;
+            return 'ok';
+          });
+        });
+      });
+      const url = await listen(server);
+      const request = fetch(url).catch(() => undefined);
+      await hookEntered.promise;
+      await server.close();
+      let drained = false;
+      const drain = tasks.drain().then(() => {
+        drained = true;
+      });
+      await nextTurn();
+      expect(drained).toBe(false);
+      hookFinish.resolve();
+      await handlerEntered.promise;
+      await nextTurn();
+      expect(drained).toBe(false);
+      handlerFinish.resolve();
+      await drain;
+      await request;
+      expect(completed).toBe(true);
+    }
+  );
+
+  test('closes an active raw SSE response and waits for its handler cleanup', async () => {
+    const { server, tasks } = setup();
+    const cleanup = gate();
+    let closed = false;
+    server.addHook('onRequest', async () => {});
+    await server.register(async (plugin) => {
+      plugin.addHook('preHandler', async () => {});
+      plugin.get('/events', async (_request, reply) => {
+        reply.raw.writeHead(200, { 'Content-Type': 'text/event-stream' });
+        reply.raw.write('data: connected\n\n');
+        await new Promise<void>((resolve) => reply.raw.once('close', resolve));
+        closed = true;
+        await cleanup.promise;
+      });
+    });
+    const url = await listen(server);
+    const response = await fetch(url + '/events');
+    const body = response.text().catch(() => undefined);
+    await server.close();
+    expect(closed).toBe(true);
+    let drained = false;
+    const drain = tasks.drain().then(() => {
+      drained = true;
+    });
+    await nextTurn();
+    expect(drained).toBe(false);
+    cleanup.resolve();
+    await drain;
+    await body;
+  });
+
+  test('drains authentication rejection without invoking a handler', async () => {
+    const { server, tasks } = setup();
+    const entered = gate();
+    const finish = gate();
+    let called = false;
+    server.addHook('preHandler', async () => {
+      entered.resolve();
+      await finish.promise;
+      throw Object.assign(new Error('Unauthorized'), { statusCode: 401 });
+    });
+    server.get('/', () => {
+      called = true;
+      return 'ok';
+    });
+    const url = await listen(server);
+    const request = fetch(url).catch(() => undefined);
+    await entered.promise;
+    await server.close();
+    const drain = tasks.drain();
+    finish.resolve();
+    await drain;
+    await request;
+    expect(called).toBe(false);
+  });
+
+  test('preserves callback hooks, route-local hooks, payloads and normal HEAD responses', async () => {
+    const { server, tasks } = setup();
+    server.addHook('preHandler', function (request, reply, done) {
+      expect(this).toBe(server);
+      expect(request.method).toMatch(/GET|HEAD/);
+      expect(reply.server).toBe(server);
+      setImmediate(done);
+    });
+    server.get(
+      '/',
+      {
+        preHandler: [
+          async (_request, reply) => {
+            reply.header('x-hook', 'yes');
+          },
+        ],
+        onSend: (_request, _reply, payload, done) => done(null, payload),
+      },
+      async function () {
+        return { ok: this === server };
+      }
+    );
+    const response = await server.inject('/');
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true });
+    expect(response.headers['x-hook']).toBe('yes');
+    const head = await server.inject({ method: 'HEAD', url: '/' });
+    expect(head.statusCode).toBe(200);
+    expect(head.body).toBe('');
+    await tasks.drain();
+  });
+
+  test('drains callback early replies and awaits async hooks working after reply.send', async () => {
+    const { server, tasks } = setup();
+    const finish = gate();
+    server.get(
+      '/callback',
+      {
+        preHandler: (_request, reply, _done) => {
+          reply.code(401).send('unauthorized');
+        },
+      },
+      () => 'unreachable'
+    );
+    server.get(
+      '/async',
+      {
+        preHandler: async (_request, reply) => {
+          reply.code(401).send('unauthorized');
+          await finish.promise;
+          return reply;
+        },
+      },
+      () => 'unreachable'
+    );
+    const url = await listen(server);
+    const callbackResponse = await fetch(url + '/callback');
+    expect(callbackResponse.status).toBe(401);
+    await callbackResponse.text();
+    await tasks.drain();
+    const asyncResponse = await fetch(url + '/async');
+    expect(asyncResponse.status).toBe(401);
+    await asyncResponse.text();
+    let drained = false;
+    const drain = tasks.drain().then(() => {
+      drained = true;
+    });
+    await nextTurn();
+    expect(drained).toBe(false);
+    finish.resolve();
+    await drain;
+  });
+});

--- a/packages/backend/src/services/runtime/__tests__/shutdown.test.ts
+++ b/packages/backend/src/services/runtime/__tests__/shutdown.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createShutdown } from '../shutdown';
+import { PendingTasks } from '../pending-tasks';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe('shutdown', () => {
+  test('closes admission immediately and waits for producers and telemetry before storage', async () => {
+    const handlers = deferred();
+    const background = deferred();
+    const telemetry = deferred();
+    const dependencies = {
+      closeServer: vi.fn(() => handlers.promise),
+      stopBackground: vi.fn(() => background.promise),
+      stopProcesses: vi.fn(async () => {}),
+      drainTelemetry: vi.fn(() => telemetry.promise),
+      closeStorage: vi.fn(async () => {}),
+    };
+    const shutdown = createShutdown(dependencies);
+    const first = shutdown();
+    expect(shutdown()).toBe(first);
+    expect(dependencies.closeServer).toHaveBeenCalledTimes(1);
+    handlers.resolve();
+    await Promise.resolve();
+    expect(dependencies.drainTelemetry).not.toHaveBeenCalled();
+    background.resolve();
+    await vi.waitFor(() => expect(dependencies.drainTelemetry).toHaveBeenCalledTimes(1));
+    expect(dependencies.closeStorage).not.toHaveBeenCalled();
+    telemetry.resolve();
+    await first;
+    expect(dependencies.closeStorage).toHaveBeenCalledTimes(1);
+  });
+
+  test('reports deadline expiry without later closing storage under running producers', async () => {
+    vi.useFakeTimers();
+    const background = deferred();
+    const closeStorage = vi.fn(async () => {});
+    const shutdown = createShutdown(
+      {
+        closeServer: async () => {},
+        stopBackground: () => background.promise,
+        stopProcesses: async () => {},
+        drainTelemetry: async () => {},
+        closeStorage,
+      },
+      100
+    );
+    const pending = shutdown();
+    const rejected = expect(pending).rejects.toThrow('Shutdown did not finish within 100ms');
+    await vi.advanceTimersByTimeAsync(100);
+    await rejected;
+    background.resolve();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(closeStorage).not.toHaveBeenCalled();
+    expect(shutdown()).toBe(pending);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('reports cleanup failure without closing storage', async () => {
+    const closeStorage = vi.fn(async () => {});
+    const shutdown = createShutdown({
+      closeServer: async () => {},
+      stopBackground: async () => {},
+      stopProcesses: async () => {
+        throw new Error('child still running');
+      },
+      drainTelemetry: async () => {},
+      closeStorage,
+    });
+    await expect(shutdown()).rejects.toThrow('Shutdown cleanup failed');
+    expect(closeStorage).not.toHaveBeenCalled();
+  });
+
+  test('waits for handlers and drains telemetry even when a background stop fails', async () => {
+    const handlers = deferred();
+    const stopProcesses = vi.fn(async () => {});
+    const drainTelemetry = vi.fn(async () => {});
+    const closeStorage = vi.fn(async () => {});
+    const shutdown = createShutdown({
+      closeServer: () => handlers.promise,
+      stopBackground: async () => {
+        throw new Error('background stop failed');
+      },
+      stopProcesses,
+      drainTelemetry,
+      closeStorage,
+    });
+    const rejected = expect(shutdown()).rejects.toThrow('Shutdown cleanup failed');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stopProcesses).not.toHaveBeenCalled();
+    expect(drainTelemetry).not.toHaveBeenCalled();
+    handlers.resolve();
+    await rejected;
+    expect(stopProcesses).toHaveBeenCalledTimes(1);
+    expect(drainTelemetry).toHaveBeenCalledTimes(1);
+    expect(closeStorage).not.toHaveBeenCalled();
+  });
+});
+
+test('pending task drain includes follow-on work and tolerates handled failures', async () => {
+  const tasks = new PendingTasks();
+  const first = deferred();
+  const second = deferred();
+  tasks.track(
+    first.promise.then(() => {
+      tasks.track(second.promise);
+    })
+  );
+  tasks.track(Promise.reject(new Error('handled'))).catch(() => {});
+  let drained = false;
+  const draining = tasks.drain().then(() => {
+    drained = true;
+  });
+  first.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(drained).toBe(false);
+  second.resolve();
+  await draining;
+  expect(drained).toBe(true);
+});

--- a/packages/backend/src/services/runtime/pending-tasks.ts
+++ b/packages/backend/src/services/runtime/pending-tasks.ts
@@ -1,0 +1,19 @@
+/** Tracks already-started work so shutdown can wait for its side effects. */
+export class PendingTasks {
+  private readonly tasks = new Set<Promise<unknown>>();
+
+  track<T>(task: Promise<T>): Promise<T> {
+    this.tasks.add(task);
+    void task.then(
+      () => this.tasks.delete(task),
+      () => this.tasks.delete(task)
+    );
+    return task;
+  }
+
+  async drain(): Promise<void> {
+    while (this.tasks.size > 0) {
+      await Promise.allSettled([...this.tasks]);
+    }
+  }
+}

--- a/packages/backend/src/services/runtime/request-lifecycle.ts
+++ b/packages/backend/src/services/runtime/request-lifecycle.ts
@@ -1,0 +1,156 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { PendingTasks } from './pending-tasks';
+
+const REQUEST_HOOKS = new Set([
+  'onRequest',
+  'preParsing',
+  'preValidation',
+  'preHandler',
+  'preSerialization',
+  'onSend',
+  'onResponse',
+  'onError',
+  'onTimeout',
+  'onRequestAbort',
+]);
+
+type Callable = (this: any, ...args: any[]) => any;
+
+/** Install before registering plugins/routes; sockets can close before their work finishes. */
+export function trackRequestHandlers(server: FastifyInstance): PendingTasks {
+  const tasks = new PendingTasks();
+  const responses = new Set<FastifyReply['raw']>();
+  const hookWrappers = new WeakMap<Callable, Callable>();
+  const handlerWrappers = new WeakMap<Callable, Callable>();
+  const registrations = new WeakSet<Callable>();
+
+  const wrapHook = (hook: Callable): Callable => {
+    const existing = hookWrappers.get(hook);
+    if (existing) return existing;
+    const invoke: Callable = function (...args) {
+      let complete!: () => void;
+      const pending = new Promise<void>((resolve) => {
+        complete = resolve;
+      });
+      tasks.track(pending);
+      const reply = args[1]?.raw ? (args[1] as FastifyReply) : undefined;
+      let invoked = false;
+      let promiseReturned = false;
+      let responseFinished = false;
+      const finish = () => {
+        reply?.raw.removeListener('finish', onResponseFinished);
+        reply?.raw.removeListener('error', onResponseFinished);
+        complete();
+      };
+      const onResponseFinished = () => {
+        responseFinished = true;
+        // Callback hooks may intentionally reply without calling done (e.g. CORS).
+        // Promise hooks may keep working after reply.send(), so await their promise.
+        if (invoked && !promiseReturned) finish();
+      };
+      reply?.raw.once('finish', onResponseFinished);
+      reply?.raw.once('error', onResponseFinished);
+      const callbackIndex = args.length - 1;
+      const callback = args[callbackIndex];
+      const hasCallback = typeof callback === 'function';
+      if (hasCallback) {
+        args[callbackIndex] = function (this: unknown, ...callbackArgs: any[]) {
+          try {
+            // Advance the hook chain before retiring this task, preventing a
+            // temporary empty queue between a hook and its downstream handler.
+            return callback.apply(this, callbackArgs);
+          } finally {
+            finish();
+          }
+        };
+      }
+      try {
+        const result = hook.apply(this, args);
+        invoked = true;
+        if (result && typeof result.then === 'function') {
+          promiseReturned = true;
+          void Promise.resolve(result).then(finish, finish);
+        } else if (!hasCallback || reply?.sent || responseFinished) {
+          finish();
+        }
+        return result;
+      } catch (error) {
+        finish();
+        throw error;
+      }
+    };
+    // A function proxy retains arity/constructor metadata, including Fastify's
+    // validation of async hook signatures, while forwarding the original result.
+    const wrapped = new Proxy(hook, {
+      apply(_target, thisArg, args) {
+        return invoke.apply(thisArg, args);
+      },
+    });
+    hookWrappers.set(hook, wrapped);
+    hookWrappers.set(wrapped, wrapped);
+    return wrapped;
+  };
+
+  const instrumentRegistration = (instance: FastifyInstance) => {
+    const addHook = instance.addHook;
+    if (registrations.has(addHook)) return;
+    // onRoute exposes route-local hooks, but not hooks inherited from plugins.
+    // Intercept their public registration API rather than inspecting Fastify internals.
+    const wrapped = function (this: FastifyInstance, name: string, hook: Callable) {
+      return (addHook as Callable).call(
+        this,
+        name,
+        REQUEST_HOOKS.has(name) && typeof hook === 'function' ? wrapHook(hook) : hook
+      );
+    };
+    registrations.add(wrapped);
+    instance.addHook = wrapped as typeof instance.addHook;
+  };
+
+  // Bun can leave a streaming ServerResponse open after closeAllConnections().
+  // Destroy response objects explicitly; tracked hook/handler work must still settle.
+  server.addHook('onRequest', (_request, reply, done) => {
+    responses.add(reply.raw);
+    const forget = () => {
+      responses.delete(reply.raw);
+      reply.raw.removeListener('finish', forget);
+      reply.raw.removeListener('close', forget);
+    };
+    reply.raw.once('finish', forget);
+    reply.raw.once('close', forget);
+    done();
+  });
+  server.addHook('preClose', async () => {
+    for (const response of responses) response.destroy();
+  });
+
+  server.addHook('onRegister', (instance) => instrumentRegistration(instance));
+  server.addHook('onRoute', (route) => {
+    for (const name of REQUEST_HOOKS) {
+      const hooks = (route as unknown as Record<string, unknown>)[name];
+      if (typeof hooks === 'function') {
+        (route as unknown as Record<string, unknown>)[name] = wrapHook(hooks as Callable);
+      } else if (Array.isArray(hooks)) {
+        (route as unknown as Record<string, unknown>)[name] = hooks.map(wrapHook);
+      }
+    }
+    const handler = route.handler;
+    const existing = handlerWrappers.get(handler);
+    if (existing) {
+      route.handler = existing;
+      return;
+    }
+    const wrapped: typeof handler = function (request, reply) {
+      const result = handler.call(this, request, reply);
+      if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+        tasks.track(Promise.resolve(result));
+      }
+      return result;
+    };
+    handlerWrappers.set(handler, wrapped);
+    handlerWrappers.set(wrapped, wrapped);
+    route.handler = wrapped;
+  });
+  instrumentRegistration(server);
+  return tasks;
+}

--- a/packages/backend/src/services/runtime/shutdown.ts
+++ b/packages/backend/src/services/runtime/shutdown.ts
@@ -1,0 +1,53 @@
+interface ShutdownDependencies {
+  closeServer(): Promise<void>;
+  stopBackground(): Promise<void>;
+  stopProcesses(): Promise<void>;
+  drainTelemetry(): Promise<void>;
+  closeStorage(): Promise<void>;
+}
+
+/** Stops producers and drains their writes before storage closes, once per process. */
+export function createShutdown(dependencies: ShutdownDependencies, timeoutMs = 30_000) {
+  let shutdown: Promise<void> | undefined;
+  return (): Promise<void> => {
+    if (shutdown) return shutdown;
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        timedOut = true;
+        reject(new Error(`Shutdown did not finish within ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+    const work = async () => {
+      // Closing admission must also drain handler work after sockets close.
+      // Wait for all producers even when one reports a cleanup failure.
+      const producers = await Promise.allSettled([
+        dependencies.closeServer(),
+        dependencies.stopBackground(),
+      ]);
+      if (timedOut) return;
+      const errors = producers.flatMap((result) =>
+        result.status === 'rejected' ? [result.reason] : []
+      );
+      // An admitted MCP handler may start a child; stop children only after
+      // every handler is done so none can be spawned after this phase.
+      try {
+        await dependencies.stopProcesses();
+      } catch (error) {
+        errors.push(error);
+      }
+      if (timedOut) return;
+      try {
+        await dependencies.drainTelemetry();
+      } catch (error) {
+        errors.push(error);
+      }
+      if (timedOut) return;
+      if (errors.length) throw new AggregateError(errors, 'Shutdown cleanup failed');
+      await dependencies.closeStorage();
+    };
+    shutdown = Promise.race([work(), deadline]).finally(() => clearTimeout(timer));
+    return shutdown;
+  };
+}

--- a/packages/backend/src/utils/__tests__/pricing_calculation.test.ts
+++ b/packages/backend/src/utils/__tests__/pricing_calculation.test.ts
@@ -8,6 +8,7 @@ import { UsageRecord } from '../../types/usage';
 
 describe('handleResponse - Pricing Calculation', () => {
   const mockStorage = {
+    trackFinalization: <T>(task: Promise<T>) => task,
     saveRequest: vi.fn(),
     updatePerformanceMetrics: vi.fn(),
   } as unknown as UsageStorageService;

--- a/packages/backend/src/utils/__tests__/pricing_metadata.test.ts
+++ b/packages/backend/src/utils/__tests__/pricing_metadata.test.ts
@@ -8,6 +8,7 @@ import { UsageRecord } from '../../types/usage';
 
 describe('handleResponse - Pricing Metadata', () => {
   const mockStorage = {
+    trackFinalization: <T>(task: Promise<T>) => task,
     saveRequest: vi.fn(),
     updatePerformanceMetrics: vi.fn(),
   } as unknown as UsageStorageService;

--- a/packages/backend/src/utils/__tests__/pricing_openrouter.test.ts
+++ b/packages/backend/src/utils/__tests__/pricing_openrouter.test.ts
@@ -10,6 +10,7 @@ import path from 'path';
 
 describe('handleResponse - OpenRouter Pricing', () => {
   const mockStorage = {
+    trackFinalization: <T>(task: Promise<T>) => task,
     saveRequest: vi.fn(),
     updatePerformanceMetrics: vi.fn(),
   } as unknown as UsageStorageService;

--- a/packages/backend/src/utils/__tests__/pricing_per_request.test.ts
+++ b/packages/backend/src/utils/__tests__/pricing_per_request.test.ts
@@ -95,6 +95,7 @@ describe('calculateCosts - per_request pricing', () => {
 
 describe('handleResponse - per_request pricing', () => {
   const mockStorage = {
+    trackFinalization: <T>(task: Promise<T>) => task,
     saveRequest: vi.fn(),
     updatePerformanceMetrics: vi.fn(),
   } as unknown as UsageStorageService;

--- a/packages/backend/src/utils/__tests__/response-handler.test.ts
+++ b/packages/backend/src/utils/__tests__/response-handler.test.ts
@@ -14,6 +14,7 @@ describe('handleResponse', () => {
   const originalAdminKey = process.env.ADMIN_KEY;
 
   const mockStorage = {
+    trackFinalization: <T>(task: Promise<T>) => task,
     saveRequest: vi.fn(),
     saveError: vi.fn(),
     updatePerformanceMetrics: vi.fn(),
@@ -56,6 +57,48 @@ describe('handleResponse', () => {
     } else {
       process.env.ADMIN_KEY = originalAdminKey;
     }
+  });
+
+  test('drain waits for the detached unary finalizer through performance writes', async () => {
+    const storage = new UsageStorageService();
+    let finishUsage!: () => void;
+    let finishMetrics!: () => void;
+    const usage = new Promise<void>((resolve) => {
+      finishUsage = resolve;
+    });
+    const metrics = new Promise<void>((resolve) => {
+      finishMetrics = resolve;
+    });
+    registerSpy(storage, 'saveRequest').mockReturnValue(usage);
+    const update = registerSpy(storage, 'updatePerformanceMetrics').mockReturnValue(metrics);
+    await handleResponse(
+      mockRequest,
+      mockReply,
+      {
+        id: 'response',
+        model: 'model',
+        content: 'done',
+        plexus: { provider: 'provider', model: 'model', apiType: 'chat' },
+      },
+      mockTransformer,
+      { requestId: 'draining' },
+      storage,
+      Date.now(),
+      'chat'
+    );
+    expect(mockReply.send).toHaveBeenCalled();
+    let drained = false;
+    const draining = storage.drain().then(() => {
+      drained = true;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+    finishUsage();
+    await vi.waitFor(() => expect(update).toHaveBeenCalledOnce());
+    expect(drained).toBe(false);
+    finishMetrics();
+    await draining;
+    expect(drained).toBe(true);
   });
 
   test('should process non-streaming response correctly', async () => {


### PR DESCRIPTION
Plexus could close storage while admitted request handlers, scheduled work, local process cleanup, or telemetry writes were still running. Active SSE responses could also keep shutdown open indefinitely.

This change adds one idempotent shutdown path for OS signals and management restarts. It closes active responses, drains admitted handlers and background producers, stops local MCP processes, flushes telemetry, and closes storage last under a bounded deadline. Schedulers and storage services gain terminal shutdown behavior so late asynchronous work cannot restart timers or write after storage closes.

The branch also passes the existing request ID into the two image-route disconnect trackers, restoring compatibility with the current upstream timeout API after rebasing.

Validation:
- Full backend suite: 3,216 of 3,217 tests passed
- The remaining Bun-specific MCP Connection header assertion is addressed separately in #870
- Image route suite: 9 tests passed
- `bun run typecheck`
- `bun run format`
- `bunx biome lint .`

