### PR TITLE
fix(observability): capture OMP terminal usage

### DIFF
--- a/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
+++ b/packages/backend/src/services/__tests__/debug-logging-reconstruction.test.ts
@@ -180,8 +180,8 @@ describe('DebugLoggingInspector Reconstruction', () => {
 
     test('finalizes a completed Responses stream before the transport ends', () => {
       const completedRequestId = 'test-responses-completed-before-end';
-      const onResponsesTerminal = vi.fn();
-      const inspector = new DebugLoggingInspector(completedRequestId, 'raw', onResponsesTerminal);
+      const onTerminal = vi.fn();
+      const inspector = new DebugLoggingInspector(completedRequestId, 'raw', onTerminal);
       const stream = inspector.createInspector('responses');
       const completedEvent = `data: ${JSON.stringify({
         type: 'response.completed',
@@ -201,7 +201,7 @@ describe('DebugLoggingInspector Reconstruction', () => {
       stream.write(Buffer.from(completedEvent.slice(40)));
 
       const log = DebugManager.getInstance().getPendingLog(completedRequestId);
-      expect(onResponsesTerminal).toHaveBeenCalledTimes(1);
+      expect(onTerminal).toHaveBeenCalledTimes(1);
       expect(log?.rawResponse).toBe(completedEvent);
       expect(log?.rawResponseSnapshot).toMatchObject({
         id: 'resp_completed',
@@ -572,6 +572,94 @@ describe('DebugLoggingInspector Reconstruction', () => {
         },
       ]);
       expect(snapshot.usage).toEqual({ input_tokens: 10, output_tokens: 5, total_tokens: 15 });
+    });
+  });
+
+  describe('reconstructChatCompletions streaming terminal finalization', () => {
+    test('finalizes a completed chat stream before the transport ends', () => {
+      const completedRequestId = 'test-chat-completed-before-end';
+      const onTerminal = vi.fn();
+      const inspector = new DebugLoggingInspector(completedRequestId, 'raw', onTerminal);
+      const stream = inspector.createInspector('chat');
+      const usageFrame = `data: ${JSON.stringify({
+        id: 'chatcmpl_completed',
+        object: 'chat.completion.chunk',
+        model: 'deepseek-v4.1-flash',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 42, completion_tokens: 7, total_tokens: 49 },
+      })}\n\n`;
+      const doneFrame = 'data: [DONE]\n\n';
+      const fullBody = `${usageFrame}${doneFrame}`;
+
+      stream.write(Buffer.from(fullBody.slice(0, 40)));
+      // A usage-bearing frame alone must not finalize: only the terminal
+      // `[DONE]` frame does.
+      expect(DebugManager.getInstance().getReconstructedRawResponse(completedRequestId)).toBeNull();
+
+      stream.write(Buffer.from(fullBody.slice(40)));
+
+      const log = DebugManager.getInstance().getPendingLog(completedRequestId);
+      expect(onTerminal).toHaveBeenCalledTimes(1);
+      expect(log?.rawResponse).toBe(fullBody);
+      expect(log?.rawResponseSnapshot).toMatchObject({
+        id: 'chatcmpl_completed',
+        choices: [{ finish_reason: 'stop' }],
+        usage: { prompt_tokens: 42, completion_tokens: 7, total_tokens: 49 },
+      });
+      stream.destroy();
+    });
+
+    test('does not finalize a chat stream on a non-terminal data frame', () => {
+      const requestIdOpen = 'test-chat-no-terminal';
+      const onTerminal = vi.fn();
+      const inspector = new DebugLoggingInspector(requestIdOpen, 'raw', onTerminal);
+      const stream = inspector.createInspector('chat');
+
+      stream.write(
+        Buffer.from(
+          `data: ${JSON.stringify({
+            id: 'chatcmpl_open',
+            object: 'chat.completion.chunk',
+            choices: [{ index: 0, delta: { content: 'hello' } }],
+          })}\n\n`
+        )
+      );
+
+      expect(onTerminal).not.toHaveBeenCalled();
+      expect(DebugManager.getInstance().getReconstructedRawResponse(requestIdOpen)).toBeNull();
+      stream.destroy();
+    });
+
+    test('detects the terminal frame after the debug body is truncated', async () => {
+      const truncatedRequestId = 'test-chat-terminal-after-truncation';
+      const onTerminal = vi.fn();
+      const inspector = new DebugLoggingInspector(truncatedRequestId, 'raw', onTerminal);
+      const stream = inspector.createInspector('chat');
+      const write = (value: string) =>
+        new Promise<void>((resolve, reject) => {
+          stream.write(Buffer.from(value), (error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+      const filler = `data: ${JSON.stringify({
+        id: 'chatcmpl_big',
+        object: 'chat.completion.chunk',
+        choices: [{ index: 0, delta: { content: 'x'.repeat(1024 * 1024) } }],
+      })}\n\n`;
+
+      // Push the capture past the 10MB debug buffer limit.
+      for (let i = 0; i < 11; i++) {
+        await write(filler);
+      }
+      expect(onTerminal).not.toHaveBeenCalled();
+
+      await write('data: [DONE]\n\n');
+
+      expect(onTerminal).toHaveBeenCalledTimes(1);
+      const log = DebugManager.getInstance().getPendingLog(truncatedRequestId);
+      expect(log?.rawResponse).toContain('[DEBUG OUTPUT TRUNCATED');
+      stream.destroy();
     });
   });
 });

--- a/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
+++ b/packages/backend/src/services/__tests__/response-handler-cancellation.test.ts
@@ -395,3 +395,156 @@ describe('handleResponse cancellation records usage from live captures (no pre-s
     expect(record.costTotal).toBeCloseTo(0.068, 10);
   });
 });
+
+// ---------------------------------------------------------------------------
+// End-to-end: client closes right after the terminal [DONE] frame
+// ---------------------------------------------------------------------------
+//
+// Fastify/Bun destroys the reply pipeline the moment the client closes the
+// socket — BEFORE the 250ms bunHandle.closed poll can run onDisconnect().
+// OpenAI-compatible clients (OMP) close immediately after `data: [DONE]`, so
+// the teardown path used to save the record as 'cancelled' with no tokens and
+// flush the debug trace before the taps were finalized. The terminal frame
+// must finalize usage/captures while the stream is still flowing, exactly
+// like Codex's `response.completed`.
+describe('handleResponse chat terminal finalization (client closes after [DONE])', () => {
+  beforeEach(() => {
+    DebugManager.getInstance().resetForTesting();
+  });
+
+  const makeRequest = () => ({ headers: {}, raw: {} });
+
+  const makeReply = (sendCalls: any[]) => ({
+    header: vi.fn(function (this: any) {
+      return this;
+    }),
+    send: vi.fn((pipeline: any) => {
+      sendCalls.push(pipeline);
+      return pipeline;
+    }),
+    code: vi.fn(function (this: any) {
+      return this;
+    }),
+  });
+
+  const makeStorage = (savedRecords: UsageRecord[]) => ({
+    saveRequest: vi.fn(async (record: UsageRecord) => {
+      savedRecords.push(record);
+    }),
+    updatePerformanceMetrics: vi.fn(async () => {}),
+    saveError: vi.fn(),
+  });
+
+  const makeUnifiedResponse = (providerStream: ReadableStream<Uint8Array>) =>
+    ({
+      id: 'resp-terminal',
+      model: 'gpt-4o',
+      content: null,
+      stream: providerStream,
+      // OMP sends OpenAI-format chat requests to an OpenAI-format provider, so
+      // the raw provider SSE is forwarded to the client verbatim.
+      bypassTransformation: true,
+      plexus: {
+        provider: 'test-provider',
+        model: 'gpt-4o',
+        apiType: 'chat',
+        pricing: { source: 'simple', input: 1000, output: 2000 },
+      },
+    }) as UnifiedChatResponse;
+
+  const usageChunk = `data: ${JSON.stringify({
+    id: 'chatcmpl_terminal',
+    object: 'chat.completion.chunk',
+    model: 'gpt-4o',
+    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 50, completion_tokens: 9, total_tokens: 59 },
+  })}\n\n`;
+
+  it('records success WITH usage when the transport is destroyed after [DONE]', async () => {
+    const encoder = new TextEncoder();
+    const providerStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl_terminal","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}\n\n'
+          )
+        );
+        controller.enqueue(encoder.encode(usageChunk));
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        // Deliberately NOT closed — the client closes its side first.
+      },
+    });
+
+    const savedRecords: UsageRecord[] = [];
+    const sendCalls: any[] = [];
+    await handleResponse(
+      makeRequest() as any,
+      makeReply(sendCalls) as any,
+      makeUnifiedResponse(providerStream),
+      new OpenAITransformer(),
+      { requestId: 'req-terminal-success' } as Partial<UsageRecord>,
+      makeStorage(savedRecords) as any,
+      Date.now(),
+      'chat'
+    );
+
+    const pipeline = sendCalls.at(-1);
+    pipeline.on('data', () => {});
+    pipeline.on('error', () => {});
+
+    // Let the terminal frame flow through the full pipeline, then simulate
+    // Fastify/Bun tearing the reply stream down when the socket closes.
+    await wait(80);
+    pipeline.destroy();
+    await wait(50);
+
+    expect(savedRecords).toHaveLength(1);
+    const record = savedRecords[0]!;
+    expect(record.responseStatus).toBe('success');
+    expect(record.tokensInput).toBe(50);
+    expect(record.tokensOutput).toBe(9);
+  });
+
+  it('still captures usage when the transport is destroyed mid-stream (no terminal frame)', async () => {
+    const encoder = new TextEncoder();
+    const providerStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"id":"chatcmpl_midstream","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}\n\n'
+          )
+        );
+        controller.enqueue(encoder.encode(usageChunk));
+        // No [DONE] and the stream stays open: this is a real cancellation.
+      },
+    });
+
+    const savedRecords: UsageRecord[] = [];
+    const sendCalls: any[] = [];
+    await handleResponse(
+      makeRequest() as any,
+      makeReply(sendCalls) as any,
+      makeUnifiedResponse(providerStream),
+      new OpenAITransformer(),
+      { requestId: 'req-terminal-midstream' } as Partial<UsageRecord>,
+      makeStorage(savedRecords) as any,
+      Date.now(),
+      'chat'
+    );
+
+    const pipeline = sendCalls.at(-1);
+    pipeline.on('data', () => {});
+    pipeline.on('error', () => {});
+
+    await wait(80);
+    // No onDisconnect() — the transport teardown runs _destroy directly.
+    pipeline.destroy();
+    await wait(50);
+
+    expect(savedRecords).toHaveLength(1);
+    const record = savedRecords[0]!;
+    expect(record.responseStatus).toBe('cancelled');
+    expect(record.tokensInput).toBe(50);
+    expect(record.tokensOutput).toBe(9);
+  });
+});

--- a/packages/backend/src/services/inspectors/debug-logging.ts
+++ b/packages/backend/src/services/inspectors/debug-logging.ts
@@ -10,6 +10,8 @@ const RESPONSES_TERMINAL_EVENT_TYPES = new Set([
   'response.failed',
   'response.incomplete',
 ]);
+/** OpenAI-compatible chat/completions streams end with this literal frame. */
+const CHAT_TERMINAL_EVENT_DATA = '[DONE]';
 
 /**
  * Provider API types whose "raw" stream is a stream of unified chunk OBJECTS
@@ -32,12 +34,12 @@ export class DebugLoggingInspector extends BaseInspector {
   private totalSize = 0;
   private truncated = false;
   private finalized = false;
-  private responsesEventParser: ReturnType<typeof createParser> | null = null;
+  private terminalEventParser: ReturnType<typeof createParser> | null = null;
 
   constructor(
     requestId: string,
     mode: 'raw' | 'transformed' = 'raw',
-    private readonly onResponsesTerminal?: () => void
+    private readonly onTerminal?: () => void
   ) {
     super(requestId);
     this.mode = mode;
@@ -45,7 +47,7 @@ export class DebugLoggingInspector extends BaseInspector {
 
   createInspector(providerApiType: string): PassThrough {
     this.providerApiType = providerApiType;
-    this.initializeResponsesTerminalEventDetection();
+    this.initializeTerminalEventDetection();
 
     // Capture happens synchronously in the transform hook (i.e. at write()
     // time), NOT in a 'data' listener: 'data' emission for the very first
@@ -76,8 +78,6 @@ export class DebugLoggingInspector extends BaseInspector {
       `[Inspector:${this.mode}] Request ${this.requestId} received chunk, length: ${chunk.length || chunk.toString().length}: ${chunk.toString()}`
     );
 
-    if (this.truncated) return;
-
     let chunkStr: string;
     if (typeof chunk === 'string') {
       chunkStr = chunk;
@@ -96,40 +96,67 @@ export class DebugLoggingInspector extends BaseInspector {
       }
     }
 
+    // Terminal detection keeps running even after the debug body is
+    // truncated: a >10MB stream still needs its terminal frame observed so
+    // usage and captures finalize before the client can close. The parser is
+    // fed AFTER the chunk is accumulated so a terminal event finalized during
+    // this feed sees the complete body.
+    if (this.truncated) {
+      this.terminalEventParser?.feed(chunkStr);
+      return;
+    }
+
     const newSize = this.totalSize + chunkStr.length;
 
     if (newSize > MAX_DEBUG_BUFFER_SIZE) {
       this.truncated = true;
       this.bodyChunks.push('\n\n[DEBUG OUTPUT TRUNCATED - Exceeded 10MB limit]');
       logger.warn(`Request ${this.requestId} debug output truncated at ${this.totalSize} bytes`);
+      this.terminalEventParser?.feed(chunkStr);
       return;
     }
 
     this.totalSize = newSize;
     this.bodyChunks.push(chunkStr);
-    this.responsesEventParser?.feed(chunkStr);
+    this.terminalEventParser?.feed(chunkStr);
   }
 
-  private initializeResponsesTerminalEventDetection(): void {
-    if (this.providerApiType !== 'responses') return;
-
-    this.responsesEventParser = createParser({
-      onEvent: (event) => {
-        try {
-          const responseEvent = JSON.parse(event.data);
-          if (RESPONSES_TERMINAL_EVENT_TYPES.has(responseEvent.type) && !this.finalized) {
-            // Codex may close its HTTP connection immediately after receiving
-            // this terminal event. Finalize before the chunk continues to the
-            // client so the completed response and usage are available during
-            // teardown.
-            this.finalize();
-            this.onResponsesTerminal?.();
+  private initializeTerminalEventDetection(): void {
+    if (this.providerApiType === 'responses') {
+      this.terminalEventParser = createParser({
+        onEvent: (event) => {
+          try {
+            const responseEvent = JSON.parse(event.data);
+            if (RESPONSES_TERMINAL_EVENT_TYPES.has(responseEvent.type)) {
+              this.finalizeOnTerminal();
+            }
+          } catch {
+            // Non-JSON SSE frames cannot be Responses terminal events.
           }
-        } catch {
-          // Non-JSON SSE frames cannot be Responses terminal events.
-        }
-      },
-    });
+        },
+      });
+      return;
+    }
+
+    if (this.providerApiType === 'chat') {
+      this.terminalEventParser = createParser({
+        onEvent: (event) => {
+          if (event.data.trim() === CHAT_TERMINAL_EVENT_DATA) {
+            this.finalizeOnTerminal();
+          }
+        },
+      });
+    }
+  }
+
+  private finalizeOnTerminal(): void {
+    if (this.finalized) return;
+    // OpenAI-compatible chat clients (e.g. OMP) close their connection
+    // immediately after `data: [DONE]`, just as Codex does after
+    // `response.completed`. Finalize before the chunk continues to the client
+    // so the completed response and usage are available during teardown.
+    this.finalize();
+    this.onTerminal?.();
   }
 
   /**

--- a/packages/backend/src/services/inspectors/usage-logging.ts
+++ b/packages/backend/src/services/inspectors/usage-logging.ts
@@ -14,6 +14,7 @@ import {
 } from '../../utils/usage-normalizer';
 import { applyProviderReportedCost, applyUsageCostDetails } from '../../utils/provider-cost';
 import { recordQuotaUsage } from '../quota/quota-middleware';
+import type { DebugLoggingInspector } from './debug-logging';
 
 export interface ExtractedObservedUsage {
   inputTokens: number;
@@ -107,6 +108,8 @@ export class UsageInspector extends PassThrough {
   private firstChunk = true;
   private quotaEnforcer?: any;
   private keyName?: string;
+  private rawDebugCapture?: DebugLoggingInspector;
+  private transformedDebugCapture?: DebugLoggingInspector;
   private _flushed = false;
 
   constructor(
@@ -121,7 +124,9 @@ export class UsageInspector extends PassThrough {
     incomingApiType?: string,
     originalRequest?: any,
     quotaEnforcer?: any,
-    keyName?: string
+    keyName?: string,
+    rawDebugCapture?: DebugLoggingInspector,
+    transformedDebugCapture?: DebugLoggingInspector
   ) {
     super();
     this.usageStorage = usageStorage;
@@ -135,6 +140,8 @@ export class UsageInspector extends PassThrough {
     this.originalRequest = originalRequest;
     this.quotaEnforcer = quotaEnforcer;
     this.keyName = keyName;
+    this.rawDebugCapture = rawDebugCapture;
+    this.transformedDebugCapture = transformedDebugCapture;
   }
 
   override _transform(chunk: any, encoding: BufferEncoding, callback: Function) {
@@ -335,6 +342,15 @@ export class UsageInspector extends PassThrough {
       callback(err);
       return;
     }
+
+    // The HTTP layer can tear the response pipeline down as soon as the
+    // client disconnects — before the 250ms socket-close poll runs
+    // onDisconnect(), which is what normally finalizes the debug taps. The
+    // taps capture synchronously at write() time, so reconstruct them here
+    // first; otherwise teardown reads no snapshot and the record is saved
+    // with no tokens and a trace with no response body.
+    this.rawDebugCapture?.finalize();
+    this.transformedDebugCapture?.finalize();
 
     const isTimeout = err?.name === 'TimeoutError' || err?.message?.includes('timeout');
     const isStall = err?.message?.includes('stalled');

--- a/packages/backend/src/services/responses/response-handler.ts
+++ b/packages/backend/src/services/responses/response-handler.ts
@@ -415,23 +415,11 @@ export async function handleResponse(
         : observedUnifiedStream;
     }
 
-    const usageInspector = new UsageInspector(
-      usageRecord.requestId!,
-      usageStorage,
-      usageRecord,
-      pricing,
-      providerDiscount,
-      startTime,
-      shouldEstimateTokens,
-      providerApiType,
-      apiType,
-      originalRequest,
-      quotaEnforcer,
-      keyName
-    );
-
     // TAP THE TRANSFORMED STREAM for debugging
-    // This captures what is actually sent to the client
+    // This captures what is actually sent to the client. The terminal
+    // callback fires lazily (when the client stream emits its terminal
+    // frame), by which point usageInspector below is assigned.
+    let usageInspector: UsageInspector;
     const transformedDebugLogging = new DebugLoggingInspector(
       usageRecord.requestId!,
       'transformed',
@@ -450,6 +438,23 @@ export async function handleResponse(
     });
 
     finalClientStream = finalClientStream.pipeThrough(transformedTapStream);
+
+    usageInspector = new UsageInspector(
+      usageRecord.requestId!,
+      usageStorage,
+      usageRecord,
+      pricing,
+      providerDiscount,
+      startTime,
+      shouldEstimateTokens,
+      providerApiType,
+      apiType,
+      originalRequest,
+      quotaEnforcer,
+      keyName,
+      rawDebugLogging,
+      transformedDebugLogging
+    );
 
     // Standard SSE headers to prevent buffering and timeouts
     reply.header('Content-Type', 'text/event-stream');


### PR DESCRIPTION
## Summary
Capture usage and debug response data for OMP's OpenAI-compatible streaming requests. Requests that close immediately after `data: [DONE]` now finalize as successful completions instead of being recorded as cancelled with null usage.

## Why / Context
Fastify/Bun can destroy the response pipeline before Plexus's socket-close poll runs. OMP closes after the terminal SSE frame, so the previous teardown race flushed the trace before the inspectors reconstructed the response.

## Changes
- Detect chat `data: [DONE]` frames and finalize response captures before transport teardown.
- Finalize raw and transformed debug captures from `UsageInspector` during early stream destruction.
- Preserve usage extraction for mid-stream teardown when a terminal frame is not available.
- Add regressions for OMP-style completion, cancellation capture, and terminal detection after the debug buffer truncates.

## Testing
- Verified the production-like Fastify/Bun disconnect sequence records success with input/output tokens and cost.
- Added streaming inspector and teardown regression coverage.
- Cora review initially found a truncation edge case, which was fixed. The follow-up review could not complete because the review service returned HTTP 500/network failure.

## Notes / Follow-ups
- No schema or API contract changes.
