### PR TITLE
perf(test): persist transformed modules with fsModuleCache

### DIFF
--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
     mockReset: true,
     pool: 'forks',
     isolate: true,
+    fsModuleCache: true,
     server: {
       deps: {
         inline: ['zod', 'yaml', '@plexus/shared', '@earendil-works/pi-ai'],


### PR DESCRIPTION
## Summary
Enable Vitest's `fsModuleCache` in `packages/backend/vitest.config.ts` so Vite module transform results are persisted across test runs instead of rebuilt every time.

## Why / Context
Vitest reported transform time dominating test runs (up to 62% of tracked time) and recommended enabling `fsModuleCache: true`. Local test runs were repeatedly re-transforming identical module graphs on every run.

## Changes
- **Backend test config**: Set `fsModuleCache: true` in `packages/backend/vitest.config.ts`. The `sqlite`, `postgres`, and `unit` projects inherit this setting via `baseConfig.test`. Cached transforms are written to `node_modules/.vitest-cache` at workspace root, which is already ignored by `.gitignore`.

## Testing
- Measured cold vs warm runs on `quota-enforcer`: transform overhead dropped from 54% (6.19s) to 13% (3.55s), reducing wall time by ~43%.
- Verified warm unit test transform overhead dropped from 66% to 13%.
- Ran full suite (`bun run test`): 279 test files, 3,214 tests passing. Overall transform share dropped from 33% to 18%.
- Verified Vitest transform diagnostic hints are cleared.

## Notes / Follow-ups
- This primarily accelerates local developer test reruns. CI runners will not see this speedup unless `node_modules/.vitest-cache` is saved and restored via `actions/cache`.
