### PR TITLE
fix(ci): use app token for repomap push

### DIFF
--- a/.github/workflows/generate-repomap.yml
+++ b/.github/workflows/generate-repomap.yml
@@ -20,10 +20,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.REPOMAP_APP_ID }}
+          private-key: ${{ secrets.REPOMAP_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install ctags and jq
         run: |


### PR DESCRIPTION
## Summary
Use the dedicated GitHub App token for the repository-map workflow's direct push to `main`, allowing the existing post-merge automation to work with the protected branch without creating a second PR.

## Changes
- **CI**: Create an installation token from `REPOMAP_APP_ID` and `REPOMAP_APP_PRIVATE_KEY`.
- **CI**: Pass the App token to `actions/checkout`, which persists it for the existing `git push` step.

## Testing
- `actionlint .github/workflows/generate-repomap.yml`
- Pre-commit hooks passed: Biome lint, migration check, typecheck, and workflow YAML validation.
