### PR TITLE
refactor(tests): extract large test fixtures

### DIFF
--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.fixtures.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.fixtures.ts
@@ -1,0 +1,314 @@
+export const ARRAY_FIELD_PAYLOAD = {
+  model: 'gpt-5.5',
+  messages: [
+    { role: 'user', content: 'hi', some_field: 'x' },
+    { role: 'assistant', content: 'yo' },
+  ],
+};
+
+export const NESTED_ARRAY_PAYLOAD = {
+  messages: [{ role: 'user', meta: { keep: 1, drop: 2 } }],
+};
+
+export const STRUCTURAL_MESSAGE_NAME_PAYLOAD = {
+  model: 'gpt-4o',
+  messages: [
+    { role: 'user', content: 'hi', name: 'bob!' },
+    { role: 'assistant', content: 'yo' },
+  ],
+};
+
+export const BRACKET_MESSAGE_NAME_PAYLOAD = {
+  model: 'gpt-4o',
+  messages: [
+    { role: 'user', content: 'hi', name: 'bob!' },
+    { role: 'assistant', content: 'yo' },
+  ],
+};
+
+export const STRUCTURAL_TOOLS_PAYLOAD = {
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: 'hi' }],
+  tools: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+};
+
+export const ARRAY_INDEX_TOOL_A = { type: 'function', name: 'a' };
+export const ARRAY_INDEX_TOOL_B = { type: 'function', name: 'b' };
+export const ARRAY_INDEX_TOOL_C = { type: 'function', name: 'c' };
+
+export const ARRAY_INDEX_TOOLS_PAYLOAD = {
+  model: 'gpt-5.5',
+  tools: [ARRAY_INDEX_TOOL_A, ARRAY_INDEX_TOOL_B, ARRAY_INDEX_TOOL_C],
+};
+
+export const SHARED_MESSAGES = [{ role: 'user', content: 'hi', bad_field: 1 }];
+
+export const SHARED_MESSAGES_PAYLOAD = {
+  model: 'claude-x',
+  messages: SHARED_MESSAGES,
+};
+
+export const TOP_LEVEL_TOOLS_PAYLOAD = {
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: 'hi' }],
+  tools: [{ type: 'function', function: { name: 'f' } }],
+};
+
+export const PROMPT_CACHE_KEY_PAYLOAD = {
+  model: 'openai/gpt-5.5',
+  input: 'hello',
+  prompt_cache_key: 'cache-key-123',
+};
+
+export const PROMPT_CACHE_METADATA_PAYLOAD = {
+  model: 'openai/gpt-5.5',
+  input: 'hello',
+  metadata: { prompt_cache_key: 'cache-key-123', session: 's1' },
+};
+
+export const THINKING_SIGNATURE_ERROR_RESPONSE_BODY = JSON.stringify({
+  type: 'error',
+  error: {
+    type: 'invalid_request_error',
+    message: 'messages.3.content.0: Invalid `signature` in `thinking` block',
+  },
+  request_id: 'req_test123',
+});
+
+export const THINKING_SIGNATURE_PLAN_ERROR_BODY = JSON.stringify({
+  error: { message: 'messages.3.content.0: Invalid `signature` in `thinking` block' },
+});
+
+export const RESPONSES_API_PAYLOAD = { model: 'gpt-5.5', input: 'hi' };
+export const ANTHROPIC_MESSAGES_PAYLOAD = { model: 'claude-x', messages: [] };
+
+export const THINKING_TEXT_PAYLOAD = {
+  model: 'claude-x',
+  messages: [
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
+        { type: 'text', text: 'the answer' },
+      ],
+    },
+  ],
+};
+
+export const THINKING_TOOL_USE_PAYLOAD = {
+  model: 'claude-x',
+  messages: [
+    { role: 'user', content: [{ type: 'text', text: 'do the thing' }] },
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
+        { type: 'tool_use', id: 'tool-1', name: 'search', input: { q: 'x' } },
+      ],
+    },
+  ],
+};
+
+export const REDACTED_THINKING_PAYLOAD = {
+  model: 'claude-x',
+  messages: [
+    {
+      role: 'assistant',
+      content: [
+        { type: 'redacted_thinking', data: 'opaque-encrypted-payload' },
+        { type: 'text', text: 'the answer' },
+      ],
+    },
+  ],
+};
+
+export const MULTIPLE_THINKING_BLOCKS_PAYLOAD = {
+  messages: [
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'a', signature: 'sig-a' },
+        { type: 'redacted_thinking', data: 'b' },
+        { type: 'text', text: 'the answer' },
+      ],
+    },
+  ],
+};
+
+export const PLAIN_STRING_MESSAGES_PAYLOAD = {
+  messages: [
+    { role: 'user', content: 'hello' },
+    { role: 'assistant', content: 'hi there' },
+  ],
+};
+
+export const ARRAY_CONTENT_NO_THINKING_PAYLOAD = {
+  model: 'gpt-4o',
+  messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+};
+
+export const THINKING_COPY_ON_WRITE_UNTOUCHED_MESSAGE = {
+  role: 'user',
+  content: [{ type: 'text', text: 'hi' }],
+};
+
+export const THINKING_COPY_ON_WRITE_PAYLOAD = {
+  model: 'claude-x',
+  messages: [
+    THINKING_COPY_ON_WRITE_UNTOUCHED_MESSAGE,
+    {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'stale', signature: 'sig-a' },
+        { type: 'text', text: 'answer' },
+      ],
+    },
+  ],
+};
+
+export const THINKING_ONLY_END_PAYLOAD = {
+  messages: [
+    { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    {
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+    },
+  ],
+};
+
+export const THINKING_ONLY_ALTERNATION_PAYLOAD = {
+  messages: [
+    { role: 'user', content: [{ type: 'text', text: 'first' }] },
+    {
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+    },
+    { role: 'user', content: [{ type: 'text', text: 'second' }] },
+  ],
+};
+
+export const THINKING_ORPHAN_TOOL_RESULT_PAYLOAD = {
+  messages: [
+    { role: 'user', content: [{ type: 'text', text: 'q' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'partial answer, no tool call' }] },
+    {
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+    },
+  ],
+};
+
+export const THINKING_PAIRED_TOOL_RESULT_PAYLOAD = {
+  messages: [
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'tool-1', name: 'search', input: {} }],
+    },
+    {
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
+    },
+  ],
+};
+
+export const ADVISOR_INVOCATION = {
+  type: 'server_tool_use',
+  id: 'srvtoolu_abc',
+  name: 'advisor',
+  input: {},
+};
+
+export const ADVISOR_RESULT = {
+  type: 'advisor_tool_result',
+  tool_use_id: 'srvtoolu_abc',
+  content: { type: 'advisor_redacted_result', encrypted_content: 'EqQhCio-sealed-by-account-a' },
+};
+
+export const ADVISOR_SINGLE_MESSAGE_PAYLOAD = {
+  model: 'claude-x',
+  messages: [
+    {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'let me consult' }, ADVISOR_INVOCATION, ADVISOR_RESULT],
+    },
+  ],
+};
+
+export const ADVISOR_SEPARATE_MESSAGES_PAYLOAD = {
+  messages: [
+    { role: 'assistant', content: [{ type: 'text', text: 'thinking' }, ADVISOR_INVOCATION] },
+    { role: 'assistant', content: [ADVISOR_RESULT, { type: 'text', text: 'the answer' }] },
+  ],
+};
+
+export const ADVISOR_UNRELATED_TOOL_PAYLOAD = {
+  messages: [
+    {
+      role: 'assistant',
+      content: [
+        { type: 'server_tool_use', id: 'srvtoolu_web', name: 'web_search', input: {} },
+        ADVISOR_INVOCATION,
+        ADVISOR_RESULT,
+      ],
+    },
+  ],
+};
+
+export const ADVISOR_PLACEHOLDER_PAYLOAD = {
+  messages: [
+    { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+    { role: 'assistant', content: [ADVISOR_INVOCATION, ADVISOR_RESULT] },
+    { role: 'user', content: [{ type: 'text', text: 'q2' }] },
+  ],
+};
+
+export const ADVISOR_DROP_PAYLOAD = {
+  messages: [
+    { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+    { role: 'assistant', content: [ADVISOR_INVOCATION, ADVISOR_RESULT] },
+  ],
+};
+
+export const ADVISOR_NO_RESULT_PAYLOAD = {
+  model: 'claude-x',
+  messages: [{ role: 'assistant', content: [{ type: 'text', text: 'hi' }] }],
+};
+
+export const ADVISOR_RESULT_ERROR_RESPONSE_BODY = JSON.stringify({
+  type: 'error',
+  error: {
+    type: 'invalid_request_error',
+    message: 'Advisor tool result content could not be processed.',
+  },
+  request_id: 'req_test123',
+});
+
+export const ADVISOR_RESULT_PLAN_ERROR_BODY = JSON.stringify({
+  error: { message: 'Advisor tool result content could not be processed.' },
+});
+
+export const LITE_UNSUPPORTED_TOOLS_ERROR_BODY = JSON.stringify({
+  error: {
+    message:
+      'X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.',
+  },
+});
+
+export const LITE_MIXED_TOOLS_PAYLOAD = {
+  model: 'gpt-5.6-luna',
+  tools: [
+    { type: 'function', name: 'exec_command' },
+    { type: 'web_search' },
+    { type: 'custom', name: 'apply_patch' },
+    { type: 'tool_search' },
+    { type: 'image_generation' },
+  ],
+};

--- a/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
+++ b/packages/backend/src/services/__tests__/dispatcher-auto-compat.test.ts
@@ -29,6 +29,50 @@ import {
   stripLiteUnsupportedTools,
   MAX_LITE_TOOL_STRIP_RETRIES,
 } from '../dispatch/dispatcher-auto-compat';
+import {
+  ADVISOR_DROP_PAYLOAD,
+  ADVISOR_INVOCATION,
+  ADVISOR_NO_RESULT_PAYLOAD,
+  ADVISOR_PLACEHOLDER_PAYLOAD,
+  ADVISOR_RESULT,
+  ADVISOR_RESULT_ERROR_RESPONSE_BODY,
+  ADVISOR_RESULT_PLAN_ERROR_BODY,
+  ADVISOR_SEPARATE_MESSAGES_PAYLOAD,
+  ADVISOR_SINGLE_MESSAGE_PAYLOAD,
+  ADVISOR_UNRELATED_TOOL_PAYLOAD,
+  ANTHROPIC_MESSAGES_PAYLOAD,
+  ARRAY_CONTENT_NO_THINKING_PAYLOAD,
+  ARRAY_FIELD_PAYLOAD,
+  ARRAY_INDEX_TOOL_A,
+  ARRAY_INDEX_TOOL_B,
+  ARRAY_INDEX_TOOL_C,
+  ARRAY_INDEX_TOOLS_PAYLOAD,
+  BRACKET_MESSAGE_NAME_PAYLOAD,
+  LITE_MIXED_TOOLS_PAYLOAD,
+  LITE_UNSUPPORTED_TOOLS_ERROR_BODY,
+  MULTIPLE_THINKING_BLOCKS_PAYLOAD,
+  NESTED_ARRAY_PAYLOAD,
+  PLAIN_STRING_MESSAGES_PAYLOAD,
+  PROMPT_CACHE_KEY_PAYLOAD,
+  PROMPT_CACHE_METADATA_PAYLOAD,
+  REDACTED_THINKING_PAYLOAD,
+  RESPONSES_API_PAYLOAD,
+  SHARED_MESSAGES,
+  SHARED_MESSAGES_PAYLOAD,
+  STRUCTURAL_MESSAGE_NAME_PAYLOAD,
+  STRUCTURAL_TOOLS_PAYLOAD,
+  THINKING_COPY_ON_WRITE_PAYLOAD,
+  THINKING_COPY_ON_WRITE_UNTOUCHED_MESSAGE,
+  THINKING_ONLY_ALTERNATION_PAYLOAD,
+  THINKING_ONLY_END_PAYLOAD,
+  THINKING_ORPHAN_TOOL_RESULT_PAYLOAD,
+  THINKING_PAIRED_TOOL_RESULT_PAYLOAD,
+  THINKING_SIGNATURE_ERROR_RESPONSE_BODY,
+  THINKING_SIGNATURE_PLAN_ERROR_BODY,
+  THINKING_TEXT_PAYLOAD,
+  THINKING_TOOL_USE_PAYLOAD,
+  TOP_LEVEL_TOOLS_PAYLOAD,
+} from './dispatcher-auto-compat.fixtures';
 
 function route(overrides: Partial<RouteResult> = {}): RouteResult {
   return {
@@ -789,13 +833,7 @@ describe('deleteDottedPath', () => {
   // payload that every upstream rejects.
   describe('array container preservation', () => {
     test('deleting a field inside an array element keeps the array an array', () => {
-      const payload: Record<string, any> = {
-        model: 'gpt-5.5',
-        messages: [
-          { role: 'user', content: 'hi', some_field: 'x' },
-          { role: 'assistant', content: 'yo' },
-        ],
-      };
+      const payload: Record<string, any> = ARRAY_FIELD_PAYLOAD;
       const snapshot = structuredClone(payload);
 
       const result = deleteDottedPath(payload, 'messages.0.some_field');
@@ -814,10 +852,10 @@ describe('deleteDottedPath', () => {
     });
 
     test('an array-index leaf removes the element splice-style (no hole, no null)', () => {
-      const t0 = { type: 'function', name: 'a' };
-      const t1 = { type: 'function', name: 'b' };
-      const t2 = { type: 'function', name: 'c' };
-      const payload: Record<string, any> = { model: 'gpt-5.5', tools: [t0, t1, t2] };
+      const t0 = ARRAY_INDEX_TOOL_A;
+      const t1 = ARRAY_INDEX_TOOL_B;
+      const t2 = ARRAY_INDEX_TOOL_C;
+      const payload: Record<string, any> = ARRAY_INDEX_TOOLS_PAYLOAD;
 
       const result = deleteDottedPath(payload, 'tools.2');
 
@@ -845,10 +883,7 @@ describe('deleteDottedPath', () => {
     });
 
     test('preserves arrays at intermediate depths of a longer path', () => {
-      const payload: Record<string, any> = {
-        messages: [{ role: 'user', meta: { keep: 1, drop: 2 } }],
-      };
-
+      const payload: Record<string, any> = NESTED_ARRAY_PAYLOAD;
       const result = deleteDottedPath(payload, 'messages.0.meta.drop');
 
       expect(result.deleted).toBe(true);
@@ -858,10 +893,10 @@ describe('deleteDottedPath', () => {
     });
 
     test('does not mutate an array shared by reference with another holder', () => {
-      const sharedMessages = [{ role: 'user', content: 'hi', bad_field: 1 }];
+      const sharedMessages = SHARED_MESSAGES;
       const request = { messages: sharedMessages };
       // Mirrors payload.messages = request.messages — same reference.
-      const payload: Record<string, any> = { model: 'claude-x', messages: request.messages };
+      const payload: Record<string, any> = SHARED_MESSAGES_PAYLOAD;
 
       const result = deleteDottedPath(payload, 'messages.0.bad_field');
 
@@ -1033,13 +1068,7 @@ describe('planUnsupportedParamStrip', () => {
 
     test('deeper paths under a structural element (messages.0.name) remain strippable', () => {
       const state = createUnsupportedParamStripState();
-      const payload: Record<string, any> = {
-        model: 'gpt-4o',
-        messages: [
-          { role: 'user', content: 'hi', name: 'bob!' },
-          { role: 'assistant', content: 'yo' },
-        ],
-      };
+      const payload: Record<string, any> = STRUCTURAL_MESSAGE_NAME_PAYLOAD;
 
       const paramToStrip = planUnsupportedParamStrip(
         '{"error":{"message":"Unsupported parameter: \'messages[0].name\'"}}',
@@ -1057,11 +1086,7 @@ describe('planUnsupportedParamStrip', () => {
 
     test('numeric leaves under NON-structural arrays (tools[2]) stay splice-deletable', () => {
       const state = createUnsupportedParamStripState();
-      const payload: Record<string, any> = {
-        model: 'gpt-4o',
-        messages: [{ role: 'user', content: 'hi' }],
-        tools: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
-      };
+      const payload: Record<string, any> = STRUCTURAL_TOOLS_PAYLOAD;
 
       const paramToStrip = planUnsupportedParamStrip(
         '{"detail":"Unsupported parameter: tools[2]"}',
@@ -1086,13 +1111,7 @@ describe('planUnsupportedParamStrip', () => {
 describe('bracket-notation unsupported params (match -> plan -> delete pipeline)', () => {
   test('a 400 naming messages[0].name deletes only that element field — the conversation array survives', () => {
     const state = createUnsupportedParamStripState();
-    const payload: Record<string, any> = {
-      model: 'gpt-4o',
-      messages: [
-        { role: 'user', content: 'hi', name: 'bob!' },
-        { role: 'assistant', content: 'yo' },
-      ],
-    };
+    const payload: Record<string, any> = BRACKET_MESSAGE_NAME_PAYLOAD;
 
     const paramToStrip = planUnsupportedParamStrip(
       '{"error":{"message":"Unsupported parameter: \'messages[0].name\'"}}',
@@ -1115,11 +1134,7 @@ describe('bracket-notation unsupported params (match -> plan -> delete pipeline)
     // a blanket "no whole fields" rule: stripping a whole `tools` (or
     // `safety_identifier`, etc.) leaves a well-formed request.
     const state = createUnsupportedParamStripState();
-    const payload: Record<string, any> = {
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: 'hi' }],
-      tools: [{ type: 'function', function: { name: 'f' } }],
-    };
+    const payload: Record<string, any> = TOP_LEVEL_TOOLS_PAYLOAD;
 
     const paramToStrip = planUnsupportedParamStrip(
       '{"detail":"Unsupported parameter: tools"}',
@@ -1147,11 +1162,7 @@ describe('bracket-notation unsupported params (match -> plan -> delete pipeline)
 describe('reactive strip-and-retry handles prompt_cache_key (not statically stripped)', () => {
   test('strips a plain top-level prompt_cache_key named in a 400', () => {
     const state = createUnsupportedParamStripState();
-    const payload: Record<string, any> = {
-      model: 'openai/gpt-5.5',
-      input: 'hello',
-      prompt_cache_key: 'cache-key-123',
-    };
+    const payload: Record<string, any> = PROMPT_CACHE_KEY_PAYLOAD;
 
     const paramToStrip = planUnsupportedParamStrip(
       '{"detail":"Unsupported parameter: prompt_cache_key"}',
@@ -1166,11 +1177,7 @@ describe('reactive strip-and-retry handles prompt_cache_key (not statically stri
 
   test('strips a dotted-path prompt_cache_key named in a 400', () => {
     const state = createUnsupportedParamStripState();
-    const payload: Record<string, any> = {
-      model: 'openai/gpt-5.5',
-      input: 'hello',
-      metadata: { prompt_cache_key: 'cache-key-123', session: 's1' },
-    };
+    const payload: Record<string, any> = PROMPT_CACHE_METADATA_PAYLOAD;
 
     const paramToStrip = planUnsupportedParamStrip(
       '{"error":{"message":"Unsupported parameter: \'metadata.prompt_cache_key\'"}}',
@@ -1202,14 +1209,7 @@ describe('reactive strip-and-retry handles prompt_cache_key (not statically stri
 
 describe('matchThinkingSignatureError', () => {
   test('matches the exact production error body', () => {
-    const body = JSON.stringify({
-      type: 'error',
-      error: {
-        type: 'invalid_request_error',
-        message: 'messages.3.content.0: Invalid `signature` in `thinking` block',
-      },
-      request_id: 'req_test123',
-    });
+    const body = THINKING_SIGNATURE_ERROR_RESPONSE_BODY;
     expect(matchThinkingSignatureError(body)).toBe(true);
   });
 
@@ -1262,18 +1262,7 @@ describe('isAnthropicMessagesPayload', () => {
 
 describe('stripThinkingSignatureBlocks', () => {
   test('removes a thinking block preceding text, preserving ordering', () => {
-    const payload: Record<string, any> = {
-      model: 'claude-x',
-      messages: [
-        {
-          role: 'assistant',
-          content: [
-            { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
-            { type: 'text', text: 'the answer' },
-          ],
-        },
-      ],
-    };
+    const payload: Record<string, any> = THINKING_TEXT_PAYLOAD;
     const snapshot = structuredClone(payload);
 
     const result = stripThinkingSignatureBlocks(payload);
@@ -1287,19 +1276,7 @@ describe('stripThinkingSignatureBlocks', () => {
   });
 
   test('removes a thinking block preceding a tool_use, preserving ordering', () => {
-    const payload: Record<string, any> = {
-      model: 'claude-x',
-      messages: [
-        { role: 'user', content: [{ type: 'text', text: 'do the thing' }] },
-        {
-          role: 'assistant',
-          content: [
-            { type: 'thinking', thinking: 'stale reasoning', signature: 'sig-from-model-a' },
-            { type: 'tool_use', id: 'tool-1', name: 'search', input: { q: 'x' } },
-          ],
-        },
-      ],
-    };
+    const payload: Record<string, any> = THINKING_TOOL_USE_PAYLOAD;
 
     const result = stripThinkingSignatureBlocks(payload);
 
@@ -1315,18 +1292,7 @@ describe('stripThinkingSignatureBlocks', () => {
   });
 
   test('removes a redacted_thinking block, preserving sibling content', () => {
-    const payload: Record<string, any> = {
-      model: 'claude-x',
-      messages: [
-        {
-          role: 'assistant',
-          content: [
-            { type: 'redacted_thinking', data: 'opaque-encrypted-payload' },
-            { type: 'text', text: 'the answer' },
-          ],
-        },
-      ],
-    };
+    const payload: Record<string, any> = REDACTED_THINKING_PAYLOAD;
 
     const result = stripThinkingSignatureBlocks(payload);
 
@@ -1337,18 +1303,7 @@ describe('stripThinkingSignatureBlocks', () => {
   });
 
   test('removes both thinking and redacted_thinking blocks in the same message', () => {
-    const payload: Record<string, any> = {
-      messages: [
-        {
-          role: 'assistant',
-          content: [
-            { type: 'thinking', thinking: 'a', signature: 'sig-a' },
-            { type: 'redacted_thinking', data: 'b' },
-            { type: 'text', text: 'the answer' },
-          ],
-        },
-      ],
-    };
+    const payload: Record<string, any> = MULTIPLE_THINKING_BLOCKS_PAYLOAD;
 
     const result = stripThinkingSignatureBlocks(payload);
 
@@ -1357,12 +1312,7 @@ describe('stripThinkingSignatureBlocks', () => {
   });
 
   test('leaves non-array content (plain string messages) untouched and returns the SAME payload reference', () => {
-    const payload: Record<string, any> = {
-      messages: [
-        { role: 'user', content: 'hello' },
-        { role: 'assistant', content: 'hi there' },
-      ],
-    };
+    const payload: Record<string, any> = PLAIN_STRING_MESSAGES_PAYLOAD;
 
     const result = stripThinkingSignatureBlocks(payload);
 
@@ -1389,10 +1339,7 @@ describe('stripThinkingSignatureBlocks', () => {
     // chat-completions payloads (they have a `messages` array too). This is
     // the known false-positive shape the dispatch loop must NOT retry on:
     // strippedCount 0 + identical payload reference is the signal.
-    const payload: Record<string, any> = {
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
-    };
+    const payload: Record<string, any> = ARRAY_CONTENT_NO_THINKING_PAYLOAD;
     const snapshot = structuredClone(payload);
 
     const result = stripThinkingSignatureBlocks(payload);
@@ -1403,20 +1350,8 @@ describe('stripThinkingSignatureBlocks', () => {
   });
 
   test('copy-on-write: never mutates the input payload, its messages array, or untouched message objects', () => {
-    const untouchedMessage = { role: 'user', content: [{ type: 'text', text: 'hi' }] };
-    const payload: Record<string, any> = {
-      model: 'claude-x',
-      messages: [
-        untouchedMessage,
-        {
-          role: 'assistant',
-          content: [
-            { type: 'thinking', thinking: 'stale', signature: 'sig-a' },
-            { type: 'text', text: 'answer' },
-          ],
-        },
-      ],
-    };
+    const untouchedMessage = THINKING_COPY_ON_WRITE_UNTOUCHED_MESSAGE;
+    const payload: Record<string, any> = THINKING_COPY_ON_WRITE_PAYLOAD;
     const originalMessages = payload.messages;
     const snapshot = structuredClone(payload);
 
@@ -1435,15 +1370,7 @@ describe('stripThinkingSignatureBlocks', () => {
   });
 
   test('drops a thinking-only assistant message at the end of the conversation (no alternation break, nothing to orphan)', () => {
-    const payload: Record<string, any> = {
-      messages: [
-        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
-        {
-          role: 'assistant',
-          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
-        },
-      ],
-    };
+    const payload: Record<string, any> = THINKING_ONLY_END_PAYLOAD;
 
     const result = stripThinkingSignatureBlocks(payload);
 
@@ -1454,16 +1381,7 @@ describe('stripThinkingSignatureBlocks', () => {
   });
 
   test('replaces a thinking-only assistant message with a placeholder when dropping it would break user/assistant alternation', () => {
-    const payload: Record<string, any> = {
-      messages: [
-        { role: 'user', content: [{ type: 'text', text: 'first' }] },
-        {
-          role: 'assistant',
-          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
-        },
-        { role: 'user', content: [{ type: 'text', text: 'second' }] },
-      ],
-    };
+    const payload: Record<string, any> = THINKING_ONLY_ALTERNATION_PAYLOAD;
 
     const result = stripThinkingSignatureBlocks(payload);
 
@@ -1481,20 +1399,7 @@ describe('stripThinkingSignatureBlocks', () => {
     // tool_result-orphan guard: `next` carries a tool_result but `prev` does
     // NOT carry the tool_use it would need to correspond to, so dropping the
     // thinking-only message would leave that tool_result dangling.
-    const payload: Record<string, any> = {
-      messages: [
-        { role: 'user', content: [{ type: 'text', text: 'q' }] },
-        { role: 'assistant', content: [{ type: 'text', text: 'partial answer, no tool call' }] },
-        {
-          role: 'assistant',
-          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
-        },
-        {
-          role: 'user',
-          content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
-        },
-      ],
-    };
+    const payload: Record<string, any> = THINKING_ORPHAN_TOOL_RESULT_PAYLOAD;
 
     const result = stripThinkingSignatureBlocks(payload);
 
@@ -1521,22 +1426,7 @@ describe('stripThinkingSignatureBlocks', () => {
   test('drops a thinking-only message when the next tool_result correctly pairs with a preceding tool_use', () => {
     // Here dropping the empty message actually restores correct adjacency
     // between the tool_use and its tool_result, so it is safe to drop.
-    const payload: Record<string, any> = {
-      messages: [
-        {
-          role: 'assistant',
-          content: [{ type: 'tool_use', id: 'tool-1', name: 'search', input: {} }],
-        },
-        {
-          role: 'assistant',
-          content: [{ type: 'thinking', thinking: 'stale', signature: 'sig-a' }],
-        },
-        {
-          role: 'user',
-          content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'result' }],
-        },
-      ],
-    };
+    const payload: Record<string, any> = THINKING_PAIRED_TOOL_RESULT_PAYLOAD;
 
     const result = stripThinkingSignatureBlocks(payload);
 
@@ -1555,10 +1445,8 @@ describe('stripThinkingSignatureBlocks', () => {
 });
 
 describe('planThinkingSignatureStrip', () => {
-  const signatureBody = JSON.stringify({
-    error: { message: 'messages.3.content.0: Invalid `signature` in `thinking` block' },
-  });
-  const anthropicPayload = { model: 'claude-x', messages: [] };
+  const signatureBody = THINKING_SIGNATURE_PLAN_ERROR_BODY;
+  const anthropicPayload = ANTHROPIC_MESSAGES_PAYLOAD;
 
   test('MAX_THINKING_SIGNATURE_STRIP_RETRIES is exactly 1 (one strip-retry per target)', () => {
     expect(MAX_THINKING_SIGNATURE_STRIP_RETRIES).toBe(1);
@@ -1624,14 +1512,7 @@ describe('planThinkingSignatureStrip', () => {
 
 describe('matchAdvisorResultError', () => {
   test('matches the exact production error body', () => {
-    const body = JSON.stringify({
-      type: 'error',
-      error: {
-        type: 'invalid_request_error',
-        message: 'Advisor tool result content could not be processed.',
-      },
-      request_id: 'req_test123',
-    });
+    const body = ADVISOR_RESULT_ERROR_RESPONSE_BODY;
     expect(matchAdvisorResultError(body)).toBe(true);
   });
 
@@ -1661,28 +1542,11 @@ describe('matchAdvisorResultError', () => {
 describe('stripAdvisorResultBlocks', () => {
   // Mirrors the echoed on-wire shape: an assistant `server_tool_use` advisor
   // invocation followed by its account-bound (encrypted) `advisor_tool_result`.
-  const advisorInvocation = {
-    type: 'server_tool_use',
-    id: 'srvtoolu_abc',
-    name: 'advisor',
-    input: {},
-  };
-  const advisorResult = {
-    type: 'advisor_tool_result',
-    tool_use_id: 'srvtoolu_abc',
-    content: { type: 'advisor_redacted_result', encrypted_content: 'EqQhCio-sealed-by-account-a' },
-  };
+  const advisorInvocation = ADVISOR_INVOCATION;
+  const advisorResult = ADVISOR_RESULT;
 
   test('strips the advisor result and its paired invocation, preserving sibling text', () => {
-    const payload: Record<string, any> = {
-      model: 'claude-x',
-      messages: [
-        {
-          role: 'assistant',
-          content: [{ type: 'text', text: 'let me consult' }, advisorInvocation, advisorResult],
-        },
-      ],
-    };
+    const payload: Record<string, any> = ADVISOR_SINGLE_MESSAGE_PAYLOAD;
     const snapshot = structuredClone(payload);
 
     const result = stripAdvisorResultBlocks(payload);
@@ -1696,12 +1560,7 @@ describe('stripAdvisorResultBlocks', () => {
   });
 
   test('pairs invocation and result by id even when they sit in separate messages', () => {
-    const payload: Record<string, any> = {
-      messages: [
-        { role: 'assistant', content: [{ type: 'text', text: 'thinking' }, advisorInvocation] },
-        { role: 'assistant', content: [advisorResult, { type: 'text', text: 'the answer' }] },
-      ],
-    };
+    const payload: Record<string, any> = ADVISOR_SEPARATE_MESSAGES_PAYLOAD;
 
     const result = stripAdvisorResultBlocks(payload);
 
@@ -1713,18 +1572,7 @@ describe('stripAdvisorResultBlocks', () => {
   });
 
   test('leaves an unrelated server_tool_use (no matching advisor result) untouched', () => {
-    const payload: Record<string, any> = {
-      messages: [
-        {
-          role: 'assistant',
-          content: [
-            { type: 'server_tool_use', id: 'srvtoolu_web', name: 'web_search', input: {} },
-            advisorInvocation,
-            advisorResult,
-          ],
-        },
-      ],
-    };
+    const payload: Record<string, any> = ADVISOR_UNRELATED_TOOL_PAYLOAD;
 
     const result = stripAdvisorResultBlocks(payload);
 
@@ -1736,13 +1584,7 @@ describe('stripAdvisorResultBlocks', () => {
   });
 
   test('drops a message emptied by the strip when doing so keeps alternation valid', () => {
-    const payload: Record<string, any> = {
-      messages: [
-        { role: 'user', content: [{ type: 'text', text: 'q1' }] },
-        { role: 'assistant', content: [advisorInvocation, advisorResult] },
-        { role: 'user', content: [{ type: 'text', text: 'q2' }] },
-      ],
-    };
+    const payload: Record<string, any> = ADVISOR_PLACEHOLDER_PAYLOAD;
 
     const result = stripAdvisorResultBlocks(payload);
 
@@ -1757,12 +1599,7 @@ describe('stripAdvisorResultBlocks', () => {
   });
 
   test('drops an emptied message entirely when alternation stays valid without it', () => {
-    const payload: Record<string, any> = {
-      messages: [
-        { role: 'user', content: [{ type: 'text', text: 'q1' }] },
-        { role: 'assistant', content: [advisorInvocation, advisorResult] },
-      ],
-    };
+    const payload: Record<string, any> = ADVISOR_DROP_PAYLOAD;
 
     const result = stripAdvisorResultBlocks(payload);
 
@@ -1774,10 +1611,7 @@ describe('stripAdvisorResultBlocks', () => {
   });
 
   test('returns the payload unchanged (0 strips) when there is no advisor result', () => {
-    const payload: Record<string, any> = {
-      model: 'claude-x',
-      messages: [{ role: 'assistant', content: [{ type: 'text', text: 'hi' }] }],
-    };
+    const payload: Record<string, any> = ADVISOR_NO_RESULT_PAYLOAD;
 
     const result = stripAdvisorResultBlocks(payload);
 
@@ -1795,10 +1629,8 @@ describe('stripAdvisorResultBlocks', () => {
 });
 
 describe('planAdvisorResultStrip', () => {
-  const advisorBody = JSON.stringify({
-    error: { message: 'Advisor tool result content could not be processed.' },
-  });
-  const anthropicPayload = { model: 'claude-x', messages: [] };
+  const advisorBody = ADVISOR_RESULT_PLAN_ERROR_BODY;
+  const anthropicPayload = ANTHROPIC_MESSAGES_PAYLOAD;
 
   test('MAX_ADVISOR_RESULT_STRIP_RETRIES is exactly 1 (one strip-retry per target)', () => {
     expect(MAX_ADVISOR_RESULT_STRIP_RETRIES).toBe(1);
@@ -1820,7 +1652,7 @@ describe('planAdvisorResultStrip', () => {
 
   test('does not plan a retry when the outbound payload is not Anthropic-messages-shaped', () => {
     const state = createAdvisorResultStripState();
-    const responsesPayload = { model: 'gpt-5.5', input: 'hi' };
+    const responsesPayload = RESPONSES_API_PAYLOAD;
     expect(planAdvisorResultStrip(advisorBody, responsesPayload, state)).toBe(false);
     expect(state.attempts).toBe(0);
   });
@@ -1854,16 +1686,7 @@ describe('planAdvisorResultStrip', () => {
 
 describe('matchLiteUnsupportedToolsError', () => {
   test('matches the responses:lite tool-type-restriction 400', () => {
-    expect(
-      matchLiteUnsupportedToolsError(
-        JSON.stringify({
-          error: {
-            message:
-              'X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.',
-          },
-        })
-      )
-    ).toBe(true);
+    expect(matchLiteUnsupportedToolsError(LITE_UNSUPPORTED_TOOLS_ERROR_BODY)).toBe(true);
   });
 
   test('is case-insensitive', () => {
@@ -1885,16 +1708,7 @@ describe('matchLiteUnsupportedToolsError', () => {
 
 describe('stripLiteUnsupportedTools', () => {
   test('removes tools whose type is not function/custom/tool_search', () => {
-    const payload = {
-      model: 'gpt-5.6-luna',
-      tools: [
-        { type: 'function', name: 'exec_command' },
-        { type: 'web_search' },
-        { type: 'custom', name: 'apply_patch' },
-        { type: 'tool_search' },
-        { type: 'image_generation' },
-      ],
-    };
+    const payload = LITE_MIXED_TOOLS_PAYLOAD;
 
     const result = stripLiteUnsupportedTools(payload);
     expect(result.strippedCount).toBe(2);
@@ -1933,12 +1747,7 @@ describe('stripLiteUnsupportedTools', () => {
 });
 
 describe('planLiteToolStrip', () => {
-  const liteToolsErrorBody = JSON.stringify({
-    error: {
-      message:
-        'X-OpenAI-Internal-Codex-Responses-Lite only supports function tools, custom tools, and client-executed tool search.',
-    },
-  });
+  const liteToolsErrorBody = LITE_UNSUPPORTED_TOOLS_ERROR_BODY;
 
   test('MAX_LITE_TOOL_STRIP_RETRIES is exactly 1 (one strip-retry per target)', () => {
     expect(MAX_LITE_TOOL_STRIP_RETRIES).toBe(1);

--- a/packages/backend/src/transformers/__tests__/responses-stream.fixtures.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.fixtures.ts
@@ -1,0 +1,1097 @@
+export const TINY_IMAGE_B64 = 'aGVsbG8=';
+export const TINY_IMAGE_MARKDOWN = `![generated image](data:image/png;base64,${TINY_IMAGE_B64})`;
+
+export const OVERSIZED_IMAGE_RESULT_6_MB = 'A'.repeat(8 * 1024 * 1024 + 1);
+export const AT_LIMIT_IMAGE_RESULT = 'A'.repeat(8 * 1024 * 1024);
+export const OVERSIZED_IMAGE_RESULT_12_MB = 'B'.repeat(2 * 8 * 1024 * 1024);
+export const NATIVE_OVERSIZED_IMAGE_RESULT = 'C'.repeat(2 * 8 * 1024 * 1024);
+export const UNARY_OVERSIZED_IMAGE_RESULT = 'D'.repeat(8 * 1024 * 1024 + 1);
+export const IMAGE_PLACEHOLDER_12_MB = '[generated image omitted: 12.0 MB exceeds inline limit]';
+export const AUTHORED_WITH_MARKDOWN = `Check this markdown I wrote myself:\n${TINY_IMAGE_MARKDOWN}\nNeat, right?`;
+export const AUTHORED_WITH_PLACEHOLDER = `If a file is too large you may see "${IMAGE_PLACEHOLDER_12_MB}" instead of the image.`;
+
+export const PARALLEL_FUNCTION_CALL_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_1', model: 'gpt-5', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.added',
+    output_index: 4,
+    item: {
+      id: 'fc_first',
+      type: 'function_call',
+      call_id: 'call_first',
+      name: 'add_task',
+    },
+  },
+  {
+    type: 'response.output_item.added',
+    output_index: 9,
+    item: {
+      id: 'fc_second',
+      type: 'function_call',
+      call_id: 'call_second',
+      name: 'add_task',
+    },
+  },
+  {
+    type: 'response.function_call_arguments.delta',
+    output_index: 9,
+    item_id: 'fc_second',
+    delta: '{"title":"second"}',
+  },
+  {
+    type: 'response.function_call_arguments.delta',
+    output_index: 4,
+    item_id: 'fc_first',
+    delta: '{"title":"first"}',
+  },
+];
+
+export const FUNCTION_CALL_COMPLETION_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.added',
+    output_index: 0,
+    item: {
+      type: 'function_call',
+      call_id: 'call_1',
+      name: 'get_date',
+      arguments: '',
+    },
+  },
+  {
+    type: 'response.function_call_arguments.delta',
+    output_index: 0,
+    item_id: 'fc_1',
+    delta: '{"timezone":"UTC"}',
+  },
+  {
+    type: 'response.completed',
+    response: { usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } },
+  },
+];
+
+export const TEXT_COMPLETION_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'Done' },
+  { type: 'response.completed', response: {} },
+];
+
+export const COMPLETED_FUNCTION_CALL_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
+  },
+  {
+    type: 'response.completed',
+    response: { output: [{ type: 'function_call' }] },
+  },
+];
+
+export const FAILED_RESPONSE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_1', model: 'gpt-5', created_at: 1234567890 },
+  },
+  {
+    type: 'response.failed',
+    response: {
+      id: 'resp_1',
+      status: 'failed',
+      error: { code: 'server_error', message: 'The model encountered an error.' },
+    },
+  },
+];
+
+export const INCOMPLETE_MAX_OUTPUT_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_2', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'Partial output' },
+  {
+    type: 'response.incomplete',
+    response: {
+      id: 'resp_2',
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+    },
+  },
+];
+
+export const INCOMPLETE_CONTENT_FILTER_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_cf', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'Partial' },
+  {
+    type: 'response.incomplete',
+    response: {
+      id: 'resp_cf',
+      status: 'incomplete',
+      incomplete_details: { reason: 'content_filter' },
+    },
+  },
+];
+
+export const INCOMPLETE_WITHOUT_DETAILS_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_nodetails', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'Partial' },
+  {
+    type: 'response.incomplete',
+    response: { id: 'resp_nodetails', status: 'incomplete' },
+  },
+];
+
+export const FAILED_WITH_USAGE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_failusage', model: 'gpt-5', created_at: 1234567890 },
+  },
+  {
+    type: 'response.failed',
+    response: {
+      id: 'resp_failusage',
+      status: 'failed',
+      error: { code: 'server_error', message: 'boom' },
+      usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+    },
+  },
+];
+
+export const INCOMPLETE_WITH_USAGE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_incompleteusage', model: 'gpt-5', created_at: 1234567890 },
+  },
+  {
+    type: 'response.incomplete',
+    response: {
+      id: 'resp_incompleteusage',
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      usage: { input_tokens: 20, output_tokens: 8, total_tokens: 28 },
+    },
+  },
+];
+
+export const FAILED_WITHOUT_USAGE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_nousage', model: 'gpt-5', created_at: 1234567890 },
+  },
+  {
+    type: 'response.failed',
+    response: { id: 'resp_nousage', status: 'failed', error: { message: 'boom' } },
+  },
+];
+
+export const GENERIC_ERROR_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_3', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'error', code: 'server_error', message: 'boom' },
+];
+
+export const IMAGE_RESPONSE = {
+  id: 'resp_img',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+  ],
+  usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+};
+
+export const IMAGE_ORDER_RESPONSE = {
+  id: 'resp_img_order',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'message',
+      id: 'msg_1',
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'Here is your image:' }],
+    },
+    { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
+  ],
+};
+
+export const createImageSniffResponse = (result: string) => ({
+  id: 'resp_img_sniff',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result }],
+});
+
+export const IMAGE_OUTPUT_FORMAT_RESPONSE = {
+  id: 'resp_img_webp',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'image_generation_call',
+      id: 'ig_1',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+      output_format: 'webp',
+    },
+  ],
+};
+
+export const IMAGE_NO_RESULT_RESPONSE = {
+  id: 'resp_img_noresult',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
+};
+
+export const TEXT_ONLY_RESPONSE = {
+  id: 'resp_text_only',
+  object: 'response',
+  model: 'gpt-4o',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'message',
+      id: 'msg_1',
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'Full answer' }],
+    },
+  ],
+};
+
+export const IMAGE_OVERSIZED_RESPONSE = {
+  id: 'resp_img_oversized',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'image_generation_call',
+      id: 'ig_1',
+      status: 'completed',
+      result: OVERSIZED_IMAGE_RESULT_6_MB,
+    },
+  ],
+};
+
+export const IMAGE_AT_LIMIT_RESPONSE = {
+  id: 'resp_img_at_limit',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'image_generation_call',
+      id: 'ig_1',
+      status: 'completed',
+      result: AT_LIMIT_IMAGE_RESULT,
+    },
+  ],
+};
+
+export const IMAGE_STREAM_ITEM_DONE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_img_s1', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      id: 'ig_1',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  },
+  { type: 'response.completed', response: {} },
+];
+
+export const IMAGE_COMPLETED_ONLY_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_img_s2', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.completed',
+    response: {
+      id: 'resp_img_s2',
+      status: 'completed',
+      output: [
+        {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+    },
+  },
+];
+
+const IMAGE_DEDUPLICATED_ITEM = {
+  id: 'ig_1',
+  type: 'image_generation_call',
+  status: 'completed',
+  result: TINY_IMAGE_B64,
+};
+
+export const IMAGE_DEDUPLICATION_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_img_s3', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  { type: 'response.output_item.done', output_index: 0, item: IMAGE_DEDUPLICATED_ITEM },
+  {
+    type: 'response.completed',
+    response: { id: 'resp_img_s3', output: [IMAGE_DEDUPLICATED_ITEM] },
+  },
+];
+
+export const IMAGE_PARTIAL_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_img_s4', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.image_generation_call.partial_image',
+    output_index: 0,
+    item_id: 'ig_1',
+    partial_image_index: 0,
+    partial_image_b64: 'UEFSVElBTA==',
+  },
+  {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      id: 'ig_1',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  },
+  { type: 'response.completed', response: {} },
+];
+
+export const IMAGE_OVERSIZED_STREAM_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_img_s5', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      id: 'ig_1',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: OVERSIZED_IMAGE_RESULT_12_MB,
+    },
+  },
+  { type: 'response.completed', response: {} },
+];
+
+export const TYPED_IMAGE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_typed_1', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      id: 'ig_1',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  },
+  { type: 'response.completed', response: {} },
+];
+
+export const TYPED_IMAGE_DELTA_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_typed_2', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      id: 'ig_1',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  },
+  { type: 'response.completed', response: {} },
+];
+
+const TYPED_IMAGE_DEDUPLICATED_ITEM = {
+  id: 'ig_1',
+  type: 'image_generation_call',
+  status: 'completed',
+  result: TINY_IMAGE_B64,
+};
+
+export const TYPED_IMAGE_DEDUPLICATION_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_typed_3', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: TYPED_IMAGE_DEDUPLICATED_ITEM,
+  },
+  {
+    type: 'response.completed',
+    response: { id: 'resp_typed_3', output: [TYPED_IMAGE_DEDUPLICATED_ITEM] },
+  },
+];
+
+export const TYPED_IMAGE_COMPLETED_ONLY_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_typed_4', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.completed',
+    response: {
+      id: 'resp_typed_4',
+      status: 'completed',
+      output: [
+        {
+          id: 'ig_9',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      ],
+    },
+  },
+];
+
+const IMAGE_NATIVE_FINISH_CHUNK = {
+  id: 'resp_native_1',
+  model: 'gpt-image-model',
+  created: 1234567890,
+  finish_reason: 'stop',
+  usage: {
+    input_tokens: 5,
+    output_tokens: 1,
+    total_tokens: 6,
+    reasoning_tokens: 0,
+    cached_tokens: 0,
+    cache_creation_tokens: 0,
+  },
+};
+
+const IMAGE_NATIVE_SINGLE_CHUNK = {
+  id: 'resp_native_1',
+  model: 'gpt-image-model',
+  created: 1234567890,
+  delta: { content: TINY_IMAGE_MARKDOWN },
+  image_generation_calls: [{ id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 }],
+  finish_reason: null,
+};
+
+export const IMAGE_NATIVE_SINGLE_EVENTS = [IMAGE_NATIVE_SINGLE_CHUNK, IMAGE_NATIVE_FINISH_CHUNK];
+
+export const IMAGE_NATIVE_OVERSIZED_EVENTS = [
+  {
+    id: 'resp_native_2',
+    model: 'gpt-image-model',
+    created: 1234567890,
+    delta: { content: IMAGE_PLACEHOLDER_12_MB },
+    image_generation_calls: [
+      { id: 'ig_big', status: 'completed', result: NATIVE_OVERSIZED_IMAGE_RESULT },
+    ],
+    finish_reason: null,
+  },
+  IMAGE_NATIVE_FINISH_CHUNK,
+];
+
+export const IMAGE_NATIVE_MESSAGE_EVENTS = [
+  {
+    id: 'resp_native_3',
+    model: 'gpt-image-model',
+    created: 1234567890,
+    delta: { content: 'Here is your image:' },
+    finish_reason: null,
+  },
+  IMAGE_NATIVE_SINGLE_CHUNK,
+  IMAGE_NATIVE_FINISH_CHUNK,
+];
+
+export const IMAGE_ROUND_TRIP_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_rt_1', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      id: 'ig_rt',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  },
+  {
+    type: 'response.completed',
+    response: { usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 } },
+  },
+];
+
+export const UNARY_TYPED_IMAGE_RESPONSE = {
+  id: 'resp_unary_typed',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'message',
+      id: 'msg_1',
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'Here is your image:' }],
+    },
+    {
+      type: 'image_generation_call',
+      id: 'ig_1',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  ],
+};
+
+export const UNARY_IMAGE_ROUND_TRIP_RESPONSE = {
+  id: 'resp_unary_rt',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'message',
+      id: 'msg_1',
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'Here is your image:' }],
+    },
+    {
+      type: 'image_generation_call',
+      id: 'ig_1',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  ],
+};
+
+export const UNARY_IMAGE_ONLY_RESPONSE = {
+  id: 'resp_unary_imgonly',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'image_generation_call',
+      id: 'ig_1',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  ],
+};
+
+export const UNARY_OVERSIZED_IMAGE_RESPONSE = {
+  id: 'resp_unary_big',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'image_generation_call',
+      id: 'ig_big',
+      status: 'completed',
+      result: UNARY_OVERSIZED_IMAGE_RESULT,
+    },
+  ],
+};
+
+export const createCollisionResponseBody = () => ({
+  id: 'resp_probe_md',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'message',
+      id: 'msg_1',
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: AUTHORED_WITH_MARKDOWN }],
+    },
+    {
+      type: 'image_generation_call',
+      id: 'ig_1',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  ],
+});
+
+export const createPlaceholderCollisionResponseBody = () => ({
+  id: 'resp_probe_ph',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [
+    {
+      type: 'message',
+      id: 'msg_1',
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: AUTHORED_WITH_PLACEHOLDER }],
+    },
+    {
+      type: 'image_generation_call',
+      id: 'ig_big',
+      status: 'completed',
+      result: OVERSIZED_IMAGE_RESULT_12_MB,
+    },
+  ],
+});
+
+export const CLIENT_FAILED_EVENTS = [
+  {
+    id: 'resp_err_1',
+    model: 'gpt-5',
+    created: 1234567890,
+    delta: { role: 'assistant', content: 'partial' },
+    finish_reason: null,
+  },
+  {
+    id: 'resp_err_1',
+    model: 'gpt-5',
+    created: 1234567890,
+    event: 'error',
+    delta: {},
+    error: {
+      statusCode: 500,
+      code: 'server_error',
+      message: 'The model encountered an error.',
+    },
+  },
+];
+
+export const CLIENT_INCOMPLETE_MAX_EVENTS = [
+  {
+    id: 'resp_err_2',
+    model: 'gpt-5',
+    created: 1234567890,
+    delta: { role: 'assistant', content: 'partial output' },
+    finish_reason: null,
+  },
+  {
+    id: 'resp_err_2',
+    model: 'gpt-5',
+    created: 1234567890,
+    event: 'error',
+    delta: {},
+    finish_reason: 'length',
+    incomplete_details: { reason: 'max_output_tokens' },
+    error: {
+      statusCode: 500,
+      code: 'max_output_tokens',
+      message: 'Response ended incomplete: max_output_tokens',
+    },
+  },
+];
+
+export const CLIENT_INCOMPLETE_CONTENT_FILTER_EVENTS = [
+  {
+    id: 'resp_err_cf',
+    model: 'gpt-5',
+    created: 1234567890,
+    delta: { role: 'assistant', content: 'partial' },
+    finish_reason: null,
+  },
+  {
+    id: 'resp_err_cf',
+    model: 'gpt-5',
+    created: 1234567890,
+    event: 'error',
+    delta: {},
+    finish_reason: 'content_filter',
+    incomplete_details: { reason: 'content_filter' },
+    usage: {
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+      reasoning_tokens: 0,
+      cached_tokens: 0,
+      cache_creation_tokens: 0,
+    },
+    error: {
+      statusCode: 500,
+      code: 'content_filter',
+      message: 'Response ended incomplete: content_filter',
+    },
+  },
+];
+
+export const DETAIL_LESS_RESPONSES_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_nodetails_rt', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'partial output' },
+  {
+    type: 'response.incomplete',
+    response: { id: 'resp_nodetails_rt', status: 'incomplete' },
+  },
+];
+
+export const DETAIL_LESS_CHAT_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_nodetails_chat', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'partial output' },
+  {
+    type: 'response.incomplete',
+    response: { id: 'resp_nodetails_chat', status: 'incomplete' },
+  },
+];
+
+export const CLIENT_INCOMPLETE_ITEMS_EVENTS = [
+  {
+    id: 'resp_inc_items',
+    model: 'gpt-5',
+    created: 1234567890,
+    delta: { role: 'assistant', reasoning_content: 'thinking...' },
+    finish_reason: null,
+  },
+  {
+    id: 'resp_inc_items',
+    model: 'gpt-5',
+    created: 1234567890,
+    delta: { content: 'partial output' },
+    finish_reason: null,
+  },
+  {
+    id: 'resp_inc_items',
+    model: 'gpt-5',
+    created: 1234567890,
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'lookup', arguments: '{"q":' },
+        },
+      ],
+    },
+    finish_reason: null,
+  },
+  {
+    id: 'resp_inc_items',
+    model: 'gpt-5',
+    created: 1234567890,
+    event: 'error',
+    delta: {},
+    finish_reason: 'length',
+    incomplete_details: { reason: 'max_output_tokens' },
+    error: {
+      statusCode: 500,
+      code: 'max_output_tokens',
+      message: 'Response ended incomplete: max_output_tokens',
+    },
+  },
+];
+
+export const CLIENT_FAILED_ITEMS_EVENTS = [
+  {
+    id: 'resp_failed_items',
+    model: 'gpt-5',
+    created: 1234567890,
+    delta: { role: 'assistant', content: 'partial' },
+    finish_reason: null,
+  },
+  {
+    id: 'resp_failed_items',
+    model: 'gpt-5',
+    created: 1234567890,
+    event: 'error',
+    delta: {},
+    error: { statusCode: 500, code: 'server_error', message: 'boom' },
+  },
+];
+
+export const CLIENT_HARD_ERROR_EVENTS = [
+  {
+    id: 'resp_hard_err',
+    model: 'gpt-5',
+    created: 1234567890,
+    delta: { role: 'assistant', content: 'partial' },
+    finish_reason: null,
+  },
+  {
+    id: 'resp_hard_err',
+    model: 'gpt-5',
+    created: 1234567890,
+    event: 'error',
+    delta: {},
+    error: { statusCode: 500, code: 'server_error', message: 'The model response failed.' },
+  },
+];
+
+export const CHAT_INCOMPLETE_CONTENT_FILTER_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_cf_chat', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'Partial' },
+  {
+    type: 'response.incomplete',
+    response: {
+      id: 'resp_cf_chat',
+      status: 'incomplete',
+      incomplete_details: { reason: 'content_filter' },
+    },
+  },
+];
+
+export const CHAT_FAILED_USAGE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_fail_usage', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'partial' },
+  {
+    type: 'response.failed',
+    response: {
+      id: 'resp_fail_usage',
+      status: 'failed',
+      error: { code: 'server_error', message: 'boom' },
+      usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+    },
+  },
+];
+
+export const CHAT_IMAGE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_img_chat', model: 'gpt-image-model', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      id: 'ig_1',
+      type: 'image_generation_call',
+      status: 'completed',
+      result: TINY_IMAGE_B64,
+    },
+  },
+  {
+    type: 'response.completed',
+    response: {
+      id: 'resp_img_chat',
+      status: 'completed',
+      output: [
+        {
+          id: 'ig_1',
+          type: 'image_generation_call',
+          status: 'completed',
+          result: TINY_IMAGE_B64,
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+    },
+  },
+];
+
+export const CHAT_INCOMPLETE_USAGE_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_incomplete_usage', model: 'gpt-5', created_at: 1234567890 },
+  },
+  { type: 'response.output_text.delta', delta: 'partial' },
+  {
+    type: 'response.incomplete',
+    response: {
+      id: 'resp_incomplete_usage',
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      usage: { input_tokens: 7, output_tokens: 3, total_tokens: 10 },
+    },
+  },
+];
+
+export const createToolSearchItem = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 'tsc_1',
+  type: 'tool_search_call',
+  call_id: 'call_1',
+  execution: 'client',
+  status: 'completed',
+  arguments: { query: 'exec_command' },
+  ...overrides,
+});
+
+export const TOOL_SEARCH_STREAM_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_tsc_1', model: 'gpt-5.6-luna', created_at: 1234567890 },
+  },
+  { type: 'response.output_item.done', output_index: 0, item: createToolSearchItem() },
+  { type: 'response.completed', response: {} },
+];
+
+const TOOL_SEARCH_DEDUPLICATED_ITEM = createToolSearchItem();
+export const TOOL_SEARCH_DEDUPLICATION_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_tsc_2', model: 'gpt-5.6-luna', created_at: 1234567890 },
+  },
+  { type: 'response.output_item.done', output_index: 0, item: TOOL_SEARCH_DEDUPLICATED_ITEM },
+  {
+    type: 'response.completed',
+    response: { id: 'resp_tsc_2', output: [TOOL_SEARCH_DEDUPLICATED_ITEM] },
+  },
+];
+
+export const TOOL_SEARCH_COMPLETED_ONLY_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_tsc_3', model: 'gpt-5.6-luna', created_at: 1234567890 },
+  },
+  {
+    type: 'response.completed',
+    response: {
+      id: 'resp_tsc_3',
+      status: 'completed',
+      output: [createToolSearchItem({ id: 'tsc_9' })],
+    },
+  },
+];
+
+export const TOOL_SEARCH_STOP_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_tsc_4', model: 'gpt-5.6-luna', created_at: 1234567890 },
+  },
+  { type: 'response.output_item.done', output_index: 0, item: createToolSearchItem() },
+  { type: 'response.completed', response: {} },
+];
+
+export const TOOL_SEARCH_COMPLETED_STOP_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_tsc_5', model: 'gpt-5.6-luna', created_at: 1234567890 },
+  },
+  {
+    type: 'response.completed',
+    response: { output: [createToolSearchItem()] },
+  },
+];
+
+export const TOOL_SEARCH_WITH_FUNCTION_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_tsc_6', model: 'gpt-5.6-luna', created_at: 1234567890 },
+  },
+  {
+    type: 'response.output_item.added',
+    output_index: 0,
+    item: { type: 'function_call', call_id: 'call_fn', name: 'get_date', arguments: '' },
+  },
+  { type: 'response.output_item.done', output_index: 1, item: createToolSearchItem() },
+  { type: 'response.completed', response: {} },
+];
+
+const TOOL_SEARCH_NATIVE_ITEM = createToolSearchItem();
+export const TOOL_SEARCH_NATIVE_CHUNKS = [
+  {
+    id: 'resp_native_tsc',
+    model: 'gpt-5.6-luna',
+    created: 1234567890,
+    delta: {},
+    client_tool_calls: [TOOL_SEARCH_NATIVE_ITEM],
+    finish_reason: null,
+  },
+  {
+    id: 'resp_native_tsc',
+    model: 'gpt-5.6-luna',
+    created: 1234567890,
+    delta: {},
+    finish_reason: 'stop',
+  },
+];
+
+export const TOOL_SEARCH_UNARY_RESPONSE = {
+  id: 'resp_tsc_ns',
+  object: 'response',
+  created_at: 1234567890,
+  status: 'completed',
+  model: 'gpt-5.6-luna',
+  output: [createToolSearchItem()],
+};
+
+export const TOOL_SEARCH_CHAT_EVENTS = [
+  {
+    type: 'response.created',
+    response: { id: 'resp_tsc_chat', model: 'gpt-5.6-luna', created_at: 1234567890 },
+  },
+  { type: 'response.output_item.done', output_index: 0, item: createToolSearchItem() },
+  { type: 'response.completed', response: {} },
+];
+
+export const UNARY_NO_RESULT_RESPONSE = {
+  id: 'resp_unary_noresult',
+  object: 'response',
+  model: 'gpt-image-model',
+  created_at: 1234567890,
+  status: 'completed',
+  output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
+};

--- a/packages/backend/src/transformers/__tests__/responses-stream.test.ts
+++ b/packages/backend/src/transformers/__tests__/responses-stream.test.ts
@@ -1,6 +1,80 @@
 import { describe, expect, test } from 'vitest';
 import { ResponsesTransformer } from '../responses';
 import { OpenAITransformer } from '../openai';
+import {
+  AT_LIMIT_IMAGE_RESULT,
+  AUTHORED_WITH_MARKDOWN,
+  AUTHORED_WITH_PLACEHOLDER,
+  CHAT_FAILED_USAGE_EVENTS,
+  CHAT_IMAGE_EVENTS,
+  CHAT_INCOMPLETE_CONTENT_FILTER_EVENTS,
+  CHAT_INCOMPLETE_USAGE_EVENTS,
+  COMPLETED_FUNCTION_CALL_EVENTS,
+  CLIENT_FAILED_EVENTS,
+  CLIENT_FAILED_ITEMS_EVENTS,
+  CLIENT_HARD_ERROR_EVENTS,
+  CLIENT_INCOMPLETE_CONTENT_FILTER_EVENTS,
+  CLIENT_INCOMPLETE_ITEMS_EVENTS,
+  CLIENT_INCOMPLETE_MAX_EVENTS,
+  DETAIL_LESS_CHAT_EVENTS,
+  DETAIL_LESS_RESPONSES_EVENTS,
+  FAILED_RESPONSE_EVENTS,
+  FAILED_WITHOUT_USAGE_EVENTS,
+  FAILED_WITH_USAGE_EVENTS,
+  FUNCTION_CALL_COMPLETION_EVENTS,
+  GENERIC_ERROR_EVENTS,
+  IMAGE_AT_LIMIT_RESPONSE,
+  IMAGE_COMPLETED_ONLY_EVENTS,
+  IMAGE_DEDUPLICATION_EVENTS,
+  IMAGE_NATIVE_MESSAGE_EVENTS,
+  IMAGE_NATIVE_OVERSIZED_EVENTS,
+  IMAGE_NATIVE_SINGLE_EVENTS,
+  IMAGE_NO_RESULT_RESPONSE,
+  IMAGE_ORDER_RESPONSE,
+  IMAGE_OUTPUT_FORMAT_RESPONSE,
+  IMAGE_OVERSIZED_RESPONSE,
+  IMAGE_OVERSIZED_STREAM_EVENTS,
+  IMAGE_PLACEHOLDER_12_MB,
+  IMAGE_PARTIAL_EVENTS,
+  IMAGE_RESPONSE,
+  IMAGE_ROUND_TRIP_EVENTS,
+  IMAGE_STREAM_ITEM_DONE_EVENTS,
+  INCOMPLETE_CONTENT_FILTER_EVENTS,
+  INCOMPLETE_WITHOUT_DETAILS_EVENTS,
+  INCOMPLETE_WITH_USAGE_EVENTS,
+  INCOMPLETE_MAX_OUTPUT_EVENTS,
+  NATIVE_OVERSIZED_IMAGE_RESULT,
+  OVERSIZED_IMAGE_RESULT_12_MB,
+  OVERSIZED_IMAGE_RESULT_6_MB,
+  PARALLEL_FUNCTION_CALL_EVENTS,
+  TEXT_COMPLETION_EVENTS,
+  TEXT_ONLY_RESPONSE,
+  TINY_IMAGE_B64,
+  TINY_IMAGE_MARKDOWN,
+  TYPED_IMAGE_COMPLETED_ONLY_EVENTS,
+  TYPED_IMAGE_DEDUPLICATION_EVENTS,
+  TYPED_IMAGE_DELTA_EVENTS,
+  TYPED_IMAGE_EVENTS,
+  UNARY_IMAGE_ONLY_RESPONSE,
+  UNARY_IMAGE_ROUND_TRIP_RESPONSE,
+  UNARY_OVERSIZED_IMAGE_RESPONSE,
+  UNARY_OVERSIZED_IMAGE_RESULT,
+  UNARY_TYPED_IMAGE_RESPONSE,
+  UNARY_NO_RESULT_RESPONSE,
+  createCollisionResponseBody,
+  createImageSniffResponse,
+  createPlaceholderCollisionResponseBody,
+  createToolSearchItem,
+  TOOL_SEARCH_CHAT_EVENTS,
+  TOOL_SEARCH_COMPLETED_ONLY_EVENTS,
+  TOOL_SEARCH_COMPLETED_STOP_EVENTS,
+  TOOL_SEARCH_DEDUPLICATION_EVENTS,
+  TOOL_SEARCH_NATIVE_CHUNKS,
+  TOOL_SEARCH_STOP_EVENTS,
+  TOOL_SEARCH_STREAM_EVENTS,
+  TOOL_SEARCH_UNARY_RESPONSE,
+  TOOL_SEARCH_WITH_FUNCTION_EVENTS,
+} from './responses-stream.fixtures';
 
 async function transformEvents(events: Record<string, unknown>[]): Promise<any[]> {
   const encoder = new TextEncoder();
@@ -26,44 +100,7 @@ async function transformEvents(events: Record<string, unknown>[]): Promise<any[]
 
 describe('ResponsesTransformer stream transformation', () => {
   test('keeps parallel function calls distinct when their argument deltas are interleaved', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_1', model: 'gpt-5', created_at: 1234567890 },
-      },
-      {
-        type: 'response.output_item.added',
-        output_index: 4,
-        item: {
-          id: 'fc_first',
-          type: 'function_call',
-          call_id: 'call_first',
-          name: 'add_task',
-        },
-      },
-      {
-        type: 'response.output_item.added',
-        output_index: 9,
-        item: {
-          id: 'fc_second',
-          type: 'function_call',
-          call_id: 'call_second',
-          name: 'add_task',
-        },
-      },
-      {
-        type: 'response.function_call_arguments.delta',
-        output_index: 9,
-        item_id: 'fc_second',
-        delta: '{"title":"second"}',
-      },
-      {
-        type: 'response.function_call_arguments.delta',
-        output_index: 4,
-        item_id: 'fc_first',
-        delta: '{"title":"first"}',
-      },
-    ]);
+    const chunks = await transformEvents(PARALLEL_FUNCTION_CALL_EVENTS);
 
     expect(chunks.filter((chunk) => chunk.delta.tool_calls)).toEqual([
       {
@@ -116,32 +153,7 @@ describe('ResponsesTransformer stream transformation', () => {
   });
 
   test('finishes with tool_calls after streaming a function call', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
-      },
-      {
-        type: 'response.output_item.added',
-        output_index: 0,
-        item: {
-          type: 'function_call',
-          call_id: 'call_1',
-          name: 'get_date',
-          arguments: '',
-        },
-      },
-      {
-        type: 'response.function_call_arguments.delta',
-        output_index: 0,
-        item_id: 'fc_1',
-        delta: '{"timezone":"UTC"}',
-      },
-      {
-        type: 'response.completed',
-        response: { usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } },
-      },
-    ]);
+    const chunks = await transformEvents(FUNCTION_CALL_COMPLETION_EVENTS);
 
     expect(chunks.find((chunk) => chunk.delta?.tool_calls)?.delta.tool_calls).toEqual([
       {
@@ -155,29 +167,13 @@ describe('ResponsesTransformer stream transformation', () => {
   });
 
   test('finishes with stop when no function call was streamed', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'Done' },
-      { type: 'response.completed', response: {} },
-    ]);
+    const chunks = await transformEvents(TEXT_COMPLETION_EVENTS);
 
     expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('stop');
   });
 
   test('recognizes function calls present only in the completed response', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_1', model: 'gpt-4o', created_at: 1234567890 },
-      },
-      {
-        type: 'response.completed',
-        response: { output: [{ type: 'function_call' }] },
-      },
-    ]);
+    const chunks = await transformEvents(COMPLETED_FUNCTION_CALL_EVENTS);
 
     expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('tool_calls');
   });
@@ -185,20 +181,7 @@ describe('ResponsesTransformer stream transformation', () => {
 
 describe('ResponsesTransformer stream transformation - error handling', () => {
   test('maps response.failed to a unified error chunk instead of dropping it', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_1', model: 'gpt-5', created_at: 1234567890 },
-      },
-      {
-        type: 'response.failed',
-        response: {
-          id: 'resp_1',
-          status: 'failed',
-          error: { code: 'server_error', message: 'The model encountered an error.' },
-        },
-      },
-    ]);
+    const chunks = await transformEvents(FAILED_RESPONSE_EVENTS);
 
     const errorChunk = chunks.find((chunk) => chunk.event === 'error');
     expect(errorChunk).toBeDefined();
@@ -208,21 +191,7 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 
   test('maps response.incomplete (max_output_tokens) to a unified error chunk carrying a length finish hint and incomplete_details', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_2', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'Partial output' },
-      {
-        type: 'response.incomplete',
-        response: {
-          id: 'resp_2',
-          status: 'incomplete',
-          incomplete_details: { reason: 'max_output_tokens' },
-        },
-      },
-    ]);
+    const chunks = await transformEvents(INCOMPLETE_MAX_OUTPUT_EVENTS);
 
     const errorChunk = chunks.find((chunk) => chunk.event === 'error');
     expect(errorChunk).toBeDefined();
@@ -232,21 +201,7 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 
   test('maps response.incomplete (content_filter) to a unified error chunk carrying a content_filter finish hint and incomplete_details', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_cf', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'Partial' },
-      {
-        type: 'response.incomplete',
-        response: {
-          id: 'resp_cf',
-          status: 'incomplete',
-          incomplete_details: { reason: 'content_filter' },
-        },
-      },
-    ]);
+    const chunks = await transformEvents(INCOMPLETE_CONTENT_FILTER_EVENTS);
 
     const errorChunk = chunks.find((chunk) => chunk.event === 'error');
     expect(errorChunk).toBeDefined();
@@ -264,17 +219,7 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
     // everything-but-content_filter default as usage-logging's raw-mode
     // incomplete mapping) — otherwise downstream renders the event as a
     // hard failure.
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_nodetails', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'Partial' },
-      {
-        type: 'response.incomplete',
-        response: { id: 'resp_nodetails', status: 'incomplete' },
-      },
-    ]);
+    const chunks = await transformEvents(INCOMPLETE_WITHOUT_DETAILS_EVENTS);
 
     const errorChunk = chunks.find((chunk) => chunk.event === 'error');
     expect(errorChunk).toBeDefined();
@@ -284,21 +229,7 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 
   test('propagates response.usage on response.failed into the unified error chunk', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_failusage', model: 'gpt-5', created_at: 1234567890 },
-      },
-      {
-        type: 'response.failed',
-        response: {
-          id: 'resp_failusage',
-          status: 'failed',
-          error: { code: 'server_error', message: 'boom' },
-          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
-        },
-      },
-    ]);
+    const chunks = await transformEvents(FAILED_WITH_USAGE_EVENTS);
 
     const errorChunk = chunks.find((chunk) => chunk.event === 'error');
     expect(errorChunk).toBeDefined();
@@ -308,21 +239,7 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 
   test('propagates response.usage on response.incomplete into the unified error chunk', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_incompleteusage', model: 'gpt-5', created_at: 1234567890 },
-      },
-      {
-        type: 'response.incomplete',
-        response: {
-          id: 'resp_incompleteusage',
-          status: 'incomplete',
-          incomplete_details: { reason: 'max_output_tokens' },
-          usage: { input_tokens: 20, output_tokens: 8, total_tokens: 28 },
-        },
-      },
-    ]);
+    const chunks = await transformEvents(INCOMPLETE_WITH_USAGE_EVENTS);
 
     const errorChunk = chunks.find((chunk) => chunk.event === 'error');
     expect(errorChunk).toBeDefined();
@@ -332,16 +249,7 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 
   test('does not attach a usage field when response.failed/response.incomplete carry none', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_nousage', model: 'gpt-5', created_at: 1234567890 },
-      },
-      {
-        type: 'response.failed',
-        response: { id: 'resp_nousage', status: 'failed', error: { message: 'boom' } },
-      },
-    ]);
+    const chunks = await transformEvents(FAILED_WITHOUT_USAGE_EVENTS);
 
     const errorChunk = chunks.find((chunk) => chunk.event === 'error');
     expect(errorChunk).toBeDefined();
@@ -349,13 +257,7 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 
   test('maps a generic top-level error event to a unified error chunk', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_3', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'error', code: 'server_error', message: 'boom' },
-    ]);
+    const chunks = await transformEvents(GENERIC_ERROR_EVENTS);
 
     const errorChunk = chunks.find((chunk) => chunk.event === 'error');
     expect(errorChunk).toBeDefined();
@@ -363,10 +265,7 @@ describe('ResponsesTransformer stream transformation - error handling', () => {
   });
 });
 
-// Tiny fake base64 payload — content is irrelevant, only the data-URI
-// plumbing matters.
-const TINY_IMAGE_B64 = 'aGVsbG8=';
-const TINY_IMAGE_MARKDOWN = `![generated image](data:image/png;base64,${TINY_IMAGE_B64})`;
+// Tiny image payloads and generated size-boundary values live in responses-stream.fixtures.ts.
 
 describe('ResponsesTransformer image_generation_call rendering (pure unified content + chat composition)', () => {
   // The chat-visible text for a unified response, exactly as a CHAT-format
@@ -381,17 +280,7 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
   };
 
   test('an image_generation_call with a base64 result renders markdown data-URI content for chat clients', async () => {
-    const unified = await new ResponsesTransformer().transformResponse({
-      id: 'resp_img',
-      object: 'response',
-      model: 'gpt-image-model',
-      created_at: 1234567890,
-      status: 'completed',
-      output: [
-        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
-      ],
-      usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
-    });
+    const unified = await new ResponsesTransformer().transformResponse(IMAGE_RESPONSE);
 
     // Unified content stays PURE — no message item, no text. The image
     // travels typed; the markdown exists only in the chat projection.
@@ -403,23 +292,7 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
   });
 
   test('chat composition appends image markdown after the authored message text', async () => {
-    const unified = await new ResponsesTransformer().transformResponse({
-      id: 'resp_img_order',
-      object: 'response',
-      model: 'gpt-image-model',
-      created_at: 1234567890,
-      status: 'completed',
-      output: [
-        {
-          type: 'message',
-          id: 'msg_1',
-          status: 'completed',
-          role: 'assistant',
-          content: [{ type: 'output_text', text: 'Here is your image:' }],
-        },
-        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
-      ],
-    });
+    const unified = await new ResponsesTransformer().transformResponse(IMAGE_ORDER_RESPONSE);
 
     expect(unified.content).toBe('Here is your image:');
     expect(await chatVisibleContent(unified)).toBe(`Here is your image:\n${TINY_IMAGE_MARKDOWN}`);
@@ -432,17 +305,10 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
   describe('mime subtype sniffing from the base64 signature', () => {
     const b64 = (bytes: number[]) => Buffer.from(bytes).toString('base64');
 
-    const renderImage = async (result: string) => {
-      const unified = await new ResponsesTransformer().transformResponse({
-        id: 'resp_img_sniff',
-        object: 'response',
-        model: 'gpt-image-model',
-        created_at: 1234567890,
-        status: 'completed',
-        output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result }],
-      });
-      return chatVisibleContent(unified);
-    };
+    const renderImage = async (result: string) =>
+      chatVisibleContent(
+        await new ResponsesTransformer().transformResponse(createImageSniffResponse(result))
+      );
 
     test('PNG signature (\\x89PNG) renders image/png', async () => {
       const png = b64([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
@@ -473,22 +339,9 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
     });
 
     test('a request-style output_format field on the item is IGNORED (not a response field)', async () => {
-      const unified = await new ResponsesTransformer().transformResponse({
-        id: 'resp_img_webp',
-        object: 'response',
-        model: 'gpt-image-model',
-        created_at: 1234567890,
-        status: 'completed',
-        output: [
-          {
-            type: 'image_generation_call',
-            id: 'ig_1',
-            status: 'completed',
-            result: TINY_IMAGE_B64,
-            output_format: 'webp',
-          },
-        ],
-      });
+      const unified = await new ResponsesTransformer().transformResponse(
+        IMAGE_OUTPUT_FORMAT_RESPONSE
+      );
 
       // The payload's actual bytes ("hello" — no signature) decide: png.
       expect(await chatVisibleContent(unified)).toBe(TINY_IMAGE_MARKDOWN);
@@ -505,14 +358,7 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
   });
 
   test('an image_generation_call without a base64 result contributes nothing', async () => {
-    const unified = await new ResponsesTransformer().transformResponse({
-      id: 'resp_img_noresult',
-      object: 'response',
-      model: 'gpt-image-model',
-      created_at: 1234567890,
-      status: 'completed',
-      output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
-    });
+    const unified = await new ResponsesTransformer().transformResponse(IMAGE_NO_RESULT_RESPONSE);
 
     expect(unified.content).toBeNull();
     expect(unified.image_generation_calls).toBeUndefined();
@@ -520,22 +366,7 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
   });
 
   test('a text-only response keeps its existing unified content shape (happy path unchanged)', async () => {
-    const unified = await new ResponsesTransformer().transformResponse({
-      id: 'resp_text_only',
-      object: 'response',
-      model: 'gpt-4o',
-      created_at: 1234567890,
-      status: 'completed',
-      output: [
-        {
-          type: 'message',
-          id: 'msg_1',
-          status: 'completed',
-          role: 'assistant',
-          content: [{ type: 'output_text', text: 'Full answer' }],
-        },
-      ],
-    });
+    const unified = await new ResponsesTransformer().transformResponse(TEXT_ONLY_RESPONSE);
 
     expect(unified.content).toBe('Full answer');
   });
@@ -543,17 +374,8 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
   test('a base64 result over the inline limit renders the omission placeholder for chat clients, not a data URI', async () => {
     // One char past MAX_INLINE_IMAGE_BASE64_CHARS (8 * 1024 * 1024).
     // Approximate decoded size = 8388609 * 3/4 bytes ≈ 6.0 MB.
-    const oversized = 'A'.repeat(8 * 1024 * 1024 + 1);
-    const unified = await new ResponsesTransformer().transformResponse({
-      id: 'resp_img_oversized',
-      object: 'response',
-      model: 'gpt-image-model',
-      created_at: 1234567890,
-      status: 'completed',
-      output: [
-        { type: 'image_generation_call', id: 'ig_1', status: 'completed', result: oversized },
-      ],
-    });
+    const oversized = OVERSIZED_IMAGE_RESULT_6_MB;
+    const unified = await new ResponsesTransformer().transformResponse(IMAGE_OVERSIZED_RESPONSE);
 
     // Pure unified content; the size guard applies only to the chat
     // projection — the typed carry keeps the full payload.
@@ -565,15 +387,8 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
   });
 
   test('a base64 result exactly at the inline limit still renders as a data URI (boundary)', async () => {
-    const atLimit = 'A'.repeat(8 * 1024 * 1024);
-    const unified = await new ResponsesTransformer().transformResponse({
-      id: 'resp_img_at_limit',
-      object: 'response',
-      model: 'gpt-image-model',
-      created_at: 1234567890,
-      status: 'completed',
-      output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed', result: atLimit }],
-    });
+    const atLimit = AT_LIMIT_IMAGE_RESULT;
+    const unified = await new ResponsesTransformer().transformResponse(IMAGE_AT_LIMIT_RESPONSE);
 
     expect(await chatVisibleContent(unified)).toBe(
       `![generated image](data:image/png;base64,${atLimit})`
@@ -583,23 +398,7 @@ describe('ResponsesTransformer image_generation_call rendering (pure unified con
 
 describe('ResponsesTransformer transformStream - image_generation_call rendering', () => {
   test('a completed image_generation_call output item becomes a unified content delta (markdown data URI)', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_img_s1', model: 'gpt-image-model', created_at: 1234567890 },
-      },
-      {
-        type: 'response.output_item.done',
-        output_index: 0,
-        item: {
-          id: 'ig_1',
-          type: 'image_generation_call',
-          status: 'completed',
-          result: TINY_IMAGE_B64,
-        },
-      },
-      { type: 'response.completed', response: {} },
-    ]);
+    const chunks = await transformEvents(IMAGE_STREAM_ITEM_DONE_EVENTS);
 
     const contentChunks = chunks.filter(
       (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
@@ -609,28 +408,7 @@ describe('ResponsesTransformer transformStream - image_generation_call rendering
   });
 
   test('an image_generation_call present only in response.completed still renders, before the final chunk', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_img_s2', model: 'gpt-image-model', created_at: 1234567890 },
-      },
-      {
-        type: 'response.completed',
-        response: {
-          id: 'resp_img_s2',
-          status: 'completed',
-          output: [
-            {
-              id: 'ig_1',
-              type: 'image_generation_call',
-              status: 'completed',
-              result: TINY_IMAGE_B64,
-            },
-          ],
-          usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
-        },
-      },
-    ]);
+    const chunks = await transformEvents(IMAGE_COMPLETED_ONLY_EVENTS);
 
     const contentIndex = chunks.findIndex((chunk) => chunk.delta?.content === TINY_IMAGE_MARKDOWN);
     const finishIndex = chunks.findIndex((chunk) => chunk.finish_reason);
@@ -639,50 +417,14 @@ describe('ResponsesTransformer transformStream - image_generation_call rendering
   });
 
   test('does not double-render an item that streamed via output_item.done AND appears in response.completed', async () => {
-    const imageItem = {
-      id: 'ig_1',
-      type: 'image_generation_call',
-      status: 'completed',
-      result: TINY_IMAGE_B64,
-    };
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_img_s3', model: 'gpt-image-model', created_at: 1234567890 },
-      },
-      { type: 'response.output_item.done', output_index: 0, item: imageItem },
-      { type: 'response.completed', response: { id: 'resp_img_s3', output: [imageItem] } },
-    ]);
+    const chunks = await transformEvents(IMAGE_DEDUPLICATION_EVENTS);
 
     const contentChunks = chunks.filter((chunk) => chunk.delta?.content === TINY_IMAGE_MARKDOWN);
     expect(contentChunks).toHaveLength(1);
   });
 
   test('partial-image delta events are skipped (explicitly out of scope) — only the completed item renders', async () => {
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_img_s4', model: 'gpt-image-model', created_at: 1234567890 },
-      },
-      {
-        type: 'response.image_generation_call.partial_image',
-        output_index: 0,
-        item_id: 'ig_1',
-        partial_image_index: 0,
-        partial_image_b64: 'UEFSVElBTA==',
-      },
-      {
-        type: 'response.output_item.done',
-        output_index: 0,
-        item: {
-          id: 'ig_1',
-          type: 'image_generation_call',
-          status: 'completed',
-          result: TINY_IMAGE_B64,
-        },
-      },
-      { type: 'response.completed', response: {} },
-    ]);
+    const chunks = await transformEvents(IMAGE_PARTIAL_EVENTS);
 
     const contentChunks = chunks.filter(
       (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
@@ -695,24 +437,8 @@ describe('ResponsesTransformer transformStream - image_generation_call rendering
   test('a base64 result over the inline limit streams the omission placeholder instead of the data URI', async () => {
     // Twice MAX_INLINE_IMAGE_BASE64_CHARS (8 * 1024 * 1024).
     // Approximate decoded size = 16777216 * 3/4 bytes = 12.0 MB.
-    const oversized = 'B'.repeat(2 * 8 * 1024 * 1024);
-    const chunks = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_img_s5', model: 'gpt-image-model', created_at: 1234567890 },
-      },
-      {
-        type: 'response.output_item.done',
-        output_index: 0,
-        item: {
-          id: 'ig_1',
-          type: 'image_generation_call',
-          status: 'completed',
-          result: oversized,
-        },
-      },
-      { type: 'response.completed', response: {} },
-    ]);
+    const oversized = OVERSIZED_IMAGE_RESULT_12_MB;
+    const chunks = await transformEvents(IMAGE_OVERSIZED_STREAM_EVENTS);
 
     const contentChunks = chunks.filter(
       (chunk) => typeof chunk.delta?.content === 'string' && chunk.delta.content.length > 0
@@ -781,23 +507,7 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
 
   describe('transformStream carries the typed item alongside the markdown', () => {
     test('a completed image item carries a typed entry on the SAME chunk as its markdown delta', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_typed_1', model: 'gpt-image-model', created_at: 1234567890 },
-        },
-        {
-          type: 'response.output_item.done',
-          output_index: 0,
-          item: {
-            id: 'ig_1',
-            type: 'image_generation_call',
-            status: 'completed',
-            result: TINY_IMAGE_B64,
-          },
-        },
-        { type: 'response.completed', response: {} },
-      ]);
+      const chunks = await transformEvents(TYPED_IMAGE_EVENTS);
 
       const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
       expect(imageChunks).toHaveLength(1);
@@ -809,23 +519,7 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('the typed entry is chunk-level, NOT inside delta (chat formatters forward delta by reference)', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_typed_2', model: 'gpt-image-model', created_at: 1234567890 },
-        },
-        {
-          type: 'response.output_item.done',
-          output_index: 0,
-          item: {
-            id: 'ig_1',
-            type: 'image_generation_call',
-            status: 'completed',
-            result: TINY_IMAGE_B64,
-          },
-        },
-        { type: 'response.completed', response: {} },
-      ]);
+      const chunks = await transformEvents(TYPED_IMAGE_DELTA_EVENTS);
 
       const imageChunk = chunks.find((chunk) => chunk.image_generation_calls);
       expect(imageChunk).toBeDefined();
@@ -833,47 +527,14 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('the completed-fallback also carries the typed entry, without double-carrying deduped items', async () => {
-      const imageItem = {
-        id: 'ig_1',
-        type: 'image_generation_call',
-        status: 'completed',
-        result: TINY_IMAGE_B64,
-      };
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_typed_3', model: 'gpt-image-model', created_at: 1234567890 },
-        },
-        { type: 'response.output_item.done', output_index: 0, item: imageItem },
-        { type: 'response.completed', response: { id: 'resp_typed_3', output: [imageItem] } },
-      ]);
+      const chunks = await transformEvents(TYPED_IMAGE_DEDUPLICATION_EVENTS);
 
       const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
       expect(imageChunks).toHaveLength(1);
     });
 
     test('a completed-only item (never streamed via output_item.done) still gets the typed carry', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_typed_4', model: 'gpt-image-model', created_at: 1234567890 },
-        },
-        {
-          type: 'response.completed',
-          response: {
-            id: 'resp_typed_4',
-            status: 'completed',
-            output: [
-              {
-                id: 'ig_9',
-                type: 'image_generation_call',
-                status: 'completed',
-                result: TINY_IMAGE_B64,
-              },
-            ],
-          },
-        },
-      ]);
+      const chunks = await transformEvents(TYPED_IMAGE_COMPLETED_ONLY_EVENTS);
 
       const imageChunks = chunks.filter((chunk) => chunk.image_generation_calls);
       expect(imageChunks).toHaveLength(1);
@@ -886,35 +547,8 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
   });
 
   describe('formatStream re-emits typed items as native output items', () => {
-    const imageChunkFor = (result: string) => ({
-      id: 'resp_native_1',
-      model: 'gpt-image-model',
-      created: 1234567890,
-      delta: { content: `![generated image](data:image/png;base64,${result})` },
-      image_generation_calls: [{ id: 'ig_1', status: 'completed', result }],
-      finish_reason: null,
-    });
-
-    const finishChunk = () => ({
-      id: 'resp_native_1',
-      model: 'gpt-image-model',
-      created: 1234567890,
-      finish_reason: 'stop',
-      usage: {
-        input_tokens: 5,
-        output_tokens: 1,
-        total_tokens: 6,
-        reasoning_tokens: 0,
-        cached_tokens: 0,
-        cache_creation_tokens: 0,
-      },
-    });
-
     test('emits a native image_generation_call output item (byte-intact) instead of markdown text', async () => {
-      const events = await collectFormatStreamEvents([
-        imageChunkFor(TINY_IMAGE_B64),
-        finishChunk(),
-      ]);
+      const events = await collectFormatStreamEvents(IMAGE_NATIVE_SINGLE_EVENTS);
 
       const doneEvents = events.filter(
         (e) => e.type === 'response.output_item.done' && e.item?.type === 'image_generation_call'
@@ -934,10 +568,7 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('the final response.completed output array includes the native image item', async () => {
-      const events = await collectFormatStreamEvents([
-        imageChunkFor(TINY_IMAGE_B64),
-        finishChunk(),
-      ]);
+      const events = await collectFormatStreamEvents(IMAGE_NATIVE_SINGLE_EVENTS);
 
       const completed = events.find((e) => e.type === 'response.completed');
       expect(completed).toBeDefined();
@@ -949,20 +580,10 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('an OVERSIZED result re-emits with the FULL base64 — the native format has no inline cap', async () => {
-      const oversized = 'C'.repeat(2 * 8 * 1024 * 1024);
+      const oversized = NATIVE_OVERSIZED_IMAGE_RESULT;
       // transformStream renders the placeholder on content for oversized
       // items — mirror that pairing here.
-      const events = await collectFormatStreamEvents([
-        {
-          id: 'resp_native_2',
-          model: 'gpt-image-model',
-          created: 1234567890,
-          delta: { content: '[generated image omitted: 12.0 MB exceeds inline limit]' },
-          image_generation_calls: [{ id: 'ig_big', status: 'completed', result: oversized }],
-          finish_reason: null,
-        },
-        finishChunk(),
-      ]);
+      const events = await collectFormatStreamEvents(IMAGE_NATIVE_OVERSIZED_EVENTS);
 
       const doneEvent = events.find(
         (e) => e.type === 'response.output_item.done' && e.item?.type === 'image_generation_call'
@@ -974,17 +595,7 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('message text on OTHER chunks still streams normally alongside a native image item', async () => {
-      const events = await collectFormatStreamEvents([
-        {
-          id: 'resp_native_3',
-          model: 'gpt-image-model',
-          created: 1234567890,
-          delta: { content: 'Here is your image:' },
-          finish_reason: null,
-        },
-        imageChunkFor(TINY_IMAGE_B64),
-        finishChunk(),
-      ]);
+      const events = await collectFormatStreamEvents(IMAGE_NATIVE_MESSAGE_EVENTS);
 
       const textDeltas = events.filter((e) => e.type === 'response.output_text.delta');
       expect(textDeltas).toHaveLength(1);
@@ -999,26 +610,7 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('full streaming round-trip (provider SSE -> unified -> client SSE) keeps the item byte-intact', async () => {
-      const unifiedChunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_rt_1', model: 'gpt-image-model', created_at: 1234567890 },
-        },
-        {
-          type: 'response.output_item.done',
-          output_index: 0,
-          item: {
-            id: 'ig_rt',
-            type: 'image_generation_call',
-            status: 'completed',
-            result: TINY_IMAGE_B64,
-          },
-        },
-        {
-          type: 'response.completed',
-          response: { usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 } },
-        },
-      ]);
+      const unifiedChunks = await transformEvents(IMAGE_ROUND_TRIP_EVENTS);
 
       const events = await collectFormatStreamEvents(unifiedChunks);
       const doneEvent = events.find(
@@ -1032,28 +624,9 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
 
   describe('formatResponse (unary) re-emits typed items as native output items', () => {
     test('transformResponse attaches the typed items and keeps unified content PURE', async () => {
-      const unified = await new ResponsesTransformer().transformResponse({
-        id: 'resp_unary_typed',
-        object: 'response',
-        model: 'gpt-image-model',
-        created_at: 1234567890,
-        status: 'completed',
-        output: [
-          {
-            type: 'message',
-            id: 'msg_1',
-            status: 'completed',
-            role: 'assistant',
-            content: [{ type: 'output_text', text: 'Here is your image:' }],
-          },
-          {
-            type: 'image_generation_call',
-            id: 'ig_1',
-            status: 'completed',
-            result: TINY_IMAGE_B64,
-          },
-        ],
-      });
+      const unified = await new ResponsesTransformer().transformResponse(
+        UNARY_TYPED_IMAGE_RESPONSE
+      );
 
       expect(unified.image_generation_calls).toEqual([
         { id: 'ig_1', status: 'completed', result: TINY_IMAGE_B64 },
@@ -1064,42 +637,14 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('a result-less image item still contributes no typed entry', async () => {
-      const unified = await new ResponsesTransformer().transformResponse({
-        id: 'resp_unary_noresult',
-        object: 'response',
-        model: 'gpt-image-model',
-        created_at: 1234567890,
-        status: 'completed',
-        output: [{ type: 'image_generation_call', id: 'ig_1', status: 'completed' }],
-      });
+      const unified = await new ResponsesTransformer().transformResponse(UNARY_NO_RESULT_RESPONSE);
 
       expect(unified.image_generation_calls).toBeUndefined();
     });
 
     test('formatResponse emits the native item and strips the paired markdown from the message text', async () => {
       const transformer = new ResponsesTransformer();
-      const unified = await transformer.transformResponse({
-        id: 'resp_unary_rt',
-        object: 'response',
-        model: 'gpt-image-model',
-        created_at: 1234567890,
-        status: 'completed',
-        output: [
-          {
-            type: 'message',
-            id: 'msg_1',
-            status: 'completed',
-            role: 'assistant',
-            content: [{ type: 'output_text', text: 'Here is your image:' }],
-          },
-          {
-            type: 'image_generation_call',
-            id: 'ig_1',
-            status: 'completed',
-            result: TINY_IMAGE_B64,
-          },
-        ],
-      });
+      const unified = await transformer.transformResponse(UNARY_IMAGE_ROUND_TRIP_RESPONSE);
 
       const formatted = await transformer.formatResponse(unified as any);
 
@@ -1121,21 +666,7 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
 
     test('an image-only unary response round-trips as a native item (no markdown text)', async () => {
       const transformer = new ResponsesTransformer();
-      const unified = await transformer.transformResponse({
-        id: 'resp_unary_imgonly',
-        object: 'response',
-        model: 'gpt-image-model',
-        created_at: 1234567890,
-        status: 'completed',
-        output: [
-          {
-            type: 'image_generation_call',
-            id: 'ig_1',
-            status: 'completed',
-            result: TINY_IMAGE_B64,
-          },
-        ],
-      });
+      const unified = await transformer.transformResponse(UNARY_IMAGE_ONLY_RESPONSE);
 
       // Pure unified content: nothing authored, nothing baked. The typed
       // carry is what keeps the empty-completion detector seeing visible
@@ -1154,18 +685,9 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('an OVERSIZED unary result re-emits byte-intact natively — the placeholder never reaches the client', async () => {
-      const oversized = 'D'.repeat(8 * 1024 * 1024 + 1);
+      const oversized = UNARY_OVERSIZED_IMAGE_RESULT;
       const transformer = new ResponsesTransformer();
-      const unified = await transformer.transformResponse({
-        id: 'resp_unary_big',
-        object: 'response',
-        model: 'gpt-image-model',
-        created_at: 1234567890,
-        status: 'completed',
-        output: [
-          { type: 'image_generation_call', id: 'ig_big', status: 'completed', result: oversized },
-        ],
-      });
+      const unified = await transformer.transformResponse(UNARY_OVERSIZED_IMAGE_RESPONSE);
 
       // Pure unified content (the guarded placeholder exists only in the
       // chat projection)...
@@ -1192,34 +714,9 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     // segment" surgery removes the FIRST occurrence — the authored copy —
     // and leaks the appended rendering: content corruption.
 
-    const authoredWithMarkdown = `Check this markdown I wrote myself:\n${TINY_IMAGE_MARKDOWN}\nNeat, right?`;
-
-    const collisionResponseBody = () => ({
-      id: 'resp_probe_md',
-      object: 'response',
-      model: 'gpt-image-model',
-      created_at: 1234567890,
-      status: 'completed',
-      output: [
-        {
-          type: 'message',
-          id: 'msg_1',
-          status: 'completed',
-          role: 'assistant',
-          content: [{ type: 'output_text', text: authoredWithMarkdown }],
-        },
-        {
-          type: 'image_generation_call',
-          id: 'ig_1',
-          status: 'completed',
-          result: TINY_IMAGE_B64,
-        },
-      ],
-    });
-
     test('authored text containing an exact copy of the image markdown reaches a responses client byte-intact', async () => {
       const transformer = new ResponsesTransformer();
-      const unified = await transformer.transformResponse(collisionResponseBody());
+      const unified = await transformer.transformResponse(createCollisionResponseBody());
       const formatted = await transformer.formatResponse(unified as any);
 
       // The native item is the image's only carrier...
@@ -1232,31 +729,15 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
       // ...and the AUTHORED text — including its own copy of the markdown —
       // survives byte-intact: nothing removed, no appended rendering leaked.
       const messageItem = formatted.output.find((item: any) => item.type === 'message');
-      expect(messageItem.content[0].text).toBe(authoredWithMarkdown);
+      expect(messageItem.content[0].text).toBe(AUTHORED_WITH_MARKDOWN);
     });
 
     test('authored text quoting the oversized-omission placeholder reaches a responses client byte-intact', async () => {
-      const oversized = 'B'.repeat(2 * 8 * 1024 * 1024); // placeholder reads "12.0 MB"
-      const placeholder = '[generated image omitted: 12.0 MB exceeds inline limit]';
-      const authored = `If a file is too large you may see "${placeholder}" instead of the image.`;
+      const oversized = OVERSIZED_IMAGE_RESULT_12_MB;
+      const placeholder = IMAGE_PLACEHOLDER_12_MB;
+      const authored = AUTHORED_WITH_PLACEHOLDER;
       const transformer = new ResponsesTransformer();
-      const unified = await transformer.transformResponse({
-        id: 'resp_probe_ph',
-        object: 'response',
-        model: 'gpt-image-model',
-        created_at: 1234567890,
-        status: 'completed',
-        output: [
-          {
-            type: 'message',
-            id: 'msg_1',
-            status: 'completed',
-            role: 'assistant',
-            content: [{ type: 'output_text', text: authored }],
-          },
-          { type: 'image_generation_call', id: 'ig_big', status: 'completed', result: oversized },
-        ],
-      });
+      const unified = await transformer.transformResponse(createPlaceholderCollisionResponseBody());
 
       const formatted = await transformer.formatResponse(unified as any);
 
@@ -1271,11 +752,13 @@ describe('ResponsesTransformer typed image_generation_call carry (responses -> r
     });
 
     test('the same authored-collision response renders authored text + appended markdown for a CHAT client (duplication is genuine content)', async () => {
-      const unified = await new ResponsesTransformer().transformResponse(collisionResponseBody());
+      const unified = await new ResponsesTransformer().transformResponse(
+        createCollisionResponseBody()
+      );
       const chat = await new OpenAITransformer().formatResponse(unified as any);
 
       expect(chat.choices[0].message.content).toBe(
-        `${authoredWithMarkdown}\n${TINY_IMAGE_MARKDOWN}`
+        `${AUTHORED_WITH_MARKDOWN}\n${TINY_IMAGE_MARKDOWN}`
       );
     });
   });
@@ -1312,27 +795,7 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
   }
 
   test('emits response.failed (not response.completed) when a unified error chunk arrives', async () => {
-    const events = await collectFormatStreamEvents([
-      {
-        id: 'resp_err_1',
-        model: 'gpt-5',
-        created: 1234567890,
-        delta: { role: 'assistant', content: 'partial' },
-        finish_reason: null,
-      },
-      {
-        id: 'resp_err_1',
-        model: 'gpt-5',
-        created: 1234567890,
-        event: 'error',
-        delta: {},
-        error: {
-          statusCode: 500,
-          code: 'server_error',
-          message: 'The model encountered an error.',
-        },
-      },
-    ]);
+    const events = await collectFormatStreamEvents(CLIENT_FAILED_EVENTS);
 
     expect(events.some((e) => e.type === 'response.completed')).toBe(false);
     const failedEvent = events.find((e) => e.type === 'response.failed');
@@ -1347,29 +810,7 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
     // incomplete" outcome (incomplete_details present), the Responses-facing
     // client must see the more specific response.incomplete event, not a
     // generic hard failure.
-    const events = await collectFormatStreamEvents([
-      {
-        id: 'resp_err_2',
-        model: 'gpt-5',
-        created: 1234567890,
-        delta: { role: 'assistant', content: 'partial output' },
-        finish_reason: null,
-      },
-      {
-        id: 'resp_err_2',
-        model: 'gpt-5',
-        created: 1234567890,
-        event: 'error',
-        delta: {},
-        finish_reason: 'length',
-        incomplete_details: { reason: 'max_output_tokens' },
-        error: {
-          statusCode: 500,
-          code: 'max_output_tokens',
-          message: 'Response ended incomplete: max_output_tokens',
-        },
-      },
-    ]);
+    const events = await collectFormatStreamEvents(CLIENT_INCOMPLETE_MAX_EVENTS);
 
     expect(events.some((e) => e.type === 'response.completed')).toBe(false);
     expect(events.some((e) => e.type === 'response.failed')).toBe(false);
@@ -1381,37 +822,7 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
   });
 
   test('emits response.incomplete (content_filter) with incomplete_details and usage for a Responses-format client', async () => {
-    const events = await collectFormatStreamEvents([
-      {
-        id: 'resp_err_cf',
-        model: 'gpt-5',
-        created: 1234567890,
-        delta: { role: 'assistant', content: 'partial' },
-        finish_reason: null,
-      },
-      {
-        id: 'resp_err_cf',
-        model: 'gpt-5',
-        created: 1234567890,
-        event: 'error',
-        delta: {},
-        finish_reason: 'content_filter',
-        incomplete_details: { reason: 'content_filter' },
-        usage: {
-          input_tokens: 10,
-          output_tokens: 5,
-          total_tokens: 15,
-          reasoning_tokens: 0,
-          cached_tokens: 0,
-          cache_creation_tokens: 0,
-        },
-        error: {
-          statusCode: 500,
-          code: 'content_filter',
-          message: 'Response ended incomplete: content_filter',
-        },
-      },
-    ]);
+    const events = await collectFormatStreamEvents(CLIENT_INCOMPLETE_CONTENT_FILTER_EVENTS);
 
     expect(events.some((e) => e.type === 'response.failed')).toBe(false);
     const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
@@ -1427,17 +838,7 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
     // must keep the event on the incomplete path — without the default, the
     // missing field made formatStream downgrade the outcome to a hard
     // response.failed.
-    const unified = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_nodetails_rt', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'partial output' },
-      {
-        type: 'response.incomplete',
-        response: { id: 'resp_nodetails_rt', status: 'incomplete' },
-      },
-    ]);
+    const unified = await transformEvents(DETAIL_LESS_RESPONSES_EVENTS);
     const events = await collectFormatStreamEvents(unified);
 
     expect(events.some((e) => e.type === 'response.failed')).toBe(false);
@@ -1454,17 +855,7 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
     // detail-less incomplete as an ordinary finish — the same rendering
     // known-reason (max_output_tokens) incompletes already get — instead of
     // the hard-error payload it produced when finish_reason was absent.
-    const unified = await transformEvents([
-      {
-        type: 'response.created',
-        response: { id: 'resp_nodetails_chat', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'partial output' },
-      {
-        type: 'response.incomplete',
-        response: { id: 'resp_nodetails_chat', status: 'incomplete' },
-      },
-    ]);
+    const unified = await transformEvents(DETAIL_LESS_CHAT_EVENTS);
 
     const reader = new OpenAITransformer()
       .formatStream(unifiedStreamFromChunks(unified))
@@ -1499,52 +890,7 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
     // the reasoning item, the message item, and the tool call — was never
     // finished, so the finalized items must carry status 'incomplete', not a
     // fabricated 'completed'.
-    const events = await collectFormatStreamEvents([
-      {
-        id: 'resp_inc_items',
-        model: 'gpt-5',
-        created: 1234567890,
-        delta: { role: 'assistant', reasoning_content: 'thinking...' },
-        finish_reason: null,
-      },
-      {
-        id: 'resp_inc_items',
-        model: 'gpt-5',
-        created: 1234567890,
-        delta: { content: 'partial output' },
-        finish_reason: null,
-      },
-      {
-        id: 'resp_inc_items',
-        model: 'gpt-5',
-        created: 1234567890,
-        delta: {
-          tool_calls: [
-            {
-              index: 0,
-              id: 'call_1',
-              type: 'function',
-              function: { name: 'lookup', arguments: '{"q":' },
-            },
-          ],
-        },
-        finish_reason: null,
-      },
-      {
-        id: 'resp_inc_items',
-        model: 'gpt-5',
-        created: 1234567890,
-        event: 'error',
-        delta: {},
-        finish_reason: 'length',
-        incomplete_details: { reason: 'max_output_tokens' },
-        error: {
-          statusCode: 500,
-          code: 'max_output_tokens',
-          message: 'Response ended incomplete: max_output_tokens',
-        },
-      },
-    ]);
+    const events = await collectFormatStreamEvents(CLIENT_INCOMPLETE_ITEMS_EVENTS);
 
     const incompleteEvent = events.find((e) => e.type === 'response.incomplete');
     expect(incompleteEvent).toBeDefined();
@@ -1568,23 +914,7 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
   });
 
   test('response.failed finalization keeps item statuses unchanged (completed)', async () => {
-    const events = await collectFormatStreamEvents([
-      {
-        id: 'resp_failed_items',
-        model: 'gpt-5',
-        created: 1234567890,
-        delta: { role: 'assistant', content: 'partial' },
-        finish_reason: null,
-      },
-      {
-        id: 'resp_failed_items',
-        model: 'gpt-5',
-        created: 1234567890,
-        event: 'error',
-        delta: {},
-        error: { statusCode: 500, code: 'server_error', message: 'boom' },
-      },
-    ]);
+    const events = await collectFormatStreamEvents(CLIENT_FAILED_ITEMS_EVENTS);
 
     const failedEvent = events.find((e) => e.type === 'response.failed');
     expect(failedEvent).toBeDefined();
@@ -1593,23 +923,7 @@ describe('ResponsesTransformer formatStream - error handling (client-facing)', (
   });
 
   test('keeps emitting response.failed exactly as before for a genuine hard error (no incomplete_details)', async () => {
-    const events = await collectFormatStreamEvents([
-      {
-        id: 'resp_hard_err',
-        model: 'gpt-5',
-        created: 1234567890,
-        delta: { role: 'assistant', content: 'partial' },
-        finish_reason: null,
-      },
-      {
-        id: 'resp_hard_err',
-        model: 'gpt-5',
-        created: 1234567890,
-        event: 'error',
-        delta: {},
-        error: { statusCode: 500, code: 'server_error', message: 'The model response failed.' },
-      },
-    ]);
+    const events = await collectFormatStreamEvents(CLIENT_HARD_ERROR_EVENTS);
 
     expect(events.some((e) => e.type === 'response.incomplete')).toBe(false);
     const failedEvent = events.find((e) => e.type === 'response.failed');
@@ -1659,21 +973,7 @@ describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream
   }
 
   test('response.incomplete (content_filter) surfaces as a chat finish_reason "content_filter"', async () => {
-    const chunks = await transformAndFormatAsChat([
-      {
-        type: 'response.created',
-        response: { id: 'resp_cf_chat', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'Partial' },
-      {
-        type: 'response.incomplete',
-        response: {
-          id: 'resp_cf_chat',
-          status: 'incomplete',
-          incomplete_details: { reason: 'content_filter' },
-        },
-      },
-    ]);
+    const chunks = await transformAndFormatAsChat(CHAT_INCOMPLETE_CONTENT_FILTER_EVENTS);
 
     const finishChunk = chunks.find(
       (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'content_filter'
@@ -1685,22 +985,7 @@ describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream
   });
 
   test('response.failed carrying usage propagates that usage to the chat client', async () => {
-    const chunks = await transformAndFormatAsChat([
-      {
-        type: 'response.created',
-        response: { id: 'resp_fail_usage', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'partial' },
-      {
-        type: 'response.failed',
-        response: {
-          id: 'resp_fail_usage',
-          status: 'failed',
-          error: { code: 'server_error', message: 'boom' },
-          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
-        },
-      },
-    ]);
+    const chunks = await transformAndFormatAsChat(CHAT_FAILED_USAGE_EVENTS);
 
     const usageChunk = chunks.find((c) => c !== '[DONE]' && c.usage);
     expect(usageChunk).toBeDefined();
@@ -1713,38 +998,7 @@ describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream
   });
 
   test('a streamed completed image_generation_call reaches a chat client as a markdown data-URI content delta', async () => {
-    const chunks = await transformAndFormatAsChat([
-      {
-        type: 'response.created',
-        response: { id: 'resp_img_chat', model: 'gpt-image-model', created_at: 1234567890 },
-      },
-      {
-        type: 'response.output_item.done',
-        output_index: 0,
-        item: {
-          id: 'ig_1',
-          type: 'image_generation_call',
-          status: 'completed',
-          result: TINY_IMAGE_B64,
-        },
-      },
-      {
-        type: 'response.completed',
-        response: {
-          id: 'resp_img_chat',
-          status: 'completed',
-          output: [
-            {
-              id: 'ig_1',
-              type: 'image_generation_call',
-              status: 'completed',
-              result: TINY_IMAGE_B64,
-            },
-          ],
-          usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
-        },
-      },
-    ]);
+    const chunks = await transformAndFormatAsChat(CHAT_IMAGE_EVENTS);
 
     const contentChunks = chunks.filter(
       (c) =>
@@ -1761,22 +1015,7 @@ describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream
   });
 
   test('response.incomplete carrying usage propagates that usage to the chat client alongside the finish_reason', async () => {
-    const chunks = await transformAndFormatAsChat([
-      {
-        type: 'response.created',
-        response: { id: 'resp_incomplete_usage', model: 'gpt-5', created_at: 1234567890 },
-      },
-      { type: 'response.output_text.delta', delta: 'partial' },
-      {
-        type: 'response.incomplete',
-        response: {
-          id: 'resp_incomplete_usage',
-          status: 'incomplete',
-          incomplete_details: { reason: 'max_output_tokens' },
-          usage: { input_tokens: 7, output_tokens: 3, total_tokens: 10 },
-        },
-      },
-    ]);
+    const chunks = await transformAndFormatAsChat(CHAT_INCOMPLETE_USAGE_EVENTS);
 
     const finishChunk = chunks.find(
       (c) => c !== '[DONE]' && c.choices?.[0]?.finish_reason === 'length'
@@ -1799,16 +1038,6 @@ describe('ResponsesTransformer transformStream -> OpenAITransformer formatStream
 // finish_reason for them would send a 'tool_calls' finish with an empty
 // tool_calls array, which SDKs commonly loop or throw on.
 describe('ResponsesTransformer typed client_tool_calls carry (tool_search_call)', () => {
-  const toolSearchItem = (overrides: Partial<Record<string, unknown>> = {}) => ({
-    id: 'tsc_1',
-    type: 'tool_search_call',
-    call_id: 'call_1',
-    execution: 'client',
-    status: 'completed',
-    arguments: { query: 'exec_command' },
-    ...overrides,
-  });
-
   function unifiedStreamFromChunks(chunks: any[]): ReadableStream {
     return new ReadableStream({
       start(controller) {
@@ -1839,51 +1068,23 @@ describe('ResponsesTransformer typed client_tool_calls carry (tool_search_call)'
 
   describe('transformStream (inbound: Responses SSE -> unified chunks)', () => {
     test('a streamed tool_search_call item carries as a chunk-level client_tool_calls entry', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_tsc_1', model: 'gpt-5.6-luna', created_at: 1234567890 },
-        },
-        { type: 'response.output_item.done', output_index: 0, item: toolSearchItem() },
-        { type: 'response.completed', response: {} },
-      ]);
+      const chunks = await transformEvents(TOOL_SEARCH_STREAM_EVENTS);
 
       const toolChunks = chunks.filter((chunk) => chunk.client_tool_calls);
       expect(toolChunks).toHaveLength(1);
-      expect(toolChunks[0].client_tool_calls).toEqual([toolSearchItem()]);
+      expect(toolChunks[0].client_tool_calls).toEqual([createToolSearchItem()]);
       // Chunk-level, not inside delta — same reason as image_generation_calls.
       expect(toolChunks[0].delta.client_tool_calls).toBeUndefined();
     });
 
     test('the completed-fallback also carries the item, without double-carrying deduped items', async () => {
-      const item = toolSearchItem();
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_tsc_2', model: 'gpt-5.6-luna', created_at: 1234567890 },
-        },
-        { type: 'response.output_item.done', output_index: 0, item },
-        { type: 'response.completed', response: { id: 'resp_tsc_2', output: [item] } },
-      ]);
+      const chunks = await transformEvents(TOOL_SEARCH_DEDUPLICATION_EVENTS);
 
       expect(chunks.filter((chunk) => chunk.client_tool_calls)).toHaveLength(1);
     });
 
     test('a completed-only item (never streamed via output_item.done) still gets carried', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_tsc_3', model: 'gpt-5.6-luna', created_at: 1234567890 },
-        },
-        {
-          type: 'response.completed',
-          response: {
-            id: 'resp_tsc_3',
-            status: 'completed',
-            output: [toolSearchItem({ id: 'tsc_9' })],
-          },
-        },
-      ]);
+      const chunks = await transformEvents(TOOL_SEARCH_COMPLETED_ONLY_EVENTS);
 
       const toolChunks = chunks.filter((chunk) => chunk.client_tool_calls);
       expect(toolChunks).toHaveLength(1);
@@ -1891,47 +1092,19 @@ describe('ResponsesTransformer typed client_tool_calls carry (tool_search_call)'
     });
 
     test('finishes with "stop", NOT "tool_calls", when the only output is a client_tool_calls item', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_tsc_4', model: 'gpt-5.6-luna', created_at: 1234567890 },
-        },
-        { type: 'response.output_item.done', output_index: 0, item: toolSearchItem() },
-        { type: 'response.completed', response: {} },
-      ]);
+      const chunks = await transformEvents(TOOL_SEARCH_STOP_EVENTS);
 
       expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('stop');
     });
 
     test('finishes with "stop" when a client_tool_calls item appears only in the completed response', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_tsc_5', model: 'gpt-5.6-luna', created_at: 1234567890 },
-        },
-        {
-          type: 'response.completed',
-          response: { output: [toolSearchItem()] },
-        },
-      ]);
+      const chunks = await transformEvents(TOOL_SEARCH_COMPLETED_STOP_EVENTS);
 
       expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('stop');
     });
 
     test('a real function_call alongside a client_tool_calls item still finishes with "tool_calls"', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_tsc_6', model: 'gpt-5.6-luna', created_at: 1234567890 },
-        },
-        {
-          type: 'response.output_item.added',
-          output_index: 0,
-          item: { type: 'function_call', call_id: 'call_fn', name: 'get_date', arguments: '' },
-        },
-        { type: 'response.output_item.done', output_index: 1, item: toolSearchItem() },
-        { type: 'response.completed', response: {} },
-      ]);
+      const chunks = await transformEvents(TOOL_SEARCH_WITH_FUNCTION_EVENTS);
 
       expect(chunks.findLast((chunk) => chunk.finish_reason)?.finish_reason).toBe('tool_calls');
     });
@@ -1939,25 +1112,8 @@ describe('ResponsesTransformer typed client_tool_calls carry (tool_search_call)'
 
   describe('formatStream (outbound: unified chunks -> native Responses output)', () => {
     test('re-emits the typed item as a native tool_search_call output item', async () => {
-      const item = toolSearchItem();
-      const chunk = {
-        id: 'resp_native_tsc',
-        model: 'gpt-5.6-luna',
-        created: 1234567890,
-        delta: {},
-        client_tool_calls: [item],
-        finish_reason: null,
-      };
-      const finishChunk = {
-        id: 'resp_native_tsc',
-        model: 'gpt-5.6-luna',
-        created: 1234567890,
-        delta: {},
-        finish_reason: 'stop',
-      };
-
       const events = await collectFormatStreamEvents(
-        [chunk, finishChunk],
+        TOOL_SEARCH_NATIVE_CHUNKS,
         new ResponsesTransformer()
       );
       const completed = events.find((e) => e.type === 'response.completed');
@@ -1976,16 +1132,9 @@ describe('ResponsesTransformer typed client_tool_calls carry (tool_search_call)'
   describe('non-streaming round trip (transformResponse -> formatResponse)', () => {
     test('transformResponse extracts client_tool_calls and formatResponse re-emits it natively', async () => {
       const transformer = new ResponsesTransformer();
-      const unified = await transformer.transformResponse({
-        id: 'resp_tsc_ns',
-        object: 'response',
-        created_at: 1234567890,
-        status: 'completed',
-        model: 'gpt-5.6-luna',
-        output: [toolSearchItem()],
-      });
+      const unified = await transformer.transformResponse(TOOL_SEARCH_UNARY_RESPONSE);
 
-      expect(unified.client_tool_calls).toEqual([toolSearchItem()]);
+      expect(unified.client_tool_calls).toEqual([createToolSearchItem()]);
 
       const formatted = await transformer.formatResponse(unified);
       const native = formatted.output.find((o: any) => o.type === 'tool_search_call');
@@ -1995,14 +1144,7 @@ describe('ResponsesTransformer typed client_tool_calls carry (tool_search_call)'
 
   describe('cross-format (Responses -> Chat Completions): no false "tool_calls" finish', () => {
     test('a chat-format client never receives finish_reason "tool_calls" for a client_tool_calls-only turn', async () => {
-      const chunks = await transformEvents([
-        {
-          type: 'response.created',
-          response: { id: 'resp_tsc_chat', model: 'gpt-5.6-luna', created_at: 1234567890 },
-        },
-        { type: 'response.output_item.done', output_index: 0, item: toolSearchItem() },
-        { type: 'response.completed', response: {} },
-      ]);
+      const chunks = await transformEvents(TOOL_SEARCH_CHAT_EVENTS);
 
       const chatEvents = await collectFormatStreamEvents(chunks, new OpenAITransformer());
       const finishEvent = chatEvents.find((e) => e !== '[DONE]' && e.choices?.[0]?.finish_reason);


### PR DESCRIPTION
## Summary

Move the large inline fixtures out of the two biggest backend test files. The tests keep the same assertions and behavior, but the test bodies are much easier to scan.

## Why / Context

`responses-stream.test.ts` and `dispatcher-auto-compat.test.ts` embedded large JSON payloads and stream data directly inside test cases. That made the assertions hard to read and fixture reuse awkward.

## Changes

- **Responses transformer tests**: move response payloads, SSE/input event arrays, image data, collision bodies, and tool-search fixtures into `responses-stream.fixtures.ts`.
- **Dispatcher compatibility tests**: move substantial request payloads, thinking/advisor/tool fixtures, and JSON error bodies into `dispatcher-auto-compat.fixtures.ts`.
- **Test structure**: update imports and references without changing production code, assertions, or fixture values.

## Testing

- Focused Vitest run: 2 test files passed, 191 tests passed.
- Commit hooks passed backend tests, formatting, lint, migration checks, and typecheck.
- Cora review passed on the committed change with no blocking findings.

## Notes / Follow-ups

No pull request template was present in the repository. No production code changed.
