### PR TITLE
refactor(frontend): split config and MCP pages

### DIFF
--- a/packages/frontend/src/components/config/BackupRestoreCard.tsx
+++ b/packages/frontend/src/components/config/BackupRestoreCard.tsx
@@ -1,0 +1,86 @@
+import type { ChangeEvent, RefObject } from 'react';
+import { AlertTriangle, Archive, HardDrive, Trash2, Upload } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+
+interface BackupRestoreCardProps {
+  restoreInputRef: RefObject<HTMLInputElement | null>;
+  restoreLoading: boolean;
+  fullBackupLoading: boolean;
+  backupLoading: boolean;
+  resetLogsLoading: boolean;
+  onRestoreClick: () => void;
+  onRestoreFileSelect: (event: ChangeEvent<HTMLInputElement>) => void | Promise<void>;
+  onFullBackupDownload: () => void;
+  onBackupDownload: () => void;
+  onResetLogs: () => void;
+}
+
+export function BackupRestoreCard({
+  restoreInputRef,
+  restoreLoading,
+  fullBackupLoading,
+  backupLoading,
+  resetLogsLoading,
+  onRestoreClick,
+  onRestoreFileSelect,
+  onFullBackupDownload,
+  onBackupDownload,
+  onResetLogs,
+}: BackupRestoreCardProps) {
+  return (
+    <Card title="Backup & Restore">
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5 rounded-md border border-warning/30 bg-warning/10 px-2 py-1 mr-1">
+          <AlertTriangle size={13} className="text-warning shrink-0" />
+          <span className="font-body text-[11px] text-text-muted">
+            Sensitive data — store securely
+          </span>
+        </div>
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={onRestoreClick}
+          isLoading={restoreLoading}
+          leftIcon={<Upload size={14} />}
+        >
+          Restore
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onFullBackupDownload}
+          isLoading={fullBackupLoading}
+          leftIcon={<Archive size={14} />}
+        >
+          Full Backup
+        </Button>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onBackupDownload}
+          isLoading={backupLoading}
+          leftIcon={<HardDrive size={14} />}
+        >
+          Config Backup
+        </Button>
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={onResetLogs}
+          isLoading={resetLogsLoading}
+          leftIcon={<Trash2 size={14} />}
+        >
+          Reset All Logs
+        </Button>
+        <input
+          ref={restoreInputRef}
+          type="file"
+          accept=".json,.tar.gz,.tgz,application/gzip,application/x-gzip,application/octet-stream"
+          className="hidden"
+          onChange={onRestoreFileSelect}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/packages/frontend/src/components/config/CardLayoutCard.tsx
+++ b/packages/frontend/src/components/config/CardLayoutCard.tsx
@@ -1,0 +1,76 @@
+import type { ChangeEvent, RefObject } from 'react';
+import { Download, Upload } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+import type { CardLayout } from '../../types/card';
+
+interface CardLayoutCardProps {
+  cardLayout: CardLayout;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  onExport: () => void;
+  onImport: () => void;
+  onFileSelect: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export function CardLayoutCard({
+  cardLayout,
+  fileInputRef,
+  onExport,
+  onImport,
+  onFileSelect,
+}: CardLayoutCardProps) {
+  return (
+    <Card
+      title="Card Layout"
+      extra={
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onExport}
+            leftIcon={<Download size={14} />}
+          >
+            Export
+          </Button>
+          <Button variant="primary" size="sm" onClick={onImport} leftIcon={<Upload size={14} />}>
+            Import
+          </Button>
+        </div>
+      }
+    >
+      <p className="text-sm text-text-secondary mb-4">
+        Import or export your Live Metrics card layout configuration.
+      </p>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json"
+        className="hidden"
+        onChange={onFileSelect}
+      />
+
+      <div>
+        <h4 className="font-heading text-xs font-semibold uppercase tracking-wider text-text-muted mb-3">
+          Current Card Order
+        </h4>
+        <div className="flex flex-wrap gap-2">
+          {cardLayout.length === 0 && (
+            <p className="text-xs text-text-muted italic">
+              Default layout — no customizations saved.
+            </p>
+          )}
+          {cardLayout.map((card, index) => (
+            <div
+              key={card.id}
+              className="px-3 py-1.5 bg-bg-glass rounded-md border border-border-glass text-xs text-text"
+            >
+              <span className="text-text-muted mr-2">{index + 1}.</span>
+              {card.id}
+            </div>
+          ))}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/packages/frontend/src/components/config/CompactionSettings.tsx
+++ b/packages/frontend/src/components/config/CompactionSettings.tsx
@@ -1,0 +1,321 @@
+import { Save } from 'lucide-react';
+import type { CompactionSettings as CompactionConfig } from '../../lib/api';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+import { Switch } from '../ui/Switch';
+
+interface CompactionSettingsProps {
+  config: CompactionConfig;
+  loaded: boolean;
+  saving: boolean;
+  onChange: (config: CompactionConfig) => void;
+  onSave: () => void;
+}
+
+export function CompactionSettings({
+  config,
+  loaded,
+  saving,
+  onChange,
+  onSave,
+}: CompactionSettingsProps) {
+  const update = (patch: Partial<CompactionConfig>) => onChange({ ...config, ...patch });
+
+  return (
+    <Disclosure
+      title="Context Compaction"
+      defaultOpen={false}
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onSave}
+          isLoading={saving}
+          disabled={!loaded}
+          leftIcon={<Save size={14} />}
+        >
+          Save
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {/* enabled toggle */}
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="font-body text-[12px] font-medium text-text">Enabled</p>
+            <p className="font-body text-[11px] text-text-muted">
+              Automatically compact context when the trigger threshold is reached.
+            </p>
+          </div>
+          <Switch
+            checked={config.enabled ?? false}
+            onChange={(enabled) => update({ enabled })}
+            aria-label="Toggle context compaction on/off"
+          />
+        </div>
+
+        {/* strategy */}
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="compactionStrategy"
+            className="font-body text-[12px] font-medium text-text"
+          >
+            Strategy
+          </label>
+          <select
+            id="compactionStrategy"
+            value={config.strategy ?? 'native'}
+            onChange={(event) => update({ strategy: event.target.value as 'native' | 'headroom' })}
+            className="w-48 h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary"
+          >
+            <option value="native">native</option>
+            <option value="headroom">headroom</option>
+          </select>
+        </div>
+
+        {/* trigger ratio + absoluteTriggerTokens */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="compactionTriggerRatio"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              Trigger Ratio <span className="text-text-muted font-normal">— fraction 0–1</span>
+            </label>
+            <input
+              id="compactionTriggerRatio"
+              type="number"
+              min={0}
+              max={1}
+              step={0.01}
+              placeholder="e.g. 0.8"
+              value={config.triggerRatio ?? ''}
+              onChange={(event) => {
+                const value = event.target.value === '' ? undefined : Number(event.target.value);
+                update({ triggerRatio: value });
+              }}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="compactionAbsoluteTrigger"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              Absolute Trigger Tokens{' '}
+              <span className="text-text-muted font-normal">— empty = off</span>
+            </label>
+            <input
+              id="compactionAbsoluteTrigger"
+              type="number"
+              min={0}
+              step={1}
+              placeholder="Disabled"
+              value={config.absoluteTriggerTokens ?? ''}
+              onChange={(event) => {
+                const value = event.target.value === '' ? null : Number(event.target.value);
+                update({ absoluteTriggerTokens: value });
+              }}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="compactionMinTokens"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              Min Tokens
+            </label>
+            <input
+              id="compactionMinTokens"
+              type="number"
+              min={0}
+              step={1}
+              placeholder="e.g. 1000"
+              value={config.minTokens ?? ''}
+              onChange={(event) => {
+                const value = event.target.value === '' ? undefined : Number(event.target.value);
+                update({ minTokens: value });
+              }}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="compactionProtectRecent"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              Protect Recent (messages)
+            </label>
+            <input
+              id="compactionProtectRecent"
+              type="number"
+              min={0}
+              step={1}
+              placeholder="e.g. 4"
+              value={config.protectRecent ?? ''}
+              onChange={(event) => {
+                const value = event.target.value === '' ? undefined : Number(event.target.value);
+                update({ protectRecent: value });
+              }}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+          </div>
+        </div>
+
+        {/* native sub-settings */}
+        {config.strategy === 'native' && (
+          <div className="flex flex-col gap-2">
+            <p className="font-body text-[12px] font-medium text-text">Native Settings</p>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="compactionNativeMaxArrayItems"
+                  className="font-body text-[12px] font-medium text-text"
+                >
+                  Max Array Items
+                </label>
+                <input
+                  id="compactionNativeMaxArrayItems"
+                  type="number"
+                  min={1}
+                  step={1}
+                  placeholder="e.g. 20"
+                  value={config.native?.maxArrayItems ?? ''}
+                  onChange={(event) => {
+                    const value =
+                      event.target.value === '' ? undefined : Number(event.target.value);
+                    update({ native: { ...config.native, maxArrayItems: value } });
+                  }}
+                  className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="compactionNativeMaxStringChars"
+                  className="font-body text-[12px] font-medium text-text"
+                >
+                  Max String Chars
+                </label>
+                <input
+                  id="compactionNativeMaxStringChars"
+                  type="number"
+                  min={1}
+                  step={1}
+                  placeholder="e.g. 500"
+                  value={config.native?.maxStringChars ?? ''}
+                  onChange={(event) => {
+                    const value =
+                      event.target.value === '' ? undefined : Number(event.target.value);
+                    update({ native: { ...config.native, maxStringChars: value } });
+                  }}
+                  className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* headroom sub-settings */}
+        {config.strategy === 'headroom' && (
+          <div className="flex flex-col gap-2">
+            <p className="font-body text-[12px] font-medium text-text">Headroom Settings</p>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-1 col-span-2">
+                <label
+                  htmlFor="compactionHeadroomBaseUrl"
+                  className="font-body text-[12px] font-medium text-text"
+                >
+                  Base URL
+                </label>
+                <input
+                  id="compactionHeadroomBaseUrl"
+                  type="text"
+                  placeholder="http://localhost:8787"
+                  value={config.headroom?.baseUrl ?? ''}
+                  onChange={(event) =>
+                    update({
+                      headroom: {
+                        ...config.headroom,
+                        baseUrl: event.target.value || undefined,
+                      },
+                    })
+                  }
+                  className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                />
+              </div>
+              <div className="flex flex-col gap-1 col-span-2">
+                <label
+                  htmlFor="compactionHeadroomApiKey"
+                  className="font-body text-[12px] font-medium text-text"
+                >
+                  API Key
+                </label>
+                <input
+                  id="compactionHeadroomApiKey"
+                  type="password"
+                  placeholder="••••••••"
+                  value={config.headroom?.apiKey ?? ''}
+                  onChange={(event) =>
+                    update({
+                      headroom: {
+                        ...config.headroom,
+                        apiKey: event.target.value || undefined,
+                      },
+                    })
+                  }
+                  className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="compactionHeadroomTargetRatio"
+                  className="font-body text-[12px] font-medium text-text"
+                >
+                  Target Ratio{' '}
+                  <span className="text-text-muted font-normal">— 0–1, empty = off</span>
+                </label>
+                <input
+                  id="compactionHeadroomTargetRatio"
+                  type="number"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  placeholder="Disabled"
+                  value={config.headroom?.targetRatio ?? ''}
+                  onChange={(event) => {
+                    const value = event.target.value === '' ? null : Number(event.target.value);
+                    update({ headroom: { ...config.headroom, targetRatio: value } });
+                  }}
+                  className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="compactionHeadroomTimeoutMs"
+                  className="font-body text-[12px] font-medium text-text"
+                >
+                  Timeout (ms)
+                </label>
+                <input
+                  id="compactionHeadroomTimeoutMs"
+                  type="number"
+                  min={0}
+                  step={1}
+                  placeholder="e.g. 30000"
+                  value={config.headroom?.timeoutMs ?? ''}
+                  onChange={(event) => {
+                    const value =
+                      event.target.value === '' ? undefined : Number(event.target.value);
+                    update({ headroom: { ...config.headroom, timeoutMs: value } });
+                  }}
+                  className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/ConfigurationSnapshot.tsx
+++ b/packages/frontend/src/components/config/ConfigurationSnapshot.tsx
@@ -1,0 +1,105 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import Editor from '@monaco-editor/react';
+import { AlertTriangle, Download, RefreshCw, RotateCcw } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+
+class EditorErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Monaco Editor failed to load:', error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="h-[400px] sm:h-[500px] flex items-center justify-center bg-bg-glass/30 text-text-secondary rounded-md">
+          <div className="text-center p-6">
+            <AlertTriangle className="mx-auto mb-3 text-warning" size={32} />
+            <p className="text-sm font-semibold mb-1">Editor failed to load</p>
+            <p className="font-body text-[11px] text-text-muted">{this.state.error.message}</p>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+interface ConfigurationSnapshotProps {
+  config: string;
+  loaded: boolean;
+  restarting: boolean;
+  onRefresh: () => void;
+  onRestart: () => void | Promise<void>;
+  onExport: () => void;
+}
+
+export function ConfigurationSnapshot({
+  config,
+  loaded,
+  restarting,
+  onRefresh,
+  onRestart,
+  onExport,
+}: ConfigurationSnapshotProps) {
+  return (
+    <Disclosure
+      title="Configuration Snapshot"
+      defaultOpen={false}
+      extra={
+        <div className="flex items-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onRefresh}
+            leftIcon={<RotateCcw size={14} />}
+          >
+            Refresh
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onRestart}
+            isLoading={restarting}
+            leftIcon={<RefreshCw size={14} />}
+          >
+            Restart
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onExport}
+            disabled={!loaded}
+            leftIcon={<Download size={14} />}
+          >
+            Export JSON
+          </Button>
+        </div>
+      }
+    >
+      <div className="h-[400px] sm:h-[500px] lg:h-[600px] rounded-sm overflow-hidden">
+        <EditorErrorBoundary>
+          <Editor
+            height="100%"
+            defaultLanguage="json"
+            value={config}
+            theme="vs-dark"
+            options={{
+              readOnly: true,
+              minimap: { enabled: false },
+              scrollBeyondLastLine: false,
+              fontSize: 13,
+              fontFamily: '"Fira Code", "Fira Mono", monospace',
+            }}
+          />
+        </EditorErrorBoundary>
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/CooldownSettings.tsx
+++ b/packages/frontend/src/components/config/CooldownSettings.tsx
@@ -1,0 +1,116 @@
+import { Save } from 'lucide-react';
+import { formatMinutesToMinSec } from '@plexus/shared';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+import type { CooldownPolicy, FieldValidation } from './types';
+
+interface CooldownSettingsProps {
+  policy: CooldownPolicy;
+  loaded: boolean;
+  saving: boolean;
+  initialInput: string;
+  maxInput: string;
+  initialValidation: FieldValidation;
+  maxValidation: FieldValidation;
+  onInitialChange: (value: string) => void;
+  onMaxChange: (value: string) => void;
+  onSave: () => void;
+}
+
+export function CooldownSettings({
+  policy,
+  loaded,
+  saving,
+  initialInput,
+  maxInput,
+  initialValidation,
+  maxValidation,
+  onInitialChange,
+  onMaxChange,
+  onSave,
+}: CooldownSettingsProps) {
+  return (
+    <Disclosure
+      title="Cooldown Settings"
+      defaultOpen={false}
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onSave}
+          isLoading={saving}
+          disabled={!loaded || !initialValidation.valid || !maxValidation.valid}
+          leftIcon={<Save size={14} />}
+        >
+          Save
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {/* Initial + Max in 2-col grid */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="cooldownInitialMinutes"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              Initial Cooldown (min){' '}
+              <span className="text-text-muted font-normal">— C₀, first failure</span>
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                id="cooldownInitialMinutes"
+                type="number"
+                min={0.1}
+                step={0.1}
+                value={initialInput}
+                onChange={(event) => onInitialChange(event.target.value)}
+                className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+              />
+              <span className="text-[11px] text-text-muted tabular-nums whitespace-nowrap">
+                {initialValidation.valid && initialValidation.value != null
+                  ? formatMinutesToMinSec(initialValidation.value)
+                  : loaded
+                    ? formatMinutesToMinSec(policy.initialMinutes)
+                    : '—'}
+              </span>
+            </div>
+            {!initialValidation.valid && initialInput !== '' && (
+              <span className="text-[11px] text-warning">{initialValidation.error}</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="cooldownMaxMinutes"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              Maximum Cooldown (min){' '}
+              <span className="text-text-muted font-normal">— C_max, upper limit</span>
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                id="cooldownMaxMinutes"
+                type="number"
+                min={0.1}
+                step={0.1}
+                value={maxInput}
+                onChange={(event) => onMaxChange(event.target.value)}
+                className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+              />
+              <span className="text-[11px] text-text-muted tabular-nums whitespace-nowrap">
+                {maxValidation.valid && maxValidation.value != null
+                  ? formatMinutesToMinSec(maxValidation.value)
+                  : loaded
+                    ? formatMinutesToMinSec(policy.maxMinutes)
+                    : '—'}
+              </span>
+            </div>
+            {!maxValidation.valid && maxInput !== '' && (
+              <span className="text-[11px] text-warning">{maxValidation.error}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/DisplayPreferencesCard.tsx
+++ b/packages/frontend/src/components/config/DisplayPreferencesCard.tsx
@@ -1,0 +1,41 @@
+import { Info } from 'lucide-react';
+import { useCurrency } from '../../lib/CurrencyContext';
+import { SUPPORTED_CURRENCIES } from '../../lib/currency';
+import { Card } from '../ui/Card';
+
+export function DisplayPreferencesCard() {
+  const { currency, setCurrency, ratesAvailable } = useCurrency();
+
+  return (
+    <Card title="Display Preferences">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="displayCurrency" className="font-body text-[12px] font-medium text-text">
+          Display currency
+        </label>
+        <select
+          id="displayCurrency"
+          value={currency}
+          onChange={(event) => {
+            const nextCurrency = SUPPORTED_CURRENCIES.find(
+              ({ code }) => code === event.target.value
+            );
+            if (nextCurrency) setCurrency(nextCurrency.code);
+          }}
+          className="w-64 max-w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary"
+        >
+          {SUPPORTED_CURRENCIES.map((option) => (
+            <option key={option.code} value={option.code}>
+              {option.label} ({option.code}) — {option.symbol}
+            </option>
+          ))}
+        </select>
+        {!ratesAvailable && currency !== 'USD' && (
+          <p className="flex items-center gap-1.5 text-[11px] text-text-muted">
+            <Info size={13} className="text-warning shrink-0" aria-hidden="true" />
+            <span>Live exchange rates are unavailable; amounts fall back to USD.</span>
+          </p>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/packages/frontend/src/components/config/ExplorationSettings.tsx
+++ b/packages/frontend/src/components/config/ExplorationSettings.tsx
@@ -1,0 +1,213 @@
+import { Radar, Save } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+import { Switch } from '../ui/Switch';
+import type { BackgroundExplorationConfig, FieldValidation } from './types';
+
+interface ExplorationSettingsProps {
+  background: BackgroundExplorationConfig;
+  saving: boolean;
+  backgroundSaving: boolean;
+  stalenessInput: string;
+  concurrencyInput: string;
+  performanceInput: string;
+  latencyInput: string;
+  e2eInput: string;
+  stalenessValidation: FieldValidation;
+  concurrencyValidation: FieldValidation;
+  performanceValidation: FieldValidation;
+  latencyValidation: FieldValidation;
+  e2eValidation: FieldValidation;
+  valid: boolean;
+  onBackgroundEnabledChange: (enabled: boolean) => void;
+  onStalenessChange: (value: string) => void;
+  onConcurrencyChange: (value: string) => void;
+  onPerformanceChange: (value: string) => void;
+  onLatencyChange: (value: string) => void;
+  onE2EChange: (value: string) => void;
+  onSave: () => void;
+}
+
+export function ExplorationSettings({
+  background,
+  saving,
+  backgroundSaving,
+  stalenessInput,
+  concurrencyInput,
+  performanceInput,
+  latencyInput,
+  e2eInput,
+  stalenessValidation,
+  concurrencyValidation,
+  performanceValidation,
+  latencyValidation,
+  e2eValidation,
+  valid,
+  onBackgroundEnabledChange,
+  onStalenessChange,
+  onConcurrencyChange,
+  onPerformanceChange,
+  onLatencyChange,
+  onE2EChange,
+  onSave,
+}: ExplorationSettingsProps) {
+  return (
+    <Disclosure
+      title="Exploration Settings"
+      defaultOpen={false}
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onSave}
+          isLoading={saving || backgroundSaving}
+          disabled={!valid}
+          leftIcon={<Save size={14} />}
+        >
+          Save
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {/* Background exploration: master toggle */}
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <Radar size={16} className="text-primary" />
+            <div>
+              <p className="font-body text-[12px] font-medium text-text">Background Exploration</p>
+              <p className="font-body text-[11px] text-text-muted">
+                Fire background probe requests instead of diverting live traffic. Probes use
+                apiKey="probe".
+              </p>
+            </div>
+          </div>
+          <Switch
+            checked={background.enabled}
+            onChange={onBackgroundEnabledChange}
+            aria-label="Toggle background exploration on/off"
+          />
+        </div>
+
+        {/* Background tunables — only rendered when background mode is on */}
+        {background.enabled && (
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="bgExplorationStaleness"
+                className="font-body text-[12px] font-medium text-text"
+              >
+                Staleness Threshold (s){' '}
+                <span className="text-text-muted font-normal">— min 1, default 600</span>
+              </label>
+              <input
+                id="bgExplorationStaleness"
+                type="number"
+                min={1}
+                step={1}
+                value={stalenessInput}
+                onChange={(event) => onStalenessChange(event.target.value)}
+                className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+              />
+              {!stalenessValidation.valid && stalenessInput !== '' && (
+                <span className="text-[11px] text-warning">{stalenessValidation.error}</span>
+              )}
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="bgExplorationConcurrency"
+                className="font-body text-[12px] font-medium text-text"
+              >
+                Worker Concurrency{' '}
+                <span className="text-text-muted font-normal">— 1–16, default 2</span>
+              </label>
+              <input
+                id="bgExplorationConcurrency"
+                type="number"
+                min={1}
+                max={16}
+                step={1}
+                value={concurrencyInput}
+                onChange={(event) => onConcurrencyChange(event.target.value)}
+                className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+              />
+              {!concurrencyValidation.valid && concurrencyInput !== '' && (
+                <span className="text-[11px] text-warning">{concurrencyValidation.error}</span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Inline rate tunables — only rendered when background mode is off */}
+        {!background.enabled && (
+          <div className="grid grid-cols-3 gap-3">
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="performanceExplorationRate"
+                className="font-body text-[12px] font-medium text-text"
+              >
+                Performance Rate{' '}
+                <span className="text-text-muted font-normal">— 0–1, default 0.05</span>
+              </label>
+              <input
+                id="performanceExplorationRate"
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={performanceInput}
+                onChange={(event) => onPerformanceChange(event.target.value)}
+                className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+              />
+              {!performanceValidation.valid && performanceInput !== '' && (
+                <span className="text-[11px] text-warning">{performanceValidation.error}</span>
+              )}
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="latencyExplorationRate"
+                className="font-body text-[12px] font-medium text-text"
+              >
+                Latency Rate{' '}
+                <span className="text-text-muted font-normal">— 0–1, default 0.05</span>
+              </label>
+              <input
+                id="latencyExplorationRate"
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={latencyInput}
+                onChange={(event) => onLatencyChange(event.target.value)}
+                className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+              />
+              {!latencyValidation.valid && latencyInput !== '' && (
+                <span className="text-[11px] text-warning">{latencyValidation.error}</span>
+              )}
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                htmlFor="e2ePerformanceExplorationRate"
+                className="font-body text-[12px] font-medium text-text"
+              >
+                E2E Rate <span className="text-text-muted font-normal">— 0–1, default 0.05</span>
+              </label>
+              <input
+                id="e2ePerformanceExplorationRate"
+                type="number"
+                min={0}
+                max={1}
+                step={0.01}
+                value={e2eInput}
+                onChange={(event) => onE2EChange(event.target.value)}
+                className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+              />
+              {!e2eValidation.valid && e2eInput !== '' && (
+                <span className="text-[11px] text-warning">{e2eValidation.error}</span>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/FailoverSettings.tsx
+++ b/packages/frontend/src/components/config/FailoverSettings.tsx
@@ -1,0 +1,110 @@
+import { Save, Shield } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+import { Switch } from '../ui/Switch';
+import type { FailoverPolicy } from './types';
+
+interface FailoverSettingsProps {
+  policy: FailoverPolicy;
+  loaded: boolean;
+  saving: boolean;
+  statusCodesText: string;
+  errorsText: string;
+  onEnabledChange: (enabled: boolean) => void;
+  onStatusCodesChange: (value: string) => void;
+  onErrorsChange: (value: string) => void;
+  onSave: () => void;
+}
+
+export function FailoverSettings({
+  policy,
+  loaded,
+  saving,
+  statusCodesText,
+  errorsText,
+  onEnabledChange,
+  onStatusCodesChange,
+  onErrorsChange,
+  onSave,
+}: FailoverSettingsProps) {
+  return (
+    <Disclosure
+      title="Failover Settings"
+      defaultOpen={false}
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onSave}
+          isLoading={saving}
+          disabled={!loaded}
+          leftIcon={<Save size={14} />}
+        >
+          Save
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {/* Enabled toggle */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Shield size={16} className="text-primary" />
+            <div>
+              <p className="font-body text-[12px] font-medium text-text">Enable Failover</p>
+              <p className="font-body text-[11px] text-text-muted">
+                When enabled, failed requests are automatically retried on the next available
+                provider.
+              </p>
+            </div>
+          </div>
+          <Switch
+            checked={policy.enabled}
+            onChange={onEnabledChange}
+            aria-label="Toggle failover on/off"
+          />
+        </div>
+
+        {/* Retryable Status Codes */}
+        <div>
+          <label
+            htmlFor="retryableStatusCodes"
+            className="font-body text-[12px] font-medium text-text"
+          >
+            Retryable Status Codes
+          </label>
+          <p className="text-xs text-text-muted mb-2">
+            HTTP status codes that trigger a retry on the next provider. Enter comma-separated
+            values (100–599). Defaults to all non-2xx codes except 413 and 422 when empty.
+          </p>
+          <textarea
+            id="retryableStatusCodes"
+            value={statusCodesText}
+            onChange={(event) => onStatusCodesChange(event.target.value)}
+            placeholder="e.g. 429, 500, 502, 503"
+            rows={3}
+            className="w-full py-1 px-2 font-mono text-[12px] text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted resize-y"
+          />
+        </div>
+
+        {/* Retryable Errors */}
+        <div>
+          <label htmlFor="retryableErrors" className="font-body text-[12px] font-medium text-text">
+            Retryable Network Errors
+          </label>
+          <p className="text-xs text-text-muted mb-2">
+            Network error codes that trigger a retry on the next provider. Enter comma-separated
+            values. Defaults to ECONNREFUSED, ETIMEDOUT, ENOTFOUND when empty.
+          </p>
+          <textarea
+            id="retryableErrors"
+            value={errorsText}
+            onChange={(event) => onErrorsChange(event.target.value)}
+            placeholder="e.g. ECONNREFUSED, ETIMEDOUT, ENOTFOUND"
+            rows={2}
+            className="w-full py-1 px-2 font-mono text-[12px] text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted resize-y"
+          />
+        </div>
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/McpOAuthSettings.tsx
+++ b/packages/frontend/src/components/config/McpOAuthSettings.tsx
@@ -1,0 +1,91 @@
+import { LockKeyhole, Save } from 'lucide-react';
+import type { McpOAuthSettings as McpOAuthConfig } from '../../lib/api';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+import { Switch } from '../ui/Switch';
+import type { FieldValidation } from './types';
+
+interface McpOAuthSettingsProps {
+  config: McpOAuthConfig;
+  loaded: boolean;
+  saving: boolean;
+  issuerInput: string;
+  issuerValidation: FieldValidation<boolean>;
+  onEnabledChange: (enabled: boolean) => void;
+  onIssuerChange: (value: string) => void;
+  onSave: () => void;
+}
+
+export function McpOAuthSettings({
+  config,
+  loaded,
+  saving,
+  issuerInput,
+  issuerValidation,
+  onEnabledChange,
+  onIssuerChange,
+  onSave,
+}: McpOAuthSettingsProps) {
+  return (
+    <Disclosure
+      title="MCP OAuth"
+      defaultOpen={false}
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onSave}
+          isLoading={saving}
+          disabled={!loaded || !issuerValidation.valid}
+          leftIcon={<Save size={14} />}
+        >
+          Save
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <LockKeyhole size={16} className="text-primary" />
+            <div>
+              <p className="font-body text-[12px] font-medium text-text">
+                Enable OAuth for MCP clients
+              </p>
+              <p className="font-body text-[11px] text-text-muted">
+                Shared OAuth authorization for each configured MCP server.
+              </p>
+            </div>
+          </div>
+          <Switch
+            checked={config.enabled}
+            onChange={onEnabledChange}
+            aria-label="Toggle MCP OAuth on/off"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="mcpOAuthIssuer" className="font-body text-[12px] font-medium text-text">
+            External issuer URL
+          </label>
+          <input
+            id="mcpOAuthIssuer"
+            type="url"
+            value={issuerInput}
+            onChange={(event) => onIssuerChange(event.target.value)}
+            placeholder="https://your-instance.example.com"
+            className="w-full h-[32px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+          />
+          {!issuerValidation.valid && (
+            <span className="text-[11px] text-warning">{issuerValidation.error}</span>
+          )}
+          <p className="font-body text-[11px] text-text-muted leading-relaxed">
+            Use the externally reachable URL for this Plexus instance, such as a Tailscale Funnel
+            URL. Each MCP server derives its protected resource from this issuer, such as{' '}
+            <code>/mcp/exa</code>. If this does not match the actual external URL, OAuth discovery
+            metadata will point at the wrong origin and MCP connections can fail.
+          </p>
+        </div>
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/ModelMetadataCard.tsx
+++ b/packages/frontend/src/components/config/ModelMetadataCard.tsx
@@ -1,0 +1,32 @@
+import { RefreshCw } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+
+interface ModelMetadataCardProps {
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+export function ModelMetadataCard({ loading, onRefresh }: ModelMetadataCardProps) {
+  return (
+    <Card
+      title="Model Metadata"
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onRefresh}
+          isLoading={loading}
+          leftIcon={<RefreshCw size={14} />}
+        >
+          Refresh Metadata
+        </Button>
+      }
+    >
+      <p className="text-sm text-text-secondary">
+        Catalog metadata for model aliases auto-refreshes every 60 minutes. Use this to trigger an
+        immediate reload from OpenRouter, models.dev, and Catwalk.
+      </p>
+    </Card>
+  );
+}

--- a/packages/frontend/src/components/config/NetworkSettings.tsx
+++ b/packages/frontend/src/components/config/NetworkSettings.tsx
@@ -1,0 +1,72 @@
+import { Network, Save } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+import { TagSelect } from '../ui/TagSelect';
+
+interface NetworkSettingsProps {
+  trustedProxies: string[];
+  loaded: boolean;
+  saving: boolean;
+  onChange: (trustedProxies: string[]) => void;
+  onSave: () => void;
+}
+
+export function NetworkSettings({
+  trustedProxies,
+  loaded,
+  saving,
+  onChange,
+  onSave,
+}: NetworkSettingsProps) {
+  return (
+    <Disclosure
+      title="Network Settings"
+      defaultOpen={false}
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onSave}
+          isLoading={saving}
+          disabled={!loaded}
+          leftIcon={<Save size={14} />}
+        >
+          Save
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <Network size={16} className="text-primary" />
+          <div>
+            <p className="font-body text-[12px] font-medium text-text">Trusted Proxies</p>
+            <p className="font-body text-[11px] text-text-muted">
+              IPs/CIDRs of reverse proxies whose forwarding headers (X-Forwarded-For,
+              CF-Connecting-IP, …) are believed when resolving a client&apos;s IP. Requests arriving
+              directly from any other address use their real connection IP instead, so spoofed
+              headers cannot defeat per-key IP allowlists.
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <TagSelect
+            label="Trusted Proxy IPs"
+            placeholder="e.g. 10.0.0.0/8  172.16.0.0/12  192.168.1.5"
+            options={[]}
+            selected={trustedProxies}
+            allowCustom
+            splitOnSpace
+            onChange={onChange}
+          />
+          <p className="text-xs text-text-muted mt-2">
+            Type entries separated by spaces. The default trust-all list is <code>0.0.0.0/0</code>{' '}
+            plus <code>::/0</code> — keep this only if Plexus is not publicly reachable except
+            through your proxy. An empty list trusts no proxies. Accepts IPv4/IPv6, CIDR, and
+            ranges.
+          </p>
+        </div>
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/StallDetectionSettings.tsx
+++ b/packages/frontend/src/components/config/StallDetectionSettings.tsx
@@ -1,0 +1,182 @@
+import { Save } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+import type { FieldValidation } from './types';
+
+interface StallDetectionSettingsProps {
+  loaded: boolean;
+  saving: boolean;
+  ttfbInput: string;
+  ttfbBytesInput: string;
+  minBpsInput: string;
+  windowInput: string;
+  graceInput: string;
+  ttfbValidation: FieldValidation<number | null>;
+  ttfbBytesValidation: FieldValidation;
+  minBpsValidation: FieldValidation<number | null>;
+  windowValidation: FieldValidation;
+  graceValidation: FieldValidation;
+  onTtfbChange: (value: string) => void;
+  onTtfbBytesChange: (value: string) => void;
+  onMinBpsChange: (value: string) => void;
+  onWindowChange: (value: string) => void;
+  onGraceChange: (value: string) => void;
+  onSave: () => void;
+}
+
+export function StallDetectionSettings({
+  loaded,
+  saving,
+  ttfbInput,
+  ttfbBytesInput,
+  minBpsInput,
+  windowInput,
+  graceInput,
+  ttfbValidation,
+  ttfbBytesValidation,
+  minBpsValidation,
+  windowValidation,
+  graceValidation,
+  onTtfbChange,
+  onTtfbBytesChange,
+  onMinBpsChange,
+  onWindowChange,
+  onGraceChange,
+  onSave,
+}: StallDetectionSettingsProps) {
+  const isValid =
+    loaded &&
+    ttfbValidation.valid &&
+    ttfbBytesValidation.valid &&
+    minBpsValidation.valid &&
+    windowValidation.valid &&
+    graceValidation.valid;
+
+  return (
+    <Disclosure
+      title="Stall Detection"
+      defaultOpen={false}
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onSave}
+          isLoading={saving}
+          disabled={!isValid}
+          leftIcon={<Save size={14} />}
+        >
+          Save
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="stallTtfbSeconds"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              TTFB Timeout (s){' '}
+              <span className="text-text-muted font-normal">— 5–120, empty = off</span>
+            </label>
+            <input
+              id="stallTtfbSeconds"
+              type="number"
+              min={5}
+              max={120}
+              step={1}
+              placeholder="Disabled"
+              value={ttfbInput}
+              onChange={(event) => onTtfbChange(event.target.value)}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+            {!ttfbValidation.valid && ttfbInput !== '' && (
+              <span className="text-[11px] text-warning">{ttfbValidation.error}</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="stallTtfbBytes" className="font-body text-[12px] font-medium text-text">
+              TTFB Byte Threshold <span className="text-text-muted font-normal">— 50–10,000</span>
+            </label>
+            <input
+              id="stallTtfbBytes"
+              type="number"
+              min={50}
+              max={10000}
+              step={1}
+              value={ttfbBytesInput}
+              onChange={(event) => onTtfbBytesChange(event.target.value)}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+            {!ttfbBytesValidation.valid && ttfbBytesInput !== '' && (
+              <span className="text-[11px] text-warning">{ttfbBytesValidation.error}</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="stallMinBps" className="font-body text-[12px] font-medium text-text">
+              Min Bytes/sec{' '}
+              <span className="text-text-muted font-normal">— 50–5,000, empty = off</span>
+            </label>
+            <input
+              id="stallMinBps"
+              type="number"
+              min={50}
+              max={5000}
+              step={1}
+              placeholder="Disabled"
+              value={minBpsInput}
+              onChange={(event) => onMinBpsChange(event.target.value)}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+            {!minBpsValidation.valid && minBpsInput !== '' && (
+              <span className="text-[11px] text-warning">{minBpsValidation.error}</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="stallWindowSeconds"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              Sliding Window (s) <span className="text-text-muted font-normal">— 3–30</span>
+            </label>
+            <input
+              id="stallWindowSeconds"
+              type="number"
+              min={3}
+              max={30}
+              step={1}
+              value={windowInput}
+              onChange={(event) => onWindowChange(event.target.value)}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+            {!windowValidation.valid && windowInput !== '' && (
+              <span className="text-[11px] text-warning">{windowValidation.error}</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="stallGraceSeconds"
+              className="font-body text-[12px] font-medium text-text"
+            >
+              Grace Period (s){' '}
+              <span className="text-text-muted font-normal">— 0–120, post-TTFB pause</span>
+            </label>
+            <input
+              id="stallGraceSeconds"
+              type="number"
+              min={0}
+              max={120}
+              step={1}
+              value={graceInput}
+              onChange={(event) => onGraceChange(event.target.value)}
+              className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+            {!graceValidation.valid && graceInput !== '' && (
+              <span className="text-[11px] text-warning">{graceValidation.error}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/TimeoutSettings.tsx
+++ b/packages/frontend/src/components/config/TimeoutSettings.tsx
@@ -1,0 +1,81 @@
+import { Save } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Disclosure } from '../ui/Disclosure';
+import type { FieldValidation, TimeoutConfig } from './types';
+
+interface TimeoutSettingsProps {
+  config: TimeoutConfig;
+  loaded: boolean;
+  saving: boolean;
+  defaultInput: string;
+  validation: FieldValidation;
+  onDefaultChange: (value: string) => void;
+  onSave: () => void;
+}
+
+function formatTimeout(seconds: number): string {
+  return seconds >= 60 ? `${Math.floor(seconds / 60)}m ${seconds % 60}s` : `${seconds}s`;
+}
+
+export function TimeoutSettings({
+  config,
+  loaded,
+  saving,
+  defaultInput,
+  validation,
+  onDefaultChange,
+  onSave,
+}: TimeoutSettingsProps) {
+  return (
+    <Disclosure
+      title="Timeout Settings"
+      defaultOpen={false}
+      extra={
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onSave}
+          isLoading={saving}
+          disabled={!loaded || !validation.valid}
+          leftIcon={<Save size={14} />}
+        >
+          Save
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <label
+            htmlFor="timeoutDefaultSeconds"
+            className="font-body text-[12px] font-medium text-text"
+          >
+            Default Timeout (seconds){' '}
+            <span className="text-text-muted font-normal">— global default, 1–3600s</span>
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id="timeoutDefaultSeconds"
+              type="number"
+              min={1}
+              max={3600}
+              step={1}
+              value={defaultInput}
+              onChange={(event) => onDefaultChange(event.target.value)}
+              className="w-48 h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
+            />
+            <span className="text-[11px] text-text-muted tabular-nums">
+              {validation.valid && validation.value != null
+                ? formatTimeout(validation.value)
+                : loaded
+                  ? formatTimeout(config.defaultSeconds)
+                  : '—'}
+            </span>
+          </div>
+          {!validation.valid && defaultInput !== '' && (
+            <span className="text-[11px] text-warning">{validation.error}</span>
+          )}
+        </div>
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/TraceCaptureSettings.tsx
+++ b/packages/frontend/src/components/config/TraceCaptureSettings.tsx
@@ -1,0 +1,40 @@
+import { AlertTriangle } from 'lucide-react';
+import { Disclosure } from '../ui/Disclosure';
+import { Switch } from '../ui/Switch';
+
+interface TraceCaptureSettingsProps {
+  enabled: boolean;
+  loaded: boolean;
+  saving: boolean;
+  onChange: (enabled: boolean) => void;
+}
+
+export function TraceCaptureSettings({
+  enabled,
+  loaded,
+  saving,
+  onChange,
+}: TraceCaptureSettingsProps) {
+  return (
+    <Disclosure title="Trace Capture" defaultOpen={false}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <AlertTriangle size={16} className="text-primary" />
+          <div>
+            <p className="font-body text-[12px] font-medium text-text">Capture Trace on Error</p>
+            <p className="font-body text-[11px] text-text-muted">
+              When enabled, debug traces are stored for requests that write to the inference error
+              log or trigger a cooldown, even while global debug tracing is off.
+            </p>
+          </div>
+        </div>
+        <Switch
+          checked={enabled}
+          onChange={onChange}
+          disabled={!loaded || saving}
+          aria-label="Toggle capture trace on error"
+        />
+      </div>
+    </Disclosure>
+  );
+}

--- a/packages/frontend/src/components/config/types.ts
+++ b/packages/frontend/src/components/config/types.ts
@@ -1,0 +1,83 @@
+import type { CompactionSettings, McpOAuthSettings } from '../../lib/api';
+
+export interface FailoverPolicy {
+  enabled: boolean;
+  retryableStatusCodes: number[];
+  retryableErrors: string[];
+}
+
+export interface CooldownPolicy {
+  initialMinutes: number;
+  maxMinutes: number;
+}
+
+export interface ExplorationRates {
+  performanceExplorationRate: number;
+  latencyExplorationRate: number;
+  e2ePerformanceExplorationRate: number;
+}
+
+export interface BackgroundExplorationConfig {
+  enabled: boolean;
+  stalenessThresholdSeconds: number;
+  workerConcurrency: number;
+}
+
+export interface TimeoutConfig {
+  defaultSeconds: number;
+}
+
+export interface StallConfig {
+  ttfbSeconds: number | null;
+  ttfbBytes: number;
+  minBytesPerSecond: number | null;
+  windowSeconds: number;
+  gracePeriodSeconds: number;
+}
+
+export interface FieldValidation<T = number> {
+  valid: boolean;
+  value?: T | null;
+  error?: string;
+}
+export const DEFAULT_EXPLORATION_RATES: ExplorationRates = {
+  performanceExplorationRate: 0.05,
+  latencyExplorationRate: 0.05,
+  e2ePerformanceExplorationRate: 0.05,
+};
+
+export const DEFAULT_TIMEOUT_CONFIG: TimeoutConfig = {
+  defaultSeconds: 300,
+};
+
+export const DEFAULT_STALL_CONFIG: StallConfig = {
+  ttfbSeconds: null,
+  ttfbBytes: 100,
+  minBytesPerSecond: null,
+  windowSeconds: 10,
+  gracePeriodSeconds: 30,
+};
+
+export const DEFAULT_BACKGROUND_EXPLORATION: BackgroundExplorationConfig = {
+  enabled: false,
+  stalenessThresholdSeconds: 600,
+  workerConcurrency: 2,
+};
+
+export const DEFAULT_COMPACTION_CONFIG: CompactionSettings = { enabled: false, strategy: 'native' };
+
+export const DEFAULT_FAILOVER_POLICY: FailoverPolicy = {
+  enabled: true,
+  retryableStatusCodes: [],
+  retryableErrors: [],
+};
+
+export const DEFAULT_MCP_OAUTH_CONFIG: McpOAuthSettings = {
+  enabled: false,
+  provider: 'plexus-idp',
+};
+
+export const DEFAULT_COOLDOWN_POLICY: CooldownPolicy = {
+  initialMinutes: 2,
+  maxMinutes: 300,
+};

--- a/packages/frontend/src/components/mcp/McpDeleteLogModal.tsx
+++ b/packages/frontend/src/components/mcp/McpDeleteLogModal.tsx
@@ -1,0 +1,36 @@
+import { Button } from '../ui/Button';
+import { Modal } from '../ui/Modal';
+
+interface McpDeleteLogModalProps {
+  isOpen: boolean;
+  isDeletingLogs: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+}
+
+export function McpDeleteLogModal({
+  isOpen,
+  isDeletingLogs,
+  onClose,
+  onConfirm,
+}: McpDeleteLogModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Confirm Deletion"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirm} disabled={isDeletingLogs}>
+            {isDeletingLogs ? 'Deleting...' : 'Delete Log'}
+          </Button>
+        </>
+      }
+    >
+      <p>Are you sure you want to delete this MCP log entry?</p>
+    </Modal>
+  );
+}

--- a/packages/frontend/src/components/mcp/McpDeleteLogsModal.tsx
+++ b/packages/frontend/src/components/mcp/McpDeleteLogsModal.tsx
@@ -1,0 +1,80 @@
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Modal } from '../ui/Modal';
+
+interface McpDeleteLogsModalProps {
+  isOpen: boolean;
+  deleteLogsMode: 'all' | 'older';
+  olderThanDays: number;
+  isDeletingLogs: boolean;
+  onClose: () => void;
+  onModeChange: (mode: 'all' | 'older') => void;
+  onOlderThanDaysChange: (days: number) => void;
+  onConfirm: () => void | Promise<void>;
+}
+
+export function McpDeleteLogsModal({
+  isOpen,
+  deleteLogsMode,
+  olderThanDays,
+  isDeletingLogs,
+  onClose,
+  onModeChange,
+  onOlderThanDaysChange,
+  onConfirm,
+}: McpDeleteLogsModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Confirm Deletion"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirm} disabled={isDeletingLogs}>
+            {isDeletingLogs ? 'Deleting...' : 'Delete Logs'}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        <p>Select which MCP logs you would like to delete:</p>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="radio"
+            id="mcp-delete-older"
+            name="deleteLogsMode"
+            checked={deleteLogsMode === 'older'}
+            onChange={() => onModeChange('older')}
+          />
+          <label htmlFor="mcp-delete-older">Delete logs older than</label>
+          <Input
+            type="number"
+            min="1"
+            value={olderThanDays}
+            onChange={(e) => onOlderThanDaysChange(parseInt(e.target.value) || 1)}
+            style={{ width: '60px', padding: '4px 8px' }}
+            disabled={deleteLogsMode !== 'older'}
+          />
+          <span>days</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            type="radio"
+            id="mcp-delete-all"
+            name="deleteLogsMode"
+            checked={deleteLogsMode === 'all'}
+            onChange={() => onModeChange('all')}
+          />
+          <label htmlFor="mcp-delete-all" style={{ color: 'var(--color-danger)' }}>
+            Delete ALL logs (Cannot be undone)
+          </label>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/frontend/src/components/mcp/McpKeyManagementModal.tsx
+++ b/packages/frontend/src/components/mcp/McpKeyManagementModal.tsx
@@ -1,0 +1,123 @@
+import { clsx } from 'clsx';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Modal } from '../ui/Modal';
+import type { McpServerKey } from '../../lib/api';
+import { formatResetsIn } from '../../lib/format';
+
+interface McpKeyManagementModalProps {
+  serverName: string | null;
+  authScheme: string | null | undefined;
+  serverKeys: McpServerKey[];
+  isLoadingKeys: boolean;
+  newServerKey: string;
+  onNewServerKeyChange: (value: string) => void;
+  isSavingKey: boolean;
+  onClose: () => void;
+  onAddKey: () => void | Promise<void>;
+  onDeleteKey: (keyId: number) => void | Promise<void>;
+  onClearCooldown: (keyId: number) => void | Promise<void>;
+}
+
+export function McpKeyManagementModal({
+  serverName,
+  authScheme,
+  serverKeys,
+  isLoadingKeys,
+  newServerKey,
+  onNewServerKeyChange,
+  isSavingKey,
+  onClose,
+  onAddKey,
+  onDeleteKey,
+  onClearCooldown,
+}: McpKeyManagementModalProps) {
+  return (
+    <Modal
+      isOpen={serverName !== null}
+      onClose={onClose}
+      title={serverName ? `Manage Keys: ${serverName}` : 'Manage Keys'}
+      footer={
+        <Button variant="secondary" onClick={onClose}>
+          Close
+        </Button>
+      }
+    >
+      <div className="space-y-4">
+        <div className="rounded-md bg-bg-surface p-3 text-sm text-text-secondary border border-border-subtle">
+          <p>
+            These keys will be load-balanced (Round Robin) and automatically rotated if a rate limit
+            or quota is exceeded. They will be injected using the server&apos;s configured{' '}
+            <strong>Auth Scheme</strong>:{' '}
+            <span className="font-mono text-text bg-bg-subtle px-1 py-0.5 rounded">
+              {serverName && authScheme ? authScheme : 'None (keys will not be sent)'}
+            </span>
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Input
+            label="New Key"
+            value={newServerKey}
+            onChange={(e) => onNewServerKeyChange(e.target.value)}
+            placeholder="Paste key value"
+            className="flex-1"
+          />
+          <Button
+            className="self-end"
+            onClick={onAddKey}
+            disabled={isSavingKey || !newServerKey.trim()}
+          >
+            {isSavingKey ? 'Adding...' : 'Add Key'}
+          </Button>
+        </div>
+
+        {isLoadingKeys ? (
+          <p className="text-sm text-text-secondary">Loading keys...</p>
+        ) : serverKeys.length === 0 ? (
+          <p className="text-sm text-text-secondary">No keys configured.</p>
+        ) : (
+          <div className="space-y-2">
+            {serverKeys.map((key) => {
+              const isExhausted =
+                key.cooldown_until !== null && new Date(key.cooldown_until).getTime() > Date.now();
+              return (
+                <div
+                  key={key.id}
+                  className="flex flex-col gap-3 rounded-md border border-border-glass bg-bg-subtle p-3 sm:flex-row sm:items-center"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-mono text-sm text-text" title={key.key}>
+                      {key.key}
+                    </div>
+                    <div
+                      className={clsx(
+                        'mt-1 text-xs font-medium',
+                        !key.is_active || isExhausted ? 'text-warning' : 'text-success'
+                      )}
+                    >
+                      {!key.is_active
+                        ? 'Inactive'
+                        : isExhausted
+                          ? `Exhausted, ${formatResetsIn(key.cooldown_until)}`
+                          : 'Active'}
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    {isExhausted && (
+                      <Button size="sm" variant="secondary" onClick={() => onClearCooldown(key.id)}>
+                        Clear Cooldown
+                      </Button>
+                    )}
+                    <Button size="sm" variant="danger" onClick={() => onDeleteKey(key.id)}>
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/packages/frontend/src/components/mcp/McpOAuthClientsCard.tsx
+++ b/packages/frontend/src/components/mcp/McpOAuthClientsCard.tsx
@@ -1,0 +1,219 @@
+import { KeyRound, RefreshCw, ShieldCheck, ShieldOff, Trash2 } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+import type { McpOAuthClientRecord } from '../../lib/api';
+
+interface McpOAuthClientsCardProps {
+  oauthClients: McpOAuthClientRecord[];
+  oauthClientsLoading: boolean;
+  revokingTokenId: number | null;
+  updatingClientId: string | null;
+  deletingClientId: string | null;
+  revokingAllClientId: string | null;
+  onRefresh: () => void | Promise<void>;
+  onRevokeToken: (tokenId: number) => void | Promise<void>;
+  onToggleClientStatus: (client: McpOAuthClientRecord) => void | Promise<void>;
+  onRevokeAllTokens: (clientId: string) => void | Promise<void>;
+  onDeleteClient: (clientId: string) => void | Promise<void>;
+}
+
+export function McpOAuthClientsCard({
+  oauthClients,
+  oauthClientsLoading,
+  revokingTokenId,
+  updatingClientId,
+  deletingClientId,
+  revokingAllClientId,
+  onRefresh,
+  onRevokeToken,
+  onToggleClientStatus,
+  onRevokeAllTokens,
+  onDeleteClient,
+}: McpOAuthClientsCardProps) {
+  return (
+    <Card className="glass-bg rounded-lg p-3 max-w-full shadow-xl overflow-hidden flex flex-col gap-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-heading text-lg font-semibold text-text m-0 mb-1">
+            MCP OAuth Clients
+          </h2>
+          <p className="text-xs text-text-muted">
+            Registered OAuth clients and their active tokens. Tokens show the bound Plexus API key
+            name only; raw secrets are never displayed.
+          </p>
+        </div>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onRefresh}
+          isLoading={oauthClientsLoading}
+          leftIcon={<RefreshCw size={14} />}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {oauthClientsLoading ? (
+        <div className="py-8 text-center text-sm text-text-secondary">Loading...</div>
+      ) : oauthClients.length === 0 ? (
+        <div className="rounded-md border border-border-glass bg-bg-subtle p-4 text-sm text-text-secondary">
+          No MCP OAuth clients registered yet.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {oauthClients.map((client) => (
+            <article
+              key={client.clientId}
+              className={`rounded-md border border-border-glass bg-bg-subtle p-3 ${
+                client.status === 'disabled' ? 'opacity-60' : ''
+              }`}
+            >
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-text">
+                    <KeyRound size={15} className="text-primary" />
+                    <span>{client.clientName || 'Unnamed client'}</span>
+                    {client.status === 'disabled' ? (
+                      <span className="rounded border border-red-500/40 bg-red-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-red-500">
+                        Disabled
+                      </span>
+                    ) : (
+                      <span className="rounded border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-emerald-500">
+                        Active
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 font-mono text-xs text-text-secondary break-all">
+                    {client.clientId}
+                  </div>
+                  <div className="mt-2 text-xs text-text-muted">
+                    Created {new Date(client.createdAt).toLocaleString()}
+                  </div>
+                </div>
+                <div className="min-w-0 lg:max-w-[45%]">
+                  <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                    Redirect URIs
+                  </div>
+                  <div className="mt-1 flex flex-col gap-1">
+                    {client.redirectUris.map((uri) => (
+                      <code
+                        key={uri}
+                        className="rounded border border-border-glass bg-bg-glass px-2 py-1 text-[11px] text-text-secondary break-all"
+                      >
+                        {uri}
+                      </code>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-3 border-t border-border-glass pt-3">
+                <div className="mb-2 text-[10px] uppercase tracking-wider text-text-muted">
+                  Active tokens
+                </div>
+                {client.tokens.length === 0 ? (
+                  <div className="text-xs text-text-muted">No active tokens for this client.</div>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full border-collapse font-body text-[12px]">
+                      <thead>
+                        <tr>
+                          <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                            Key name
+                          </th>
+                          <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                            Scope
+                          </th>
+                          <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                            Access expires
+                          </th>
+                          <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                            Issued
+                          </th>
+                          <th className="px-2 py-2 text-right border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
+                            Action
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {client.tokens.map((token) => (
+                          <tr key={token.id} className="hover:bg-bg-hover">
+                            <td className="px-2 py-2 border-b border-border-glass text-text">
+                              <span className="font-mono">{token.keyName}</span>
+                            </td>
+                            <td className="px-2 py-2 border-b border-border-glass text-text-secondary">
+                              {token.scope || '-'}
+                            </td>
+                            <td className="px-2 py-2 border-b border-border-glass text-text-secondary whitespace-nowrap">
+                              {new Date(token.accessTokenExpiresAt).toLocaleString()}
+                            </td>
+                            <td className="px-2 py-2 border-b border-border-glass text-text-secondary whitespace-nowrap">
+                              {new Date(token.createdAt).toLocaleString()}
+                            </td>
+                            <td className="px-2 py-2 border-b border-border-glass text-right">
+                              <Button
+                                size="sm"
+                                variant="danger"
+                                onClick={() => onRevokeToken(token.id)}
+                                isLoading={revokingTokenId === token.id}
+                                leftIcon={<ShieldOff size={13} />}
+                              >
+                                Revoke
+                              </Button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-3 flex flex-wrap gap-2 border-t border-border-glass pt-3">
+                {client.status === 'disabled' ? (
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    onClick={() => onToggleClientStatus(client)}
+                    isLoading={updatingClientId === client.clientId}
+                    leftIcon={<ShieldCheck size={13} />}
+                  >
+                    Enable
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="danger"
+                    onClick={() => onToggleClientStatus(client)}
+                    isLoading={updatingClientId === client.clientId}
+                    leftIcon={<ShieldOff size={13} />}
+                  >
+                    Disable
+                  </Button>
+                )}
+                <Button
+                  size="sm"
+                  variant="danger"
+                  onClick={() => onRevokeAllTokens(client.clientId)}
+                  isLoading={revokingAllClientId === client.clientId}
+                  leftIcon={<KeyRound size={13} />}
+                >
+                  Revoke all tokens
+                </Button>
+                <Button
+                  size="sm"
+                  variant="danger"
+                  onClick={() => onDeleteClient(client.clientId)}
+                  isLoading={deletingClientId === client.clientId}
+                  leftIcon={<Trash2 size={13} />}
+                >
+                  Delete client
+                </Button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/packages/frontend/src/components/mcp/McpServerEditorModal.tsx
+++ b/packages/frontend/src/components/mcp/McpServerEditorModal.tsx
@@ -1,0 +1,355 @@
+import { MinusCircle, PlusCircle } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Input } from '../ui/Input';
+import { Modal } from '../ui/Modal';
+import type { LocalMcpServer, McpServer, RemoteMcpServer } from '../../lib/api';
+
+interface McpServerEditorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  editingServerName: string | null;
+  serverNameInput: string;
+  onServerNameInputChange: (value: string) => void;
+  editingServer: McpServer;
+  onEditingServerChange: (server: McpServer) => void;
+  argsInput: string;
+  onArgsInputChange: (value: string) => void;
+  headerKey: string;
+  onHeaderKeyChange: (value: string) => void;
+  headerValue: string;
+  onHeaderValueChange: (value: string) => void;
+  envKey: string;
+  onEnvKeyChange: (value: string) => void;
+  envValue: string;
+  onEnvValueChange: (value: string) => void;
+  emptyServer: RemoteMcpServer;
+  emptyLocalServer: LocalMcpServer;
+  getNextLocalMcpPort: () => number;
+  onAddHeader: () => void;
+  onRemoveHeader: (key: string) => void;
+  onAddEnv: () => void;
+  onRemoveEnv: (key: string) => void;
+  onSave: () => void | Promise<void>;
+  isSaving: boolean;
+}
+
+export function McpServerEditorModal({
+  isOpen,
+  onClose,
+  editingServerName,
+  serverNameInput,
+  onServerNameInputChange,
+  editingServer,
+  onEditingServerChange,
+  argsInput,
+  onArgsInputChange,
+  headerKey,
+  onHeaderKeyChange,
+  headerValue,
+  onHeaderValueChange,
+  envKey,
+  onEnvKeyChange,
+  envValue,
+  onEnvValueChange,
+  emptyServer,
+  emptyLocalServer,
+  getNextLocalMcpPort,
+  onAddHeader,
+  onRemoveHeader,
+  onAddEnv,
+  onRemoveEnv,
+  onSave,
+  isSaving,
+}: McpServerEditorModalProps) {
+  const localServer = editingServer.mode === 'local_http' ? editingServer : null;
+  const remoteServer = editingServer.mode === 'local_http' ? null : editingServer;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={editingServerName ? `Edit ${editingServerName}` : 'Add MCP Server'}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={onSave} disabled={isSaving}>
+            {isSaving ? 'Saving...' : 'Save'}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {!editingServerName && (
+          <Input
+            label="Server Name"
+            value={serverNameInput}
+            onChange={(e) =>
+              onServerNameInputChange(e.target.value.toLowerCase().replace(/[^a-z0-9-_]/g, ''))
+            }
+            placeholder="my-mcp-server"
+          />
+        )}
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-text-secondary">Server Type</label>
+          <select
+            className="w-full rounded-md border border-border-glass bg-bg-surface px-3 py-2 text-sm text-text"
+            value={editingServer.mode === 'local_http' ? 'local_http' : 'remote_http'}
+            onChange={(e) => {
+              if (e.target.value === 'local_http') {
+                onArgsInputChange((emptyLocalServer.args || []).join(' '));
+                onEditingServerChange({
+                  ...emptyLocalServer,
+                  enabled: editingServer.enabled,
+                  headers: editingServer.headers,
+                  port: getNextLocalMcpPort(),
+                } as LocalMcpServer);
+              } else {
+                onEditingServerChange({
+                  ...emptyServer,
+                  enabled: editingServer.enabled,
+                  headers: editingServer.headers,
+                } as RemoteMcpServer);
+              }
+            }}
+          >
+            <option value="remote_http">Remote HTTP</option>
+            <option value="local_http">Local HTTP</option>
+          </select>
+        </div>
+
+        {localServer ? (
+          <>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-text-secondary">Launcher</label>
+              <select
+                className="w-full rounded-md border border-border-glass bg-bg-surface px-3 py-2 text-sm text-text"
+                value={localServer.launcher}
+                onChange={(e) =>
+                  onEditingServerChange({
+                    ...localServer,
+                    launcher: e.target.value as 'bunx' | 'uvx',
+                  })
+                }
+              >
+                <option value="bunx">bunx</option>
+                <option value="uvx">uvx</option>
+              </select>
+            </div>
+            <Input
+              label="Package"
+              value={localServer.package}
+              onChange={(e) => onEditingServerChange({ ...localServer, package: e.target.value })}
+              placeholder="@example/mcp-server"
+            />
+            <Input
+              label="Arguments"
+              value={argsInput}
+              onChange={(e) => onArgsInputChange(e.target.value)}
+              placeholder="--port {{PORT}}"
+            />
+            <p className="-mt-2 text-xs text-text-muted">
+              Available interpolations: {'{{PORT}}'} for the configured port and {'{{HOST}}'} for
+              127.0.0.1.
+            </p>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <Input
+                label="Port"
+                type="number"
+                value={localServer.port}
+                onChange={(e) =>
+                  onEditingServerChange({
+                    ...localServer,
+                    port: parseInt(e.target.value) || 7345,
+                  })
+                }
+              />
+              <Input
+                label="Path"
+                value={localServer.path ?? '/mcp'}
+                onChange={(e) => onEditingServerChange({ ...localServer, path: e.target.value })}
+              />
+              <Input
+                label="Startup Timeout (ms)"
+                type="number"
+                value={localServer.startup_timeout_ms || 30000}
+                onChange={(e) =>
+                  onEditingServerChange({
+                    ...localServer,
+                    startup_timeout_ms: parseInt(e.target.value) || 30000,
+                  })
+                }
+              />
+            </div>
+
+            <div className="space-y-2 rounded-md border border-border-glass p-3">
+              <label className="text-sm font-medium text-text-secondary">
+                Environment Variables
+              </label>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+                <div className="min-w-0 flex-1">
+                  <Input
+                    label="Env Key"
+                    value={envKey}
+                    onChange={(e) => onEnvKeyChange(e.target.value)}
+                    placeholder="API_KEY"
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <Input
+                    label="Env Value"
+                    value={envValue}
+                    onChange={(e) => onEnvValueChange(e.target.value)}
+                    placeholder="secret value"
+                  />
+                </div>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={onAddEnv}
+                  className="w-full sm:w-auto"
+                >
+                  <PlusCircle size={16} />
+                </Button>
+              </div>
+              {localServer.env && Object.keys(localServer.env).length > 0 && (
+                <div className="space-y-2">
+                  {Object.entries(localServer.env).map(([key, value]) => (
+                    <div
+                      key={key}
+                      className="flex flex-col gap-2 p-2 bg-bg-hover rounded-md sm:flex-row sm:items-center"
+                    >
+                      <span className="min-w-0 flex-1 break-all font-mono text-xs">{key}</span>
+                      <span className="flex-1 font-mono text-xs text-text-secondary truncate">
+                        {value}
+                      </span>
+                      <button
+                        onClick={() => onRemoveEnv(key)}
+                        className="p-1 hover:bg-bg-surface rounded"
+                      >
+                        <MinusCircle size={14} className="text-danger" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <Input
+            label="Upstream URL"
+            value={remoteServer?.upstream_url ?? ''}
+            onChange={(e) =>
+              onEditingServerChange({
+                ...(remoteServer || emptyServer),
+                upstream_url: e.target.value,
+              })
+            }
+            placeholder="https://mcp.example.com/mcp"
+          />
+        )}
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <Input
+            label="Auth Scheme"
+            value={editingServer.auth_scheme ?? ''}
+            onChange={(e) =>
+              onEditingServerChange({ ...editingServer, auth_scheme: e.target.value || null })
+            }
+            placeholder="bearer"
+          />
+          <Input
+            label="Rate Limit Cooldown (ms)"
+            type="number"
+            min="0"
+            value={editingServer.rate_limit_cooldown_ms ?? 60_000}
+            onChange={(e) =>
+              onEditingServerChange({
+                ...editingServer,
+                rate_limit_cooldown_ms: Number(e.target.value),
+              })
+            }
+          />
+          <Input
+            label="Quota Cooldown (ms)"
+            type="number"
+            min="0"
+            value={editingServer.quota_cooldown_ms ?? 86_400_000}
+            onChange={(e) =>
+              onEditingServerChange({
+                ...editingServer,
+                quota_cooldown_ms: Number(e.target.value),
+              })
+            }
+          />
+        </div>
+
+        <div className="mt-4 rounded-md border border-border-glass p-3">
+          <div className="mb-3">
+            <label className="text-sm font-medium text-text-secondary">
+              Static Headers (Optional)
+            </label>
+            <p className="text-xs text-text-muted mt-1">
+              These headers are injected into every request. For load-balanced authentication keys,
+              use the <strong>Auth Scheme</strong> above and the <strong>Manage Keys</strong>{' '}
+              button.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="min-w-0 flex-1">
+              <Input
+                label="Header Key"
+                value={headerKey}
+                onChange={(e) => onHeaderKeyChange(e.target.value)}
+                placeholder="X-Custom-Header"
+              />
+            </div>
+            <div className="min-w-0 flex-1">
+              <Input
+                label="Header Value"
+                value={headerValue}
+                onChange={(e) => onHeaderValueChange(e.target.value)}
+                placeholder="value..."
+              />
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={onAddHeader}
+              className="w-full sm:w-auto"
+            >
+              <PlusCircle size={16} />
+            </Button>
+          </div>
+
+          {editingServer.headers && Object.keys(editingServer.headers).length > 0 && (
+            <div className="space-y-2 mt-4">
+              <label className="text-sm font-medium text-text-secondary">
+                Configured Static Headers
+              </label>
+              {Object.entries(editingServer.headers).map(([key, value]) => (
+                <div
+                  key={key}
+                  className="flex flex-col gap-2 p-2 bg-bg-hover rounded-md sm:flex-row sm:items-center"
+                >
+                  <span className="min-w-0 flex-1 break-all font-mono text-xs">{key}</span>
+                  <span className="flex-1 font-mono text-xs text-text-secondary truncate">
+                    {value}
+                  </span>
+                  <button
+                    onClick={() => onRemoveHeader(key)}
+                    className="p-1 hover:bg-bg-surface rounded"
+                  >
+                    <MinusCircle size={14} className="text-danger" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/frontend/src/components/mcp/McpServerTable.tsx
+++ b/packages/frontend/src/components/mcp/McpServerTable.tsx
@@ -1,0 +1,266 @@
+import { Copy, Edit2, Trash2 } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+import { Switch } from '../ui/Switch';
+import type { McpServer } from '../../lib/api';
+
+interface McpServerTableProps {
+  servers: Record<string, McpServer>;
+  serverNames: string[];
+  mcpEnabled: boolean;
+  onEdit: (serverName: string) => void;
+  onManageKeys: (serverName: string) => void;
+  onToggleEnabled: (serverName: string, newState: boolean) => void | Promise<void>;
+  onToggleMcpEnabled: (enabled: boolean) => void | Promise<void>;
+  onDelete: (serverName: string) => void | Promise<void>;
+  mcpPathForServer: (serverName: string) => string;
+  onCopyMcpPath: (path: string) => void | Promise<void>;
+}
+
+export function McpServerTable({
+  servers,
+  serverNames,
+  mcpEnabled,
+  onEdit,
+  onManageKeys,
+  onToggleEnabled,
+  onToggleMcpEnabled,
+  onDelete,
+  mcpPathForServer,
+  onCopyMcpPath,
+}: McpServerTableProps) {
+  return (
+    <Card title="MCP Servers">
+      {serverNames.length === 0 ? (
+        <div className="p-4 text-text-secondary text-center">
+          No MCP servers configured. Click "Add MCP Server" to create one.
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3 md:hidden">
+            {serverNames.map((name) => {
+              const server = servers[name];
+              const headerCount = server.headers ? Object.keys(server.headers).length : 0;
+
+              return (
+                <article
+                  key={name}
+                  className="rounded-md border border-border-glass bg-bg-subtle p-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <button
+                      type="button"
+                      onClick={() => onEdit(name)}
+                      className="min-w-0 flex-1 text-left"
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        <Edit2 size={12} className="shrink-0 opacity-60" />
+                        <span className="truncate font-heading text-sm font-semibold text-text">
+                          {name}
+                        </span>
+                      </div>
+                      <div className="mt-1 break-all text-xs text-text-muted">
+                        {server.mode === 'local_http'
+                          ? `${server.launcher} ${server.package} → 127.0.0.1:${server.port}${server.path || '/mcp'}`
+                          : server.upstream_url}
+                      </div>
+                    </button>
+                    <div className="flex shrink-0 items-center gap-2">
+                      {server.mode !== 'local_http' && (
+                        <Button size="sm" variant="secondary" onClick={() => onManageKeys(name)}>
+                          Manage Keys
+                        </Button>
+                      )}
+                      <Switch
+                        checked={server.enabled !== false}
+                        onChange={(val) => onToggleEnabled(name, val)}
+                        size="sm"
+                      />
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => onDelete(name)}
+                        className="text-danger"
+                        aria-label={`Delete ${name}`}
+                      >
+                        <Trash2 size={14} />
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="mt-3 rounded border border-border-glass bg-bg-glass px-2 py-1.5 text-xs">
+                    <span className="text-text-muted">Headers: </span>
+                    <span className="font-medium text-text-secondary">
+                      {headerCount > 0 ? `${headerCount} configured` : '-'}
+                    </span>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+
+          <div className="hidden overflow-x-auto md:block">
+            <table className="w-full border-collapse font-body text-[13px]">
+              <thead>
+                <tr>
+                  <th
+                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                    style={{ paddingLeft: '24px' }}
+                  >
+                    Name
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Upstream
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Path
+                  </th>
+                  <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
+                    Status
+                  </th>
+                  <th
+                    className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
+                    style={{ paddingRight: '24px', textAlign: 'right' }}
+                  >
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {/* Plexus Management MCP — fixed row */}
+                <tr className="bg-primary/5 border-b border-primary/30">
+                  <td
+                    className="px-4 py-3 text-left border-b border-border-glass text-text"
+                    style={{ paddingLeft: '24px' }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      <div style={{ fontWeight: 600 }}>Plexus Management</div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-left border-b border-border-glass text-text-muted text-xs">
+                    —
+                  </td>
+                  <td className="px-4 py-3 text-left border-b border-border-glass text-text whitespace-nowrap">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-xs">/mcp/plexus</span>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onCopyMcpPath('/mcp/plexus');
+                        }}
+                        className="rounded p-1 text-text-muted hover:bg-bg-hover hover:text-text"
+                        title="Copy path"
+                        aria-label="Copy /mcp/plexus"
+                      >
+                        <Copy size={13} />
+                      </button>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                    <Switch checked={mcpEnabled} onChange={onToggleMcpEnabled} size="sm" />
+                  </td>
+                  <td
+                    className="px-4 py-3 text-left border-b border-border-glass text-text"
+                    style={{ paddingRight: '24px', textAlign: 'right' }}
+                  />
+                </tr>
+
+                {serverNames.map((name) => {
+                  const server = servers[name];
+                  return (
+                    <tr
+                      key={name}
+                      onClick={() => onEdit(name)}
+                      style={{ cursor: 'pointer' }}
+                      className="hover:bg-bg-hover"
+                    >
+                      <td
+                        className="px-4 py-3 text-left border-b border-border-glass text-text"
+                        style={{ paddingLeft: '24px' }}
+                      >
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                          <Edit2 size={12} style={{ opacity: 0.5 }} />
+                          <div style={{ fontWeight: 600 }}>{name}</div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                        <div
+                          style={{
+                            maxWidth: '400px',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {server.mode === 'local_http'
+                            ? `${server.launcher} ${server.package} → 127.0.0.1:${server.port}${server.path || '/mcp'}`
+                            : server.upstream_url}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-left border-b border-border-glass text-text whitespace-nowrap">
+                        <div
+                          className="flex items-center gap-2"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <span className="font-mono text-xs">{mcpPathForServer(name)}</span>
+                          <button
+                            type="button"
+                            onClick={() => onCopyMcpPath(mcpPathForServer(name))}
+                            className="rounded p-1 text-text-muted hover:bg-bg-hover hover:text-text"
+                            title="Copy path"
+                            aria-label={`Copy ${mcpPathForServer(name)}`}
+                          >
+                            <Copy size={13} />
+                          </button>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-left border-b border-border-glass text-text">
+                        <div onClick={(e) => e.stopPropagation()}>
+                          <Switch
+                            checked={server.enabled !== false}
+                            onChange={(val) => onToggleEnabled(name, val)}
+                            size="sm"
+                          />
+                        </div>
+                      </td>
+                      <td
+                        className="px-4 py-3 text-left border-b border-border-glass text-text"
+                        style={{ paddingRight: '24px', textAlign: 'right' }}
+                      >
+                        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+                          {server.mode !== 'local_http' && (
+                            <Button
+                              size="sm"
+                              variant="secondary"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onManageKeys(name);
+                              }}
+                            >
+                              Manage Keys
+                            </Button>
+                          )}
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onDelete(name);
+                            }}
+                            style={{ color: 'var(--color-danger)' }}
+                          >
+                            <Trash2 size={14} />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/packages/frontend/src/components/mcp/McpUsageLogsCard.tsx
+++ b/packages/frontend/src/components/mcp/McpUsageLogsCard.tsx
@@ -1,0 +1,423 @@
+import {
+  AlertTriangle,
+  CheckCircle,
+  ChevronLeft,
+  ChevronRight,
+  Filter,
+  Search,
+  Trash2,
+  Zap,
+  ZapOff,
+} from 'lucide-react';
+import { clsx } from 'clsx';
+import { Button } from '../ui/Button';
+import { Card } from '../ui/Card';
+import { Input } from '../ui/Input';
+import type { McpLogRecord } from '../../lib/api';
+import { formatMs } from '../../lib/format';
+
+export interface McpLogsFilters {
+  serverName: string;
+  apiKey: string;
+}
+
+interface McpUsageLogsCardProps {
+  logs: McpLogRecord[];
+  logsTotal: number;
+  logsLoading: boolean;
+  logsLimit: number;
+  logsOffset: number;
+  logsFilters: McpLogsFilters;
+  onFiltersChange: (filters: McpLogsFilters) => void;
+  onSearch: (event: React.FormEvent<HTMLFormElement>) => void;
+  onDeleteAll: () => void;
+  onDeleteLog: (requestId: string) => void;
+  onOffsetChange: (offset: number) => void;
+}
+
+const statusColor = (status: number | null): string => {
+  if (status === null) return 'text-text-secondary';
+  if (status >= 200 && status < 300) return 'text-success';
+  if (status >= 400 && status < 500) return 'text-warning';
+  return 'text-danger';
+};
+
+export function McpUsageLogsCard({
+  logs,
+  logsTotal,
+  logsLoading,
+  logsLimit,
+  logsOffset,
+  logsFilters,
+  onFiltersChange,
+  onSearch,
+  onDeleteAll,
+  onDeleteLog,
+  onOffsetChange,
+}: McpUsageLogsCardProps) {
+  const logsTotalPages = Math.ceil(logsTotal / logsLimit);
+  const logsCurrentPage = Math.floor(logsOffset / logsLimit) + 1;
+
+  return (
+    <Card className="glass-bg rounded-lg p-3 max-w-full shadow-xl overflow-hidden flex flex-col gap-2">
+      <div className="mb-2">
+        <h2 className="font-heading text-lg font-semibold text-text m-0 mb-3">MCP Usage Logs</h2>
+        <form onSubmit={onSearch} className="flex flex-col gap-2 lg:flex-row lg:justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <div className="relative w-full sm:w-50">
+              <Search
+                size={16}
+                style={{
+                  position: 'absolute',
+                  left: '10px',
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  color: 'var(--color-text-secondary)',
+                }}
+              />
+              <Input
+                placeholder="Filter by Server..."
+                value={logsFilters.serverName}
+                onChange={(e) => onFiltersChange({ ...logsFilters, serverName: e.target.value })}
+                style={{ paddingLeft: '32px' }}
+              />
+            </div>
+            <div className="relative w-full sm:w-44">
+              <Filter
+                size={16}
+                style={{
+                  position: 'absolute',
+                  left: '10px',
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  color: 'var(--color-text-secondary)',
+                }}
+              />
+              <Input
+                placeholder="Filter by Key..."
+                value={logsFilters.apiKey}
+                onChange={(e) => onFiltersChange({ ...logsFilters, apiKey: e.target.value })}
+                style={{ paddingLeft: '32px' }}
+              />
+            </div>
+            <Button type="submit" variant="primary" className="w-full sm:w-auto">
+              Search
+            </Button>
+          </div>
+          <Button
+            onClick={onDeleteAll}
+            variant="danger"
+            className="flex w-full items-center gap-2 sm:w-auto"
+            disabled={logs.length === 0}
+            type="button"
+          >
+            <Trash2 size={16} />
+            Delete All
+          </Button>
+        </form>
+      </div>
+
+      <div className="space-y-3 lg:hidden">
+        {logsLoading ? (
+          <div className="py-8 text-center text-sm text-text-secondary">Loading...</div>
+        ) : logs.length === 0 ? (
+          <div className="py-8 text-center text-sm text-text-secondary">No MCP logs found</div>
+        ) : (
+          logs.map((log) => (
+            <article
+              key={log.request_id}
+              className="rounded-md border border-border-glass bg-bg-subtle p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-xs font-medium text-text">
+                    {new Date(log.created_at).toLocaleString()}
+                  </div>
+                  <div className="mt-1 truncate text-xs text-text-muted">
+                    {log.api_key || '-'} {log.attribution ? `(${log.attribution})` : ''}
+                  </div>
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => onDeleteLog(log.request_id)}
+                  className="text-danger"
+                  aria-label="Delete MCP log"
+                >
+                  <Trash2 size={14} />
+                </Button>
+              </div>
+
+              <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
+                <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                  <div className="text-[10px] uppercase tracking-wider text-text-muted">Server</div>
+                  <div className="truncate font-medium text-text-secondary">{log.server_name}</div>
+                </div>
+                <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                  <div className="text-[10px] uppercase tracking-wider text-text-muted">Method</div>
+                  <div className="truncate font-medium text-text-secondary">
+                    {log.method} {log.is_streamed ? 'streamed' : 'buffered'}
+                  </div>
+                </div>
+                <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                  <div className="text-[10px] uppercase tracking-wider text-text-muted">RPC</div>
+                  <div className="truncate font-mono text-text">{log.jsonrpc_method || '-'}</div>
+                </div>
+                <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
+                  <div className="text-[10px] uppercase tracking-wider text-text-muted">
+                    Duration
+                  </div>
+                  <div className="truncate font-medium text-text">
+                    {log.duration_ms != null ? formatMs(log.duration_ms) : '-'}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-3 flex items-center justify-between gap-3 rounded border border-border-glass bg-bg-glass px-2 py-2 text-xs">
+                <span className={clsx('font-semibold', statusColor(log.response_status))}>
+                  Status {log.response_status ?? '?'}
+                </span>
+                {log.error_message && (
+                  <span className="min-w-0 truncate text-danger" title={log.error_message}>
+                    {log.error_message}
+                  </span>
+                )}
+              </div>
+            </article>
+          ))
+        )}
+      </div>
+
+      <div className="hidden overflow-x-auto lg:block">
+        <table className="w-full border-collapse font-body text-[13px]">
+          <thead>
+            <tr className="text-center border-b border-border">
+              <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                Date
+              </th>
+              <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                Key
+              </th>
+              <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                Server
+              </th>
+              <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                Method
+              </th>
+              <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                RPC Method
+              </th>
+              <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                Duration
+              </th>
+              <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                Status
+              </th>
+              <th className="px-2 py-1.5 text-center border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
+                <div className="flex justify-center">
+                  <Trash2 size={12} />
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {logsLoading ? (
+              <tr>
+                <td colSpan={8} className="p-5 text-center">
+                  Loading...
+                </td>
+              </tr>
+            ) : logs.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="p-5 text-center text-text-secondary">
+                  No MCP logs found
+                </td>
+              </tr>
+            ) : (
+              logs.map((log) => (
+                <tr
+                  key={log.request_id}
+                  className="group border-b border-border-glass hover:bg-bg-hover"
+                >
+                  {/* Date */}
+                  <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                    <div className="flex flex-col">
+                      <span className="font-medium">
+                        {new Date(log.created_at).toLocaleTimeString()}
+                      </span>
+                      <span className="text-text-secondary" style={{ fontSize: '0.85em' }}>
+                        {new Date(log.created_at).toISOString().split('T')[0]}
+                      </span>
+                    </div>
+                  </td>
+
+                  {/* Key / Attribution */}
+                  <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
+                    <div className="flex flex-col">
+                      <span className="font-medium">{log.api_key || '-'}</span>
+                      {log.attribution && (
+                        <span className="text-text-secondary" style={{ fontSize: '0.85em' }}>
+                          {log.attribution}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+
+                  {/* Server */}
+                  <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                    <div className="flex flex-col">
+                      <span className="font-medium">{log.server_name}</span>
+                      <span
+                        className="text-text-secondary"
+                        style={{
+                          fontSize: '0.85em',
+                          maxWidth: '200px',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {log.upstream_url}
+                      </span>
+                    </div>
+                  </td>
+
+                  {/* HTTP Method */}
+                  <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                    <div className="flex flex-col gap-1">
+                      <span
+                        className={clsx(
+                          'text-xs font-semibold',
+                          log.method === 'GET'
+                            ? 'text-blue-400'
+                            : log.method === 'POST'
+                              ? 'text-green-400'
+                              : 'text-red-400'
+                        )}
+                      >
+                        {log.method}
+                      </span>
+                      <div className="flex items-center gap-1">
+                        {log.is_streamed ? (
+                          <Zap size={11} className="text-blue-400" />
+                        ) : (
+                          <ZapOff size={11} className="text-gray-400" />
+                        )}
+                        <span className="text-text-secondary" style={{ fontSize: '0.8em' }}>
+                          {log.is_streamed ? 'streamed' : 'buffered'}
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+
+                  {/* JSON-RPC Method + Tool Name */}
+                  <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                    <div className="flex flex-col gap-0.5">
+                      <span className="font-mono text-xs">
+                        {log.jsonrpc_method || <span className="text-text-secondary">-</span>}
+                      </span>
+                      {log.tool_name && (
+                        <span className="font-mono text-xs text-info" title={log.tool_name}>
+                          {log.tool_name}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+
+                  {/* Duration */}
+                  <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
+                    <span>{log.duration_ms != null ? formatMs(log.duration_ms) : '-'}</span>
+                  </td>
+
+                  {/* Status */}
+                  <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
+                    <div className="flex flex-col gap-1">
+                      {log.error_code ? (
+                        <div
+                          className={clsx(
+                            'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
+                            'text-danger border-danger/30 bg-red-500/15'
+                          )}
+                          style={{ width: '52px' }}
+                        >
+                          <AlertTriangle size={12} />
+                          <span className="font-semibold">{log.response_status ?? '?'}</span>
+                        </div>
+                      ) : (
+                        <div
+                          className={clsx(
+                            'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
+                            log.response_status != null &&
+                              log.response_status >= 200 &&
+                              log.response_status < 300
+                              ? 'text-success border-success/30 bg-emerald-500/15'
+                              : 'text-danger border-danger/30 bg-red-500/15'
+                          )}
+                          style={{ width: '52px' }}
+                        >
+                          <CheckCircle size={12} />
+                          <span className={clsx('font-semibold', statusColor(log.response_status))}>
+                            {log.response_status ?? '?'}
+                          </span>
+                        </div>
+                      )}
+                      {log.error_message && (
+                        <span
+                          className="text-danger"
+                          style={{
+                            fontSize: '0.78em',
+                            maxWidth: '160px',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            display: 'block',
+                          }}
+                          title={log.error_message}
+                        >
+                          {log.error_message}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+
+                  {/* Delete */}
+                  <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
+                    <button
+                      onClick={() => onDeleteLog(log.request_id)}
+                      className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger opacity-100 lg:opacity-0 lg:group-hover:opacity-100"
+                      title="Delete log"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-col items-stretch gap-3 mt-3 sm:flex-row sm:items-center sm:justify-end">
+        <span style={{ fontSize: '14px', color: 'var(--color-text-secondary)' }}>
+          Page {logsCurrentPage} of {Math.max(1, logsTotalPages)}
+        </span>
+        <div className="flex gap-1">
+          <Button
+            variant="secondary"
+            disabled={logsOffset === 0}
+            onClick={() => onOffsetChange(Math.max(0, logsOffset - logsLimit))}
+          >
+            <ChevronLeft size={16} />
+          </Button>
+          <Button
+            variant="secondary"
+            disabled={logsOffset + logsLimit >= logsTotal}
+            onClick={() => onOffsetChange(logsOffset + logsLimit)}
+          >
+            <ChevronRight size={16} />
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/packages/frontend/src/pages/Config.tsx
+++ b/packages/frontend/src/pages/Config.tsx
@@ -1,145 +1,50 @@
-import { Component, useEffect, useRef, useState, useCallback } from 'react';
-import type { ErrorInfo, ReactNode } from 'react';
-import Editor from '@monaco-editor/react';
-import {
-  RotateCcw,
-  AlertTriangle,
-  Download,
-  Upload,
-  RefreshCw,
-  HardDrive,
-  Archive,
-  Shield,
-  Save,
-  Radar,
-  Network,
-  Trash2,
-  LockKeyhole,
-  Info,
-} from 'lucide-react';
+import { useEffect, useRef, useState, useCallback } from 'react';
+import type { ChangeEvent } from 'react';
 import { api } from '../lib/api';
-import type { CompactionSettings, McpOAuthSettings } from '../lib/api';
-import { formatMinutesToMinSec } from '@plexus/shared';
+import type {
+  CompactionSettings as CompactionConfig,
+  McpOAuthSettings as McpOAuthConfig,
+} from '../lib/api';
 import { useToast } from '../contexts/ToastContext';
-import { useCurrency } from '../lib/CurrencyContext';
-import { SUPPORTED_CURRENCIES } from '../lib/currency';
-import { Card } from '../components/ui/Card';
-import { Button } from '../components/ui/Button';
-import { Switch } from '../components/ui/Switch';
-import { Disclosure } from '../components/ui/Disclosure';
-import { TagSelect } from '../components/ui/TagSelect';
 import { PageHeader } from '../components/layout/PageHeader';
 import { PageContainer } from '../components/layout/PageContainer';
 import type { CardLayout } from '../types/card';
 import { DEFAULT_CARD_ORDER, LAYOUT_STORAGE_KEY } from '../types/card';
-
-class EditorErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
-  state: { error: Error | null } = { error: null };
-
-  static getDerivedStateFromError(error: Error) {
-    return { error };
-  }
-
-  componentDidCatch(error: Error, info: ErrorInfo) {
-    console.error('Monaco Editor failed to load:', error, info);
-  }
-
-  render() {
-    if (this.state.error) {
-      return (
-        <div className="h-[400px] sm:h-[500px] flex items-center justify-center bg-bg-glass/30 text-text-secondary rounded-md">
-          <div className="text-center p-6">
-            <AlertTriangle className="mx-auto mb-3 text-warning" size={32} />
-            <p className="text-sm font-semibold mb-1">Editor failed to load</p>
-            <p className="font-body text-[11px] text-text-muted">{this.state.error.message}</p>
-          </div>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
-
-interface FailoverPolicy {
-  enabled: boolean;
-  retryableStatusCodes: number[];
-  retryableErrors: string[];
-}
-
-interface CooldownPolicy {
-  initialMinutes: number;
-  maxMinutes: number;
-}
-
-interface ExplorationRates {
-  performanceExplorationRate: number;
-  latencyExplorationRate: number;
-  e2ePerformanceExplorationRate: number;
-}
-
-const DEFAULT_EXPLORATION_RATES: ExplorationRates = {
-  performanceExplorationRate: 0.05,
-  latencyExplorationRate: 0.05,
-  e2ePerformanceExplorationRate: 0.05,
-};
-
-interface BackgroundExplorationConfig {
-  enabled: boolean;
-  stalenessThresholdSeconds: number;
-  workerConcurrency: number;
-}
-
-interface TimeoutConfig {
-  defaultSeconds: number;
-}
-
-interface StallConfig {
-  ttfbSeconds: number | null;
-  ttfbBytes: number;
-  minBytesPerSecond: number | null;
-  windowSeconds: number;
-  gracePeriodSeconds: number;
-}
-
-const DEFAULT_TIMEOUT_CONFIG: TimeoutConfig = {
-  defaultSeconds: 300,
-};
-
-const DEFAULT_STALL_CONFIG: StallConfig = {
-  ttfbSeconds: null,
-  ttfbBytes: 100,
-  minBytesPerSecond: null,
-  windowSeconds: 10,
-  gracePeriodSeconds: 30,
-};
-
-const DEFAULT_BACKGROUND_EXPLORATION: BackgroundExplorationConfig = {
-  enabled: false,
-  stalenessThresholdSeconds: 600,
-  workerConcurrency: 2,
-};
-
-const DEFAULT_COMPACTION_CONFIG: CompactionSettings = { enabled: false, strategy: 'native' };
-
-const DEFAULT_FAILOVER_POLICY: FailoverPolicy = {
-  enabled: true,
-  retryableStatusCodes: [],
-  retryableErrors: [],
-};
-
-const DEFAULT_MCP_OAUTH_CONFIG: McpOAuthSettings = {
-  enabled: false,
-  provider: 'plexus-idp',
-};
-
-const DEFAULT_COOLDOWN_POLICY: CooldownPolicy = {
-  initialMinutes: 2,
-  maxMinutes: 300,
-};
+import { DisplayPreferencesCard } from '../components/config/DisplayPreferencesCard';
+import { FailoverSettings } from '../components/config/FailoverSettings';
+import { TraceCaptureSettings } from '../components/config/TraceCaptureSettings';
+import { CooldownSettings } from '../components/config/CooldownSettings';
+import { TimeoutSettings } from '../components/config/TimeoutSettings';
+import { StallDetectionSettings } from '../components/config/StallDetectionSettings';
+import { CompactionSettings } from '../components/config/CompactionSettings';
+import { McpOAuthSettings } from '../components/config/McpOAuthSettings';
+import { ExplorationSettings } from '../components/config/ExplorationSettings';
+import { NetworkSettings } from '../components/config/NetworkSettings';
+import { ModelMetadataCard } from '../components/config/ModelMetadataCard';
+import { BackupRestoreCard } from '../components/config/BackupRestoreCard';
+import { CardLayoutCard } from '../components/config/CardLayoutCard';
+import { ConfigurationSnapshot } from '../components/config/ConfigurationSnapshot';
+import {
+  DEFAULT_BACKGROUND_EXPLORATION,
+  DEFAULT_COMPACTION_CONFIG,
+  DEFAULT_COOLDOWN_POLICY,
+  DEFAULT_EXPLORATION_RATES,
+  DEFAULT_FAILOVER_POLICY,
+  DEFAULT_MCP_OAUTH_CONFIG,
+  DEFAULT_STALL_CONFIG,
+  DEFAULT_TIMEOUT_CONFIG,
+} from '../components/config/types';
+import type {
+  BackgroundExplorationConfig,
+  CooldownPolicy,
+  ExplorationRates,
+  FailoverPolicy,
+  StallConfig,
+  TimeoutConfig,
+} from '../components/config/types';
 
 export const Config = () => {
   const toast = useToast();
-  const { currency, setCurrency, ratesAvailable } = useCurrency();
   const [config, setConfig] = useState('');
   const [isConfigLoaded, setIsConfigLoaded] = useState(false);
   const [isRestarting, setIsRestarting] = useState(false);
@@ -210,12 +115,12 @@ export const Config = () => {
 
   // Context Compaction settings state
   const [compactionConfig, setCompactionConfig] =
-    useState<CompactionSettings>(DEFAULT_COMPACTION_CONFIG);
+    useState<CompactionConfig>(DEFAULT_COMPACTION_CONFIG);
   const [compactionLoaded, setCompactionLoaded] = useState(false);
   const [compactionSaving, setCompactionSaving] = useState(false);
 
   // MCP OAuth settings state
-  const [mcpOAuthConfig, setMcpOAuthConfig] = useState<McpOAuthSettings>(DEFAULT_MCP_OAUTH_CONFIG);
+  const [mcpOAuthConfig, setMcpOAuthConfig] = useState<McpOAuthConfig>(DEFAULT_MCP_OAUTH_CONFIG);
   const [mcpOAuthLoaded, setMcpOAuthLoaded] = useState(false);
   const [mcpOAuthSaving, setMcpOAuthSaving] = useState(false);
   const [mcpOAuthIssuerInput, setMcpOAuthIssuerInput] = useState('');
@@ -235,7 +140,6 @@ export const Config = () => {
   };
 
   const issuerValidation = validateIssuerInput(mcpOAuthIssuerInput);
-  const isMcpOAuthValid = mcpOAuthLoaded && issuerValidation.valid;
 
   // Validate timeout input
   const validateTimeoutInput = (
@@ -258,7 +162,6 @@ export const Config = () => {
   };
 
   const timeoutDefaultValidation = validateTimeoutInput(timeoutDefaultInput);
-  const isTimeoutValid = timeoutLoaded && timeoutDefaultValidation.valid;
 
   // Validate stall detection inputs
   const validateStallInput = (
@@ -284,17 +187,9 @@ export const Config = () => {
   const stallMinBpsValidation = validateStallInput(stallMinBpsInput, 50, 5000, true);
   const stallWindowValidation = validateStallInput(stallWindowInput, 3, 30, false);
   const stallGraceValidation = validateStallInput(stallGraceInput, 0, 120, false);
-  const isStallValid =
-    stallLoaded &&
-    stallTtfbValidation.valid &&
-    stallTtfbBytesValidation.valid &&
-    stallMinBpsValidation.valid &&
-    stallWindowValidation.valid &&
-    stallGraceValidation.valid;
 
   const initialValidation = validateCooldownInput(cooldownInitialInput);
   const maxValidation = validateCooldownInput(cooldownMaxInput);
-  const isCooldownValid = cooldownLoaded && initialValidation.valid && maxValidation.valid;
 
   // Exploration rate settings state (setter only needed, value derived from inputs)
   const [, setExplorationRates] = useState<ExplorationRates>(DEFAULT_EXPLORATION_RATES);
@@ -575,8 +470,8 @@ export const Config = () => {
   const loadMcpOAuthConfig = useCallback(async () => {
     try {
       const settings = await api.getSystemSettings();
-      const raw = settings.mcpOAuth as Partial<McpOAuthSettings> | undefined;
-      const cfg: McpOAuthSettings = {
+      const raw = settings.mcpOAuth as Partial<McpOAuthConfig> | undefined;
+      const cfg: McpOAuthConfig = {
         enabled: raw?.enabled === true,
         provider: raw?.provider === 'plexus-idp' ? raw.provider : 'plexus-idp',
         ...(typeof raw?.issuer === 'string' && raw.issuer.trim()
@@ -681,7 +576,7 @@ export const Config = () => {
     setMcpOAuthSaving(true);
     try {
       const issuer = mcpOAuthIssuerInput.trim();
-      const next: McpOAuthSettings = {
+      const next: McpOAuthConfig = {
         enabled: mcpOAuthConfig.enabled,
         provider: 'plexus-idp',
         ...(issuer ? { issuer } : {}),
@@ -821,7 +716,7 @@ export const Config = () => {
 
   const handleImportLayout = () => fileInputRef.current?.click();
 
-  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
 
@@ -898,7 +793,7 @@ export const Config = () => {
 
   const handleRestoreClick = () => restoreInputRef.current?.click();
 
-  const handleRestoreFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRestoreFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     event.target.value = '';
     if (!file) return;
@@ -1003,1208 +898,157 @@ export const Config = () => {
 
       <PageContainer>
         <div className="flex flex-col gap-6">
-          <Card title="Display Preferences">
-            <div className="flex flex-col gap-1">
-              <label
-                htmlFor="displayCurrency"
-                className="font-body text-[12px] font-medium text-text"
-              >
-                Display currency
-              </label>
-              <select
-                id="displayCurrency"
-                value={currency}
-                onChange={(event) => {
-                  const nextCurrency = SUPPORTED_CURRENCIES.find(
-                    ({ code }) => code === event.target.value
-                  );
-                  if (nextCurrency) setCurrency(nextCurrency.code);
-                }}
-                className="w-64 max-w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary"
-              >
-                {SUPPORTED_CURRENCIES.map((option) => (
-                  <option key={option.code} value={option.code}>
-                    {option.label} ({option.code}) — {option.symbol}
-                  </option>
-                ))}
-              </select>
-              {!ratesAvailable && currency !== 'USD' && (
-                <p className="flex items-center gap-1.5 text-[11px] text-text-muted">
-                  <Info size={13} className="text-warning shrink-0" aria-hidden="true" />
-                  <span>Live exchange rates are unavailable; amounts fall back to USD.</span>
-                </p>
-              )}
-            </div>
-          </Card>
+          <DisplayPreferencesCard />
 
-          {/* ─── Failover Settings ──────────────────────────────────── */}
-          <Disclosure
-            title="Failover Settings"
-            defaultOpen={false}
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleSaveFailover}
-                isLoading={failoverSaving}
-                disabled={!failoverLoaded}
-                leftIcon={<Save size={14} />}
-              >
-                Save
-              </Button>
+          <FailoverSettings
+            policy={failoverPolicy}
+            loaded={failoverLoaded}
+            saving={failoverSaving}
+            statusCodesText={statusCodesText}
+            errorsText={errorsText}
+            onEnabledChange={(enabled) =>
+              setFailoverPolicy((previous) => ({ ...previous, enabled }))
             }
-          >
-            <div className="flex flex-col gap-3">
-              {/* Enabled toggle */}
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Shield size={16} className="text-primary" />
-                  <div>
-                    <p className="font-body text-[12px] font-medium text-text">Enable Failover</p>
-                    <p className="font-body text-[11px] text-text-muted">
-                      When enabled, failed requests are automatically retried on the next available
-                      provider.
-                    </p>
-                  </div>
-                </div>
-                <Switch
-                  checked={failoverPolicy.enabled}
-                  onChange={(checked) =>
-                    setFailoverPolicy((prev) => ({ ...prev, enabled: checked }))
-                  }
-                  aria-label="Toggle failover on/off"
-                />
-              </div>
+            onStatusCodesChange={setStatusCodesText}
+            onErrorsChange={setErrorsText}
+            onSave={handleSaveFailover}
+          />
 
-              {/* Retryable Status Codes */}
-              <div>
-                <label
-                  htmlFor="retryableStatusCodes"
-                  className="font-body text-[12px] font-medium text-text"
-                >
-                  Retryable Status Codes
-                </label>
-                <p className="text-xs text-text-muted mb-2">
-                  HTTP status codes that trigger a retry on the next provider. Enter comma-separated
-                  values (100–599). Defaults to all non-2xx codes except 413 and 422 when empty.
-                </p>
-                <textarea
-                  id="retryableStatusCodes"
-                  value={statusCodesText}
-                  onChange={(e) => setStatusCodesText(e.target.value)}
-                  placeholder="e.g. 429, 500, 502, 503"
-                  rows={3}
-                  className="w-full py-1 px-2 font-mono text-[12px] text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted resize-y"
-                />
-              </div>
+          <TraceCaptureSettings
+            enabled={captureTraceOnError}
+            loaded={captureTraceLoaded}
+            saving={captureTraceSaving}
+            onChange={handleToggleCaptureTraceOnError}
+          />
 
-              {/* Retryable Errors */}
-              <div>
-                <label
-                  htmlFor="retryableErrors"
-                  className="font-body text-[12px] font-medium text-text"
-                >
-                  Retryable Network Errors
-                </label>
-                <p className="text-xs text-text-muted mb-2">
-                  Network error codes that trigger a retry on the next provider. Enter
-                  comma-separated values. Defaults to ECONNREFUSED, ETIMEDOUT, ENOTFOUND when empty.
-                </p>
-                <textarea
-                  id="retryableErrors"
-                  value={errorsText}
-                  onChange={(e) => setErrorsText(e.target.value)}
-                  placeholder="e.g. ECONNREFUSED, ETIMEDOUT, ENOTFOUND"
-                  rows={2}
-                  className="w-full py-1 px-2 font-mono text-[12px] text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted resize-y"
-                />
-              </div>
-            </div>
-          </Disclosure>
+          <CooldownSettings
+            policy={cooldownPolicy}
+            loaded={cooldownLoaded}
+            saving={cooldownSaving}
+            initialInput={cooldownInitialInput}
+            maxInput={cooldownMaxInput}
+            initialValidation={initialValidation}
+            maxValidation={maxValidation}
+            onInitialChange={setCooldownInitialInput}
+            onMaxChange={setCooldownMaxInput}
+            onSave={handleSaveCooldown}
+          />
 
-          {/* ─── Trace Capture ──────────────────────────────────────── */}
-          <Disclosure title="Trace Capture" defaultOpen={false}>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <AlertTriangle size={16} className="text-primary" />
-                <div>
-                  <p className="font-body text-[12px] font-medium text-text">
-                    Capture Trace on Error
-                  </p>
-                  <p className="font-body text-[11px] text-text-muted">
-                    When enabled, debug traces are stored for requests that write to the inference
-                    error log or trigger a cooldown, even while global debug tracing is off.
-                  </p>
-                </div>
-              </div>
-              <Switch
-                checked={captureTraceOnError}
-                onChange={handleToggleCaptureTraceOnError}
-                disabled={!captureTraceLoaded || captureTraceSaving}
-                aria-label="Toggle capture trace on error"
-              />
-            </div>
-          </Disclosure>
+          <TimeoutSettings
+            config={timeoutConfig}
+            loaded={timeoutLoaded}
+            saving={timeoutSaving}
+            defaultInput={timeoutDefaultInput}
+            validation={timeoutDefaultValidation}
+            onDefaultChange={setTimeoutDefaultInput}
+            onSave={handleSaveTimeout}
+          />
 
-          {/* ─── Cooldown Settings ──────────────────────────────────── */}
-          <Disclosure
-            title="Cooldown Settings"
-            defaultOpen={false}
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleSaveCooldown}
-                isLoading={cooldownSaving}
-                disabled={!isCooldownValid}
-                leftIcon={<Save size={14} />}
-              >
-                Save
-              </Button>
+          <StallDetectionSettings
+            loaded={stallLoaded}
+            saving={stallSaving}
+            ttfbInput={stallTtfbInput}
+            ttfbBytesInput={stallTtfbBytesInput}
+            minBpsInput={stallMinBpsInput}
+            windowInput={stallWindowInput}
+            graceInput={stallGraceInput}
+            ttfbValidation={stallTtfbValidation}
+            ttfbBytesValidation={stallTtfbBytesValidation}
+            minBpsValidation={stallMinBpsValidation}
+            windowValidation={stallWindowValidation}
+            graceValidation={stallGraceValidation}
+            onTtfbChange={setStallTtfbInput}
+            onTtfbBytesChange={setStallTtfbBytesInput}
+            onMinBpsChange={setStallMinBpsInput}
+            onWindowChange={setStallWindowInput}
+            onGraceChange={setStallGraceInput}
+            onSave={handleSaveStall}
+          />
+
+          <CompactionSettings
+            config={compactionConfig}
+            loaded={compactionLoaded}
+            saving={compactionSaving}
+            onChange={setCompactionConfig}
+            onSave={handleSaveCompaction}
+          />
+
+          <McpOAuthSettings
+            config={mcpOAuthConfig}
+            loaded={mcpOAuthLoaded}
+            saving={mcpOAuthSaving}
+            issuerInput={mcpOAuthIssuerInput}
+            issuerValidation={issuerValidation}
+            onEnabledChange={(enabled) => setMcpOAuthConfig({ ...mcpOAuthConfig, enabled })}
+            onIssuerChange={setMcpOAuthIssuerInput}
+            onSave={handleSaveMcpOAuth}
+          />
+
+          <ExplorationSettings
+            background={bgExploration}
+            saving={explorationSaving}
+            backgroundSaving={bgExplorationSaving}
+            stalenessInput={bgStalenessInput}
+            concurrencyInput={bgConcurrencyInput}
+            performanceInput={explorationPerformanceInput}
+            latencyInput={explorationLatencyInput}
+            e2eInput={explorationE2EInput}
+            stalenessValidation={stalenessValidation}
+            concurrencyValidation={concurrencyValidation}
+            performanceValidation={perfValidation}
+            latencyValidation={latValidation}
+            e2eValidation={e2eValidation}
+            valid={isExplorationValid}
+            onBackgroundEnabledChange={(enabled) =>
+              setBgExploration((previous) => ({ ...previous, enabled }))
             }
-          >
-            <div className="flex flex-col gap-3">
-              {/* Initial + Max in 2-col grid */}
-              <div className="grid grid-cols-2 gap-3">
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="cooldownInitialMinutes"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Initial Cooldown (min){' '}
-                    <span className="text-text-muted font-normal">— C₀, first failure</span>
-                  </label>
-                  <div className="flex items-center gap-2">
-                    <input
-                      id="cooldownInitialMinutes"
-                      type="number"
-                      min={0.1}
-                      step={0.1}
-                      value={cooldownInitialInput}
-                      onChange={(e) => setCooldownInitialInput(e.target.value)}
-                      className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                    />
-                    <span className="text-[11px] text-text-muted tabular-nums whitespace-nowrap">
-                      {initialValidation.valid && initialValidation.value !== undefined
-                        ? formatMinutesToMinSec(initialValidation.value)
-                        : cooldownLoaded
-                          ? formatMinutesToMinSec(cooldownPolicy.initialMinutes)
-                          : '—'}
-                    </span>
-                  </div>
-                  {!initialValidation.valid && cooldownInitialInput !== '' && (
-                    <span className="text-[11px] text-warning">{initialValidation.error}</span>
-                  )}
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="cooldownMaxMinutes"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Maximum Cooldown (min){' '}
-                    <span className="text-text-muted font-normal">— C_max, upper limit</span>
-                  </label>
-                  <div className="flex items-center gap-2">
-                    <input
-                      id="cooldownMaxMinutes"
-                      type="number"
-                      min={0.1}
-                      step={0.1}
-                      value={cooldownMaxInput}
-                      onChange={(e) => setCooldownMaxInput(e.target.value)}
-                      className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                    />
-                    <span className="text-[11px] text-text-muted tabular-nums whitespace-nowrap">
-                      {maxValidation.valid && maxValidation.value !== undefined
-                        ? formatMinutesToMinSec(maxValidation.value)
-                        : cooldownLoaded
-                          ? formatMinutesToMinSec(cooldownPolicy.maxMinutes)
-                          : '—'}
-                    </span>
-                  </div>
-                  {!maxValidation.valid && cooldownMaxInput !== '' && (
-                    <span className="text-[11px] text-warning">{maxValidation.error}</span>
-                  )}
-                </div>
-              </div>
-            </div>
-          </Disclosure>
+            onStalenessChange={setBgStalenessInput}
+            onConcurrencyChange={setBgConcurrencyInput}
+            onPerformanceChange={setExplorationPerformanceInput}
+            onLatencyChange={setExplorationLatencyInput}
+            onE2EChange={setExplorationE2EInput}
+            onSave={handleSaveExploration}
+          />
 
-          {/* ─── Timeout Settings ───────────────────────────────────── */}
-          <Disclosure
-            title="Timeout Settings"
-            defaultOpen={false}
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleSaveTimeout}
-                isLoading={timeoutSaving}
-                disabled={!isTimeoutValid}
-                leftIcon={<Save size={14} />}
-              >
-                Save
-              </Button>
-            }
-          >
-            <div className="flex flex-col gap-3">
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="timeoutDefaultSeconds"
-                  className="font-body text-[12px] font-medium text-text"
-                >
-                  Default Timeout (seconds){' '}
-                  <span className="text-text-muted font-normal">— global default, 1–3600s</span>
-                </label>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="timeoutDefaultSeconds"
-                    type="number"
-                    min={1}
-                    max={3600}
-                    step={1}
-                    value={timeoutDefaultInput}
-                    onChange={(e) => setTimeoutDefaultInput(e.target.value)}
-                    className="w-48 h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                  <span className="text-[11px] text-text-muted tabular-nums">
-                    {timeoutDefaultValidation.valid && timeoutDefaultValidation.value !== undefined
-                      ? timeoutDefaultValidation.value >= 60
-                        ? `${Math.floor(timeoutDefaultValidation.value / 60)}m ${timeoutDefaultValidation.value % 60}s`
-                        : `${timeoutDefaultValidation.value}s`
-                      : timeoutLoaded
-                        ? timeoutConfig.defaultSeconds >= 60
-                          ? `${Math.floor(timeoutConfig.defaultSeconds / 60)}m ${timeoutConfig.defaultSeconds % 60}s`
-                          : `${timeoutConfig.defaultSeconds}s`
-                        : '—'}
-                  </span>
-                </div>
-                {!timeoutDefaultValidation.valid && timeoutDefaultInput !== '' && (
-                  <span className="text-[11px] text-warning">{timeoutDefaultValidation.error}</span>
-                )}
-              </div>
-            </div>
-          </Disclosure>
+          <NetworkSettings
+            trustedProxies={trustedProxies}
+            loaded={trustedProxiesLoaded}
+            saving={trustedProxiesSaving}
+            onChange={setTrustedProxies}
+            onSave={handleSaveTrustedProxies}
+          />
 
-          {/* ─── Stall Detection Settings ────────────────────────────── */}
-          <Disclosure
-            title="Stall Detection"
-            defaultOpen={false}
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleSaveStall}
-                isLoading={stallSaving}
-                disabled={!isStallValid}
-                leftIcon={<Save size={14} />}
-              >
-                Save
-              </Button>
-            }
-          >
-            <div className="flex flex-col gap-3">
-              <div className="grid grid-cols-2 gap-3">
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="stallTtfbSeconds"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    TTFB Timeout (s){' '}
-                    <span className="text-text-muted font-normal">— 5–120, empty = off</span>
-                  </label>
-                  <input
-                    id="stallTtfbSeconds"
-                    type="number"
-                    min={5}
-                    max={120}
-                    step={1}
-                    placeholder="Disabled"
-                    value={stallTtfbInput}
-                    onChange={(e) => setStallTtfbInput(e.target.value)}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                  {!stallTtfbValidation.valid && stallTtfbInput !== '' && (
-                    <span className="text-[11px] text-warning">{stallTtfbValidation.error}</span>
-                  )}
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="stallTtfbBytes"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    TTFB Byte Threshold{' '}
-                    <span className="text-text-muted font-normal">— 50–10,000</span>
-                  </label>
-                  <input
-                    id="stallTtfbBytes"
-                    type="number"
-                    min={50}
-                    max={10000}
-                    step={1}
-                    value={stallTtfbBytesInput}
-                    onChange={(e) => setStallTtfbBytesInput(e.target.value)}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                  {!stallTtfbBytesValidation.valid && stallTtfbBytesInput !== '' && (
-                    <span className="text-[11px] text-warning">
-                      {stallTtfbBytesValidation.error}
-                    </span>
-                  )}
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="stallMinBps"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Min Bytes/sec{' '}
-                    <span className="text-text-muted font-normal">— 50–5,000, empty = off</span>
-                  </label>
-                  <input
-                    id="stallMinBps"
-                    type="number"
-                    min={50}
-                    max={5000}
-                    step={1}
-                    placeholder="Disabled"
-                    value={stallMinBpsInput}
-                    onChange={(e) => setStallMinBpsInput(e.target.value)}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                  {!stallMinBpsValidation.valid && stallMinBpsInput !== '' && (
-                    <span className="text-[11px] text-warning">{stallMinBpsValidation.error}</span>
-                  )}
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="stallWindowSeconds"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Sliding Window (s) <span className="text-text-muted font-normal">— 3–30</span>
-                  </label>
-                  <input
-                    id="stallWindowSeconds"
-                    type="number"
-                    min={3}
-                    max={30}
-                    step={1}
-                    value={stallWindowInput}
-                    onChange={(e) => setStallWindowInput(e.target.value)}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                  {!stallWindowValidation.valid && stallWindowInput !== '' && (
-                    <span className="text-[11px] text-warning">{stallWindowValidation.error}</span>
-                  )}
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="stallGraceSeconds"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Grace Period (s){' '}
-                    <span className="text-text-muted font-normal">— 0–120, post-TTFB pause</span>
-                  </label>
-                  <input
-                    id="stallGraceSeconds"
-                    type="number"
-                    min={0}
-                    max={120}
-                    step={1}
-                    value={stallGraceInput}
-                    onChange={(e) => setStallGraceInput(e.target.value)}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                  {!stallGraceValidation.valid && stallGraceInput !== '' && (
-                    <span className="text-[11px] text-warning">{stallGraceValidation.error}</span>
-                  )}
-                </div>
-              </div>
-            </div>
-          </Disclosure>
+          <ModelMetadataCard loading={isMetadataRefreshLoading} onRefresh={handleRefreshMetadata} />
 
-          {/* ─── Context Compaction Settings ────────────────────────────── */}
-          <Disclosure
-            title="Context Compaction"
-            defaultOpen={false}
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleSaveCompaction}
-                isLoading={compactionSaving}
-                disabled={!compactionLoaded}
-                leftIcon={<Save size={14} />}
-              >
-                Save
-              </Button>
-            }
-          >
-            <div className="flex flex-col gap-3">
-              {/* enabled toggle */}
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <p className="font-body text-[12px] font-medium text-text">Enabled</p>
-                  <p className="font-body text-[11px] text-text-muted">
-                    Automatically compact context when the trigger threshold is reached.
-                  </p>
-                </div>
-                <Switch
-                  checked={compactionConfig.enabled ?? false}
-                  onChange={(checked) =>
-                    setCompactionConfig({ ...compactionConfig, enabled: checked })
-                  }
-                  aria-label="Toggle context compaction on/off"
-                />
-              </div>
+          <BackupRestoreCard
+            restoreInputRef={restoreInputRef}
+            restoreLoading={isRestoreLoading}
+            fullBackupLoading={isFullBackupLoading}
+            backupLoading={isBackupLoading}
+            resetLogsLoading={isResetLogsLoading}
+            onRestoreClick={handleRestoreClick}
+            onRestoreFileSelect={handleRestoreFileSelect}
+            onFullBackupDownload={handleFullBackupDownload}
+            onBackupDownload={handleBackupDownload}
+            onResetLogs={handleResetLogs}
+          />
 
-              {/* strategy */}
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="compactionStrategy"
-                  className="font-body text-[12px] font-medium text-text"
-                >
-                  Strategy
-                </label>
-                <select
-                  id="compactionStrategy"
-                  value={compactionConfig.strategy ?? 'native'}
-                  onChange={(e) =>
-                    setCompactionConfig({
-                      ...compactionConfig,
-                      strategy: e.target.value as 'native' | 'headroom',
-                    })
-                  }
-                  className="w-48 h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary"
-                >
-                  <option value="native">native</option>
-                  <option value="headroom">headroom</option>
-                </select>
-              </div>
+          <CardLayoutCard
+            cardLayout={cardLayout}
+            fileInputRef={fileInputRef}
+            onExport={handleExportLayout}
+            onImport={handleImportLayout}
+            onFileSelect={handleFileSelect}
+          />
 
-              {/* trigger ratio + absoluteTriggerTokens */}
-              <div className="grid grid-cols-2 gap-3">
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="compactionTriggerRatio"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Trigger Ratio{' '}
-                    <span className="text-text-muted font-normal">— fraction 0–1</span>
-                  </label>
-                  <input
-                    id="compactionTriggerRatio"
-                    type="number"
-                    min={0}
-                    max={1}
-                    step={0.01}
-                    placeholder="e.g. 0.8"
-                    value={compactionConfig.triggerRatio ?? ''}
-                    onChange={(e) => {
-                      const v = e.target.value === '' ? undefined : Number(e.target.value);
-                      setCompactionConfig({ ...compactionConfig, triggerRatio: v });
-                    }}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="compactionAbsoluteTrigger"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Absolute Trigger Tokens{' '}
-                    <span className="text-text-muted font-normal">— empty = off</span>
-                  </label>
-                  <input
-                    id="compactionAbsoluteTrigger"
-                    type="number"
-                    min={0}
-                    step={1}
-                    placeholder="Disabled"
-                    value={compactionConfig.absoluteTriggerTokens ?? ''}
-                    onChange={(e) => {
-                      const v = e.target.value === '' ? null : Number(e.target.value);
-                      setCompactionConfig({ ...compactionConfig, absoluteTriggerTokens: v });
-                    }}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="compactionMinTokens"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Min Tokens
-                  </label>
-                  <input
-                    id="compactionMinTokens"
-                    type="number"
-                    min={0}
-                    step={1}
-                    placeholder="e.g. 1000"
-                    value={compactionConfig.minTokens ?? ''}
-                    onChange={(e) => {
-                      const v = e.target.value === '' ? undefined : Number(e.target.value);
-                      setCompactionConfig({ ...compactionConfig, minTokens: v });
-                    }}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="compactionProtectRecent"
-                    className="font-body text-[12px] font-medium text-text"
-                  >
-                    Protect Recent (messages)
-                  </label>
-                  <input
-                    id="compactionProtectRecent"
-                    type="number"
-                    min={0}
-                    step={1}
-                    placeholder="e.g. 4"
-                    value={compactionConfig.protectRecent ?? ''}
-                    onChange={(e) => {
-                      const v = e.target.value === '' ? undefined : Number(e.target.value);
-                      setCompactionConfig({ ...compactionConfig, protectRecent: v });
-                    }}
-                    className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                  />
-                </div>
-              </div>
-
-              {/* native sub-settings */}
-              {compactionConfig.strategy === 'native' && (
-                <div className="flex flex-col gap-2">
-                  <p className="font-body text-[12px] font-medium text-text">Native Settings</p>
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="flex flex-col gap-1">
-                      <label
-                        htmlFor="compactionNativeMaxArrayItems"
-                        className="font-body text-[12px] font-medium text-text"
-                      >
-                        Max Array Items
-                      </label>
-                      <input
-                        id="compactionNativeMaxArrayItems"
-                        type="number"
-                        min={1}
-                        step={1}
-                        placeholder="e.g. 20"
-                        value={compactionConfig.native?.maxArrayItems ?? ''}
-                        onChange={(e) => {
-                          const v = e.target.value === '' ? undefined : Number(e.target.value);
-                          setCompactionConfig({
-                            ...compactionConfig,
-                            native: { ...compactionConfig.native, maxArrayItems: v },
-                          });
-                        }}
-                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <label
-                        htmlFor="compactionNativeMaxStringChars"
-                        className="font-body text-[12px] font-medium text-text"
-                      >
-                        Max String Chars
-                      </label>
-                      <input
-                        id="compactionNativeMaxStringChars"
-                        type="number"
-                        min={1}
-                        step={1}
-                        placeholder="e.g. 500"
-                        value={compactionConfig.native?.maxStringChars ?? ''}
-                        onChange={(e) => {
-                          const v = e.target.value === '' ? undefined : Number(e.target.value);
-                          setCompactionConfig({
-                            ...compactionConfig,
-                            native: { ...compactionConfig.native, maxStringChars: v },
-                          });
-                        }}
-                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                      />
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {/* headroom sub-settings */}
-              {compactionConfig.strategy === 'headroom' && (
-                <div className="flex flex-col gap-2">
-                  <p className="font-body text-[12px] font-medium text-text">Headroom Settings</p>
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="flex flex-col gap-1 col-span-2">
-                      <label
-                        htmlFor="compactionHeadroomBaseUrl"
-                        className="font-body text-[12px] font-medium text-text"
-                      >
-                        Base URL
-                      </label>
-                      <input
-                        id="compactionHeadroomBaseUrl"
-                        type="text"
-                        placeholder="http://localhost:8787"
-                        value={compactionConfig.headroom?.baseUrl ?? ''}
-                        onChange={(e) =>
-                          setCompactionConfig({
-                            ...compactionConfig,
-                            headroom: {
-                              ...compactionConfig.headroom,
-                              baseUrl: e.target.value || undefined,
-                            },
-                          })
-                        }
-                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1 col-span-2">
-                      <label
-                        htmlFor="compactionHeadroomApiKey"
-                        className="font-body text-[12px] font-medium text-text"
-                      >
-                        API Key
-                      </label>
-                      <input
-                        id="compactionHeadroomApiKey"
-                        type="password"
-                        placeholder="••••••••"
-                        value={compactionConfig.headroom?.apiKey ?? ''}
-                        onChange={(e) =>
-                          setCompactionConfig({
-                            ...compactionConfig,
-                            headroom: {
-                              ...compactionConfig.headroom,
-                              apiKey: e.target.value || undefined,
-                            },
-                          })
-                        }
-                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <label
-                        htmlFor="compactionHeadroomTargetRatio"
-                        className="font-body text-[12px] font-medium text-text"
-                      >
-                        Target Ratio{' '}
-                        <span className="text-text-muted font-normal">— 0–1, empty = off</span>
-                      </label>
-                      <input
-                        id="compactionHeadroomTargetRatio"
-                        type="number"
-                        min={0}
-                        max={1}
-                        step={0.01}
-                        placeholder="Disabled"
-                        value={compactionConfig.headroom?.targetRatio ?? ''}
-                        onChange={(e) => {
-                          const v = e.target.value === '' ? null : Number(e.target.value);
-                          setCompactionConfig({
-                            ...compactionConfig,
-                            headroom: { ...compactionConfig.headroom, targetRatio: v },
-                          });
-                        }}
-                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <label
-                        htmlFor="compactionHeadroomTimeoutMs"
-                        className="font-body text-[12px] font-medium text-text"
-                      >
-                        Timeout (ms)
-                      </label>
-                      <input
-                        id="compactionHeadroomTimeoutMs"
-                        type="number"
-                        min={0}
-                        step={1}
-                        placeholder="e.g. 30000"
-                        value={compactionConfig.headroom?.timeoutMs ?? ''}
-                        onChange={(e) => {
-                          const v = e.target.value === '' ? undefined : Number(e.target.value);
-                          setCompactionConfig({
-                            ...compactionConfig,
-                            headroom: { ...compactionConfig.headroom, timeoutMs: v },
-                          });
-                        }}
-                        className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                      />
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          </Disclosure>
-
-          {/* ─── MCP OAuth Settings ─────────────────────────────────────── */}
-          <Disclosure
-            title="MCP OAuth"
-            defaultOpen={false}
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleSaveMcpOAuth}
-                isLoading={mcpOAuthSaving}
-                disabled={!isMcpOAuthValid}
-                leftIcon={<Save size={14} />}
-              >
-                Save
-              </Button>
-            }
-          >
-            <div className="flex flex-col gap-4">
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex items-center gap-2">
-                  <LockKeyhole size={16} className="text-primary" />
-                  <div>
-                    <p className="font-body text-[12px] font-medium text-text">
-                      Enable OAuth for MCP clients
-                    </p>
-                    <p className="font-body text-[11px] text-text-muted">
-                      Shared OAuth authorization for each configured MCP server.
-                    </p>
-                  </div>
-                </div>
-                <Switch
-                  checked={mcpOAuthConfig.enabled}
-                  onChange={(checked) => setMcpOAuthConfig({ ...mcpOAuthConfig, enabled: checked })}
-                  aria-label="Toggle MCP OAuth on/off"
-                />
-              </div>
-
-              <div className="flex flex-col gap-1">
-                <label
-                  htmlFor="mcpOAuthIssuer"
-                  className="font-body text-[12px] font-medium text-text"
-                >
-                  External issuer URL
-                </label>
-                <input
-                  id="mcpOAuthIssuer"
-                  type="url"
-                  value={mcpOAuthIssuerInput}
-                  onChange={(e) => setMcpOAuthIssuerInput(e.target.value)}
-                  placeholder="https://your-instance.example.com"
-                  className="w-full h-[32px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                />
-                {!issuerValidation.valid && (
-                  <span className="text-[11px] text-warning">{issuerValidation.error}</span>
-                )}
-                <p className="font-body text-[11px] text-text-muted leading-relaxed">
-                  Use the externally reachable URL for this Plexus instance, such as a Tailscale
-                  Funnel URL. Each MCP server derives its protected resource from this issuer, such
-                  as <code>/mcp/exa</code>. If this does not match the actual external URL, OAuth
-                  discovery metadata will point at the wrong origin and MCP connections can fail.
-                </p>
-              </div>
-            </div>
-          </Disclosure>
-
-          {/* ─── Exploration Settings (inline rates + background mode) ───── */}
-          <Disclosure
-            title="Exploration Settings"
-            defaultOpen={false}
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleSaveExploration}
-                isLoading={explorationSaving || bgExplorationSaving}
-                disabled={!isExplorationValid}
-                leftIcon={<Save size={14} />}
-              >
-                Save
-              </Button>
-            }
-          >
-            <div className="flex flex-col gap-3">
-              {/* Background exploration: master toggle */}
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex items-center gap-2">
-                  <Radar size={16} className="text-primary" />
-                  <div>
-                    <p className="font-body text-[12px] font-medium text-text">
-                      Background Exploration
-                    </p>
-                    <p className="font-body text-[11px] text-text-muted">
-                      Fire background probe requests instead of diverting live traffic. Probes use
-                      apiKey="probe".
-                    </p>
-                  </div>
-                </div>
-                <Switch
-                  checked={bgExploration.enabled}
-                  onChange={(checked) =>
-                    setBgExploration((prev) => ({ ...prev, enabled: checked }))
-                  }
-                  aria-label="Toggle background exploration on/off"
-                />
-              </div>
-
-              {/* Background tunables — only rendered when background mode is on */}
-              {bgExploration.enabled && (
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="flex flex-col gap-1">
-                    <label
-                      htmlFor="bgExplorationStaleness"
-                      className="font-body text-[12px] font-medium text-text"
-                    >
-                      Staleness Threshold (s){' '}
-                      <span className="text-text-muted font-normal">— min 1, default 600</span>
-                    </label>
-                    <input
-                      id="bgExplorationStaleness"
-                      type="number"
-                      min={1}
-                      step={1}
-                      value={bgStalenessInput}
-                      onChange={(e) => setBgStalenessInput(e.target.value)}
-                      className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                    />
-                    {!stalenessValidation.valid && bgStalenessInput !== '' && (
-                      <span className="text-[11px] text-warning">{stalenessValidation.error}</span>
-                    )}
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <label
-                      htmlFor="bgExplorationConcurrency"
-                      className="font-body text-[12px] font-medium text-text"
-                    >
-                      Worker Concurrency{' '}
-                      <span className="text-text-muted font-normal">— 1–16, default 2</span>
-                    </label>
-                    <input
-                      id="bgExplorationConcurrency"
-                      type="number"
-                      min={1}
-                      max={16}
-                      step={1}
-                      value={bgConcurrencyInput}
-                      onChange={(e) => setBgConcurrencyInput(e.target.value)}
-                      className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                    />
-                    {!concurrencyValidation.valid && bgConcurrencyInput !== '' && (
-                      <span className="text-[11px] text-warning">
-                        {concurrencyValidation.error}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Inline rate tunables — only rendered when background mode is off */}
-              {!bgExploration.enabled && (
-                <div className="grid grid-cols-3 gap-3">
-                  <div className="flex flex-col gap-1">
-                    <label
-                      htmlFor="performanceExplorationRate"
-                      className="font-body text-[12px] font-medium text-text"
-                    >
-                      Performance Rate{' '}
-                      <span className="text-text-muted font-normal">— 0–1, default 0.05</span>
-                    </label>
-                    <input
-                      id="performanceExplorationRate"
-                      type="number"
-                      min={0}
-                      max={1}
-                      step={0.01}
-                      value={explorationPerformanceInput}
-                      onChange={(e) => setExplorationPerformanceInput(e.target.value)}
-                      className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                    />
-                    {!perfValidation.valid && explorationPerformanceInput !== '' && (
-                      <span className="text-[11px] text-warning">{perfValidation.error}</span>
-                    )}
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <label
-                      htmlFor="latencyExplorationRate"
-                      className="font-body text-[12px] font-medium text-text"
-                    >
-                      Latency Rate{' '}
-                      <span className="text-text-muted font-normal">— 0–1, default 0.05</span>
-                    </label>
-                    <input
-                      id="latencyExplorationRate"
-                      type="number"
-                      min={0}
-                      max={1}
-                      step={0.01}
-                      value={explorationLatencyInput}
-                      onChange={(e) => setExplorationLatencyInput(e.target.value)}
-                      className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                    />
-                    {!latValidation.valid && explorationLatencyInput !== '' && (
-                      <span className="text-[11px] text-warning">{latValidation.error}</span>
-                    )}
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <label
-                      htmlFor="e2ePerformanceExplorationRate"
-                      className="font-body text-[12px] font-medium text-text"
-                    >
-                      E2E Rate{' '}
-                      <span className="text-text-muted font-normal">— 0–1, default 0.05</span>
-                    </label>
-                    <input
-                      id="e2ePerformanceExplorationRate"
-                      type="number"
-                      min={0}
-                      max={1}
-                      step={0.01}
-                      value={explorationE2EInput}
-                      onChange={(e) => setExplorationE2EInput(e.target.value)}
-                      className="w-full h-[27px] py-0 px-2 font-mono text-[12px] leading-none text-text bg-bg-subtle border border-border-glass rounded-sm outline-none focus:border-primary placeholder:text-text-muted"
-                    />
-                    {!e2eValidation.valid && explorationE2EInput !== '' && (
-                      <span className="text-[11px] text-warning">{e2eValidation.error}</span>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-          </Disclosure>
-
-          {/* ─── Network / Trusted Proxies ──────────────────────────── */}
-          <Disclosure
-            title="Network Settings"
-            defaultOpen={false}
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleSaveTrustedProxies}
-                isLoading={trustedProxiesSaving}
-                disabled={!trustedProxiesLoaded}
-                leftIcon={<Save size={14} />}
-              >
-                Save
-              </Button>
-            }
-          >
-            <div className="flex flex-col gap-3">
-              <div className="flex items-center gap-2">
-                <Network size={16} className="text-primary" />
-                <div>
-                  <p className="font-body text-[12px] font-medium text-text">Trusted Proxies</p>
-                  <p className="font-body text-[11px] text-text-muted">
-                    IPs/CIDRs of reverse proxies whose forwarding headers (X-Forwarded-For,
-                    CF-Connecting-IP, …) are believed when resolving a client&apos;s IP. Requests
-                    arriving directly from any other address use their real connection IP instead,
-                    so spoofed headers cannot defeat per-key IP allowlists.
-                  </p>
-                </div>
-              </div>
-
-              <div>
-                <TagSelect
-                  label="Trusted Proxy IPs"
-                  placeholder="e.g. 10.0.0.0/8  172.16.0.0/12  192.168.1.5"
-                  options={[]}
-                  selected={trustedProxies}
-                  allowCustom
-                  splitOnSpace
-                  onChange={setTrustedProxies}
-                />
-                <p className="text-xs text-text-muted mt-2">
-                  Type entries separated by spaces. The default trust-all list is{' '}
-                  <code>0.0.0.0/0</code> plus <code>::/0</code> — keep this only if Plexus is not
-                  publicly reachable except through your proxy. An empty list trusts no proxies.
-                  Accepts IPv4/IPv6, CIDR, and ranges.
-                </p>
-              </div>
-            </div>
-          </Disclosure>
-
-          <Card
-            title="Model Metadata"
-            extra={
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleRefreshMetadata}
-                isLoading={isMetadataRefreshLoading}
-                leftIcon={<RefreshCw size={14} />}
-              >
-                Refresh Metadata
-              </Button>
-            }
-          >
-            <p className="text-sm text-text-secondary">
-              Catalog metadata for model aliases auto-refreshes every 60 minutes. Use this to
-              trigger an immediate reload from OpenRouter, models.dev, and Catwalk.
-            </p>
-          </Card>
-
-          <Card title="Backup & Restore">
-            <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1.5 rounded-md border border-warning/30 bg-warning/10 px-2 py-1 mr-1">
-                <AlertTriangle size={13} className="text-warning shrink-0" />
-                <span className="font-body text-[11px] text-text-muted">
-                  Sensitive data — store securely
-                </span>
-              </div>
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={handleRestoreClick}
-                isLoading={isRestoreLoading}
-                leftIcon={<Upload size={14} />}
-              >
-                Restore
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleFullBackupDownload}
-                isLoading={isFullBackupLoading}
-                leftIcon={<Archive size={14} />}
-              >
-                Full Backup
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                onClick={handleBackupDownload}
-                isLoading={isBackupLoading}
-                leftIcon={<HardDrive size={14} />}
-              >
-                Config Backup
-              </Button>
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={handleResetLogs}
-                isLoading={isResetLogsLoading}
-                leftIcon={<Trash2 size={14} />}
-              >
-                Reset All Logs
-              </Button>
-              <input
-                ref={restoreInputRef}
-                type="file"
-                accept=".json,.tar.gz,.tgz,application/gzip,application/x-gzip,application/octet-stream"
-                className="hidden"
-                onChange={handleRestoreFileSelect}
-              />
-            </div>
-          </Card>
-
-          <Card
-            title="Card Layout"
-            extra={
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleExportLayout}
-                  leftIcon={<Download size={14} />}
-                >
-                  Export
-                </Button>
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onClick={handleImportLayout}
-                  leftIcon={<Upload size={14} />}
-                >
-                  Import
-                </Button>
-              </div>
-            }
-          >
-            <p className="text-sm text-text-secondary mb-4">
-              Import or export your Live Metrics card layout configuration.
-            </p>
-
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".json"
-              className="hidden"
-              onChange={handleFileSelect}
-            />
-
-            <div>
-              <h4 className="font-heading text-xs font-semibold uppercase tracking-wider text-text-muted mb-3">
-                Current Card Order
-              </h4>
-              <div className="flex flex-wrap gap-2">
-                {cardLayout.length === 0 && (
-                  <p className="text-xs text-text-muted italic">
-                    Default layout — no customizations saved.
-                  </p>
-                )}
-                {cardLayout.map((card, index) => (
-                  <div
-                    key={card.id}
-                    className="px-3 py-1.5 bg-bg-glass rounded-md border border-border-glass text-xs text-text"
-                  >
-                    <span className="text-text-muted mr-2">{index + 1}.</span>
-                    {card.id}
-                  </div>
-                ))}
-              </div>
-            </div>
-          </Card>
-
-          {/* ─── Configuration Snapshot ─────────────────────────────── */}
-          <Disclosure
-            title="Configuration Snapshot"
-            defaultOpen={false}
-            extra={
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={loadConfig}
-                  leftIcon={<RotateCcw size={14} />}
-                >
-                  Refresh
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={handleRestart}
-                  isLoading={isRestarting}
-                  leftIcon={<RefreshCw size={14} />}
-                >
-                  Restart
-                </Button>
-                <Button
-                  variant="primary"
-                  size="sm"
-                  onClick={handleExportConfig}
-                  disabled={!isConfigLoaded}
-                  leftIcon={<Download size={14} />}
-                >
-                  Export JSON
-                </Button>
-              </div>
-            }
-          >
-            <div className="h-[400px] sm:h-[500px] lg:h-[600px] rounded-sm overflow-hidden">
-              <EditorErrorBoundary>
-                <Editor
-                  height="100%"
-                  defaultLanguage="json"
-                  value={config}
-                  theme="vs-dark"
-                  options={{
-                    readOnly: true,
-                    minimap: { enabled: false },
-                    scrollBeyondLastLine: false,
-                    fontSize: 13,
-                    fontFamily: '"Fira Code", "Fira Mono", monospace',
-                  }}
-                />
-              </EditorErrorBoundary>
-            </div>
-          </Disclosure>
+          <ConfigurationSnapshot
+            config={config}
+            loaded={isConfigLoaded}
+            restarting={isRestarting}
+            onRefresh={loadConfig}
+            onRestart={handleRestart}
+            onExport={handleExportConfig}
+          />
         </div>
       </PageContainer>
     </div>

--- a/packages/frontend/src/pages/Mcp.tsx
+++ b/packages/frontend/src/pages/Mcp.tsx
@@ -1,38 +1,28 @@
 import { useEffect, useState, useRef } from 'react';
-import { api, McpServer, McpLogRecord, McpOAuthClientRecord, McpServerKey } from '../lib/api';
+import {
+  api,
+  McpServer,
+  McpLogRecord,
+  McpOAuthClientRecord,
+  McpServerKey,
+  RemoteMcpServer,
+  LocalMcpServer,
+} from '../lib/api';
 import { Button } from '../components/ui/Button';
-import { Modal } from '../components/ui/Modal';
-import { Input } from '../components/ui/Input';
 import { Card } from '../components/ui/Card';
 import { CopyButton } from '../components/ui/CopyButton';
 import { PageHeader } from '../components/layout/PageHeader';
 import { PageContainer } from '../components/layout/PageContainer';
+import { McpServerTable } from '../components/mcp/McpServerTable';
+import { McpOAuthClientsCard } from '../components/mcp/McpOAuthClientsCard';
+import { McpUsageLogsCard } from '../components/mcp/McpUsageLogsCard';
+import { McpServerEditorModal } from '../components/mcp/McpServerEditorModal';
+import { McpKeyManagementModal } from '../components/mcp/McpKeyManagementModal';
+import { McpDeleteLogsModal } from '../components/mcp/McpDeleteLogsModal';
+import { McpDeleteLogModal } from '../components/mcp/McpDeleteLogModal';
 import { useToast } from '../contexts/ToastContext';
-import {
-  Plus,
-  Trash2,
-  Edit2,
-  PlusCircle,
-  MinusCircle,
-  ChevronLeft,
-  ChevronRight,
-  Search,
-  Filter,
-  AlertTriangle,
-  CheckCircle,
-  Zap,
-  ZapOff,
-  Download,
-  Package,
-  Copy,
-  RefreshCw,
-  KeyRound,
-  ShieldOff,
-  ShieldCheck,
-} from 'lucide-react';
-import { Switch } from '../components/ui/Switch';
+import { Plus, Download, Package } from 'lucide-react';
 import { clsx } from 'clsx';
-import { formatMs, formatResetsIn } from '../lib/format';
 import { isClipboardAvailable, copyToClipboard } from '../lib/clipboard';
 import plexusCliSkill from '../../../../.agents/skills/plexus-cli/SKILL.md' with { type: 'text' };
 import plexusRestApiSkill from '../../../../.agents/skills/plexus-rest-api/SKILL.md' with {
@@ -43,14 +33,14 @@ const LOCAL_MCP_DEFAULT_PORT = 7345;
 const CLI_BUNX_COMMAND = 'bunx @mcowger/plexus-cli';
 const CLI_GLOBAL_INSTALL_COMMAND = 'bun install -g @mcowger/plexus-cli';
 
-const EMPTY_SERVER: McpServer = {
+const EMPTY_SERVER: RemoteMcpServer = {
   mode: 'remote_http',
   upstream_url: '',
   enabled: true,
   headers: {},
 };
 
-const EMPTY_LOCAL_SERVER: McpServer = {
+const EMPTY_LOCAL_SERVER: LocalMcpServer = {
   mode: 'local_http',
   enabled: true,
   launcher: 'bunx',
@@ -601,15 +591,6 @@ export const McpPage: React.FC = () => {
   };
 
   const serverNames = Object.keys(servers);
-  const logsTotalPages = Math.ceil(logsTotal / logsLimit);
-  const logsCurrentPage = Math.floor(logsOffset / logsLimit) + 1;
-
-  const statusColor = (status: number | null): string => {
-    if (status === null) return 'text-text-secondary';
-    if (status >= 200 && status < 300) return 'text-success';
-    if (status >= 400 && status < 500) return 'text-warning';
-    return 'text-danger';
-  };
 
   if (isLoading) {
     return (
@@ -768,1289 +749,109 @@ export const McpPage: React.FC = () => {
       />
       <PageContainer>
         <div className="flex flex-col gap-5">
-          {/* Servers Config Card */}
-          <Card title="MCP Servers">
-            {serverNames.length === 0 ? (
-              <div className="p-4 text-text-secondary text-center">
-                No MCP servers configured. Click "Add MCP Server" to create one.
-              </div>
-            ) : (
-              <>
-                <div className="space-y-3 md:hidden">
-                  {serverNames.map((name) => {
-                    const server = servers[name];
-                    const headerCount = server.headers ? Object.keys(server.headers).length : 0;
+          <McpServerTable
+            servers={servers}
+            serverNames={serverNames}
+            mcpEnabled={mcpEnabled}
+            onEdit={handleEdit}
+            onManageKeys={handleManageKeys}
+            onToggleEnabled={handleToggleEnabled}
+            onToggleMcpEnabled={handleToggleMcpEnabled}
+            onDelete={handleDelete}
+            mcpPathForServer={mcpPathForServer}
+            onCopyMcpPath={handleCopyMcpPath}
+          />
 
-                    return (
-                      <article
-                        key={name}
-                        className="rounded-md border border-border-glass bg-bg-subtle p-3"
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <button
-                            type="button"
-                            onClick={() => handleEdit(name)}
-                            className="min-w-0 flex-1 text-left"
-                          >
-                            <div className="flex min-w-0 items-center gap-2">
-                              <Edit2 size={12} className="shrink-0 opacity-60" />
-                              <span className="truncate font-heading text-sm font-semibold text-text">
-                                {name}
-                              </span>
-                            </div>
-                            <div className="mt-1 break-all text-xs text-text-muted">
-                              {server.mode === 'local_http'
-                                ? `${server.launcher} ${server.package} → 127.0.0.1:${server.port}${server.path || '/mcp'}`
-                                : server.upstream_url}
-                            </div>
-                          </button>
-                          <div className="flex shrink-0 items-center gap-2">
-                            {server.mode !== 'local_http' && (
-                              <Button
-                                size="sm"
-                                variant="secondary"
-                                onClick={() => handleManageKeys(name)}
-                              >
-                                Manage Keys
-                              </Button>
-                            )}
-                            <Switch
-                              checked={server.enabled !== false}
-                              onChange={(val) => handleToggleEnabled(name, val)}
-                              size="sm"
-                            />
-                            <Button
-                              size="icon"
-                              variant="ghost"
-                              onClick={() => handleDelete(name)}
-                              className="text-danger"
-                              aria-label={`Delete ${name}`}
-                            >
-                              <Trash2 size={14} />
-                            </Button>
-                          </div>
-                        </div>
-                        <div className="mt-3 rounded border border-border-glass bg-bg-glass px-2 py-1.5 text-xs">
-                          <span className="text-text-muted">Headers: </span>
-                          <span className="font-medium text-text-secondary">
-                            {headerCount > 0 ? `${headerCount} configured` : '-'}
-                          </span>
-                        </div>
-                      </article>
-                    );
-                  })}
-                </div>
+          <McpOAuthClientsCard
+            oauthClients={oauthClients}
+            oauthClientsLoading={oauthClientsLoading}
+            revokingTokenId={revokingTokenId}
+            updatingClientId={updatingClientId}
+            deletingClientId={deletingClientId}
+            revokingAllClientId={revokingAllClientId}
+            onRefresh={loadOAuthClients}
+            onRevokeToken={handleRevokeOAuthToken}
+            onToggleClientStatus={handleToggleOAuthClientStatus}
+            onRevokeAllTokens={handleRevokeAllOAuthTokens}
+            onDeleteClient={handleDeleteOAuthClient}
+          />
 
-                <div className="hidden overflow-x-auto md:block">
-                  <table className="w-full border-collapse font-body text-[13px]">
-                    <thead>
-                      <tr>
-                        <th
-                          className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                          style={{ paddingLeft: '24px' }}
-                        >
-                          Name
-                        </th>
-                        <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                          Upstream
-                        </th>
-                        <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                          Path
-                        </th>
-                        <th className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider">
-                          Status
-                        </th>
-                        <th
-                          className="px-4 py-3 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider"
-                          style={{ paddingRight: '24px', textAlign: 'right' }}
-                        >
-                          Actions
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {/* Plexus Management MCP — fixed row */}
-                      <tr className="bg-primary/5 border-b border-primary/30">
-                        <td
-                          className="px-4 py-3 text-left border-b border-border-glass text-text"
-                          style={{ paddingLeft: '24px' }}
-                        >
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                            <div style={{ fontWeight: 600 }}>Plexus Management</div>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-left border-b border-border-glass text-text-muted text-xs">
-                          —
-                        </td>
-                        <td className="px-4 py-3 text-left border-b border-border-glass text-text whitespace-nowrap">
-                          <div className="flex items-center gap-2">
-                            <span className="font-mono text-xs">/mcp/plexus</span>
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleCopyMcpPath('/mcp/plexus');
-                              }}
-                              className="rounded p-1 text-text-muted hover:bg-bg-hover hover:text-text"
-                              title="Copy path"
-                              aria-label="Copy /mcp/plexus"
-                            >
-                              <Copy size={13} />
-                            </button>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                          <Switch
-                            checked={mcpEnabled}
-                            onChange={(val) => handleToggleMcpEnabled(val)}
-                            size="sm"
-                          />
-                        </td>
-                        <td
-                          className="px-4 py-3 text-left border-b border-border-glass text-text"
-                          style={{ paddingRight: '24px', textAlign: 'right' }}
-                        />
-                      </tr>
+          <McpUsageLogsCard
+            logs={logs}
+            logsTotal={logsTotal}
+            logsLoading={logsLoading}
+            logsLimit={logsLimit}
+            logsOffset={logsOffset}
+            logsFilters={logsFilters}
+            onFiltersChange={setLogsFilters}
+            onSearch={handleLogSearch}
+            onDeleteAll={handleDeleteAllLogs}
+            onDeleteLog={handleDeleteLog}
+            onOffsetChange={setLogsOffset}
+          />
 
-                      {serverNames.map((name) => {
-                        const server = servers[name];
-                        return (
-                          <tr
-                            key={name}
-                            onClick={() => handleEdit(name)}
-                            style={{ cursor: 'pointer' }}
-                            className="hover:bg-bg-hover"
-                          >
-                            <td
-                              className="px-4 py-3 text-left border-b border-border-glass text-text"
-                              style={{ paddingLeft: '24px' }}
-                            >
-                              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                                <Edit2 size={12} style={{ opacity: 0.5 }} />
-                                <div style={{ fontWeight: 600 }}>{name}</div>
-                              </div>
-                            </td>
-                            <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                              <div
-                                style={{
-                                  maxWidth: '400px',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                }}
-                              >
-                                {server.mode === 'local_http'
-                                  ? `${server.launcher} ${server.package} → 127.0.0.1:${server.port}${server.path || '/mcp'}`
-                                  : server.upstream_url}
-                              </div>
-                            </td>
-                            <td className="px-4 py-3 text-left border-b border-border-glass text-text whitespace-nowrap">
-                              <div
-                                className="flex items-center gap-2"
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                <span className="font-mono text-xs">{mcpPathForServer(name)}</span>
-                                <button
-                                  type="button"
-                                  onClick={() => handleCopyMcpPath(mcpPathForServer(name))}
-                                  className="rounded p-1 text-text-muted hover:bg-bg-hover hover:text-text"
-                                  title="Copy path"
-                                  aria-label={`Copy ${mcpPathForServer(name)}`}
-                                >
-                                  <Copy size={13} />
-                                </button>
-                              </div>
-                            </td>
-                            <td className="px-4 py-3 text-left border-b border-border-glass text-text">
-                              <div onClick={(e) => e.stopPropagation()}>
-                                <Switch
-                                  checked={server.enabled !== false}
-                                  onChange={(val) => handleToggleEnabled(name, val)}
-                                  size="sm"
-                                />
-                              </div>
-                            </td>
-                            <td
-                              className="px-4 py-3 text-left border-b border-border-glass text-text"
-                              style={{ paddingRight: '24px', textAlign: 'right' }}
-                            >
-                              <div
-                                style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}
-                              >
-                                {server.mode !== 'local_http' && (
-                                  <Button
-                                    size="sm"
-                                    variant="secondary"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      handleManageKeys(name);
-                                    }}
-                                  >
-                                    Manage Keys
-                                  </Button>
-                                )}
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleDelete(name);
-                                  }}
-                                  style={{ color: 'var(--color-danger)' }}
-                                >
-                                  <Trash2 size={14} />
-                                </Button>
-                              </div>
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              </>
-            )}
-          </Card>
-
-          {/* ── OAuth Clients + Tokens Card ── */}
-          <Card className="glass-bg rounded-lg p-3 max-w-full shadow-xl overflow-hidden flex flex-col gap-3">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <h2 className="font-heading text-lg font-semibold text-text m-0 mb-1">
-                  MCP OAuth Clients
-                </h2>
-                <p className="text-xs text-text-muted">
-                  Registered OAuth clients and their active tokens. Tokens show the bound Plexus API
-                  key name only; raw secrets are never displayed.
-                </p>
-              </div>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={loadOAuthClients}
-                isLoading={oauthClientsLoading}
-                leftIcon={<RefreshCw size={14} />}
-              >
-                Refresh
-              </Button>
-            </div>
-
-            {oauthClientsLoading ? (
-              <div className="py-8 text-center text-sm text-text-secondary">Loading...</div>
-            ) : oauthClients.length === 0 ? (
-              <div className="rounded-md border border-border-glass bg-bg-subtle p-4 text-sm text-text-secondary">
-                No MCP OAuth clients registered yet.
-              </div>
-            ) : (
-              <div className="flex flex-col gap-3">
-                {oauthClients.map((client) => (
-                  <article
-                    key={client.clientId}
-                    className={`rounded-md border border-border-glass bg-bg-subtle p-3 ${
-                      client.status === 'disabled' ? 'opacity-60' : ''
-                    }`}
-                  >
-                    <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2 text-sm font-semibold text-text">
-                          <KeyRound size={15} className="text-primary" />
-                          <span>{client.clientName || 'Unnamed client'}</span>
-                          {client.status === 'disabled' ? (
-                            <span className="rounded border border-red-500/40 bg-red-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-red-500">
-                              Disabled
-                            </span>
-                          ) : (
-                            <span className="rounded border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-emerald-500">
-                              Active
-                            </span>
-                          )}
-                        </div>
-                        <div className="mt-1 font-mono text-xs text-text-secondary break-all">
-                          {client.clientId}
-                        </div>
-                        <div className="mt-2 text-xs text-text-muted">
-                          Created {new Date(client.createdAt).toLocaleString()}
-                        </div>
-                      </div>
-                      <div className="min-w-0 lg:max-w-[45%]">
-                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
-                          Redirect URIs
-                        </div>
-                        <div className="mt-1 flex flex-col gap-1">
-                          {client.redirectUris.map((uri) => (
-                            <code
-                              key={uri}
-                              className="rounded border border-border-glass bg-bg-glass px-2 py-1 text-[11px] text-text-secondary break-all"
-                            >
-                              {uri}
-                            </code>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="mt-3 border-t border-border-glass pt-3">
-                      <div className="mb-2 text-[10px] uppercase tracking-wider text-text-muted">
-                        Active tokens
-                      </div>
-                      {client.tokens.length === 0 ? (
-                        <div className="text-xs text-text-muted">
-                          No active tokens for this client.
-                        </div>
-                      ) : (
-                        <div className="overflow-x-auto">
-                          <table className="w-full border-collapse font-body text-[12px]">
-                            <thead>
-                              <tr>
-                                <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
-                                  Key name
-                                </th>
-                                <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
-                                  Scope
-                                </th>
-                                <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
-                                  Access expires
-                                </th>
-                                <th className="px-2 py-2 text-left border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
-                                  Issued
-                                </th>
-                                <th className="px-2 py-2 text-right border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[10px] uppercase tracking-wider">
-                                  Action
-                                </th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {client.tokens.map((token) => (
-                                <tr key={token.id} className="hover:bg-bg-hover">
-                                  <td className="px-2 py-2 border-b border-border-glass text-text">
-                                    <span className="font-mono">{token.keyName}</span>
-                                  </td>
-                                  <td className="px-2 py-2 border-b border-border-glass text-text-secondary">
-                                    {token.scope || '-'}
-                                  </td>
-                                  <td className="px-2 py-2 border-b border-border-glass text-text-secondary whitespace-nowrap">
-                                    {new Date(token.accessTokenExpiresAt).toLocaleString()}
-                                  </td>
-                                  <td className="px-2 py-2 border-b border-border-glass text-text-secondary whitespace-nowrap">
-                                    {new Date(token.createdAt).toLocaleString()}
-                                  </td>
-                                  <td className="px-2 py-2 border-b border-border-glass text-right">
-                                    <Button
-                                      size="sm"
-                                      variant="danger"
-                                      onClick={() => handleRevokeOAuthToken(token.id)}
-                                      isLoading={revokingTokenId === token.id}
-                                      leftIcon={<ShieldOff size={13} />}
-                                    >
-                                      Revoke
-                                    </Button>
-                                  </td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </table>
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="mt-3 flex flex-wrap gap-2 border-t border-border-glass pt-3">
-                      {client.status === 'disabled' ? (
-                        <Button
-                          size="sm"
-                          variant="primary"
-                          onClick={() => handleToggleOAuthClientStatus(client)}
-                          isLoading={updatingClientId === client.clientId}
-                          leftIcon={<ShieldCheck size={13} />}
-                        >
-                          Enable
-                        </Button>
-                      ) : (
-                        <Button
-                          size="sm"
-                          variant="danger"
-                          onClick={() => handleToggleOAuthClientStatus(client)}
-                          isLoading={updatingClientId === client.clientId}
-                          leftIcon={<ShieldOff size={13} />}
-                        >
-                          Disable
-                        </Button>
-                      )}
-                      <Button
-                        size="sm"
-                        variant="danger"
-                        onClick={() => handleRevokeAllOAuthTokens(client.clientId)}
-                        isLoading={revokingAllClientId === client.clientId}
-                        leftIcon={<KeyRound size={13} />}
-                      >
-                        Revoke all tokens
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="danger"
-                        onClick={() => handleDeleteOAuthClient(client.clientId)}
-                        isLoading={deletingClientId === client.clientId}
-                        leftIcon={<Trash2 size={13} />}
-                      >
-                        Delete client
-                      </Button>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            )}
-          </Card>
-
-          {/* ── Usage Logs Card ── */}
-          <Card className="glass-bg rounded-lg p-3 max-w-full shadow-xl overflow-hidden flex flex-col gap-2">
-            <div className="mb-2">
-              <h2 className="font-heading text-lg font-semibold text-text m-0 mb-3">
-                MCP Usage Logs
-              </h2>
-              <form
-                onSubmit={handleLogSearch}
-                className="flex flex-col gap-2 lg:flex-row lg:justify-between"
-              >
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <div className="relative w-full sm:w-50">
-                    <Search
-                      size={16}
-                      style={{
-                        position: 'absolute',
-                        left: '10px',
-                        top: '50%',
-                        transform: 'translateY(-50%)',
-                        color: 'var(--color-text-secondary)',
-                      }}
-                    />
-                    <Input
-                      placeholder="Filter by Server..."
-                      value={logsFilters.serverName}
-                      onChange={(e) =>
-                        setLogsFilters({ ...logsFilters, serverName: e.target.value })
-                      }
-                      style={{ paddingLeft: '32px' }}
-                    />
-                  </div>
-                  <div className="relative w-full sm:w-44">
-                    <Filter
-                      size={16}
-                      style={{
-                        position: 'absolute',
-                        left: '10px',
-                        top: '50%',
-                        transform: 'translateY(-50%)',
-                        color: 'var(--color-text-secondary)',
-                      }}
-                    />
-                    <Input
-                      placeholder="Filter by Key..."
-                      value={logsFilters.apiKey}
-                      onChange={(e) => setLogsFilters({ ...logsFilters, apiKey: e.target.value })}
-                      style={{ paddingLeft: '32px' }}
-                    />
-                  </div>
-                  <Button type="submit" variant="primary" className="w-full sm:w-auto">
-                    Search
-                  </Button>
-                </div>
-                <Button
-                  onClick={handleDeleteAllLogs}
-                  variant="danger"
-                  className="flex w-full items-center gap-2 sm:w-auto"
-                  disabled={logs.length === 0}
-                  type="button"
-                >
-                  <Trash2 size={16} />
-                  Delete All
-                </Button>
-              </form>
-            </div>
-
-            <div className="space-y-3 lg:hidden">
-              {logsLoading ? (
-                <div className="py-8 text-center text-sm text-text-secondary">Loading...</div>
-              ) : logs.length === 0 ? (
-                <div className="py-8 text-center text-sm text-text-secondary">
-                  No MCP logs found
-                </div>
-              ) : (
-                logs.map((log) => (
-                  <article
-                    key={log.request_id}
-                    className="rounded-md border border-border-glass bg-bg-subtle p-3"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="text-xs font-medium text-text">
-                          {new Date(log.created_at).toLocaleString()}
-                        </div>
-                        <div className="mt-1 truncate text-xs text-text-muted">
-                          {log.api_key || '-'} {log.attribution ? `(${log.attribution})` : ''}
-                        </div>
-                      </div>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        onClick={() => handleDeleteLog(log.request_id)}
-                        className="text-danger"
-                        aria-label="Delete MCP log"
-                      >
-                        <Trash2 size={14} />
-                      </Button>
-                    </div>
-
-                    <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
-                      <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
-                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
-                          Server
-                        </div>
-                        <div className="truncate font-medium text-text-secondary">
-                          {log.server_name}
-                        </div>
-                      </div>
-                      <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
-                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
-                          Method
-                        </div>
-                        <div className="truncate font-medium text-text-secondary">
-                          {log.method} {log.is_streamed ? 'streamed' : 'buffered'}
-                        </div>
-                      </div>
-                      <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
-                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
-                          RPC
-                        </div>
-                        <div className="truncate font-mono text-text">
-                          {log.jsonrpc_method || '-'}
-                        </div>
-                      </div>
-                      <div className="min-w-0 rounded border border-border-glass bg-bg-glass px-2 py-1.5">
-                        <div className="text-[10px] uppercase tracking-wider text-text-muted">
-                          Duration
-                        </div>
-                        <div className="truncate font-medium text-text">
-                          {log.duration_ms != null ? formatMs(log.duration_ms) : '-'}
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="mt-3 flex items-center justify-between gap-3 rounded border border-border-glass bg-bg-glass px-2 py-2 text-xs">
-                      <span className={clsx('font-semibold', statusColor(log.response_status))}>
-                        Status {log.response_status ?? '?'}
-                      </span>
-                      {log.error_message && (
-                        <span className="min-w-0 truncate text-danger" title={log.error_message}>
-                          {log.error_message}
-                        </span>
-                      )}
-                    </div>
-                  </article>
-                ))
-              )}
-            </div>
-
-            <div className="hidden overflow-x-auto lg:block">
-              <table className="w-full border-collapse font-body text-[13px]">
-                <thead>
-                  <tr className="text-center border-b border-border">
-                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                      Date
-                    </th>
-                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                      Key
-                    </th>
-                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                      Server
-                    </th>
-                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                      Method
-                    </th>
-                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                      RPC Method
-                    </th>
-                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                      Duration
-                    </th>
-                    <th className="px-2 py-1.5 text-center border-b border-border-glass border-r border-r-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                      Status
-                    </th>
-                    <th className="px-2 py-1.5 text-center border-b border-border-glass bg-bg-hover font-semibold text-text-secondary text-[11px] uppercase tracking-wider whitespace-nowrap">
-                      <div className="flex justify-center">
-                        <Trash2 size={12} />
-                      </div>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {logsLoading ? (
-                    <tr>
-                      <td colSpan={8} className="p-5 text-center">
-                        Loading...
-                      </td>
-                    </tr>
-                  ) : logs.length === 0 ? (
-                    <tr>
-                      <td colSpan={8} className="p-5 text-center text-text-secondary">
-                        No MCP logs found
-                      </td>
-                    </tr>
-                  ) : (
-                    logs.map((log) => (
-                      <tr
-                        key={log.request_id}
-                        className="group border-b border-border-glass hover:bg-bg-hover"
-                      >
-                        {/* Date */}
-                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                          <div className="flex flex-col">
-                            <span className="font-medium">
-                              {new Date(log.created_at).toLocaleTimeString()}
-                            </span>
-                            <span className="text-text-secondary" style={{ fontSize: '0.85em' }}>
-                              {new Date(log.created_at).toISOString().split('T')[0]}
-                            </span>
-                          </div>
-                        </td>
-
-                        {/* Key / Attribution */}
-                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
-                          <div className="flex flex-col">
-                            <span className="font-medium">{log.api_key || '-'}</span>
-                            {log.attribution && (
-                              <span className="text-text-secondary" style={{ fontSize: '0.85em' }}>
-                                {log.attribution}
-                              </span>
-                            )}
-                          </div>
-                        </td>
-
-                        {/* Server */}
-                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                          <div className="flex flex-col">
-                            <span className="font-medium">{log.server_name}</span>
-                            <span
-                              className="text-text-secondary"
-                              style={{
-                                fontSize: '0.85em',
-                                maxWidth: '200px',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              {log.upstream_url}
-                            </span>
-                          </div>
-                        </td>
-
-                        {/* HTTP Method */}
-                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                          <div className="flex flex-col gap-1">
-                            <span
-                              className={clsx(
-                                'text-xs font-semibold',
-                                log.method === 'GET'
-                                  ? 'text-blue-400'
-                                  : log.method === 'POST'
-                                    ? 'text-green-400'
-                                    : 'text-red-400'
-                              )}
-                            >
-                              {log.method}
-                            </span>
-                            <div className="flex items-center gap-1">
-                              {log.is_streamed ? (
-                                <Zap size={11} className="text-blue-400" />
-                              ) : (
-                                <ZapOff size={11} className="text-gray-400" />
-                              )}
-                              <span className="text-text-secondary" style={{ fontSize: '0.8em' }}>
-                                {log.is_streamed ? 'streamed' : 'buffered'}
-                              </span>
-                            </div>
-                          </div>
-                        </td>
-
-                        {/* JSON-RPC Method + Tool Name */}
-                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                          <div className="flex flex-col gap-0.5">
-                            <span className="font-mono text-xs">
-                              {log.jsonrpc_method || <span className="text-text-secondary">-</span>}
-                            </span>
-                            {log.tool_name && (
-                              <span className="font-mono text-xs text-info" title={log.tool_name}>
-                                {log.tool_name}
-                              </span>
-                            )}
-                          </div>
-                        </td>
-
-                        {/* Duration */}
-                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle whitespace-nowrap">
-                          <span>{log.duration_ms != null ? formatMs(log.duration_ms) : '-'}</span>
-                        </td>
-
-                        {/* Status */}
-                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
-                          <div className="flex flex-col gap-1">
-                            {log.error_code ? (
-                              <div
-                                className={clsx(
-                                  'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
-                                  'text-danger border-danger/30 bg-red-500/15'
-                                )}
-                                style={{ width: '52px' }}
-                              >
-                                <AlertTriangle size={12} />
-                                <span className="font-semibold">{log.response_status ?? '?'}</span>
-                              </div>
-                            ) : (
-                              <div
-                                className={clsx(
-                                  'inline-flex items-center justify-center gap-1.5 py-1 px-2 rounded-xl text-xs font-medium border',
-                                  log.response_status != null &&
-                                    log.response_status >= 200 &&
-                                    log.response_status < 300
-                                    ? 'text-success border-success/30 bg-emerald-500/15'
-                                    : 'text-danger border-danger/30 bg-red-500/15'
-                                )}
-                                style={{ width: '52px' }}
-                              >
-                                <CheckCircle size={12} />
-                                <span
-                                  className={clsx(
-                                    'font-semibold',
-                                    statusColor(log.response_status)
-                                  )}
-                                >
-                                  {log.response_status ?? '?'}
-                                </span>
-                              </div>
-                            )}
-                            {log.error_message && (
-                              <span
-                                className="text-danger"
-                                style={{
-                                  fontSize: '0.78em',
-                                  maxWidth: '160px',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                  display: 'block',
-                                }}
-                                title={log.error_message}
-                              >
-                                {log.error_message}
-                              </span>
-                            )}
-                          </div>
-                        </td>
-
-                        {/* Delete */}
-                        <td className="px-2 py-1.5 text-left border-b border-border-glass text-text align-middle">
-                          <button
-                            onClick={() => handleDeleteLog(log.request_id)}
-                            className="bg-transparent border-0 text-text-muted p-1 rounded cursor-pointer transition-all duration-200 flex items-center justify-center hover:bg-red-600/10 hover:text-danger opacity-100 lg:opacity-0 lg:group-hover:opacity-100"
-                            title="Delete log"
-                          >
-                            <Trash2 size={14} />
-                          </button>
-                        </td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </div>
-
-            <div className="flex flex-col items-stretch gap-3 mt-3 sm:flex-row sm:items-center sm:justify-end">
-              <span style={{ fontSize: '14px', color: 'var(--color-text-secondary)' }}>
-                Page {logsCurrentPage} of {Math.max(1, logsTotalPages)}
-              </span>
-              <div className="flex gap-1">
-                <Button
-                  variant="secondary"
-                  disabled={logsOffset === 0}
-                  onClick={() => setLogsOffset(Math.max(0, logsOffset - logsLimit))}
-                >
-                  <ChevronLeft size={16} />
-                </Button>
-                <Button
-                  variant="secondary"
-                  disabled={logsOffset + logsLimit >= logsTotal}
-                  onClick={() => setLogsOffset(logsOffset + logsLimit)}
-                >
-                  <ChevronRight size={16} />
-                </Button>
-              </div>
-            </div>
-          </Card>
-
-          {/* ── Server Edit/Add Modal ── */}
-          <Modal
+          <McpServerEditorModal
             isOpen={isModalOpen}
             onClose={() => setIsModalOpen(false)}
-            title={editingServerName ? `Edit ${editingServerName}` : 'Add MCP Server'}
-            footer={
-              <>
-                <Button variant="secondary" onClick={() => setIsModalOpen(false)}>
-                  Cancel
-                </Button>
-                <Button variant="primary" onClick={handleSave} disabled={isSaving}>
-                  {isSaving ? 'Saving...' : 'Save'}
-                </Button>
-              </>
+            editingServerName={editingServerName}
+            serverNameInput={serverNameInput}
+            onServerNameInputChange={setServerNameInput}
+            editingServer={editingServer}
+            onEditingServerChange={setEditingServer}
+            argsInput={argsInput}
+            onArgsInputChange={setArgsInput}
+            headerKey={headerKey}
+            onHeaderKeyChange={setHeaderKey}
+            headerValue={headerValue}
+            onHeaderValueChange={setHeaderValue}
+            envKey={envKey}
+            onEnvKeyChange={setEnvKey}
+            envValue={envValue}
+            onEnvValueChange={setEnvValue}
+            emptyServer={EMPTY_SERVER}
+            emptyLocalServer={EMPTY_LOCAL_SERVER}
+            getNextLocalMcpPort={getNextLocalMcpPort}
+            onAddHeader={addHeader}
+            onRemoveHeader={removeHeader}
+            onAddEnv={addEnv}
+            onRemoveEnv={removeEnv}
+            onSave={handleSave}
+            isSaving={isSaving}
+          />
+
+          <McpKeyManagementModal
+            serverName={keyManagementServerName}
+            authScheme={
+              keyManagementServerName ? servers[keyManagementServerName]?.auth_scheme : undefined
             }
-          >
-            <div className="space-y-4">
-              {!editingServerName && (
-                <Input
-                  label="Server Name"
-                  value={serverNameInput}
-                  onChange={(e) =>
-                    setServerNameInput(e.target.value.toLowerCase().replace(/[^a-z0-9-_]/g, ''))
-                  }
-                  placeholder="my-mcp-server"
-                />
-              )}
-
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Server Type
-                </label>
-                <select
-                  className="w-full rounded-md border border-border-glass bg-bg-surface px-3 py-2 text-sm text-text"
-                  value={editingServer.mode === 'local_http' ? 'local_http' : 'remote_http'}
-                  onChange={(e) => {
-                    if (e.target.value === 'local_http') {
-                      setArgsInput((EMPTY_LOCAL_SERVER.args || []).join(' '));
-                      setEditingServer({
-                        ...EMPTY_LOCAL_SERVER,
-                        enabled: editingServer.enabled,
-                        headers: editingServer.headers,
-                        port: getNextLocalMcpPort(),
-                      });
-                    } else {
-                      setEditingServer({
-                        ...EMPTY_SERVER,
-                        enabled: editingServer.enabled,
-                        headers: editingServer.headers,
-                      });
-                    }
-                  }}
-                >
-                  <option value="remote_http">Remote HTTP</option>
-                  <option value="local_http">Local HTTP</option>
-                </select>
-              </div>
-
-              {editingServer.mode === 'local_http' ? (
-                <>
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-text-secondary">
-                      Launcher
-                    </label>
-                    <select
-                      className="w-full rounded-md border border-border-glass bg-bg-surface px-3 py-2 text-sm text-text"
-                      value={editingServer.launcher}
-                      onChange={(e) =>
-                        setEditingServer({
-                          ...editingServer,
-                          launcher: e.target.value as 'bunx' | 'uvx',
-                        })
-                      }
-                    >
-                      <option value="bunx">bunx</option>
-                      <option value="uvx">uvx</option>
-                    </select>
-                  </div>
-                  <Input
-                    label="Package"
-                    value={editingServer.package}
-                    onChange={(e) =>
-                      setEditingServer({ ...editingServer, package: e.target.value })
-                    }
-                    placeholder="@example/mcp-server"
-                  />
-                  <Input
-                    label="Arguments"
-                    value={argsInput}
-                    onChange={(e) => setArgsInput(e.target.value)}
-                    placeholder="--port {{PORT}}"
-                  />
-                  <p className="-mt-2 text-xs text-text-muted">
-                    Available interpolations: {'{{PORT}}'} for the configured port and {'{{HOST}}'}
-                    for 127.0.0.1.
-                  </p>
-                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                    <Input
-                      label="Port"
-                      type="number"
-                      value={editingServer.port}
-                      onChange={(e) =>
-                        setEditingServer({
-                          ...editingServer,
-                          port: parseInt(e.target.value) || 7345,
-                        })
-                      }
-                    />
-                    <Input
-                      label="Path"
-                      value={editingServer.path ?? '/mcp'}
-                      onChange={(e) => setEditingServer({ ...editingServer, path: e.target.value })}
-                    />
-                    <Input
-                      label="Startup Timeout (ms)"
-                      type="number"
-                      value={editingServer.startup_timeout_ms || 30000}
-                      onChange={(e) =>
-                        setEditingServer({
-                          ...editingServer,
-                          startup_timeout_ms: parseInt(e.target.value) || 30000,
-                        })
-                      }
-                    />
-                  </div>
-
-                  <div className="space-y-2 rounded-md border border-border-glass p-3">
-                    <label className="text-sm font-medium text-text-secondary">
-                      Environment Variables
-                    </label>
-                    <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-                      <div className="min-w-0 flex-1">
-                        <Input
-                          label="Env Key"
-                          value={envKey}
-                          onChange={(e) => setEnvKey(e.target.value)}
-                          placeholder="API_KEY"
-                        />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <Input
-                          label="Env Value"
-                          value={envValue}
-                          onChange={(e) => setEnvValue(e.target.value)}
-                          placeholder="secret value"
-                        />
-                      </div>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={addEnv}
-                        className="w-full sm:w-auto"
-                      >
-                        <PlusCircle size={16} />
-                      </Button>
-                    </div>
-                    {editingServer.env && Object.keys(editingServer.env).length > 0 && (
-                      <div className="space-y-2">
-                        {Object.entries(editingServer.env).map(([key, value]) => (
-                          <div
-                            key={key}
-                            className="flex flex-col gap-2 p-2 bg-bg-hover rounded-md sm:flex-row sm:items-center"
-                          >
-                            <span className="min-w-0 flex-1 break-all font-mono text-xs">
-                              {key}
-                            </span>
-                            <span className="flex-1 font-mono text-xs text-text-secondary truncate">
-                              {value}
-                            </span>
-                            <button
-                              onClick={() => removeEnv(key)}
-                              className="p-1 hover:bg-bg-surface rounded"
-                            >
-                              <MinusCircle size={14} className="text-danger" />
-                            </button>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </>
-              ) : (
-                <Input
-                  label="Upstream URL"
-                  value={editingServer.upstream_url}
-                  onChange={(e) =>
-                    setEditingServer({ ...editingServer, upstream_url: e.target.value })
-                  }
-                  placeholder="https://mcp.example.com/mcp"
-                />
-              )}
-
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                <Input
-                  label="Auth Scheme"
-                  value={editingServer.auth_scheme ?? ''}
-                  onChange={(e) =>
-                    setEditingServer({ ...editingServer, auth_scheme: e.target.value || null })
-                  }
-                  placeholder="bearer"
-                />
-                <Input
-                  label="Rate Limit Cooldown (ms)"
-                  type="number"
-                  min="0"
-                  value={editingServer.rate_limit_cooldown_ms ?? 60_000}
-                  onChange={(e) =>
-                    setEditingServer({
-                      ...editingServer,
-                      rate_limit_cooldown_ms: Number(e.target.value),
-                    })
-                  }
-                />
-                <Input
-                  label="Quota Cooldown (ms)"
-                  type="number"
-                  min="0"
-                  value={editingServer.quota_cooldown_ms ?? 86_400_000}
-                  onChange={(e) =>
-                    setEditingServer({
-                      ...editingServer,
-                      quota_cooldown_ms: Number(e.target.value),
-                    })
-                  }
-                />
-              </div>
-
-              <div className="mt-4 rounded-md border border-border-glass p-3">
-                <div className="mb-3">
-                  <label className="text-sm font-medium text-text-secondary">
-                    Static Headers (Optional)
-                  </label>
-                  <p className="text-xs text-text-muted mt-1">
-                    These headers are injected into every request. For load-balanced authentication
-                    keys, use the <strong>Auth Scheme</strong> above and the{' '}
-                    <strong>Manage Keys</strong> button.
-                  </p>
-                </div>
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-                  <div className="min-w-0 flex-1">
-                    <Input
-                      label="Header Key"
-                      value={headerKey}
-                      onChange={(e) => setHeaderKey(e.target.value)}
-                      placeholder="X-Custom-Header"
-                    />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <Input
-                      label="Header Value"
-                      value={headerValue}
-                      onChange={(e) => setHeaderValue(e.target.value)}
-                      placeholder="value..."
-                    />
-                  </div>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={addHeader}
-                    className="w-full sm:w-auto"
-                  >
-                    <PlusCircle size={16} />
-                  </Button>
-                </div>
-
-                {editingServer.headers && Object.keys(editingServer.headers).length > 0 && (
-                  <div className="space-y-2 mt-4">
-                    <label className="text-sm font-medium text-text-secondary">
-                      Configured Static Headers
-                    </label>
-                    {Object.entries(editingServer.headers).map(([key, value]) => (
-                      <div
-                        key={key}
-                        className="flex flex-col gap-2 p-2 bg-bg-hover rounded-md sm:flex-row sm:items-center"
-                      >
-                        <span className="min-w-0 flex-1 break-all font-mono text-xs">{key}</span>
-                        <span className="flex-1 font-mono text-xs text-text-secondary truncate">
-                          {value}
-                        </span>
-                        <button
-                          onClick={() => removeHeader(key)}
-                          className="p-1 hover:bg-bg-surface rounded"
-                        >
-                          <MinusCircle size={14} className="text-danger" />
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          </Modal>
-
-          <Modal
-            isOpen={keyManagementServerName !== null}
+            serverKeys={serverKeys}
+            isLoadingKeys={isLoadingKeys}
+            newServerKey={newServerKey}
+            onNewServerKeyChange={setNewServerKey}
+            isSavingKey={isSavingKey}
             onClose={() => setKeyManagementServerName(null)}
-            title={
-              keyManagementServerName ? `Manage Keys: ${keyManagementServerName}` : 'Manage Keys'
-            }
-            footer={
-              <Button variant="secondary" onClick={() => setKeyManagementServerName(null)}>
-                Close
-              </Button>
-            }
-          >
-            <div className="space-y-4">
-              <div className="rounded-md bg-bg-surface p-3 text-sm text-text-secondary border border-border-subtle">
-                <p>
-                  These keys will be load-balanced (Round Robin) and automatically rotated if a rate
-                  limit or quota is exceeded. They will be injected using the server's configured{' '}
-                  <strong>Auth Scheme</strong>:{' '}
-                  <span className="font-mono text-text bg-bg-subtle px-1 py-0.5 rounded">
-                    {keyManagementServerName && servers[keyManagementServerName]?.auth_scheme
-                      ? servers[keyManagementServerName].auth_scheme
-                      : 'None (keys will not be sent)'}
-                  </span>
-                </p>
-              </div>
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <Input
-                  label="New Key"
-                  value={newServerKey}
-                  onChange={(e) => setNewServerKey(e.target.value)}
-                  placeholder="Paste key value"
-                  className="flex-1"
-                />
-                <Button
-                  className="self-end"
-                  onClick={handleAddServerKey}
-                  disabled={isSavingKey || !newServerKey.trim()}
-                >
-                  {isSavingKey ? 'Adding...' : 'Add Key'}
-                </Button>
-              </div>
+            onAddKey={handleAddServerKey}
+            onDeleteKey={handleDeleteServerKey}
+            onClearCooldown={handleClearServerKeyCooldown}
+          />
 
-              {isLoadingKeys ? (
-                <p className="text-sm text-text-secondary">Loading keys...</p>
-              ) : serverKeys.length === 0 ? (
-                <p className="text-sm text-text-secondary">No keys configured.</p>
-              ) : (
-                <div className="space-y-2">
-                  {serverKeys.map((key) => {
-                    const isExhausted =
-                      key.cooldown_until !== null &&
-                      new Date(key.cooldown_until).getTime() > Date.now();
-                    return (
-                      <div
-                        key={key.id}
-                        className="flex flex-col gap-3 rounded-md border border-border-glass bg-bg-subtle p-3 sm:flex-row sm:items-center"
-                      >
-                        <div className="min-w-0 flex-1">
-                          <div className="truncate font-mono text-sm text-text" title={key.key}>
-                            {key.key}
-                          </div>
-                          <div
-                            className={clsx(
-                              'mt-1 text-xs font-medium',
-                              !key.is_active || isExhausted ? 'text-warning' : 'text-success'
-                            )}
-                          >
-                            {!key.is_active
-                              ? 'Inactive'
-                              : isExhausted
-                                ? `Exhausted, ${formatResetsIn(key.cooldown_until)}`
-                                : 'Active'}
-                          </div>
-                        </div>
-                        <div className="flex gap-2">
-                          {isExhausted && (
-                            <Button
-                              size="sm"
-                              variant="secondary"
-                              onClick={() => handleClearServerKeyCooldown(key.id)}
-                            >
-                              Clear Cooldown
-                            </Button>
-                          )}
-                          <Button
-                            size="sm"
-                            variant="danger"
-                            onClick={() => handleDeleteServerKey(key.id)}
-                          >
-                            Delete
-                          </Button>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          </Modal>
-
-          {/* ── Delete All Logs Modal ── */}
-          <Modal
+          <McpDeleteLogsModal
             isOpen={isDeleteLogsModalOpen}
+            deleteLogsMode={deleteLogsMode}
+            olderThanDays={olderThanDays}
+            isDeletingLogs={isDeletingLogs}
             onClose={() => setIsDeleteLogsModalOpen(false)}
-            title="Confirm Deletion"
-            footer={
-              <>
-                <Button variant="secondary" onClick={() => setIsDeleteLogsModalOpen(false)}>
-                  Cancel
-                </Button>
-                <Button variant="danger" onClick={confirmDeleteAllLogs} disabled={isDeletingLogs}>
-                  {isDeletingLogs ? 'Deleting...' : 'Delete Logs'}
-                </Button>
-              </>
-            }
-          >
-            <div className="flex flex-col gap-4">
-              <p>Select which MCP logs you would like to delete:</p>
+            onModeChange={setDeleteLogsMode}
+            onOlderThanDaysChange={setOlderThanDays}
+            onConfirm={confirmDeleteAllLogs}
+          />
 
-              <div className="flex flex-wrap items-center gap-2">
-                <input
-                  type="radio"
-                  id="mcp-delete-older"
-                  name="deleteLogsMode"
-                  checked={deleteLogsMode === 'older'}
-                  onChange={() => setDeleteLogsMode('older')}
-                />
-                <label htmlFor="mcp-delete-older">Delete logs older than</label>
-                <Input
-                  type="number"
-                  min="1"
-                  value={olderThanDays}
-                  onChange={(e) => setOlderThanDays(parseInt(e.target.value) || 1)}
-                  style={{ width: '60px', padding: '4px 8px' }}
-                  disabled={deleteLogsMode !== 'older'}
-                />
-                <span>days</span>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  id="mcp-delete-all"
-                  name="deleteLogsMode"
-                  checked={deleteLogsMode === 'all'}
-                  onChange={() => setDeleteLogsMode('all')}
-                />
-                <label htmlFor="mcp-delete-all" style={{ color: 'var(--color-danger)' }}>
-                  Delete ALL logs (Cannot be undone)
-                </label>
-              </div>
-            </div>
-          </Modal>
-
-          {/* ── Single Log Delete Modal ── */}
-          <Modal
+          <McpDeleteLogModal
             isOpen={isSingleDeleteModalOpen}
+            isDeletingLogs={isDeletingLogs}
             onClose={() => setIsSingleDeleteModalOpen(false)}
-            title="Confirm Deletion"
-            footer={
-              <>
-                <Button variant="secondary" onClick={() => setIsSingleDeleteModalOpen(false)}>
-                  Cancel
-                </Button>
-                <Button variant="danger" onClick={confirmDeleteSingleLog} disabled={isDeletingLogs}>
-                  {isDeletingLogs ? 'Deleting...' : 'Delete Log'}
-                </Button>
-              </>
-            }
-          >
-            <p>Are you sure you want to delete this MCP log entry?</p>
-          </Modal>
+            onConfirm={confirmDeleteSingleLog}
+          />
         </div>
       </PageContainer>
     </div>


### PR DESCRIPTION
## Summary
Split the oversized Config and MCP admin pages into focused, typed components without changing their page-level orchestration or behavior.

## Why / Context
Both pages mixed API/state management with every card, table, and modal, which made the files difficult to scan and maintain. The extracted components now own section-local markup while the pages retain state, API calls, callbacks, and ordering.

## Changes
- **Config**: extract configuration cards and forms for failover, trace capture, cooldowns, timeout/stall handling, compaction, MCP OAuth, exploration, network settings, metadata, backup/restore, card layout, and configuration snapshots.
- **MCP**: extract the server table, OAuth clients/tokens card, usage logs card, server editor, key management, bulk-delete, and single-delete modals.
- **Shared types**: move Config section types/defaults into the config component directory and preserve nullable validation values used by stall settings.

## Testing
- Manually verified `/ui/config` renders all extracted cards and expands the Failover settings card.
- Manually verified `/ui/mcp` renders the server table, OAuth clients, and usage logs, and that the Add MCP Server modal opens and closes.
- `bun run format:check` passed.

## Notes
No API or user-facing behavior changes intended. The worktree dev stack was left running for follow-up review.
