### PR TITLE
fix(anthropic): clamp effort and handle cannot-disable models on Claude paths

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -145,6 +145,166 @@ describe('Dispatcher registry auto-compat', () => {
     expect(result.payload.temperature).toBeUndefined();
   });
 
+  test('clamps minimal effort to low for Anthropic adaptive thinking models', async () => {
+    vi.mocked(piAiRegistry.resolvePiAiModel).mockReturnValue(
+      piModel({
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        compat: { forceAdaptiveThinking: true },
+      })
+    );
+    const dispatcher = new Dispatcher() as any;
+
+    const result = await dispatcher.transformRequestPayload(
+      request({
+        reasoning: { effort: 'minimal', enabled: true },
+      }),
+      route({
+        config: {
+          api_base_url: 'https://api.anthropic.com',
+          api_key: 'test-key',
+          auto_compat: true,
+          pi_ai_provider: 'anthropic',
+        } as any,
+      }),
+      {
+        transformRequest: vi.fn(async () => ({
+          model: 'provider-model',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+          max_tokens: 4096,
+        })),
+      },
+      'messages',
+      []
+    );
+
+    expect(result.payload.thinking).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+    });
+    expect(result.payload.output_config).toEqual({ effort: 'low' });
+  });
+
+  test('clamps disabled thinking to adaptive with low effort for Opus 5 cannot-disable model', async () => {
+    vi.mocked(piAiRegistry.resolvePiAiModel).mockReturnValue(
+      piModel({
+        id: 'claude-opus-5',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        thinkingLevelMap: { off: null, xhigh: 'xhigh', max: 'max' },
+        compat: { forceAdaptiveThinking: true },
+      })
+    );
+    const dispatcher = new Dispatcher() as any;
+
+    const result = await dispatcher.transformRequestPayload(
+      request({
+        reasoning: { enabled: false },
+      }),
+      route({
+        model: 'claude-opus-5',
+        config: {
+          api_base_url: 'https://api.anthropic.com',
+          api_key: 'test-key',
+          auto_compat: true,
+          pi_ai_provider: 'anthropic',
+        } as any,
+      }),
+      {
+        transformRequest: vi.fn(async () => ({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+          max_tokens: 4096,
+        })),
+      },
+      'messages',
+      []
+    );
+
+    expect(result.payload.thinking).toEqual({
+      type: 'adaptive',
+      display: 'summarized',
+    });
+    expect(result.payload.output_config).toEqual({ effort: 'low' });
+  });
+
+  test('maps transformed payload output_config.effort off to disabled thinking on supported model', async () => {
+    vi.mocked(piAiRegistry.resolvePiAiModel).mockReturnValue(
+      piModel({
+        id: 'claude-sonnet-4-6',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        compat: { forceAdaptiveThinking: true },
+      })
+    );
+    const dispatcher = new Dispatcher() as any;
+
+    const result = await dispatcher.transformRequestPayload(
+      request({}),
+      route({
+        model: 'claude-sonnet-4-6',
+        config: {
+          api_base_url: 'https://api.anthropic.com',
+          api_key: 'test-key',
+          auto_compat: true,
+          pi_ai_provider: 'anthropic',
+        } as any,
+      }),
+      {
+        transformRequest: vi.fn(async () => ({
+          model: 'claude-sonnet-4-6',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+          max_tokens: 4096,
+          output_config: { effort: 'off' },
+        })),
+      },
+      'messages',
+      []
+    );
+
+    expect(result.payload.thinking).toEqual({ type: 'disabled' });
+    expect(result.payload.output_config).toBeUndefined();
+  });
+
+  test('clamps transformed payload output_config.effort off to adaptive low effort on Opus 5', async () => {
+    vi.mocked(piAiRegistry.resolvePiAiModel).mockReturnValue(
+      piModel({
+        id: 'claude-opus-5',
+        api: 'anthropic-messages',
+        provider: 'anthropic',
+        thinkingLevelMap: { off: null, xhigh: 'xhigh', max: 'max' },
+        compat: { forceAdaptiveThinking: true },
+      })
+    );
+    const dispatcher = new Dispatcher() as any;
+
+    const result = await dispatcher.transformRequestPayload(
+      request({}),
+      route({
+        model: 'claude-opus-5',
+        config: {
+          api_base_url: 'https://api.anthropic.com',
+          api_key: 'test-key',
+          auto_compat: true,
+          pi_ai_provider: 'anthropic',
+        } as any,
+      }),
+      {
+        transformRequest: vi.fn(async () => ({
+          model: 'claude-opus-5',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+          max_tokens: 4096,
+          output_config: { effort: 'off' },
+        })),
+      },
+      'messages',
+      []
+    );
+
+    expect(result.payload.thinking).toEqual({ type: 'adaptive' });
+    expect(result.payload.output_config).toEqual({ effort: 'low' });
+  });
+
   test('skips auto-compat when the model has no pi_ai_model_id', async () => {
     const dispatcher = new Dispatcher() as any;
 

--- a/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
+++ b/packages/backend/src/services/dispatch/dispatcher-auto-compat.ts
@@ -5,8 +5,9 @@ import { buildGenerationOptions, resolvePiAiModel } from '../pi-ai/registry';
 import type { GenerationIntent } from '../pi-ai/generation';
 import { normalizeVerbosity } from '../pi-ai/generation';
 import type { ReasoningIntent, ReasoningVisibility } from '../pi-ai/reasoning';
-import { normalizeEffort, normalizeVisibility } from '../pi-ai/reasoning';
+import { clampEffortToWindow, normalizeEffort, normalizeVisibility } from '../pi-ai/reasoning';
 import { projectReasoningForResponses } from '../../transformers/utils';
+import { clampAnthropicEffortAndThinking } from '../../transformers/anthropic/thinking-clamp';
 
 function hasOwn(value: Record<string, any>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
@@ -374,7 +375,8 @@ function projectAnthropicAutoCompat(
     if (model.compat?.forceAdaptiveThinking === true) {
       next.thinking = { type: 'adaptive', display };
       if (options.effort) {
-        next.output_config = { ...(next.output_config ?? {}), effort: options.effort };
+        const clampedEffort = clampEffortToWindow(options.effort, 'low', 'max');
+        next.output_config = { ...(next.output_config ?? {}), effort: clampedEffort };
       }
     } else {
       next.thinking = {
@@ -385,9 +387,13 @@ function projectAnthropicAutoCompat(
     }
   } else if (options.thinkingEnabled === false) {
     next.thinking = { type: 'disabled' };
+    if (next.output_config?.effort) {
+      delete next.output_config.effort;
+      if (Object.keys(next.output_config).length === 0) delete next.output_config;
+    }
   }
 
-  return next;
+  return clampAnthropicEffortAndThinking(next, model.id);
 }
 
 function projectGeminiAutoCompat(

--- a/packages/backend/src/services/dispatch/request-payload-builder.ts
+++ b/packages/backend/src/services/dispatch/request-payload-builder.ts
@@ -24,6 +24,8 @@ import {
   stripLiteUnsupportedTools,
 } from './dispatcher-auto-compat';
 import { appendUserAfterTextOnlyModelTail } from '../../transformers/gemini/utils/model-tail';
+import { isAnthropicTargetProvider } from './adapter-resolver';
+import { clampAnthropicEffortAndThinking } from '../../transformers/anthropic/thinking-clamp';
 
 /** Symbol stash for the native OAuth prep, read by the standard dispatch seams. */
 export const NATIVE_OAUTH_STASH = Symbol('nativeOAuthPrep');
@@ -215,6 +217,14 @@ export async function buildRequestPayload(
       `Adapters applied (preDispatch): [${adapters.map((entry) => entry.adapter.name).join(', ')}] ` +
         `for ${route.provider}/${route.model}`
     );
+  }
+
+  if (
+    isAnthropicTargetProvider(route, targetApiType) ||
+    getApiBaseType(targetApiType) === 'messages'
+  ) {
+    const outboundModel = typeof payload?.model === 'string' ? payload.model : route.model;
+    payload = clampAnthropicEffortAndThinking(payload, outboundModel);
   }
 
   // The provider-side `X-OpenAI-Internal-Codex-Responses-Lite` header (set in

--- a/packages/backend/src/services/oauth/__tests__/oauth-native-request-effort.test.ts
+++ b/packages/backend/src/services/oauth/__tests__/oauth-native-request-effort.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { prepareOAuthNativeRequest } from '../oauth-native-request';
+
+const AUTH_OAUTH = { mode: 'oauth', token: 'sk-ant-oat-test-token' } as const;
+const AUTH_MASKING = { mode: 'apiKey', apiKey: 'sk-ant-api03-test-key' } as const;
+
+describe('prepareOAuthNativeRequest — Claude OAuth effort clamping', () => {
+  describe('claude-opus-5 (cannot disable thinking)', () => {
+    it('clamps output_config.effort: minimal to low', () => {
+      const nativeBody = {
+        model: 'claude-opus-5',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello' }],
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'minimal' },
+      };
+      const prepared = prepareOAuthNativeRequest(
+        'anthropic',
+        'claude-opus-5',
+        AUTH_OAUTH,
+        nativeBody,
+        false
+      );
+      expect(prepared.body.output_config).toEqual({ effort: 'low' });
+      expect(prepared.body.thinking).toEqual({ type: 'adaptive' });
+    });
+
+    it('clamps thinking: disabled to adaptive with effort: low', () => {
+      const nativeBody = {
+        model: 'claude-opus-5',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello' }],
+        thinking: { type: 'disabled' },
+      };
+      const prepared = prepareOAuthNativeRequest(
+        'anthropic',
+        'claude-opus-5',
+        AUTH_OAUTH,
+        nativeBody,
+        false
+      );
+      expect(prepared.body.thinking).toEqual({ type: 'adaptive' });
+      expect(prepared.body.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('clamps output_config.effort: off to adaptive with effort: low', () => {
+      const nativeBody = {
+        model: 'claude-opus-5',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello' }],
+        output_config: { effort: 'off' },
+      };
+      const prepared = prepareOAuthNativeRequest(
+        'anthropic',
+        'claude-opus-5',
+        AUTH_OAUTH,
+        nativeBody,
+        false
+      );
+      expect(prepared.body.thinking).toEqual({ type: 'adaptive' });
+      expect(prepared.body.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('preserves valid effort levels like high or max', () => {
+      const nativeBody = {
+        model: 'claude-opus-5',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello' }],
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'max' },
+      };
+      const prepared = prepareOAuthNativeRequest(
+        'anthropic',
+        'claude-opus-5',
+        AUTH_OAUTH,
+        nativeBody,
+        false
+      );
+      expect(prepared.body.output_config).toEqual({ effort: 'max' });
+    });
+  });
+
+  describe('claude-sonnet-4-6 (supports disable)', () => {
+    it('clamps output_config.effort: minimal to low', () => {
+      const nativeBody = {
+        model: 'claude-sonnet-4-6',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello' }],
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'minimal' },
+      };
+      const prepared = prepareOAuthNativeRequest(
+        'anthropic',
+        'claude-sonnet-4-6',
+        AUTH_OAUTH,
+        nativeBody,
+        false
+      );
+      expect(prepared.body.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('maps output_config.effort: off to thinking: disabled and removes output_config.effort', () => {
+      const nativeBody = {
+        model: 'claude-sonnet-4-6',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello' }],
+        output_config: { effort: 'off' },
+      };
+      const prepared = prepareOAuthNativeRequest(
+        'anthropic',
+        'claude-sonnet-4-6',
+        AUTH_OAUTH,
+        nativeBody,
+        false
+      );
+      expect(prepared.body.thinking).toEqual({ type: 'disabled' });
+      expect(prepared.body.output_config).toBeUndefined();
+    });
+  });
+
+  describe('Claude masking API key route (useClaudeMasking)', () => {
+    it('applies effort clamping on the Claude masking route', () => {
+      const nativeBody = {
+        model: 'claude-opus-5',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello' }],
+        output_config: { effort: 'minimal' },
+      };
+      const prepared = prepareOAuthNativeRequest(
+        'anthropic',
+        'claude-opus-5',
+        AUTH_MASKING,
+        nativeBody,
+        false
+      );
+      expect(prepared.body.output_config).toEqual({ effort: 'low' });
+    });
+  });
+});

--- a/packages/backend/src/services/oauth/oauth-native-request.ts
+++ b/packages/backend/src/services/oauth/oauth-native-request.ts
@@ -41,6 +41,7 @@ import {
 import type { RenamePair } from '../../transformers/oauth/masking/types';
 import { CodexVersionService } from './codex-version-service';
 import { stripUnsupportedGpt5Options } from '../../transformers/adapters/suppress-unsupported-gpt5-options.adapter';
+import { clampAnthropicEffortAndThinking } from '../../transformers/anthropic/thinking-clamp';
 
 /**
  * Auth for a native Anthropic request. Two modes, mirroring the old executor:
@@ -134,6 +135,7 @@ function prepareAnthropicOAuthRequest(
   streaming: boolean,
   callerBetas?: string
 ): PreparedOAuthRequest {
+  const preparedBody = clampAnthropicEffortAndThinking(nativeBody, modelId);
   // The token used to GATE masking (not necessarily the auth credential). For
   // the API-key masking route we force the masking's OAuth codepath with the
   // same `sk-ant-oat-mask-` shim the old executor used; the real key still goes
@@ -148,7 +150,7 @@ function prepareAnthropicOAuthRequest(
   // We keep these verbatim for the body (verified byte-for-byte against a
   // canon-only variant, which drops the system relocation). We do NOT reuse
   // their internal rename bookkeeping for the response — see reversal below.
-  const { payload: transformed } = applyClaudeOAuthTransform(nativeBody, maskingToken, {
+  const { payload: transformed } = applyClaudeOAuthTransform(preparedBody, maskingToken, {
     version: '2.1.63',
     entrypoint: 'cli',
     workload: '',
@@ -164,7 +166,7 @@ function prepareAnthropicOAuthRequest(
   // EVERY rename in one place regardless of which internal step produced it.
   // The response reversal is simply this map inverted — no per-mechanism
   // bookkeeping, no dependency on masking-internal flags.
-  const callerToolNames: string[] = (Array.isArray(nativeBody?.tools) ? nativeBody.tools : [])
+  const callerToolNames: string[] = (Array.isArray(preparedBody?.tools) ? preparedBody.tools : [])
     .map((t: any) => t?.name)
     .filter((n: any): n is string => typeof n === 'string');
 

--- a/packages/backend/src/services/pi-ai/__tests__/build-reasoning-for-model.test.ts
+++ b/packages/backend/src/services/pi-ai/__tests__/build-reasoning-for-model.test.ts
@@ -239,6 +239,18 @@ describe('buildReasoningOptionsForModel', () => {
       // off is unsupported → clamp to lowest non-off supported level (minimal)
       expect(opts.reasoningEffort).toBe('minimal');
     });
+
+    it('anthropic cannot-disable model (like opus-5) clamps to low instead of minimal', () => {
+      const model = {
+        api: 'anthropic-messages',
+        reasoning: true,
+        thinkingLevelMap: { off: null, xhigh: 'xhigh', max: 'max' },
+        compat: { forceAdaptiveThinking: true },
+      } as any;
+      const opts = buildReasoningOptionsForModel(model, intent({ enabled: false }));
+      expect(opts.thinkingEnabled).toBe(true);
+      expect(opts.effort).toBe('low');
+    });
   });
 
   describe('clamping unsupported levels', () => {
@@ -255,6 +267,20 @@ describe('buildReasoningOptionsForModel', () => {
       );
       // medium unsupported → clamp up to high
       expect(opts.thinking).toEqual({ enabled: true, includeThoughts: true, level: 'HIGH' });
+    });
+
+    it('clamps minimal effort to low for anthropic models with adaptive thinking', () => {
+      const model = {
+        api: 'anthropic-messages',
+        reasoning: true,
+        compat: { forceAdaptiveThinking: true },
+      } as any;
+      const opts = buildReasoningOptionsForModel(
+        model,
+        intent({ effort: 'minimal', enabled: true })
+      );
+      expect(opts.thinkingEnabled).toBe(true);
+      expect(opts.effort).toBe('low');
     });
   });
 });

--- a/packages/backend/src/services/pi-ai/registry.ts
+++ b/packages/backend/src/services/pi-ai/registry.ts
@@ -19,7 +19,7 @@ import { getCatalogModel } from './catalog';
 
 import type { RouteResult } from '../routing/router';
 import type { ReasoningEffort, ReasoningIntent } from './reasoning';
-import { effortToBudget, intentToEffort } from './reasoning';
+import { clampEffortToWindow, effortToBudget, intentToEffort } from './reasoning';
 import type { GenerationIntent } from './generation';
 
 // ─── resolveBaseUrl ───────────────────────────────────────────────────────────
@@ -143,10 +143,13 @@ export function buildReasoningOptionsForModel(
     if (!modelSupportsDisable(model as PiAiModel<any>)) {
       // Model cannot disable thinking — clamp to its lowest supported level
       // instead of emitting an option the provider will reject.
+      const isAdaptiveAnthropic =
+        api === 'anthropic-messages' &&
+        (model.compat as { forceAdaptiveThinking?: boolean })?.forceAdaptiveThinking === true;
       const supported = getSupportedThinkingLevels(model as PiAiModel<any>).filter(
-        (l) => l !== 'off'
+        (l) => l !== 'off' && (!isAdaptiveAnthropic || l !== 'minimal')
       );
-      const lowest = supported[0] as ReasoningEffort | undefined;
+      const lowest = isAdaptiveAnthropic ? 'low' : (supported[0] as ReasoningEffort | undefined);
       if (!lowest) return {};
       return buildEnabledOptions(model, lowest, intent);
     }
@@ -213,8 +216,8 @@ function buildEnabledOptions(
       } else {
         // Client committed to a magnitude (explicit effort / reasoning suffix):
         // pass it and let pi-ai map it via thinkingLevelMap (e.g. xhigh → "max"
-        // on Opus 4.6).
-        base.effort = effort;
+        // on Opus 4.6). Clamp to Anthropic's allowed window ['low', 'max'].
+        base.effort = clampEffortToWindow(effort, 'low', 'max');
       }
     } else {
       // Budget-based thinking for older Claude models. Round-trip the client's

--- a/packages/backend/src/transformers/anthropic/__tests__/thinking-clamp.test.ts
+++ b/packages/backend/src/transformers/anthropic/__tests__/thinking-clamp.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { anthropicModelSupportsDisable, clampAnthropicEffortAndThinking } from '../thinking-clamp';
+
+describe('anthropicModelSupportsDisable', () => {
+  it('identifies models that cannot disable thinking', () => {
+    expect(anthropicModelSupportsDisable('claude-opus-5')).toBe(false);
+    expect(anthropicModelSupportsDisable('claude-opus-5-20260301')).toBe(false);
+    expect(anthropicModelSupportsDisable('anthropic/claude-opus-5')).toBe(false);
+    expect(anthropicModelSupportsDisable('claude-opus-5:off')).toBe(false);
+    expect(anthropicModelSupportsDisable('claude-fable-5')).toBe(false);
+    expect(anthropicModelSupportsDisable('claude-fable-5-1')).toBe(false);
+    expect(anthropicModelSupportsDisable('custom-opus-5')).toBe(false);
+  });
+
+  it('identifies models that can disable thinking or do not restrict off', () => {
+    expect(anthropicModelSupportsDisable('claude-sonnet-4-6')).toBe(true);
+    expect(anthropicModelSupportsDisable('claude-3-7-sonnet')).toBe(true);
+    expect(anthropicModelSupportsDisable('claude-haiku-4-5')).toBe(true);
+    expect(anthropicModelSupportsDisable('claude-opus-4-6')).toBe(true);
+    expect(anthropicModelSupportsDisable(undefined)).toBe(true);
+  });
+});
+
+describe('clampAnthropicEffortAndThinking', () => {
+  describe('models that cannot disable thinking (e.g. claude-opus-5)', () => {
+    it('clamps thinking: disabled to adaptive with effort: low', () => {
+      const payload = {
+        model: 'claude-opus-5',
+        thinking: { type: 'disabled' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.thinking).toEqual({ type: 'adaptive' });
+      expect(result.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('clamps output_config.effort: off to adaptive with effort: low', () => {
+      const payload = {
+        model: 'claude-opus-5',
+        output_config: { effort: 'off' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.thinking).toEqual({ type: 'adaptive' });
+      expect(result.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('clamps effort: minimal to low', () => {
+      const payload = {
+        model: 'claude-opus-5',
+        thinking: { type: 'adaptive' },
+        output_config: { effort: 'minimal' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.thinking).toEqual({ type: 'adaptive' });
+      expect(result.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('preserves valid effort levels (low, medium, high, max)', () => {
+      for (const effort of ['low', 'medium', 'high', 'max'] as const) {
+        const payload = {
+          model: 'claude-opus-5',
+          thinking: { type: 'adaptive' },
+          output_config: { effort },
+        };
+        const result = clampAnthropicEffortAndThinking(payload);
+        expect(result.output_config).toEqual({ effort });
+      }
+    });
+
+    it('preserves thinking display option when mapping from disabled', () => {
+      const payload = {
+        model: 'claude-opus-5',
+        thinking: { type: 'disabled', display: 'raw' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.thinking).toEqual({ type: 'adaptive', display: 'raw' });
+      expect(result.output_config).toEqual({ effort: 'low' });
+    });
+  });
+
+  describe('models that can disable thinking (e.g. claude-sonnet-4-6)', () => {
+    it('clamps effort: minimal to low', () => {
+      const payload = {
+        model: 'claude-sonnet-4-6',
+        output_config: { effort: 'minimal' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.output_config).toEqual({ effort: 'low' });
+    });
+
+    it('maps effort: off to thinking: disabled and removes output_config.effort', () => {
+      const payload = {
+        model: 'claude-sonnet-4-6',
+        output_config: { effort: 'off' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.thinking).toEqual({ type: 'disabled' });
+      expect(result.output_config).toBeUndefined();
+    });
+
+    it('removes output_config.effort if thinking is explicitly disabled', () => {
+      const payload = {
+        model: 'claude-sonnet-4-6',
+        thinking: { type: 'disabled' },
+        output_config: { effort: 'high' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.thinking).toEqual({ type: 'disabled' });
+      expect(result.output_config).toBeUndefined();
+    });
+
+    it('preserves thinking: disabled when output_config is absent', () => {
+      const payload = {
+        model: 'claude-sonnet-4-6',
+        thinking: { type: 'disabled' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.thinking).toEqual({ type: 'disabled' });
+      expect(result.output_config).toBeUndefined();
+    });
+
+    it('preserves valid effort levels', () => {
+      const payload = {
+        model: 'claude-sonnet-4-6',
+        output_config: { effort: 'high' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.output_config).toEqual({ effort: 'high' });
+    });
+
+    it('handles case-insensitive effort values', () => {
+      const payload = {
+        model: 'claude-sonnet-4-6',
+        output_config: { effort: 'MINIMAL' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.output_config).toEqual({ effort: 'low' });
+    });
+  });
+
+  describe('passthrough and defensive guards', () => {
+    it('returns falsy or non-object payloads untouched', () => {
+      expect(
+        clampAnthropicEffortAndThinking(null as unknown as Record<string, unknown>)
+      ).toBeNull();
+      expect(
+        clampAnthropicEffortAndThinking(undefined as unknown as Record<string, unknown>)
+      ).toBeUndefined();
+      expect(clampAnthropicEffortAndThinking('string' as unknown as Record<string, unknown>)).toBe(
+        'string'
+      );
+    });
+
+    it('clamps unrecognized effort strings to low', () => {
+      const payload = {
+        model: 'claude-opus-5',
+        output_config: { effort: 'turbo' },
+      };
+      const result = clampAnthropicEffortAndThinking(payload);
+      expect(result.output_config).toEqual({ effort: 'low' });
+    });
+  });
+});

--- a/packages/backend/src/transformers/anthropic/request-builder.ts
+++ b/packages/backend/src/transformers/anthropic/request-builder.ts
@@ -1,5 +1,6 @@
 import { UnifiedChatRequest } from '../../types/unified';
 import { convertUnifiedToolsToAnthropic } from './tool-mapper';
+import { clampAnthropicEffortAndThinking } from './thinking-clamp';
 
 /**
  * Transforms a Unified request into Anthropic API format.
@@ -148,5 +149,5 @@ export async function buildAnthropicRequest(request: UnifiedChatRequest): Promis
     }
   }
 
-  return payload;
+  return clampAnthropicEffortAndThinking(payload, request.model);
 }

--- a/packages/backend/src/transformers/anthropic/thinking-clamp.ts
+++ b/packages/backend/src/transformers/anthropic/thinking-clamp.ts
@@ -1,0 +1,118 @@
+import { getCatalogModel } from '../../services/pi-ai/catalog';
+import {
+  clampEffortToWindow,
+  normalizeEffort,
+  splitReasoningSuffix,
+} from '../../services/pi-ai/reasoning';
+
+/**
+ * Check whether an Anthropic model supports disabling thinking.
+ *
+ * Models like Claude Opus 5 and Claude Fable 5 have `thinkingLevelMap.off === null`,
+ * meaning thinking cannot be disabled. For these models, any client attempt to turn
+ * thinking off (e.g. `thinking: { type: 'disabled' }` or `output_config: { effort: 'off' }`)
+ * must be clamped to the model's lowest supported thinking mode: adaptive thinking with low effort.
+ */
+export function anthropicModelSupportsDisable(modelId?: string): boolean {
+  if (!modelId) return true;
+  let cleanId = modelId.trim().toLowerCase();
+  cleanId = splitReasoningSuffix(cleanId).alias;
+  cleanId = cleanId.replace(/^anthropic\//, '');
+  const baseId = cleanId.replace(/-\d{8}$/, '');
+  const model = getCatalogModel('anthropic', cleanId) ?? getCatalogModel('anthropic', baseId);
+  if (model && typeof model === 'object' && 'thinkingLevelMap' in model) {
+    const map = model.thinkingLevelMap;
+    if (map && typeof map === 'object' && 'off' in map) {
+      return (map as Record<string, unknown>).off !== null;
+    }
+  }
+  if (/(?:opus-5|fable-5)/i.test(cleanId)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Clamp Anthropic thinking and effort values to valid ranges.
+ *
+ * Anthropic's Messages API accepts only 'low', 'medium', 'high', 'xhigh', 'max'
+ * for `output_config.effort`. It rejects 'minimal' or 'off' with:
+ *   "Provider failed: 400 output_config.effort: Input should be 'low', 'medium', 'high', 'xhigh' or 'max'"
+ *
+ * This function:
+ * 1. Clamps any `output_config.effort` to `['low', 'max']` (e.g. 'minimal' -> 'low').
+ * 2. If a model cannot disable thinking (e.g. Claude Opus 5), maps disabled thinking
+ *    or effort 'off' to adaptive thinking with effort 'low'.
+ * 3. If a model can disable thinking and effort is 'off', removes `output_config.effort`
+ *    and sets `thinking: { type: 'disabled' }`.
+ * 4. Ensures `output_config.effort` is not sent when `thinking: { type: 'disabled' }`.
+ */
+export function clampAnthropicEffortAndThinking<T extends Record<string, unknown>>(
+  payload: T,
+  modelId?: string
+): T & {
+  thinking?: { type: string; display?: string };
+  output_config?: { effort?: string };
+} {
+  if (!payload || typeof payload !== 'object') return payload;
+
+  const rawModel =
+    typeof payload.model === 'string' && payload.model.trim() ? payload.model.trim() : undefined;
+  const model = rawModel || modelId;
+  const supportsDisable = anthropicModelSupportsDisable(model);
+
+  const outputConfig =
+    payload.output_config && typeof payload.output_config === 'object'
+      ? (payload.output_config as Record<string, unknown>)
+      : undefined;
+  const rawEffort = outputConfig?.effort;
+  const hasEffort = rawEffort !== undefined;
+  const normalizedEffort = hasEffort ? normalizeEffort(rawEffort) : undefined;
+
+  const thinking =
+    payload.thinking && typeof payload.thinking === 'object'
+      ? (payload.thinking as Record<string, unknown>)
+      : undefined;
+  const thinkingDisabled = thinking?.type === 'disabled';
+
+  if (!supportsDisable) {
+    // Model cannot disable thinking (e.g. Claude Opus 5, Fable 5)
+    if (thinkingDisabled || normalizedEffort === 'off') {
+      (payload as Record<string, unknown>).thinking = {
+        type: 'adaptive',
+        ...(typeof thinking?.display === 'string' ? { display: thinking.display } : {}),
+      };
+      (payload as Record<string, unknown>).output_config = {
+        ...(outputConfig ?? {}),
+        effort: 'low',
+      };
+    } else if (hasEffort && outputConfig) {
+      const clamped = normalizedEffort
+        ? clampEffortToWindow(normalizedEffort, 'low', 'max')
+        : 'low';
+      outputConfig.effort = clamped;
+    }
+  } else {
+    if (normalizedEffort === 'off') {
+      if (outputConfig) {
+        delete outputConfig.effort;
+        if (Object.keys(outputConfig).length === 0)
+          delete (payload as Record<string, unknown>).output_config;
+      }
+      (payload as Record<string, unknown>).thinking = { type: 'disabled' };
+    } else if (thinkingDisabled) {
+      if (outputConfig?.effort) {
+        delete outputConfig.effort;
+        if (Object.keys(outputConfig).length === 0)
+          delete (payload as Record<string, unknown>).output_config;
+      }
+    } else if (hasEffort && outputConfig) {
+      const clamped = normalizedEffort
+        ? clampEffortToWindow(normalizedEffort, 'low', 'max')
+        : 'low';
+      outputConfig.effort = clamped;
+    }
+  }
+
+  return payload;
+}

--- a/packages/backend/src/transformers/oauth/oauth-claude.ts
+++ b/packages/backend/src/transformers/oauth/oauth-claude.ts
@@ -8,6 +8,7 @@
  */
 
 import { logger } from '../../utils/logger';
+import { clampAnthropicEffortAndThinking } from '../anthropic/thinking-clamp';
 
 // ============================================================================
 // Tool Name Remapping
@@ -682,6 +683,8 @@ export function applyClaudeOAuthTransform(
   logger.debug('Applying Claude OAuth transforms for token');
 
   let result = JSON.parse(JSON.stringify(payload));
+  const modelId = typeof result?.model === 'string' ? result.model : undefined;
+  result = clampAnthropicEffortAndThinking(result, modelId);
   let toolNamesRemapped = false;
 
   // 1. Tool name remapping


### PR DESCRIPTION
## Summary
Clamp Anthropic thinking effort values to `['low', 'max']` and automatically map disabled thinking requests to adaptive low effort for models that cannot disable reasoning (such as Claude Opus 5 and Claude Fable 5). This prevents upstream 400 rejection errors (`output_config.effort: Input should be 'low', 'medium', 'high', 'xhigh' or 'max'`) when clients like Claude Code send `/effort off` or `'minimal'` on Claude OAuth and Messages paths.

## Context
1. Anthropic's Messages API (and the `effort-2025-11-24` beta merged on Claude Code OAuth paths) strictly validates `output_config.effort` as `'low' | 'medium' | 'high' | 'xhigh' | 'max'`. It rejects `'minimal'`, `'off'`, and unrecognized values with a 400 error.
2. In the model registry, Claude Opus 5 and Claude Fable 5 carry `thinkingLevelMap.off === null`, indicating they cannot disable reasoning. When Claude Code or other clients requested reasoning set to "Off", Plexus recognized that the model cannot disable thinking but selected the lowest level from pi-ai's default list, which was `'minimal'`. This caused Plexus to inject `output_config: { effort: 'minimal' }`, triggering the upstream 400 failure.
3. For pass-through and direct OAuth requests, any incoming `output_config.effort: 'off'` or `'minimal'` was passed upstream unvalidated, leading to the same rejection.

## Changes
- **Transformers (Anthropic)**: add `clampAnthropicEffortAndThinking` in `thinking-clamp.ts` to clamp `output_config.effort` into `['low', 'max']` (`minimal` -> `low`), map disabled thinking to adaptive `low` effort on cannot-disable models (e.g. Opus 5), and strip `output_config.effort` when thinking is disabled on disablable models.
- **Registry (`services/pi-ai/registry.ts`)**: in `buildReasoningOptionsForModel`, explicitly set the adaptive floor to `'low'` for Anthropic models that cannot disable thinking, while preserving the 1024 token budget for older budget-based models requesting `'minimal'`.
- **Auto-compat (`services/dispatch/dispatcher-auto-compat.ts`)**: run `clampAnthropicEffortAndThinking` on Anthropic projections to clamp effort and handle `output_config.effort: 'off'`.
- **OAuth & Dispatch Pipeline**: clamp payloads before masking and signing in `prepareAnthropicOAuthRequest` and `applyClaudeOAuthTransform`, and clamp outbound Anthropic payloads in `buildRequestPayload` and `buildAnthropicRequest`.

## Testing
- Added unit tests in `packages/backend/src/transformers/anthropic/__tests__/thinking-clamp.test.ts` covering `anthropicModelSupportsDisable` and `clampAnthropicEffortAndThinking` across Opus 5, Fable 5, and Sonnet permutations.
- Added Claude OAuth tests in `packages/backend/src/services/oauth/__tests__/oauth-native-request-effort.test.ts` covering OAuth and `useClaudeMasking` routes with Opus 5 and Sonnet.
- Added registry tests in `packages/backend/src/services/pi-ai/__tests__/build-reasoning-for-model.test.ts` for cannot-disable Anthropic models and `'minimal'` clamping.
- Added auto-compat tests in `packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts` for adaptive models and Opus 5.
- Verified all pre-commit hooks, typechecks, and the full test suite (115 files, 1,146 tests passing).
