### PR TITLE
chore: move repomap generation to CI

### DIFF
--- a/.github/workflows/generate-repomap.yml
+++ b/.github/workflows/generate-repomap.yml
@@ -1,0 +1,60 @@
+name: Generate Repo Map
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'package.json'
+      - '.github/workflows/generate-repomap.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: generate-repomap
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    name: Generate Repo Map
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install ctags and jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes universal-ctags jq
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate repo map
+        run: bun run generate:repomap
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet -- .repomap.txt; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push repo map
+        if: steps.check.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .repomap.txt
+          git commit -m "chore: regenerate repository map"
+          git push

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -49,10 +49,6 @@ pre-commit:
         - "packages/backend/src/assets/openapi.json"
       run: bunx biome format --write {staged_files} && git add {staged_files}
 
-    # --- Repo map: regenerate and stage before committing -------------------
-    repomap:
-      run: bun run generate:repomap && git add .repomap.txt
-
     # --- Biome: lint all sources ---------------------------------------------
     biome-lint:
       run: bunx biome lint .

--- a/packages/backend/src/routes/inference/images.ts
+++ b/packages/backend/src/routes/inference/images.ts
@@ -140,7 +140,7 @@ export async function registerImagesRoute(
     const startTime = Date.now();
     const abortController = new AbortController();
     const { signal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-    const disconnect = wireEarlyDisconnectDetection(request, abortController);
+    const disconnect = wireEarlyDisconnectDetection(request, abortController, requestId);
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,
@@ -307,7 +307,7 @@ export async function registerImagesRoute(
     const startTime = Date.now();
     const abortController = new AbortController();
     const { signal, resolveTimeoutMs } = wireUpstreamTimeout(abortController);
-    const disconnect = wireEarlyDisconnectDetection(request, abortController);
+    const disconnect = wireEarlyDisconnectDetection(request, abortController, requestId);
 
     let usageRecord: Partial<UsageRecord> = {
       requestId,


### PR DESCRIPTION
## Summary
Move repo map generation out of the local pre-commit path and regenerate `.repomap.txt` in GitHub Actions after changes land on `main`.

The workflow keeps the existing generated-artifact pattern used by migrations and OpenAPI bundles. It also installs the external `ctags` and `jq` tools it needs.

## Changes

- Remove repomap generation and staging from `lefthook.yml`'s `pre-commit` hook.
- Add `.github/workflows/generate-repomap.yml` for pushes to `main` and manual runs.
- Generate and commit `.repomap.txt` only when the output changes.
- Serialize repomap runs and grant the workflow `contents: write` permission.
- Pass the request ID to image-route disconnect detection so the existing typecheck gate passes.

## Testing

- `bun run generate:repomap`
- `bun run typecheck`
- `mise exec -- actionlint .github/workflows/generate-repomap.yml`
- Commit hooks passed for both commits, including backend tests, Biome lint, typecheck, and workflow validation.
