### PR TITLE
feat(dev): expose frpc URL through temp file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ To get the current worktree's FRP URL without scraping startup logs, run:
 bun run dev:get:frp-url
 ```
 
-Use `bun run dev:get:frp-url -- --hostname`, `--subdomain`, or `--json` for a hostname, subdomain, or machine-readable result. The command derives the same deterministic endpoint as the dev lifecycle; it does not check whether the tunnel is reachable.
+Use `bun run dev:get:frp-url -- --hostname`, `--subdomain`, or `--json` for a hostname, subdomain, or machine-readable result. Use `--file` to print the path of the temporary URL file written while the tunnel is running. The command derives the same deterministic endpoint as the dev lifecycle; it does not check whether the tunnel is reachable.
 
 #### Background dev stack
 

--- a/paseo.json
+++ b/paseo.json
@@ -1,44 +1,40 @@
 {
   "worktree": {
     "setup": ["cp \"$PASEO_SOURCE_CHECKOUT_PATH/.env\" .env", "bun run scripts/init_worktree.ts"],
-    "teardown": "bun run dev:stop",
-    "servicePorts": {
-      "portScript": "scripts/dev-port-allocator.ts",
-      "range": "10000-19999"
-    }
+    "teardown": "bun run dev:stop"
   },
   "scripts": {
     "dev": {
-      "type": "service",
-      "command": "PORT=$PASEO_PORT bun run dev --no-open"
+      "type": "task",
+      "command": "bun run dev --no-open"
     },
     "dev:full": {
-      "type": "service",
-      "command": "PORT=$PASEO_PORT bun run dev:full --no-open"
+      "type": "task",
+      "command": "bun run dev:full --no-open"
     },
     "dev:pglite": {
-      "type": "service",
-      "command": "PORT=$PASEO_PORT bun run dev:pglite --no-open"
+      "type": "task",
+      "command": "bun run dev:pglite --no-open"
     },
     "prep-dev": {
-      "type": "service",
-      "command": "PLEXUS_URL=http://localhost PLEXUS_PORT=$PASEO_SERVICE_DEV_PORT bun run prep-dev"
+      "type": "task",
+      "command": "PLEXUS_URL=http://localhost bun run prep-dev"
     },
     "prep-dev:save": {
-      "type": "service",
-      "command": "PLEXUS_URL=http://localhost PLEXUS_PORT=$PASEO_SERVICE_DEV_PORT bun run prep-dev --save"
+      "type": "task",
+      "command": "PLEXUS_URL=http://localhost bun run prep-dev --save"
     },
     "prep-dev:live": {
-      "type": "service",
-      "command": "PLEXUS_URL=http://localhost PLEXUS_PORT=$PASEO_SERVICE_DEV_PORT bun run prep-dev --live"
+      "type": "task",
+      "command": "PLEXUS_URL=http://localhost bun run prep-dev --live"
     },
     "prep-dev:clear": {
-      "type": "service",
-      "command": "PLEXUS_URL=http://localhost PLEXUS_PORT=$PASEO_SERVICE_DEV_PORT bun run prep-dev --clear"
+      "type": "task",
+      "command": "PLEXUS_URL=http://localhost bun run prep-dev --clear"
     },
     "prep-dev:reset": {
-      "type": "service",
-      "command": "PLEXUS_URL=http://localhost PLEXUS_PORT=$PASEO_SERVICE_DEV_PORT bun run prep-dev --reset"
+      "type": "task",
+      "command": "PLEXUS_URL=http://localhost bun run prep-dev --reset"
     },
     "deploy:staging": {
       "type": "command",

--- a/scripts/__tests__/frpc.test.ts
+++ b/scripts/__tests__/frpc.test.ts
@@ -1,12 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildFrpcArgs,
   buildFrpcEndpoint,
   buildFrpcSubdomain,
   buildFrpcUrl,
+  getFrpcUrlFilePath,
+  removeFrpcUrlFile,
   repositoryNameFromRemote,
   sanitizeDnsLabel,
+  writeFrpcUrlFile,
 } from '../frpc';
+
+const TEST_WORKTREE_NAME = `frpc-test-${process.pid}`;
+
+afterEach(() => {
+  removeFrpcUrlFile(TEST_WORKTREE_NAME);
+});
 
 describe('frpc helpers', () => {
   it('extracts repository names from common git remote formats', () => {
@@ -74,5 +84,16 @@ describe('frpc helpers', () => {
       subdomain: 'plexus-purple-turtle',
       url: 'https://plexus-purple-turtle.dev.home.cowger.us',
     });
+  });
+
+  it('writes and removes the URL file for later tools', () => {
+    const url = 'https://plexus-purple-turtle.dev.home.cowger.us';
+    const filePath = getFrpcUrlFilePath(TEST_WORKTREE_NAME);
+
+    writeFrpcUrlFile(url, TEST_WORKTREE_NAME);
+    expect(readFileSync(filePath, 'utf8')).toBe(`${url}\n`);
+
+    removeFrpcUrlFile(TEST_WORKTREE_NAME);
+    expect(() => readFileSync(filePath, 'utf8')).toThrow();
   });
 });

--- a/scripts/dev-config.ts
+++ b/scripts/dev-config.ts
@@ -11,7 +11,13 @@
 import { join, basename } from 'path';
 import { tmpdir } from 'os';
 import { deriveDevPort } from './dev-port-allocator';
-import { buildFrpcEndpoint, getRepositoryName, isFrpcAvailable, type FrpcEndpoint } from './frpc';
+import {
+  buildFrpcEndpoint,
+  getFrpcUrlFilePath,
+  getRepositoryName,
+  isFrpcAvailable,
+  type FrpcEndpoint,
+} from './frpc';
 import { getPaseoScriptStatus } from './lib/paseo';
 
 const dirName = basename(process.cwd());
@@ -65,11 +71,17 @@ function getFrpEndpoint(): FrpcEndpoint {
 }
 
 function printFrpEndpoint(args: string[]) {
+  const urlFile = getFrpcUrlFilePath(dirName);
+  if (args.includes('--file')) {
+    console.log(urlFile);
+    return;
+  }
+
   const endpoint = getFrpEndpoint();
   const hostname = endpoint.url ? new URL(endpoint.url).hostname : undefined;
 
   if (args.includes('--json')) {
-    console.log(JSON.stringify({ ...endpoint, hostname: hostname ?? null }));
+    console.log(JSON.stringify({ ...endpoint, hostname: hostname ?? null, urlFile }));
     return;
   }
   if (args.includes('--subdomain')) {
@@ -99,7 +111,7 @@ if (import.meta.main) {
       printFrpEndpoint(process.argv.slice(3));
     } else {
       throw new Error(
-        'Usage: bun run scripts/dev-config.ts <port|db_path|frp_url> [--hostname|--subdomain|--json]'
+        'Usage: bun run scripts/dev-config.ts <port|db_path|frp_url> [--hostname|--subdomain|--json|--file]'
       );
     }
   } catch (error) {

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -10,6 +10,8 @@ import {
   DEFAULT_FRPC_SERVER_PORT,
   getRepositoryName,
   isFrpcAvailable,
+  removeFrpcUrlFile,
+  writeFrpcUrlFile,
 } from './frpc';
 
 // --- Dev defaults (only applied when not already set in environment) ---
@@ -164,6 +166,7 @@ await new Promise<void>((resolve, reject) => {
 
 const PID_FILE = join(tmpdir(), `plexus-${dirName}.pid`);
 writeFileSync(PID_FILE, String(process.pid));
+removeFrpcUrlFile(dirName);
 
 // --- Startup ---
 
@@ -200,6 +203,7 @@ function spawnManaged(
 function killAll() {
   if (isShuttingDown) return;
   isShuttingDown = true;
+  removeFrpcUrlFile(dirName);
 
   if (frpcProcess?.pid) {
     try {
@@ -269,11 +273,17 @@ function startFrpc() {
     subdomain,
   });
 
+  if (publicUrl) {
+    writeFrpcUrlFile(publicUrl, dirName);
+  }
+
   console.log(`[frpc] Starting tunnel for subdomain: ${subdomain}`);
   const proc = spawnManaged('frpc', args, process.cwd(), { detached: false });
   frpcProcess = proc;
+  proc.on('error', () => removeFrpcUrlFile(dirName));
   proc.on('exit', (code, signal) => {
     if (frpcProcess === proc) frpcProcess = undefined;
+    removeFrpcUrlFile(dirName);
     if (!isShuttingDown && code !== 0) {
       console.error(`[frpc] Tunnel exited with ${signal ? `signal ${signal}` : `code ${code}`}.`);
     }

--- a/scripts/frpc.ts
+++ b/scripts/frpc.ts
@@ -1,10 +1,13 @@
 import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
-import { basename } from 'path';
+import { unlinkSync, renameSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { basename, join } from 'path';
 
 export const DEFAULT_FRPC_SERVER_PORT = 7000;
 
 const MAX_DNS_LABEL_LENGTH = 63;
+const FRPC_URL_FILE_SUFFIX = '.frpc-url';
 const LONG_LABEL_HASH_LENGTH = 8;
 
 export function sanitizeDnsLabel(value: string, fallback: string): string {
@@ -69,6 +72,30 @@ export function buildFrpcUrl(subdomain: string, subdomainHost?: string): string 
 export interface FrpcEndpoint {
   subdomain: string;
   url?: string;
+}
+
+export function getFrpcUrlFilePath(worktreeName = basename(process.cwd())): string {
+  return join(tmpdir(), `plexus-${worktreeName}${FRPC_URL_FILE_SUFFIX}`);
+}
+
+export function writeFrpcUrlFile(url: string, worktreeName = basename(process.cwd())): void {
+  const filePath = getFrpcUrlFilePath(worktreeName);
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporaryPath, `${url}\n`, { encoding: 'utf8', mode: 0o600 });
+    renameSync(temporaryPath, filePath);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {}
+    throw error;
+  }
+}
+
+export function removeFrpcUrlFile(worktreeName = basename(process.cwd())): void {
+  try {
+    unlinkSync(getFrpcUrlFilePath(worktreeName));
+  } catch {}
 }
 
 export function buildFrpcEndpoint(


### PR DESCRIPTION
## Summary
Expose the active FRPC tunnel URL through a stable per-worktree temporary file so later tools can consume it without scraping logs.

## Changes
- Write `/tmp/plexus-<worktree>.frpc-url` while the FRPC tunnel is active.
- Remove the URL file when the dev process or FRPC exits.
- Add `bun run dev:get:frp-url -- --file` and include the path in JSON output.
- Convert Paseo dev entries from services to tasks and remove Paseo port allocation configuration.
- Add regression coverage and document the file lookup.
